### PR TITLE
All Simplification and Errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = $(shell command -v python3.11)
+PYTHON = $(shell command -v python3.12)
 
 LIB_DIR = ./lib
 TEST_PASS_DIR = ./test/should-pass

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1395,7 +1395,7 @@ class All(Formula):
     result = ''
     if s + 1 == e:
       result += "(all "
-    result += f"{v} : {str(t)}"
+    result += f"{v}:{str(t)}"
     if s == 0:
       result += ". "
     else:
@@ -1705,6 +1705,7 @@ class AllElimTypes(Proof):
   pos: Tuple[int, int]
 
   def __str__(self):
+    print(self.pos)
     s, e = self.pos
     res = str(self.univ)
     if s == 0:

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1379,6 +1379,7 @@ class IfThen(Formula):
 class All(Formula):
   vars: list[Tuple[str,Type]]
   body: Formula
+  # TODO
 
   def copy(self):
     return All(self.location,
@@ -1682,6 +1683,7 @@ class AllIntro(Proof):
 class AllElimTypes(Proof):
   univ: Proof
   args: List[Type]
+  # TODO: This is cursed
 
   def __str__(self):
     return str(self.univ) + '<' + ','.join([str(arg) for arg in self.args]) + '>'
@@ -1695,6 +1697,7 @@ class AllElimTypes(Proof):
 class AllElim(Proof):
   univ: Proof
   args: List[Term]
+  # TODO
 
   def __str__(self):
     return str(self.univ) + '[' + ','.join([str(arg) for arg in self.args]) + ']'

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1377,26 +1377,34 @@ class IfThen(Formula):
 
 @dataclass
 class All(Formula):
-  vars: list[Tuple[str,Type]]
+  var: Tuple[str,Type]
+  pos: Tuple[int, int]
   body: Formula
-  # TODO
 
   def copy(self):
-    return All(self.location,
-               [(x, t.copy()) for (x,t) in self.vars],
-               self.body.copy())
+    x, t = self.var
+    return All(self.location, (x, t.copy()), self.pos, self.body.copy())
   
   def __str__(self):
-    if get_verbose():
-      params = self.vars
+    v, t = self.var
+    if not get_verbose():
+      v = base_name(v)
+
+    (s, e) = self.pos
+
+    result = ''
+    if s + 1 == e:
+      result += "(all "
+    result += f"{v} : {str(t)}"
+    if s == 0:
+      result += ". "
     else:
-      params = [(base_name(x), t)for (x,t) in self.vars]
-    return '(all ' + ", ".join([v + ":" + str(t) \
-                                for (v,t) in params]) \
-        + '. ' + str(self.body) + ')'
+      result += ", "
+
+    result += f"{str(self.body)})"
+    return result
 
   def reduce(self, env):
-    n = len(self.vars)
     new_body = self.body.reduce(env)
     match new_body:
       case Bool(loc, tyof, b):
@@ -1404,35 +1412,37 @@ class All(Formula):
           print('reduce ' + str(self) + '\n\t==> ' + str(new_body))
         return new_body
       case _:
+        x, ty = self.var
         return All(self.location,
                    self.typeof,
-                   [(x, ty.reduce(env)) for (x,ty) in self.vars],
+                   (x, ty.reduce(env)),
+                   self.pos,
                    new_body)
 
   def substitute(self, sub):
-    n = len(self.vars)
+    x, ty = self.var
     return All(self.location,
                self.typeof,
-               [(x, ty.substitute(sub)) for (x,ty) in self.vars],
+               (x, ty.substitute(sub)),
+               self.pos,
                self.body.substitute(sub))
   
   def __eq__(self, other):
     if not isinstance(other, All):
       return False
-    sub = {y: Var(self.location, None, x, [x]) \
-           for ((x,tx),(y,ty)) in zip(self.vars, other.vars)}
+    x, tx = self.var
+    y, ty = other.var
+    sub = { y: Var(self.location, None, x, [x]) }
     return self.body == other.body.substitute(sub)
 
   def uniquify(self, env):
     body_env = {x:y for (x,y) in env.items()}
-    new_vars = []
-    for (x,ty) in self.vars:
-      t = ty.copy()
-      t.uniquify(body_env)
-      new_x = generate_name(x)
-      new_vars.append( (new_x,t) )
-      body_env[x] = [new_x]
-    self.vars = new_vars
+    (x,ty) = self.var
+    t = ty.copy()
+    t.uniquify(body_env)
+    new_x = generate_name(x)
+    body_env[x] = [new_x]
+    self.var = (new_x,t)
     self.body.uniquify(body_env)
     
 @dataclass
@@ -1660,52 +1670,79 @@ class ImpIntro(Proof):
     
 @dataclass
 class AllIntro(Proof):
-  vars: List[Tuple[str,Type]]
+  var: Tuple[str,Type]
+  pos: Tuple[int, int]
   body: Proof
 
   def __str__(self):
-    return 'arbitrary ' + ",".join([x + ":" + str(t) for (x,t) in self.vars]) \
-        + '; ' + str(self.body)
+    s, e = self.pos
+    x, t = self.var
+    res = ''
+    if s + 1 == e:
+      res += 'arbitrary'
+    res += f"{x} : {str(t)}"
+    if s == 0:
+      res += ";"
+    else:
+      res += ","
+    
+    return res + str(self.body)
 
   def uniquify(self, env):
     body_env = copy_dict(env)
-    new_vars = []
-    for (x,ty) in self.vars:
-      t = ty.copy()
-      t.uniquify(body_env)
-      new_x = generate_name(x)
-      new_vars.append( (new_x,t) )
-      body_env[x] = [new_x]
-    self.vars = new_vars
+    x, ty = self.var
+    new_t = ty.copy()
+    new_t.uniquify(body_env)
+    new_x = generate_name(x)
+    body_env[x] = [new_x]
+    self.var = (new_x, new_t)
     self.body.uniquify(body_env)
     
 @dataclass
 class AllElimTypes(Proof):
   univ: Proof
-  args: List[Type]
-  # TODO: This is cursed
+  arg: Type
+  pos: Tuple[int, int]
 
   def __str__(self):
-    return str(self.univ) + '<' + ','.join([str(arg) for arg in self.args]) + '>'
+    s, e = self.pos
+    res = str(self.univ)
+    if s == 0:
+      res += f"<{self.arg}"
+    else:
+      res += f", {self.arg}"
+
+    if s + 1 == e:
+      res += ">"
+
+    return res
 
   def uniquify(self, env):
     self.univ.uniquify(env)
-    for arg in self.args:
-      arg.uniquify(env)
+    self.arg.uniquify(env)
       
 @dataclass
 class AllElim(Proof):
   univ: Proof
-  args: List[Term]
-  # TODO
+  arg: Term
+  pos: Tuple[int, int]
 
   def __str__(self):
-    return str(self.univ) + '[' + ','.join([str(arg) for arg in self.args]) + ']'
+    s, e = self.pos
+    res = str(self.univ)
+    if s == 0:
+      res += f"[{self.arg}"
+    else:
+      res += f", {self.arg}"
+
+    if s + 1 == e:
+      res += "]"
+
+    return res
 
   def uniquify(self, env):
     self.univ.uniquify(env)
-    for arg in self.args:
-      arg.uniquify(env)
+    self.arg.uniquify(env)
       
 @dataclass
 class SomeIntro(Proof):
@@ -2750,7 +2787,7 @@ def count_marks(formula):
       return sum([count_marks(arg) for arg in args])
     case IfThen(loc2, tyof, prem, conc):
       return count_marks(prem) + count_marks(conc)
-    case All(loc2, tyof, vars, frm2):
+    case All(loc2, tyof, var, _, frm2):
       return count_marks(frm2)
     case Some(loc2, tyof, vars, frm2):
       return count_marks(frm2)
@@ -2796,7 +2833,7 @@ def find_mark(formula):
     case IfThen(loc2, tyof, prem, conc):
       find_mark(prem)
       find_mark(conc)
-    case All(loc2, tyof, vars, frm2):
+    case All(loc2, tyof, var, pos, frm2):
       find_mark(frm2)
     case Some(loc2, tyof, vars, frm2):
       find_mark(frm2)
@@ -2847,8 +2884,8 @@ def replace_mark(formula, replacement):
     case IfThen(loc2, tyof, prem, conc):
       return IfThen(loc2, tyof, replace_mark(prem, replacement),
                     replace_mark(conc, replacement))
-    case All(loc2, tyof, vars, frm2):
-      return All(loc2, tyof, vars, replace_mark(frm2, replacement))
+    case All(loc2, tyof, var, pos, frm2):
+      return All(loc2, tyof, var, pos, replace_mark(frm2, replacement))
     case Some(loc2, tyof, vars, frm2):
       return Some(loc2, tyof, vars, replace_mark(frm2, replacement))
     case Call(loc2, tyof, rator, args, infix):

--- a/lib/List.pf
+++ b/lib/List.pf
@@ -526,7 +526,7 @@ proof
     case node(x, xs') {
       suppose prem
       have x_xxs: x ∈ (single(x) ∪ set_of(xs'))
-        by apply in_left_union<T>[set_of(xs'), x, single(x)]
+        by apply in_left_union<T>[set_of(xs')]
 	   to single_member<T>[x]
       conclude false
         by apply empty_no_members<T>[x]

--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -448,7 +448,7 @@ proof
         by definition {operator*, operator+}
     equations   suc(n + m' * suc(n))
               = suc(n + (m' + m' * n))       by rewrite IH[n]
-          ... = suc( #(n + m') + m' * n# )   by rewrite add_assoc[n][m', m' * n]
+          ... = suc( #(n + m') + m' * n# )   by rewrite add_assoc[n][m'][m' * n]
           ... = suc((m' + n) + m' * n)       by rewrite add_commute[n][m']
           ... = suc(m' + (n + m' * n))       by rewrite add_assoc[m'][n, m' * n]
   }

--- a/parser.py
+++ b/parser.py
@@ -168,14 +168,19 @@ def parse_tree_to_ast(e, parent):
        subject = parse_tree_to_ast(e.children[0], e)
        return IfThen(e.meta, None, subject, Bool(e.meta, None, False))
     elif e.data == 'all_formula':
-        return All(e.meta, None,
-                   parse_tree_to_list(e.children[0], e),
-                   parse_tree_to_ast(e.children[1], e))
+        vars = parse_tree_to_list(e.children[0], e)
+        body = parse_tree_to_ast(e.children[1], e)
+        result = body
+        for i, var in enumerate(reversed(vars)):
+            result = All(e.meta, None, var, (i, len(vars)), result)
+        return result
     elif e.data == 'alltype_formula':
         vars = parse_tree_to_list(e.children[0], e)
-        return All(e.meta, None,
-                   [(v, TypeType(e.meta)) for v in vars],
-                   parse_tree_to_ast(e.children[1], e))
+        body = parse_tree_to_ast(e.children[1], e)
+        result = body
+        for i, ty in enumerate(reversed(vars)):
+            result = All(e.meta, None, (ty, TypeType(e.meta)), (i, len(vars)), result)
+        return result
     elif e.data == 'some_formula':
         return Some(e.meta, None,
                     parse_tree_to_list(e.children[0], e),
@@ -400,15 +405,24 @@ def parse_tree_to_ast(e, parent):
     elif e.data == 'all_intro':
         vars = parse_tree_to_list(e.children[0], e)
         body = parse_tree_to_ast(e.children[1], e)
-        return AllIntro(e.meta, vars, body)
+        result = body
+        for i, var in enumerate(reversed(vars)):
+            result = AllIntro(e.meta, var, (i, len(vars)), result)
+        return result
     elif e.data == 'all_elim':
         univ = parse_tree_to_ast(e.children[0], e)
         args = parse_tree_to_list(e.children[1], e)
-        return AllElim(e.meta, univ, args)
+        result = univ
+        for i,var in enumerate(args):
+            result = AllElim(e.meta, result, var, (i, len(args)))
+        return result
     elif e.data == 'all_elim_types':
         univ = parse_tree_to_ast(e.children[0], e)
         type_args = parse_tree_to_list(e.children[1], e)
-        return AllElimTypes(e.meta, univ, type_args)
+        result = univ
+        for i, ty in enumerate(type_args):
+            result = AllElimTypes(e.meta, result, ty, (e ,len(type_args)))
+        return result
     elif e.data == 'some_intro':
         witnesses = parse_tree_to_list(e.children[0], e)
         body = parse_tree_to_ast(e.children[1], e)

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -491,10 +491,21 @@ def check_proof(proof, env):
       allfrm = check_proof(univ, env)
       match allfrm:
         case All(loc2, tyof, vars, frm):
+          # TODO: Temporary - will change when we sugar
+          if len(vars) != len(args):
+            error(loc, f"Instantiation of\n\t{univ} : {allfrm}\n" \
+                  + f"expected {len(vars)} arguments, but got {len(args)}")
           sub = {}
           new_args = []
           for ((var,ty), arg) in zip(vars, args):
-            new_arg = type_check_term(arg, ty.substitute(sub), env, None, [])
+            try:
+              new_arg = type_check_term(arg, ty.substitute(sub), env, None, [])
+            except Exception as e:
+              if isinstance(ty, TypeType):
+                error(loc, f"In instantiation of\n\t{str(univ)} : {str(allfrm)}\n" \
+                      + f"expected a type argument, but was given '{arg}'")
+              else:
+                raise e
             if isinstance(ty, TypeType):
                 error(loc, 'to instantiate:\n\t' + str(univ)+' : '+str(allfrm) \
                       +'\nwith type arguments, instead write:\n\t' \

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -485,7 +485,7 @@ def check_proof(proof, env):
       formula = check_proof(body, body_env)
       ret = All(loc, BoolType(loc), var, pos, formula)
       
-    case AllElim(loc, univ, arg, _):
+    case AllElim(loc, univ, arg, pos):
       allfrm = check_proof(univ, env)
       match allfrm:
         case All(loc2, tyof, var, _, frm):
@@ -503,8 +503,7 @@ def check_proof(proof, env):
           if isinstance(ty, TypeType):
               error(loc, 'to instantiate:\n\t' + str(univ)+' : '+str(allfrm) \
                     +'\nwith type arguments, instead write:\n\t' \
-                    +str(univ) + '<' \
-                    + ', '.join([str(arg) for arg in args]) + '>\n')
+                    +str(univ) + '<' + str(arg) + '>\n')
           new_args.append(new_arg)
         case _:
           error(loc, 'expected all formula to instantiate, not ' + str(allfrm) \

--- a/test/should-error/inst-term-angle-bracket.pf
+++ b/test/should-error/inst-term-angle-bracket.pf
@@ -1,4 +1,5 @@
 import List
+import Nat
 
 theorem thm: if (<T> all xs:List<T>. map(xs, fun x:T { x }) = xs)
   then map(node(1, empty), fun x:Nat { x }) = node(1, empty)

--- a/test/should-error/inst-term-angle-bracket.pf.err
+++ b/test/should-error/inst-term-angle-bracket.pf.err
@@ -1,2 +1,2 @@
-./test/should-error/inst-term-angle-bracket.pf:7.17-7.18: error in parsing, unexpected token: (
+./test/should-error/inst-term-angle-bracket.pf:8.17-8.18: error in parsing, unexpected token: (
 (The error may be immediately before this token.)

--- a/test/should-error/inst-type-square-bracket.pf.err
+++ b/test/should-error/inst-type-square-bracket.pf.err
@@ -1,1 +1,5 @@
-./test/should-error/inst-type-square-bracket.pf:4.17-4.18: undefined variable `suc`	(uniquify)
+./test/should-error/inst-type-square-bracket.pf:8.3-8.12: to instantiate:
+	prem : (all T:type. (all xs:List<T>. map(xs, λx:T{x}) = xs))
+with type arguments, instead write:
+	prem<Nat>
+

--- a/test/should-error/inst_type_forget.pf
+++ b/test/should-error/inst_type_forget.pf
@@ -5,5 +5,5 @@ theorem thm: if (<T> all xs:List<T>. map(xs, fun x:T { x }) = xs)
   then map(node(1, empty), fun x:Nat { x }) = node(1, empty)
 proof
   suppose prem: (<T> all xs:List<T>. map(xs, fun x:T { x }) = xs)
-  prem[Nat][node(1,empty)]
+  prem[node(1,empty)]
 end

--- a/test/should-error/inst_type_forget.pf.err
+++ b/test/should-error/inst_type_forget.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/inst_type_forget.pf:8.3-8.22: In instantiation of
+	prem : (all T:type. (all xs:List<T>. map(xs, λx:T{x}) = xs))
+expected a type argument, but was given 'node(1, [])'


### PR DESCRIPTION
## Changes
- Commas in `all`, `arbitrary`, and theorem instantiation are now syntactic sugar
  - Removed lists from AST nodes, and added position property to allow for pretty printing.
- Error message suggesting a type argument when someone forgets it (https://github.com/jsiek/deduce/issues/27)

## Possible Enhancements
- [] Factor out repeated code for wrapping and desugaring
  - I want to make sure that it's still clear what the code is doing
  - I didn't see anywhere obvious to add utility functions