### PR TITLE
Typecheck patch

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1377,8 +1377,7 @@ class Call(Term):
       return explicit_term_inst(flat_results[0])
     else:
       return Call(self.location, self.typeof,
-                  Var(loc, FunctionType(loc, [], params, returns),
-                      name, [name]),
+                  fun,
                   flat_results)
   
   def substitute(self, sub):
@@ -4627,7 +4626,8 @@ def rewrite_aux(loc, formula, equation, env, depth = -1):
       if get_verbose():
           print('is_assoc? ' + str(is_assoc))
       if is_assoc:
-          args = sum([flatten_assoc(rator_name(rator), arg) for arg in args], [])
+          # args = sum([flatten_assoc(rator_name(rator), arg) for arg in args], [])
+          args = flatten_assoc_list(rator_name(rator), args)
       new_rator = rewrite_aux(loc, rator, equation, env, depth - 1)
       new_args = [rewrite_aux(loc, arg, equation, env, depth - 1) for arg in args]
       if get_verbose():

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1363,7 +1363,6 @@ def check_proof_of(proof, formula, env):
       new_formula = formula.reduce(env)
       #print('new_formula: ' + str(new_formula))
       new_formula = apply_rewrites(loc, new_formula, eqns, env)
-      new_formula = check_formula(new_formula, env)
       check_proof_of(body, new_formula, env)
       
     case ApplyDefsGoal(loc, defs, body):

--- a/test/should-validate/replace_inst_assoc.pf
+++ b/test/should-validate/replace_inst_assoc.pf
@@ -13,7 +13,7 @@ proof
         replace append_empty
         .
     }
-    case node(x, xs') assume IH {
+    case node(x, xs') assume IH : all ys : List<U>. reverse(reverse(xs') ++ ys) = reverse(ys) ++ reverse(reverse(xs')) {
         arbitrary ys:List<U>
         expand reverse
         expand 2* operator ++


### PR DESCRIPTION
In lecture Matei found a weird bug related to this proof

```
import UInt
import List

lemma rev_rev_lemma2: all U:type. all xs : List<U>, ys :List<U>.
    reverse(reverse(xs) ++ ys) = reverse(ys) ++ reverse(reverse(xs))
proof
    arbitrary U:type
    induction List<U>
    case [] {
        arbitrary ys:List<U>
        expand reverse
        expand operator ++
        replace append_empty
        .
    }
    case node(x, xs') assume IH {
        arbitrary ys:List<U>
        expand reverse
        expand 2* operator ++
        replace IH[node(x, ys)]
        expand reverse
        replace IH[[x]]
        evaluate
    }
end
```

The problem was twofold
1. When the last evaluate is commented out, the last `reverse(reverse(xs'))` was admitted from the goal printed out in the proof advice. This was fixed by updating `type_check_call_funty` to handle associative operators in the case where it has to infer a TermInst.
2. The evaluate wouldn't evaluate the RHS, due to missing TermInst nodes that should have wrapped the ++ operator. I was able to fix this by typechecking the formula after performing a rewrite. However, the fact that this wasn't a concern before makes me wonder if there's an alternate fix that can happen when related to somewhere we do something wrong with associativity. The fact that tests haven't failed before now makes me think that that may be the case, because then we should see issues pop up elsewhere, in almost any proof where we do a rewrite with anything related to append.

I don't know if you have thoughts of another place to fix the second issue, I haven't been able to fix it otherwise, I'm going to spend some time trying to replicate the error in a simpler proof.