### PR TITLE
Refactor tester ifs

### DIFF
--- a/deduce.py
+++ b/deduce.py
@@ -14,6 +14,14 @@ from pathlib import Path
 traceback_flag = False
 suppress_theorems = False
 
+# os.listdir returns files inside of said dir in a random order
+# In order to avoid undefined behavior (e.g. deduce works on one computer but not another)
+# Use this function (or a similar one) instead 
+def list_dir_sorted(dir):
+    ret = os.listdir(dir)
+    ret.sort()
+    return ret
+
 def handle_sigint(signal, stack_frame):
     print('SIGINT caught, exiting...')
     exit(137)
@@ -76,7 +84,7 @@ def deduce_file(filename, error_expected):
 def deduce_directory(directory, recursive_directories):
     if directory[-1] != '/' or directory[-1] != '\\': # Windows moment
         directory += '/'
-    for file in os.listdir(directory):
+    for file in list_dir_sorted(directory):
         if os.path.isfile(directory + file):
             if file[-3:] == '.pf':
                 deduce_file(directory + file, error_expected)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -13,6 +13,14 @@ error_dir = './test/should-error'
 site_dir = './gh-pages/deduce-code'
 max_threads = 10
 
+# os.listdir returns files inside of said dir in a random order
+# In order to avoid undefined behavior (e.g. tests work on one computer but not another)
+# Use this function (or a similar one) instead 
+def list_dir_sorted(dir):
+    ret = os.listdir(dir)
+    ret.sort()
+    return ret
+
 def handle_sigint(signal, stack_frame):
     print('SIGINT caught, exiting...')
     exit(137)
@@ -48,7 +56,7 @@ def generate_deduce_errors(deduce_call, path):
 
         if path[-1] != '/' or path[-1] != '\\':
             path += '/'
-        for file in os.listdir(path): 
+        for file in list_dir_sorted(path): 
             if os.path.isfile(path + file):
                 if file[-3:] == '.pf':
                     thread = Thread(target=generate_deduce_errors, args=(deduce_call, path + file))
@@ -60,7 +68,7 @@ def generate_deduce_errors(deduce_call, path):
                         t.join()
                         running_threads.remove(t)
 
-            elif os.path.isdir(path + file):
+            elif list_dir_sorted(path + file):
                 # TODO: recursive directories
                 pass
         for t in running_threads:
@@ -123,7 +131,7 @@ def test_deduce_errors(deduce_call, path):
             path += '/'
 
         threads = []
-        for file in os.listdir(path):
+        for file in list_dir_sorted(path):
             if os.path.isfile(path + file):
                 if file[-3:] == '.pf':
                     if not os.path.isfile(path + file + '.err'):


### PR DESCRIPTION
This pull request serves to alter how the tester works without changing its underlying behavior. 

1. First, the tester now runs every file it's provided in a defined order. That being either lib then "passable" then "regenerables" then "errors", and then alphabetically by filename, or by the order of the parameters then filename.  I've also gone ahead and added the same behavior filename into `deduce.py`, which should remove the undefined behavior when processing a directory of files.
2. The test cases associated with `--site` have been moved to a function to gather them all up, and return them as a list
3. The "if then problem" referenced in #110 has been largely solved, except for:
4. The tester now detects if it should run everything by summing the lengths of the `valid_test_cases`, `error_test_cases`, and `regenerables` list, and if they add up to 0 then all tests get run by adding them into lists. 

The problem (4) with this is that it looks horrendous, and if a new category of tests is added then the case needs to be adjusted accordingly. The reason [I don't do as Matei said here](https://github.com/jsiek/deduce/issues/110#issuecomment-2640464278), is due to the `extra-arguments` feature. For example, if one does `python3 test-deduce.py --traceback`, no tests will be run. However, we could solve this problem by adding `--traceback` as an argument that the tester itself looks for, and then concatenating it into the `deduce_call`.  The problem with this lies in that if we want to use any other command line arguments, we'd then have to hard code them into the tester, or we'd have to ensure that the `tester-deduce.py` maintains parity with `deduce.py` with respect to command line arguments. Another solution might be something like a `shoud-run-all` flag, that we then set to false if we see `-passable` or `-errors` passed in, however that runs into the exact same problem we current have, where if we add another category of tests we then need to duplicate the `should-run-all = False` line.

For (4), what would people prefer? I propose either getting rid of the `extra-arguments` feature, or keeping it as I have in the current PR. If anyone has another solution, I'd be happy to hear it.