### PR TITLE
Edit distance optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ deduce-release.zip
 # Generated content for site
 gh_pages/pages
 gh_pages/deduce-code
+
+# temp error file
+actual_error.tmp
+
+# Generated deduce profile image
+profile.png

--- a/profile.sh
+++ b/profile.sh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+
+# requires python cProfile and gprof2dot packages
+
+if [[ -z $1 ]]; then
+   echo "Please enter a file to deduce"
+else
+	python -m cProfile -o profile.pstats deduce.py $1
+	python -m gprof2dot -f pstats profile.pstats -o profile.dot
+	dot -Tpng -o profile.png profile.dot
+	open profile.png
+
+	# clean up
+	rm profile.pstats profile.dot
+fi

--- a/test/should-error/cases_error.pf.err
+++ b/test/should-error/cases_error.pf.err
@@ -1,8 +1,4 @@
 ./test/should-error/cases_error.pf:1.1-4.10: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
-./test/should-error/cases_error.pf:4.5-4.10: while parsing cases (use a logical or)
-	conclusion ::= "cases" proof case_clause*
-	case_clause ::= "case" identifier ":" term "{" proof "}"
-
-./test/should-error/cases_error.pf:5.5-5.9: expected a proof.
-Did you mean "cases" instead of "case"?
+./test/should-error/cases_error.pf:5.5-5.9: expected a closing "}" around proof, not
+	case


### PR DESCRIPTION
- Removed redundant calls to `closest_keyword`. 
  - What happens now is a first parsing pass with no `closest_keyword` calls. If that parse errors, then we call `closest_keyword` to see if the error was caused by a typo or a more general parse error.
- Added a profiling script which generates a graph of all function calls and the amount of runtime spent on all those calls
- Added a parameter to `parse_proof` to disallow holes on certain calls
  - This is necessary because `cases` calls `parse_proof` on the proof term you are doing case analysis on, and this term should not be a hole.
  - There might be other places we need to set `allow_missing` to False, but I did not do that

> [!Note]
> The error message for `cases_error.pf` is still a little misleading. The issue is that there should be a proof term after the `cases`, but the error message doesn't make that clear.