### PR TITLE
emable is gone 🥳

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -214,8 +214,6 @@ ident: IDENT              -> ident
     | "define" IDENT "=" term                       -> define_term_proof
     | "_definition" "{" ident_list "}"              -> apply_defs_goal
     | "_definition" ident                           -> apply_defs_goal_one
-    | "enable" "{" ident_list "}"                   -> enable_defs
-    | "enable" ident                                -> enable_def
     | "extensionality"                              -> extensionality_proof
     | "have" IDENT ":" term "by" proof              -> let
     | "have" ":" term "by" proof                    -> let_anon

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -2154,7 +2154,7 @@ class Cases(Proof):
 
   def pretty_print(self, indent):
       cases_str = ''
-      for (label, frm, body) in cases:
+      for (label, frm, body) in self.cases:
           cases_str += indent*' ' + 'case ' + base_name(label) + ' : ' + str(frm) + '{\n' \
               + body.pretty_print(indent+2) + '\n' \
               + indent*' ' + '}'
@@ -2705,20 +2705,6 @@ class ApplyDefsFact(Proof):
     for d in self.definitions:
       d.uniquify(env)
     self.subject.uniquify(env)
-
-@dataclass
-class EnableDefs(Proof):
-  definitions: List[Term]
-  body: Proof
-
-  def __str__(self):
-      return 'enable { ' + ', '.join([str(d) for d in self.definitions]) \
-        + ' };' + maybe_str(self.body)
-
-  def uniquify(self, env):
-    for d in self.definitions:
-      d.uniquify(env)
-    self.body.uniquify(env)
     
 @dataclass
 class Rewrite(Proof):

--- a/gh_pages/deduce-code/proof_intro_less_irreflexive.pf
+++ b/gh_pages/deduce-code/proof_intro_less_irreflexive.pf
@@ -9,8 +9,7 @@ proof
   }
   case suc(x') assume IH: not (x' < x') {
     assume sx_l_sx: suc(x') < suc(x')
-    enable {operator <, operator ≤}
-    have x_l_x: x' < x' by sx_l_sx
+    have x_l_x: x' < x' by apply less_suc_iff_suc_less to sx_l_sx
     conclude false by apply IH to x_l_x
   }
 end

--- a/gh_pages/deduce-code/reference_choose_example.pf
+++ b/gh_pages/deduce-code/reference_choose_example.pf
@@ -3,6 +3,5 @@
 theorem choose_example: some x:Nat. 6 = 2 * x
 proof
   choose 3
-  enable {operator*, operator+, operator+, operator+}
-  conclude 6 = 2 * 3   by .
+  conclude 6 = 2 * 3   by evaluate
 end

--- a/gh_pages/doc/ProofIntro.md
+++ b/gh_pages/doc/ProofIntro.md
@@ -1284,8 +1284,7 @@ So we assume the premise `suc(x') < suc(x')` from which we
 can prove that `x' < x'` using the definitions of `<` and `≤`.
 
     assume sx_l_sx: suc(x') < suc(x')
-    enable {operator <, operator ≤}
-    have x_l_x: x' < x' by sx_l_sx
+    have x_l_x: x' < x' by apply less_suc_iff_suc_less to sx_l_sx
 
 We conclude this case by applying the induction hypothesis to `x' < x'`.
 
@@ -1304,8 +1303,7 @@ proof
   }
   case suc(x') assume IH: not (x' < x') {
     assume sx_l_sx: suc(x') < suc(x')
-    enable {operator <, operator ≤}
-    have x_l_x: x' < x' by sx_l_sx
+    have x_l_x: x' < x' by apply less_suc_iff_suc_less to sx_l_sx
     conclude false by apply IH to x_l_x
   }
 end

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -388,8 +388,7 @@ Example:
 theorem choose_example: some x:Nat. 6 = 2 * x
 proof
   choose 3
