### PR TITLE
Patch

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2088,7 +2088,14 @@ def type_check_term(term, typ, env, recfun, subterms):
           new_body = type_check_term(body, return_type, body_env,
                                      recfun, subterms)
           return Lambda(loc, typ, params, new_body)
+        case FunctionType(loc2, ty_params, _, _):
+          pretty_params = ", ".join([base_name(x) for x in ty_params])
+          plural = 's' if len(ty_params) > 1 else ''
+
+          error(loc, f'Expected type parameter{plural} {pretty_params}, but got a lambda.\n\t' + \
+                f'Add generic {pretty_params} {"{ ... }"} around the function body.')
         case _:
+          print(type(typ))
           error(loc, 'expected a term of type ' + str(typ) + '\n'\
                 + 'but instead got a lambda')
           

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1760,7 +1760,7 @@ def type_first_letter(typ):
       print('error in type_first_letter: unhandled type ' + repr(typ))
       exit(-1)
 
-def type_check_term_inst(loc, subject, tyargs, inferred):
+def type_check_term_inst(loc, subject, tyargs, inferred, recfun, subterms, env):
   for ty in tyargs:
       check_type(ty, env)
   new_subject = type_synth_term(subject, env, recfun, subterms)
@@ -1990,7 +1990,7 @@ def type_synth_term(term, env, recfun, subterms):
                                      inferred, env)
       
     case TermInst(loc, _, subject, tyargs, inferred):
-      ret = type_check_term_inst(loc, subject, tyargs, inferred)
+      ret = type_check_term_inst(loc, subject, tyargs, inferred, recfun, subterms, env)
           
     case TAnnote(loc, tyof, subject, typ):
       check_type(typ, env)
@@ -2173,7 +2173,7 @@ def type_check_term(term, typ, env, recfun, subterms):
                                       inferred, env)
       
     case TermInst(loc, _, subject, tyargs, inferred):
-      return type_check_term_inst(loc, subject, tyargs, inferred)
+      return type_check_term_inst(loc, subject, tyargs, inferred, recfun, subterms, env)
   
     case _:
       if get_verbose():

--- a/test/should-error/missing_generic.pf
+++ b/test/should-error/missing_generic.pf
@@ -1,0 +1,1 @@
+define id_gen : fn<E> E -> E = fun x { x } 

--- a/test/should-error/missing_generic.pf.err
+++ b/test/should-error/missing_generic.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/missing_generic.pf:1.32-1.43: Expected type parameter E, but got a lambda.
+	Add generic E { ... } around the function body.


### PR DESCRIPTION
env, recfun, and subterms were undefined in the method type_check_term_inst. 

Here is the file that triggered the error:
```
import List
import Nat
import Option

theorem rev_correct : all T : type, i : Nat, xs : List<T>.
  get(reverse(xs), i) = get(xs, length(xs) - 1 - i)
proof
  arbitrary T : type, i : Nat
  induction List<T>
  case [] {
    suffices ? by definition { length, get }
    ?
  }
  case node(x, xs') suppose IH {
    ?
  }
end
```

Gotta love that python lets you have undefined variables floating around.
