### PR TITLE
More informative errors in definition

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -3603,6 +3603,13 @@ class Env:
     else:
       return None
 
+  def _term_var_defined(self, curr, name):
+    if name in curr.keys():
+      binding = curr[name]
+      if isinstance(binding, TermBinding) or isinstance(binding, TypeBinding):
+        return True
+    return False
+
   def _value_of_term_var(self, curr, name):
     if name in curr.keys():
       return curr[name].defn
@@ -3639,13 +3646,13 @@ class Env:
 
   def term_var_is_defined(self, tvar):
     match tvar:
-      case Var(loc, tyof, name):
-        if self._type_of_term_var(self.dict, name):
-          return True
+      case Var(loc, tyof, name, resolved_names):
+        if isinstance(resolved_names, str):
+          error(loc, 'resolved_names is a string but should be a list: ' + str(tvar))
+        if len(resolved_names) > 0:
+          return any([self._term_var_defined(self.dict, x) for x in resolved_names])
         else:
-          return False
-      case _:
-        raise Exception('expected a term variable, not ' + str(tvar))
+          return self._term_var_defined(self.dict, name)
         
   def proof_var_is_defined(self, pvar):
     match pvar:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -450,10 +450,8 @@ def check_proof(proof, env):
       ret = red_formula
           
     case ApplyDefsFact(loc, definitions, subject):
-      defs = [type_synth_term(d, env, None, []) for d in definitions]
-      defs = [d.reduce(env) for d in defs]
       formula = check_proof(subject, env)
-      new_formula = apply_definitions(loc, formula, defs, env)
+      new_formula = apply_definitions(loc, formula, definitions, env)
       ret = new_formula
       
     case RewriteFact(loc, subject, equation_proofs):
@@ -1202,9 +1200,7 @@ def check_proof_of(proof, formula, env):
       return red_formula
   
     case ApplyDefs(loc, definitions):