-  enable {operator*, operator+, operator+, operator+}
-  conclude 6 = 2 * 3   by .
+  conclude 6 = 2 * 3   by evaluate
 end
 ```
 

--- a/gh_pages/doc/lib_generate.py
+++ b/gh_pages/doc/lib_generate.py
@@ -179,7 +179,6 @@ known_tokens = {
     'DOLLAR': 'operator',
     'DOT': 'operator',
     'ELSE': 'keyword',
-    'ENABLE': 'keyword',
     'END': 'keyword',
     'EQUAL': 'operator',
     'EQUATIONS': 'keyword',

--- a/gh_pages/js/codeUtils.js
+++ b/gh_pages/js/codeUtils.js
@@ -19,7 +19,7 @@ const keywords = [
     "generic", "assert", "have", "transitive", "symmetric", "extensionality", "reflexive",
     "injective", "sorry", "help", "conclude", "suffices", "enough", "by", "rewrite",
     "conjunct", "induction", "where", "suppose", "with", "definition", "apply", "to", "cases",
-    "obtain", "enable", "stop", "equations", "of", "arbitrary", "choose", "term", "from",
+    "obtain", "stop", "equations", "of", "arbitrary", "choose", "term", "from",
     "assume", "for", "recall", "in", "and", "or", "print", "not", "some", "all", "theorem",
     "lemma", "proof", "end", "replace", "recursive"
 ]

--- a/gh_pages/js/sandbox.js
+++ b/gh_pages/js/sandbox.js
@@ -76,7 +76,7 @@ require(['vs/editor/editor.main'], function () {
             "generic", "assert", "have", "transitive", "symmetric", "extensionality", "reflexive",
             "injective", "sorry", "help", "conclude", "suffices", "enough", "by", "rewrite",
             "conjunct", "induction", "where", "suppose", "with", "definition", "apply", "to", "cases",
-            "obtain", "enable", "stop", "equations", "of", "arbitrary", "choose", "term", "from",
+            "obtain", "stop", "equations", "of", "arbitrary", "choose", "term", "from",
             "assume", "for", "recall", "in", "and", "or", "print", "not", "some", "all", "theorem",
             "lemma", "proof", "end"
         ],

--- a/lib/List.pf
+++ b/lib/List.pf
@@ -188,18 +188,17 @@ theorem append_assoc: all U :type, xs :List<U>, ys :List<U>, zs:List<U>.
   (xs ++ ys) ++ zs = xs ++ (ys ++ zs)
 proof
   arbitrary U :type
-  enable {operator++}
   induction List<U>
   case empty {
-    arbitrary ys :List<U>, zs :List<U>
-    conclude (@empty<U> ++ ys) ++ zs = empty ++ (ys ++ zs)  by .
+    evaluate
   }
   case node(n, xs') suppose IH {
     arbitrary ys :List<U>, zs :List<U>
     equations
       (node(n,xs') ++ ys) ++ zs
-          = node(n, (xs' ++ ys) ++ zs)  by .
-      ... = node(n,xs') ++ (ys ++ zs)  by rewrite IH[ys,zs]
+          = node(n, (xs' ++ ys) ++ zs)  by definition operator++
+      ... = node(n, xs' ++ (ys ++ zs)) by rewrite IH[ys, zs]
+      ... = # node(n,xs') ++ (ys ++ zs) #  by definition operator++
   }
 end
 
@@ -231,14 +230,15 @@ proof
         by definition reverse
   }
   case node(n, xs') suppose IH {
-    enable {length, reverse, operator +}
     equations
       length(reverse(node(n,xs')))
-          = length(reverse(xs') ++ node(n,empty)) by .
+          = length(reverse(xs') ++ node(n,empty)) by definition reverse
       ... = length(reverse(xs')) + length(node(n,empty))
                     by rewrite length_append<U>[reverse(xs')][node(n,empty)]
-      ... = length(xs') + 1        by rewrite IH
-      ... = length(node(n,xs'))    by rewrite add_one[length(xs')]
+      ... = length(xs') + length(node(n,empty))   by rewrite IH
+      ... = length(xs') + 1                       by evaluate
+      ... = 1 + length(xs')                       by rewrite add_commute
+      ... = # length(node(n,xs')) #               by definition length
   }
 end
 
@@ -320,12 +320,11 @@ proof
   case node(x, xs')
     suppose IH: map(xs' ++ ys, f) = map(xs',f) ++ map(ys, f)
   {
-    enable {map, operator++}
     equations
       map((node(x,xs') ++ ys), f)
-          = node(f(x), map(xs' ++ ys, f))         by .
+          = node(f(x), map(xs' ++ ys, f))         by definition operator++ | map
       ... = node(f(x), map(xs',f) ++ map(ys,f))   by rewrite IH
-      ... = map(node(x,xs'),f) ++ map(ys,f)       by .
+      ... = # map(node(x,xs'),f) ++ map(ys,f) #   by definition map | operator++
   }
 end
 
@@ -337,12 +336,11 @@ proof
   induction List<T>
   case empty { definition map }
   case node(x, ls) suppose IH {
-    enable {map, operator ∘}
     equations
       map(map(node(x,ls),f),g)
-	  = node(g(f(x)), map(map(ls, f), g))  by .
+	  = node(g(f(x)), map(map(ls, f), g))        by evaluate
       ... = node(g(f(x)), map(ls, g ∘ f))      by rewrite IH
-      ... = map(node(x,ls), g .o. f)           by .
+      ... = map(node(x,ls), g .o. f)           by evaluate
   }
 end
 
@@ -706,10 +704,9 @@ proof
         suffices get(xs ++ ys, i') = get(xs, i')
            by definition {operator++, get, pred}
 	have i_xs: i' < length(xs) by
-	    enable {operator <, operator ≤}
-	    conclude i' < length(xs)
-              by rewrite i_si in
-                 definition {length, operator+,operator+} in i_xxs
+      apply less_suc_iff_suc_less to
+        definition {length, operator+, operator+} 
+        in rewrite i_si in i_xxs
 	apply IH[ys, i'] to i_xs
       }
     }

--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -1962,11 +1962,11 @@ proof
     have IH': summation(k',suc(s),f) = summation(k',suc(t),g)
       by apply IH[f,g,suc(s),suc(t)] 
          to arbitrary i:Nat suppose i_k: i < k'
-            suffices f(suc(s) + i) = g(suc(t) + i)  by .
+            suffices f(suc(s + i)) = g(suc(t + i))  by evaluate
             have fsi_gtsi: f(s + suc(i)) = g(t + suc(i))
-              by apply f_g[suc(i)] to
-                 enable {operator <, operator ≤, operator ≤} i_k
-            enable {operator +} replace add_suc in fsi_gtsi
+              by suffices suc(i) < suc(k') by f_g[suc(i)] 
+                 apply less_suc_iff_suc_less to i_k
+            replace add_suc  in fsi_gtsi
     replace f_g_s | IH'
   }
 end
@@ -1989,8 +1989,7 @@ proof
     have f_g_s: f(s) = g(s) by {
       have s_s: s ≤ s by less_equal_refl[s]
       have s_sk: s < s + suc(k') by {
-        enable {operator <,operator ≤}
-        suffices s ≤ s + k'    by replace add_suc
+        suffices s ≤ s + k' by definition operator < | operator ≤ and replace add_suc
         less_equal_add[s][k']
       }
       apply f_g[s] to s_s, s_sk
@@ -2073,13 +2072,12 @@ proof
   case zero {
     arbitrary b:Nat, s:Nat, t:Nat, f:fn Nat->Nat, g:fn Nat->Nat, h:fn Nat->Nat
     suppose g_f_and_h_f
-    enable {operator +}
-    suffices summation(b,s,f) = summation(b,t,h)  by definition summation
+    suffices summation(b,s,f) = summation(b,t,h)  by definition { operator+, summation }
     apply summation_cong[b][f,h,s,t]
     to arbitrary i:Nat
        suppose i_b: i < b
        conclude f(s + i) = h(t + i)
-       by symmetric (apply (conjunct 1 of g_f_and_h_f)[i] to i_b)
+       by definition operator+ in symmetric (apply (conjunct 1 of g_f_and_h_f)[i] to i_b)
   }
   case suc(a') suppose IH {
     arbitrary b:Nat, s:Nat, t:Nat, f:fn Nat->Nat, g:fn Nat->Nat, h:fn Nat->Nat
@@ -2094,8 +2092,10 @@ proof
             = summation(a',suc(s),g) + summation(b,t,h)
       by have p1: all i:Nat. (if i < a' then g(suc(s) + i) = f(suc(s) + i))
            by arbitrary i:Nat suppose i_a: i < a'
-              enable {operator +, operator ≤}  replace add_suc in
-              (apply (conjunct 0 of g_f_and_h_f)[suc(i)] to enable {operator <, operator ≤} i_a)
+              have i_sa : suc(i) < suc(a') by 
+                apply less_suc_iff_suc_less to i_a
+              replace add_suc | symmetric suc_add[s, i]
+                in apply (conjunct 0 of g_f_and_h_f)[suc(i)] to i_sa
          have p2: all i:Nat. (if i < b then h(t + i) = f(suc(s) + (a' + i)))
            by arbitrary i:Nat suppose i_b: i < b
               suffices __ by definition 2*operator+

--- a/lib/Set.pf
+++ b/lib/Set.pf
@@ -54,8 +54,7 @@ proof
   arbitrary T:type
   arbitrary x:T, y:T
   suppose y_in_x: y ∈ single(x)
-  enable {operator ∈, single, rep}
-  y_in_x
+  evaluate in y_in_x
 end
 
 theorem single_equal_equal: all T:type. all x:T, y:T.
@@ -72,8 +71,7 @@ proof
   arbitrary T:type
   arbitrary x:T
   suppose x_in_empty: x ∈ ∅
-  enable {operator ∈, rep}
-  x_in_empty
+  evaluate in x_in_empty
 end
 
 theorem rep_char_fun: all T:type, f: fn T -> bool. rep(char_fun(f)) = f
@@ -108,8 +106,8 @@ proof
   arbitrary T:type
   arbitrary x:T, A:Set<T>, B:Set<T>
   suppose x_AB: x in (A | B)
-  enable {operator in, operator |, rep}
-  x_AB
+  suffices __ by evaluate
+  evaluate in x_AB
 end
 
 theorem member_union_equal: all T:type. all x:T, A:Set<T>, B:Set<T>.

--- a/parser.py
+++ b/parser.py
@@ -527,11 +527,6 @@ def parse_tree_to_ast(e, parent):
         return ApplyDefsFact(e.meta,
                              [Var(e.meta, None, t, []) for t in definitions],
                              subject)
-    elif e.data == 'enable_defs':
-        definitions = parse_tree_to_list(e.children[0], e)
-        return EnableDefs(e.meta,
-                          [Var(e.meta, None, x, []) for x in definitions],
-                          None)
     elif e.data == 'reason_definition':
         definitions = parse_tree_to_list(e.children[0], e)
         return ApplyDefs(e.meta, [Var(e.meta, None, t, []) for t in definitions])
@@ -542,12 +537,6 @@ def parse_tree_to_ast(e, parent):
         return ApplyDefsGoal(e.meta,
                              [Var(e.meta, None, t, []) for t in definitions],
                              Rewrite(e.meta, eqns))
-    elif e.data == 'enable_def':
-        definition = parse_tree_to_ast(e.children[0], e)
-        subject = parse_tree_to_ast(e.children[1], e)
-        return EnableDefs(e.meta,
-                          [Var(e.meta, None, definition, [])],
-                          subject)
     elif e.data == 'rewrite_goal':
         eqns = parse_tree_to_list(e.children[0], e)
         return RewriteGoal(e.meta, eqns, None)

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -456,14 +456,6 @@ def check_proof(proof, env):
       new_formula = apply_definitions(loc, formula, defs, env)
       ret = new_formula
       
-    case EnableDefs(loc, definitions, body):
-      defs = [type_synth_term(d, env, None, []) for d in definitions]
-      defs = [d.reduce(env) for d in defs]
-      old_defs = get_reduce_only()
-      set_reduce_only(defs + old_defs)
-      ret = check_proof(body, env)
-      set_reduce_only(old_defs)
-      
     case RewriteFact(loc, subject, equation_proofs):
       formula = check_proof(subject, env)
       eqns = [check_proof(proof, env) for proof in equation_proofs]
@@ -1017,14 +1009,6 @@ def check_proof_of(proof, formula, env):
 
     case PSorry(loc):
       warning(loc, 'unfinished proof')
-      
-    case EnableDefs(loc, definitions, subject):
-      defs = [type_synth_term(d, env, None, []) for d in definitions]
-      defs = [d.reduce(env) for d in defs]
-      old_defs = get_reduce_only()
-      set_reduce_only(defs + old_defs)
-      check_proof_of(subject, formula, env)
-      set_reduce_only(old_defs)
       
     case PReflexive(loc):
       match formula:

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -618,7 +618,7 @@ def parse_assumption():
 proof_keywords = {'apply', 'arbitrary', 'assume',
                   'cases', 'choose', 'conclude', 'conjunct',
                   'definition',
-                  'enable', 'equations', 'evaluate', 'extensionality',
+                  'equations', 'evaluate', 'extensionality',
                   'have', 'induction', 'injective', 'obtain',
                   'recall', 'reflexive', 'rewrite',
                   'suffices', 'suppose', 'switch', 'symmetric',
@@ -1078,20 +1078,6 @@ def parse_proof_statement():
     meta = meta_from_tokens(token, previous_token())
     return SomeElim(meta, witnesses, label, premise, some, None)
     
-  elif token.type == 'ENABLE':
-    advance()
-    if current_token().type != 'LBRACE':
-      raise ParseError(meta_from_tokens(current_token(), current_token()),
-            'expected "{" after "enable"')
-    advance()
-    defs = parse_ident_list()
-    if current_token().type != 'RBRACE':
-      raise ParseError(meta_from_tokens(current_token(), current_token()),
-            'expected closing "}" in "enable"')
-    advance()
-    meta = meta_from_tokens(token, previous_token())
-    return EnableDefs(meta, [Var(meta, None, x) for x in defs], None)
-      
   elif token.type == 'HAVE':
     return parse_have()
 


### PR DESCRIPTION
#181 

Someone might want to double check the example for working with not (the proof of less_irreflexive) since it now relies on less_suc_iff_suc_less, which makes things not quite so clear. I didn't see any quick examples in the docs, but maybe we can find some other example.

(Maybe proving `if x then not (not x)` would work)