### PR TITLE
Reference duplicate entagled code block name

### DIFF
--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -1986,7 +1986,7 @@ contains the items that occur in either set.
 
 Example:
 
-```{.deduce^#union_example}
+```{.deduce^#set_union_example}
 define C' = single(1) ∪ single(2)
 define D' = single(2) ∪ single(3)
 assert 1 ∈ C' ∪ D'
@@ -2064,5 +2064,6 @@ import Maps
 <<suffices_example>>
 <<true_example>>
 <<union_example>>
+<<set_union_example>>
 ```
 -->


### PR DESCRIPTION
Two code blocks in the Reference.md doc file had the same entangled id of `union_example`. I renamed one of them to `set_union_example`. 

I am not sure of how entangled handled duplicate names, but I am currently working on a system of generating html from markdown files for the website and duplicate names caused errors.