### PR TITLE
Remove lib/Sums.pf

### DIFF
--- a/test/should-validate/fib.pf
+++ b/test/should-validate/fib.pf
@@ -1,5 +1,4 @@
 import Nat
-import Sums
 
 recfun fib(n : Nat) -> Nat
   measure n of Nat


### PR DESCRIPTION
This PR removes the empty `Sums.pf` file inside of `lib`  
Notably however `test/should-validate/fib.pf` imported it so maybe there was a reason it was there?