### PR TITLE
Forget def / recall

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from lark.tree import Meta
 from typing import Any, Tuple, List
-from error import error, warning, set_verbose, get_verbose, get_unique_names, VerboseLevel, EnvLookupException
+from error import error, warning, set_verbose, get_verbose, get_unique_names, VerboseLevel
 from pathlib import Path
 from edit_distance import edit_distance
 from math import ceil
@@ -3210,7 +3210,7 @@ class Env:
       elif isinstance(binding, TypeBinding):
         return TypeType(None)
       else:
-        raise EnvLookupException('expected a term or type variable, not ' + base_name(name))
+        raise Exception('expected a term or type variable, not ' + base_name(name))
     else:
       return None
 
@@ -3226,15 +3226,15 @@ class Env:
         case ProofBinding(loc, formula):
           return formula
         case TermBinding(loc, FunctionType()):
-          raise EnvLookupException('expected a proof but instead got term `' + base_name(name) + '`.'\
+          raise Exception('expected a proof but instead got term `' + base_name(name) + '`.'\
                         + '\nPerhaps you meant `definition ' + base_name(name) + '`?')
         case TermBinding():
-          raise EnvLookupException('expected a proof but instead got term `' + base_name(name) + '`.'\
+          raise Exception('expected a proof but instead got term `' + base_name(name) + '`.'\
                         + '\nPerhaps you meant `recall ' + base_name(name) + '`?')
         case TypeBinding():
-          raise EnvLookupException('expected a proof but instead got type ' + base_name(name))
+          raise Exception('expected a proof but instead got type ' + base_name(name))
         case _:
-          raise EnvLookupException('expected a proof but instead got ' + base_name(name))
+          raise Exception('expected a proof but instead got ' + base_name(name))
     else:
       return None
     
@@ -3246,7 +3246,7 @@ class Env:
         else:
           return name in self.dict.keys()
       case _:
-        raise EnvLookupException('expected a type name, not ' + str(tyname))
+        raise Exception('expected a type name, not ' + str(tyname))
 
   def term_var_is_defined(self, tvar):
     match tvar:
@@ -3256,7 +3256,7 @@ class Env:
         else:
           return False
       case _:
-        raise EnvLookupException('expected a term variable, not ' + str(tvar))
+        raise Exception('expected a term variable, not ' + str(tvar))
         
   def proof_var_is_defined(self, pvar):
     match pvar:
@@ -3266,7 +3266,7 @@ class Env:
         else:
           return False
       case _:
-        raise EnvLookupException('expected proof var, not ' + str(pvar))
+        raise Exception('expected proof var, not ' + str(pvar))
 
   def get_assoc_types(self, opname):
     full_name = '__associative_' + opname
@@ -3280,14 +3280,14 @@ class Env:
       case Var(loc, tyof, name):
         return self._def_of_type_var(self.dict, name)
       case _:
-        raise EnvLookupException('get_def_of_type_var: unexpected ' + str(var))
+        raise Exception('get_def_of_type_var: unexpected ' + str(var))
       
   def get_formula_of_proof_var(self, pvar):
     match pvar:
       case PVar(loc, name):
         return self._formula_of_proof_var(self.dict, name)
       case _:
-        raise EnvLookupException('get_formula_of_proof_var: expected PVar, not ' + str(pvar))
+        raise Exception('get_formula_of_proof_var: expected PVar, not ' + str(pvar))
           
   def get_type_of_term_var(self, tvar):
     match tvar:

--- a/error.py
+++ b/error.py
@@ -67,6 +67,9 @@ def error(location, msg):
   exc.depth = 0
   raise exc
 
+class EnvLookupException(Exception):
+  pass
+
 class IncompleteProof(Exception):
   pass
 

--- a/error.py
+++ b/error.py
@@ -67,9 +67,6 @@ def error(location, msg):
   exc.depth = 0
   raise exc
 
-class EnvLookupException(Exception):
-  pass
-
 class IncompleteProof(Exception):
   pass
 

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -483,8 +483,6 @@ def check_proof(proof, env):
             return ret
         else:
             error(loc, 'could not find given: ' + name)
-      except EnvLookupException as e:
-        raise(EnvLookupException(error_header(loc) + str(e)))
       except Exception as e:
         error(loc, str(e))
       
@@ -1556,8 +1554,6 @@ def check_proof_of(proof, formula, env):
         formula_red = formula.reduce(env)
         check_implies(proof.location, form_red, remove_mark(formula_red))
       except IncompleteProof as e:
-        raise e
-      except EnvLookupException as e:
         raise e
       except Exception as e:
         msg = str(e)

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -484,6 +484,8 @@ def check_proof(proof, env):
             return ret
         else:
             error(loc, 'could not find given: ' + name)
+      except EnvLookupException as e:
+        raise(EnvLookupException(error_header(loc) + str(e)))
       except Exception as e:
         error(loc, str(e))
       
@@ -1518,10 +1520,25 @@ def check_proof_of(proof, formula, env):
       check_proof_of(body, new_formula, env)
       #warning(loc, 'old-style definition will be deprecated')
     case _:
-      form = check_proof(proof, env)
-      form_red = form.reduce(env)
-      formula_red = formula.reduce(env)
-      check_implies(proof.location, form_red, remove_mark(formula_red))
+      try:
+        form = check_proof(proof, env)
+        form_red = form.reduce(env)
+        formula_red = formula.reduce(env)
+        check_implies(proof.location, form_red, remove_mark(formula_red))
+      except IncompleteProof as e:
+        raise e
+      except EnvLookupException as e:
+        raise e
+      except Exception as e:
+        msg = str(e)
+        # It could be that form is never reduced, such as in a PHelpUse
+        # In that case, we don't give 'replace' advice
+        try: 
+          if is_equation(form_red): 
+            msg += '\nDid you mean `replace ' + str(proof) + '`?'
+        finally:
+          raise(Exception(msg))
+
 
 def apply_definitions(loc, formula, defs, env):
   num_marks = count_marks(formula)

--- a/test/should-error/forgot_def.pf
+++ b/test/should-error/forgot_def.pf
@@ -1,0 +1,8 @@
+define xor : fn bool, bool -> bool
+  = fun P, Q { if P then (not Q) else Q }
+
+theorem neq_xor : all P : bool, Q : bool.
+  if P /= Q then xor(P, Q)
+proof
+  suffices ? by xor
+end

--- a/test/should-error/forgot_def.pf.err
+++ b/test/should-error/forgot_def.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/forgot_def.pf:7.17-7.20: expected a proof but instead got term `xor`.
+Perhaps you meant `definition xor`?

--- a/test/should-error/forgot_def_pvar.pf
+++ b/test/should-error/forgot_def_pvar.pf
@@ -1,0 +1,16 @@
+// Definitely not Nat
+union Blah {
+  A
+  B(Blah)
+}
+
+recursive even(Blah) -> bool {
+  even(A) = true
+  even(B(b)) = not(even(b))
+}
+
+theorem not_B_even : all n : Blah.
+  (not even(n)) = even(B(n))
+proof
+  even
+end

--- a/test/should-error/forgot_def_pvar.pf.err
+++ b/test/should-error/forgot_def_pvar.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/forgot_def_pvar.pf:15.3-15.7: expected a proof but instead got term `even`.
+Perhaps you meant `definition even`?

--- a/test/should-error/forgot_def_rec.pf
+++ b/test/should-error/forgot_def_rec.pf
@@ -1,0 +1,17 @@
+// Definitely not Nat
+union Blah {
+  A
+  B(Blah)
+}
+
+recursive even(Blah) -> bool {
+  even(A) = true
+  even(B(b)) = not(even(b))
+}
+
+theorem not_B_even : all n : Blah.
+  if even(n) then not (even(B(n)))
+proof
+  arbitrary n : Blah
+  suffices if even(n) then not not even(n) by even
+end

--- a/test/should-error/forgot_def_rec.pf.err
+++ b/test/should-error/forgot_def_rec.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/forgot_def_rec.pf:16.47-16.51: expected a proof but instead got term `even`.
+Perhaps you meant `definition even`?

--- a/test/should-error/forgot_replace_all.pf
+++ b/test/should-error/forgot_replace_all.pf
@@ -1,0 +1,18 @@
+import Nat
+
+define bigO : fn (fn Nat -> Nat), (fn Nat -> Nat) -> bool =
+ fun f, g{ all x : Nat. some k : Nat, c : Nat. if x >= k then f(x) <= c * g(x) }
+
+theorem n_big_o_n2 : bigO(fun x { x }, fun x { x * x })
+proof
+  suffices (all x:Nat. some k:Nat,c:Nat. (if x ≥ k then x ≤ c * (x * x)))
+    by definition bigO
+  arbitrary x : Nat
+  choose 1, 1
+  suffices if x ≥ 1 then x ≤ x * x 
+    by one_mult
+  assume prem : x >= 1
+  have one_le_x : 1 <= x by definition operator>= in prem
+  have x_le_xx : x * 1 <= x * x by apply mult_mono_le[x, 1, x] to one_le_x
+  conclude x <= x * x by rewrite mult_one[x] in x_le_xx
+end

--- a/test/should-error/forgot_replace_all.pf.err
+++ b/test/should-error/forgot_replace_all.pf.err
@@ -1,0 +1,9 @@
+./test/should-error/forgot_replace_all.pf:13.8-13.16: 
+Could not prove that
+	(all n:Nat. 1 * n = n)
+instantiates to
+	(if (if x ≥ 1 then x ≤ x * x) then (if x ≥ 1 then x ≤ 1 * x * x))
+because
+./test/should-error/forgot_replace_all.pf:13.8-13.16: formula: (if (if x ≥ 1 then x ≤ x * x) then (if x ≥ 1 then x ≤ 1 * x * x))
+does not match expected formula: 1 * n = n
+Did you mean `replace one_mult`?

--- a/test/should-error/forgot_replace_allelim.pf
+++ b/test/should-error/forgot_replace_allelim.pf
@@ -1,0 +1,18 @@
+import Nat
+
+define bigO : fn (fn Nat -> Nat), (fn Nat -> Nat) -> bool =
+ fun f, g{ all x : Nat. some k : Nat, c : Nat. if x >= k then f(x) <= c * g(x) }
+
+theorem n_big_o_n2 : bigO(fun x { x }, fun x { x * x })
+proof
+  suffices (all x:Nat. some k:Nat,c:Nat. (if x ≥ k then x ≤ c * (x * x)))
+    by definition bigO
+  arbitrary x : Nat
+  choose 1, 1
+  suffices if x ≥ 1 then x ≤ x * x 
+    by one_mult[x*x]
+  assume prem : x >= 1
+  have one_le_x : 1 <= x by definition operator>= in prem
+  have x_le_xx : x * 1 <= x * x by apply mult_mono_le[x, 1, x] to one_le_x
+  conclude x <= x * x by rewrite mult_one[x] in x_le_xx
+end

--- a/test/should-error/forgot_replace_allelim.pf.err
+++ b/test/should-error/forgot_replace_allelim.pf.err
@@ -1,0 +1,6 @@
+./test/should-error/forgot_replace_allelim.pf:13.8-13.21: 
+Could not prove that
+	1 * x * x = x * x
+implies
+	(if (if x ≥ 1 then x ≤ x * x) then (if x ≥ 1 then x ≤ 1 * x * x))
+Did you mean `replace one_mult[x * x]`?

--- a/test/should-error/forgot_replace_recall.pf
+++ b/test/should-error/forgot_replace_recall.pf
@@ -1,0 +1,7 @@
+theorem blah : all A : bool, B : bool.
+  if A = B then B = A
+proof
+  arbitrary A : bool, B : bool
+  assume prem
+  recall A = B
+end

--- a/test/should-error/forgot_replace_recall.pf.err
+++ b/test/should-error/forgot_replace_recall.pf.err
@@ -1,0 +1,9 @@
+./test/should-error/forgot_replace_recall.pf:6.3-6.15: error, the proved formula:
+	A = B
+does not match the goal:
+	B = A
+because
+	A
+	≠ B
+
+Did you mean `replace recall A = B`?


### PR DESCRIPTION
Advice for when 'replace' or 'definition' could be used (#139)

As opposed to the suggestion of the issue, I do this in the final case of `check_proof_of`, which handles (among other things) AllElim, PVar, and Recall nodes, and offer the advice when the proof fails, and the attempted proof was equational in nature.

The benefit of doing the check here, rather than in `check_implies` is that there is more information available about the actual form that the used typed, rather than check_implies, which has only `form_red`, and check implies also handles many more cases so the behavior is harder to control and predict there.

I also updated `Env._formula_of_proof_var` to  check if the user is mistakenly trying to use a function-typed Term Var as a proof var, and suggest definition, rather than recall in that case.