### PR TITLE
Tweaks

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1874,7 +1874,7 @@ class AllIntro(Proof):
     x, t = self.var
     res = ''
     if s + 1 == e:
-      res += 'arbitrary'
+      res += 'arbitrary '
     res += f"{x} : {str(t)}"
     if s == 0:
       res += ";"
@@ -2324,7 +2324,7 @@ class Theorem(Statement):
   def __str__(self):
     return ('lemma ' if self.isLemma else 'theorem ') \
       + self.name + ': ' + str(self.what) \
-      + '\nbegin\n' + str(self.proof) + '\nend\n'
+      + '\nproof\n' + str(self.proof) + '\nend\n'
 
   def uniquify(self, env):
     if self.name in env.keys():

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1451,11 +1451,11 @@ def parse_recursive_function():
     type_params = parse_type_parameters()
 
     if current_token().type == 'LPAR':
-      start_token = current_token()
+      paren_start_token = current_token()
       advance()
       param_types = parse_type_list()
       if current_token().type != 'RPAR':
-        raise ParseError(meta_from_tokens(start_token, previous_token()),
+        raise ParseError(meta_from_tokens(paren_start_token, previous_token()),
               'expected a closing parenthesis, not\n\t' \
               + quote(current_token().value))
       advance()

--- a/test/should-error/function_case_missing_equal.pf.err
+++ b/test/should-error/function_case_missing_equal.pf.err
@@ -3,7 +3,7 @@
 ./test/should-error/function_case_missing_equal.pf:8.3-8.9: while parsing
 	fun_case ::= identifier "(" param_list ")" "=" term
 
-./test/should-error/function_case_missing_equal.pf:6.11-8.9: while parsing
+./test/should-error/function_case_missing_equal.pf:6.1-8.9: while parsing
 	statement ::= "function" identifier type_params_opt "(" type_list ")"
 			 "->" type "{" fun_case* "}"
 


### PR DESCRIPTION
- Fixed position tracking for RecFun statements to enclose the whole definition
- Replaced `begin` with `proof` in the `__str__` method for theorems
- Added a space after arbitrary when printing 