-      defs = [type_synth_term(d, env, None, []) for d in definitions]
-      defs = [d.reduce(env) for d in defs]
-      new_formula = apply_definitions(loc, formula, defs, env)
+      new_formula = apply_definitions(loc, formula, definitions, env)
       if new_formula != Bool(loc, None, True):
           error(loc, 'error, remains to prove:\n\t' + str(new_formula) + '\n'\
                 + 'Replace this proof statement with:\n' \
@@ -1226,15 +1222,16 @@ def check_proof_of(proof, formula, env):
       def_or_rewrite = False
       evaluate = False
 
+      definitions = []
       # should evaluate be handled up here? -Jeremy
       match reason:
         case ApplyDefs(loc2, defs):
            def_or_rewrite = True
-           definitions = [type_synth_term(d, env, None, []) for d in defs]
+           definitions = defs
            equation_proofs = [] 
         case ApplyDefsGoal(loc2, defs, Rewrite(loc3, eqns)):
            def_or_rewrite = True
-           definitions = [type_synth_term(d, env, None, []) for d in defs]
+           definitions = defs
            equation_proofs = eqns 
         case Rewrite(loc2, eqns):
            def_or_rewrite = True
@@ -1256,9 +1253,8 @@ def check_proof_of(proof, formula, env):
 
         else:
           red_claim = new_claim.reduce(env)
-          defs = [d.reduce(env) for d in definitions]
           equations = [check_proof(proof, env) for proof in equation_proofs]
-          new_formula = apply_definitions(loc, formula, defs, env)
+          new_formula = apply_definitions(loc, formula, definitions, env)
           new_formula = new_formula.reduce(env)
 
           eqns = [equation.reduce(env) for equation in equations]
@@ -1282,7 +1278,7 @@ def check_proof_of(proof, formula, env):
             try:
               check_implies(loc, red_claim, new_formula)
             except Exception as e:
-              error(loc, str(e) + '\nGivens:\n' + env.proofs_str())
+              raise Exception(str(e) + '\nGivens:\n' + env.proofs_str())
             check_proof_of(rest, new_claim, env)
       else:
         new_claim = type_check_term(claim, BoolType(loc), env, None, [])
@@ -1537,9 +1533,7 @@ def check_proof_of(proof, formula, env):
       new_formula = apply_rewrites(loc, new_formula, eqns, env)
       check_proof_of(body, new_formula, env)
       #warning(loc, 'old-style rewrite will be deprecated')
-    case ApplyDefsGoal(loc, definitions, body):
-      defs = [type_synth_term(d, env, None, []) for d in definitions]
-      defs = [d.reduce(env) for d in defs]
+    case ApplyDefsGoal(loc, defs, body):
       new_formula = apply_definitions(loc, formula, defs, env)
       check_proof_of(body, new_formula, env)
       #warning(loc, 'old-style definition will be deprecated')
@@ -1579,6 +1573,17 @@ def apply_definitions(loc, formula, defs, env):
   if get_verbose():
       print('apply definitions to formula: ' + str(new_formula))
   for var in defs:
+    name = var
+    try:
+      # TODO: We might not need the type_synth
+      # And just env.get_type_of_term var might cut it,
+      # Then we get the error messages we want, when trying to
+      # do stuff with GenericUnknownInst and union constructors and whatnot
+      var = type_synth_term(var, env, None, [])
+      var = var.reduce(env)
+    except Exception as e:
+      error(loc, f"Expected a term or a type variable when attempting to use the definition of {name}." +\
+               f"\n\tIf {name} is a theorem or a lemma, you might want to use 'replace'")
     # it's a bit strange that RecDef's can find there way into defs -Jeremy
     if isinstance(var, Var):
       reduced_one = False
@@ -1984,7 +1989,7 @@ def type_synth_term(term, env, recfun, subterms):
       try:
         ty = env.get_type_of_term_var(term)
         if ty == None:
-          error(loc, 'while type checking, undefined variable ' + str(term) \
+          raise Exception('while type checking, undefined variable ' + str(term) \
                 + '\nin scope:\n' + str(env))
       except Exception as e:
         error(loc, str(e))

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1575,11 +1575,7 @@ def apply_definitions(loc, formula, defs, env):
   for var in defs:
     name = var
     try:
-      # TODO: We might not need the type_synth
-      # And just env.get_type_of_term var might cut it,
-      # Then we get the error messages we want, when trying to
-      # do stuff with GenericUnknownInst and union constructors and whatnot
-      var = type_synth_term(var, env, None, [])
+      env.term_var_is_defined(var)
       var = var.reduce(env)
     except Exception as e:
       error(loc, f"Expected a term or a type variable when attempting to use the definition of {name}." +\

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1573,13 +1573,10 @@ def apply_definitions(loc, formula, defs, env):
   if get_verbose():
       print('apply definitions to formula: ' + str(new_formula))
   for var in defs:
-    name = var
-    try:
-      env.term_var_is_defined(var)
-      var = var.reduce(env)
-    except Exception as e:
-      error(loc, f"Expected a term or a type variable when attempting to use the definition of {name}." +\
-               f"\n\tIf {name} is a theorem or a lemma, you might want to use 'replace'")
+    if not env.term_var_is_defined(var):
+      error(loc, f"Expected a term or a type variable when attempting to use the definition of {var}." +\
+               f"\n\tIf {var} is a theorem or a lemma, you might want to use 'replace'")
+    var = var.reduce(env)
     # it's a bit strange that RecDef's can find there way into defs -Jeremy
     if isinstance(var, Var):
       reduced_one = False

--- a/test/should-error/def_generic_terminst.pf
+++ b/test/should-error/def_generic_terminst.pf
@@ -1,0 +1,13 @@
+union A<T> {
+  a
+}
+
+lemma L1: true
+proof
+  .
+end
+
+lemma L2: true
+proof
+  definition a
+end

--- a/test/should-error/def_generic_terminst.pf.err
+++ b/test/should-error/def_generic_terminst.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/def_generic_terminst.pf:12.3-12.15: could not find definition of a

--- a/test/should-error/def_proof_var.pf
+++ b/test/should-error/def_proof_var.pf
@@ -1,0 +1,9 @@
+lemma L1: true
+proof
+  .
+end
+
+lemma L2: true
+proof
+  definition L1
+end

--- a/test/should-error/def_proof_var.pf.err
+++ b/test/should-error/def_proof_var.pf.err
@@ -1,1 +1,2 @@
-'ProofBinding' object has no attribute 'defn'
+./test/should-error/def_proof_var.pf:8.3-8.16: Expected a term or a type variable when attempting to use the definition of L1.
+	If L1 is a theorem or a lemma, you might want to use 'replace'

--- a/test/should-error/def_proof_var.pf.err
+++ b/test/should-error/def_proof_var.pf.err
@@ -1,0 +1,1 @@
+'ProofBinding' object has no attribute 'defn'


### PR DESCRIPTION
I refactored some code into apply_definitions, and fixed some miscellaneous error message bugs, in addition to addressing #175 with this message
```
/home/calvin/Documents/Programming/343/deduce/blah.pf:8.3-8.16: Expected a term or a type variable when attempting to use the definition of L1.
        If L1 is a theorem or a lemma, you might want to use 'replace'
```