### PR TITLE
comments can work at the end of files now

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -6,7 +6,7 @@ OPERATOR: /[\-\+*%=≠<>≤≥&∘∪∩⊆∈⨄]/
 IDENT: (/_/|UPPER|LOWER) (/_/|UPPER|LOWER|DIGIT|/[₀₁₂₃₄₅₆₇₈₉!?']/)*
 NEWLINE: (/\r/? /\n/)+
 WS: /[ \t\f\r\n]/+
-LINECOMMENT: "//" /[^\n]*/ NEWLINE
+LINECOMMENT: "//" /[^\n]*/ 
 COMMENT: /\/\*([^\*]|\*+[^\/])*\*+\//
 
 ?term: term "and" term_compare                    -> and_formula


### PR DESCRIPTION
Files with a comment as the last line weren't parsing correctly.
Example
```
import Nat
print 5
// This breaks the code!
```

I removed the requirement of a newline, since the regex handles this just fine.

All tests are passing (at least on linux), but I can't see windows being too much of an issue, since the \r would just be consumed as part of the comment.