### PR TITLE
Automatic induction and switch assumptions

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1337,6 +1337,10 @@ def check_proof_of(proof, formula, env):
             pre_goal = instantiate(loc, formula, new_trm)
             goal = check_formula(pre_goal, body_env)
             
+            # fill the rest of the given induction_hypotheses with _ labels
+            for i in range(len(indcase.induction_hypotheses), len(induction_hypotheses)):
+              indcase.induction_hypotheses.append((generate_name('_'), None))
+
             for ((x,frm1),frm2) in zip(indcase.induction_hypotheses, induction_hypotheses):
               if frm1 != None:
                 new_frm1 = check_formula(frm1, body_env)
@@ -1430,6 +1434,9 @@ def check_proof_of(proof, formula, env):
                 if isinstance(new_subject_case, TermInst):
                     new_subject_case.inferred = False
 
+                if len(scase.assumptions) == 0:
+                  scase.assumptions.append((generate_name('_'), None))
+                  
                 assumptions = [(label,check_formula(asm, body_env) if asm else None) for (label,asm) in scase.assumptions]
                 if len(assumptions) == 1:
                   assumption = mkEqual(scase.location, new_subject, subject_case)

--- a/test/should-error/sum_foldr_switch.pf.err
+++ b/test/should-error/sum_foldr_switch.pf.err
@@ -10,3 +10,5 @@ Advice:
 		rewrite
 		equations
 
+Givens:
+	_: ls = []

--- a/test/should-pass/induction_auto_assume.pf
+++ b/test/should-pass/induction_auto_assume.pf
@@ -1,0 +1,11 @@
+import Nat
+
+theorem add_zero_auto: all x:Nat. x + 0 = x
+proof
+    induction Nat
+    case 0 { evaluate }
+    case suc(n') {
+        suffices suc(n' + 0) = suc(n') by evaluate
+        rewrite recall n' + 0 = n'
+    }
+end

--- a/test/should-pass/switch_auto_assume.pf
+++ b/test/should-pass/switch_auto_assume.pf
@@ -1,0 +1,29 @@
+union A {
+    a
+    b
+}
+
+fun test(x : A){
+    switch x {
+        case a { true }
+        case b { false }
+    }
+}
+
+
+theorem test_thm: all x:A. test(x) = true or test(x) = false
+proof
+    arbitrary x:A
+    switch x {
+        case a assume G {
+            suffices test(x) = true by rewrite symmetric G
+            suffices test(a) = true by rewrite G
+            evaluate
+        }
+        case b {
+            suffices test(x) = false by rewrite symmetric recall x = b
+            suffices test(b) = false by rewrite recall x = b
+            evaluate
+        }
+    }
+end


### PR DESCRIPTION
Addresses #127 

For induction deduce now adds in however many un-assumed assumptions (as underscores) needed to match the number that there should be.

Since switch can only have one assumption, if there is none deduce will add one (as an underscore)