### PR TITLE
Double import now has a gooder error message

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2585,9 +2585,9 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
             ast2.append(new_s)
 
           ast3 = []
-          already_imported = set()
+          already_done_imports = set()
           for s in ast2:
-            new_s = type_check_stmt(s, env, already_imported)
+            new_s = type_check_stmt(s, env, already_done_imports)
             ast3.append(new_s)
 
           for s in ast3:
@@ -3064,8 +3064,9 @@ def check_deduce(ast, module_name, modified):
     print('--------- Type Checking ------------------------')
   ast3 = []
 
+  already_done_imports = set()
   for s in ast2:
-    new_s = type_check_stmt(s, env, set())
+    new_s = type_check_stmt(s, env, already_done_imports)
     ast3.append(new_s)
   if get_verbose():
     for s in ast3:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2585,8 +2585,9 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
             ast2.append(new_s)
 
           ast3 = []
+          already_imported = set()
           for s in ast2:
-            new_s = type_check_stmt(s, env, None)
+            new_s = type_check_stmt(s, env, already_imported)
             ast3.append(new_s)
 
           for s in ast3:
@@ -2738,10 +2739,9 @@ def type_check_stmt(stmt, env, already_done_imports : set):
       return stmt
   
     case Import(loc, name, ast):
-      if already_done_imports != None:
-        if name in already_done_imports:
-          error(loc, "error, module:\n\t" + name + "\nwas imported twice")
-        already_done_imports.add(name)
+      if name in already_done_imports:
+        error(loc, "error, module:\n\t" + name + "\nwas imported twice")
+      already_done_imports.add(name)
       return stmt
   
     case Assert(loc, frm):
@@ -3064,9 +3064,8 @@ def check_deduce(ast, module_name, modified):
     print('--------- Type Checking ------------------------')
   ast3 = []
 
-  already_done_imports = set()
   for s in ast2:
-    new_s = type_check_stmt(s, env, already_done_imports)
+    new_s = type_check_stmt(s, env, set())
     ast3.append(new_s)
   if get_verbose():
     for s in ast3:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2586,7 +2586,7 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
 
           ast3 = []
           for s in ast2:
-            new_s = type_check_stmt(s, env)
+            new_s = type_check_stmt(s, env, None)
             ast3.append(new_s)
 
           for s in ast3:
@@ -2655,7 +2655,7 @@ def type_check_fun_case(fun_case, name, params, returns, body_env, cases_present
     return FunCase(fun_case.location, fun_case.rator,
                    fun_case.pattern, fun_case.parameters, new_body)
 
-def type_check_stmt(stmt, env):
+def type_check_stmt(stmt, env, already_done_imports : set):
   if get_verbose():
     print('type_check_stmt(' + str(stmt) + ')')
   match stmt:
@@ -2738,6 +2738,10 @@ def type_check_stmt(stmt, env):
       return stmt
   
     case Import(loc, name, ast):
+      if already_done_imports != None:
+        if name in already_done_imports:
+          error(loc, "error, module:\n\t" + name + "\nwas imported twice")
+        already_done_imports.add(name)
       return stmt
   
     case Assert(loc, frm):
@@ -3059,8 +3063,10 @@ def check_deduce(ast, module_name, modified):
   if get_verbose():
     print('--------- Type Checking ------------------------')
   ast3 = []
+
+  already_done_imports = set()
   for s in ast2:
-    new_s = type_check_stmt(s, env)
+    new_s = type_check_stmt(s, env, already_done_imports)
     ast3.append(new_s)
   if get_verbose():
     for s in ast3:

--- a/test/should-error/double_import.pf
+++ b/test/should-error/double_import.pf
@@ -1,0 +1,4 @@
+import UInt
+import UInt
+
+assert 1 = 1

--- a/test/should-error/double_import.pf.err
+++ b/test/should-error/double_import.pf.err
@@ -1,3 +1,3 @@
-test/should-error/double_import_naked.pf:2.1-2.12: error, module:
+./test/should-error/double_import.pf:2.1-2.12: error, module:
 	UInt
 was imported twice

--- a/test/should-error/double_import.pf.err
+++ b/test/should-error/double_import.pf.err
@@ -1,0 +1,3 @@
+test/should-error/double_import_naked.pf:2.1-2.12: error, module:
+	UInt
+was imported twice

--- a/test/should-error/double_import_naked.pf
+++ b/test/should-error/double_import_naked.pf
@@ -1,0 +1,2 @@
+import UInt
+import UInt

--- a/test/should-error/double_import_naked.pf.err
+++ b/test/should-error/double_import_naked.pf.err
@@ -1,3 +1,3 @@
-test/should-error/double_import_naked.pf:2.1-2.12: error, module:
+./test/should-error/double_import_naked.pf:2.1-2.12: error, module:
 	UInt
 was imported twice

--- a/test/should-error/double_import_naked.pf.err
+++ b/test/should-error/double_import_naked.pf.err
@@ -1,0 +1,3 @@
+test/should-error/double_import_naked.pf:2.1-2.12: error, module:
+	UInt
+was imported twice


### PR DESCRIPTION
The following file (the same as the one in #217):

```
import UInt
import UInt

assert 1 = 1
```
would previously talk about "ambigous overloads" while type checking. Now instead, the it produces the error message:

```
file:2.1-2.12: error, module:
	UInt
was imported twice
```

The way I accomplished this was modifying `type_check_stmt` to take in a set that had the names of already imported modules, then when an import was being typed checked if the name of the imported module was already in the set throw an error. The reason I chose `type_check_stmt` and not `process_declarations` is so I had to modify less functions.

One thing I wanted incorporate into the error message was saying "hey you can safely delete this line" but I couldn't find the wording for it.