### PR TITLE
Add make target for releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ personal
 test/**/*.thm
 lib/*.thm
 .vscode
+deduce-release.zip

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ tests-lib:
 
 tests: tests-should-pass tests-should-error
 
+package:
+	zip "deduce-release" lib abstract_syntax.py alist.py Deduce.lark deduce.py \
+						edit_distance.py error.py parser.py proof_checker.py README.md rec_desc_parser.py 
+
 clean:
 	rm -f ./lib/*.thm
 	rm -f ./test/should-pass/*.thm
+	rm -f deduce-release.zip


### PR DESCRIPTION
Now we should be able to just do "make package" and deduce will use the Unix "zip" command in order to create a zip file named "deduce-release.zip" that we can plop onto the releases page.
I also updated "make clean" to remove the release file, and added the zip file to  .gitignore.
The file should contain the minimum files needed to run deduce, and also the standard library. Note that test-deduce and the test folder isn't included.