### PR TITLE
Fixing escaped error

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -720,6 +720,11 @@ def parse_proof_hi():
   elif token.type == 'CONJUNCT':
     advance()
     meta = meta_from_tokens(current_token(),current_token())
+
+    if current_token().type != 'INT' and current_token().value != '0':
+      error(meta, 'expected an int literal after "conjunct", not\n\t' \
+            + current_token().value)
+      
     index = int(current_token().value)
     advance()
     if current_token().type != 'OF':

--- a/test/should-error/conjunct.pf
+++ b/test/should-error/conjunct.pf
@@ -1,0 +1,14 @@
+union Nat {
+  zero
+  suc(Nat)
+}
+
+define num = 0
+
+theorem blah: all a : bool, b : bool.
+  if a and b then a
+proof
+  arbitrary a : bool, b : bool
+  suppose prem
+  conjunct num of prem
+end

--- a/test/should-error/conjunct.pf.err
+++ b/test/should-error/conjunct.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/conjunct.pf:13.12-13.15: expected an int literal after "conjunct", not
+	num
+./test/should-error/conjunct.pf:8.1-13.11: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"


### PR DESCRIPTION
We were doing an unchecked int cast in the rule for conjunct. Making sure that it's correct here!