### PR TITLE
Add more verbose error for missing `generic` keyword

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2088,7 +2088,14 @@ def type_check_term(term, typ, env, recfun, subterms):
           new_body = type_check_term(body, return_type, body_env,
                                      recfun, subterms)
           return Lambda(loc, typ, params, new_body)
+        case FunctionType(loc2, ty_params, _, _):
+          pretty_params = ", ".join([base_name(x) for x in ty_params])
+          plural = 's' if len(ty_params) > 1 else ''
+
+          error(loc, f'Expected type parameter{plural} {pretty_params}, but got a lambda.\n\t' + \
+                f'Add generic {pretty_params} {"{ ... }"} around the function body.')
         case _:
+          print(type(typ))
           error(loc, 'expected a term of type ' + str(typ) + '\n'\
                 + 'but instead got a lambda')
           

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2095,7 +2095,6 @@ def type_check_term(term, typ, env, recfun, subterms):
           error(loc, f'Expected type parameter{plural} {pretty_params}, but got a lambda.\n\t' + \
                 f'Add generic {pretty_params} {"{ ... }"} around the function body.')
         case _:
-          print(type(typ))
           error(loc, 'expected a term of type ' + str(typ) + '\n'\
                 + 'but instead got a lambda')
           

--- a/test/should-error/missing_generic.pf
+++ b/test/should-error/missing_generic.pf
@@ -1,0 +1,1 @@
+define id_gen : fn<E> E -> E = fun x { x } 

--- a/test/should-error/missing_generic.pf.err
+++ b/test/should-error/missing_generic.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/missing_generic.pf:1.32-1.43: Expected type parameter E, but got a lambda.
+	Add generic E { ... } around the function body.


### PR DESCRIPTION
This occurs in situations like these, where something with generics is expected.
`define id_gen : fn<E> E -> E = fun x { x } `.

The previous error was: \
`expected a term of type (fn <E> E -> E) but instead got a lambda`, \
and it is now
```
test.pf:1.32-1.43: Expected type parameter E, but got a lambda.
        Add generic E { ... } around the function body.
```
