### PR TITLE
Better proof defines (TLet) + tests

### DIFF
--- a/test/should-validate/all-elim-tlet.pf
+++ b/test/should-validate/all-elim-tlet.pf
@@ -1,0 +1,14 @@
+// all elim
+lemma blah:
+	(define R = all P: bool. if P then P; R)
+proof
+	arbitrary P: bool
+	assume: P
+	recall P
+end
+
+theorem allElimTLet: all P: bool. if P then P
+proof
+	arbitrary P: bool
+	blah[P]
+end

--- a/test/should-validate/all-elim-types-tlet.pf
+++ b/test/should-validate/all-elim-types-tlet.pf
@@ -1,0 +1,14 @@
+// all elim types
+lemma bleh:
+	(define R = all T: type. if true then true; R)
+proof
+	arbitrary T: type
+	assume prem
+	.
+end
+
+theorem allElimTypesTLet: all T: type. if true then true
+proof
+	arbitrary T: type
+	bleh<T>
+end

--- a/test/should-validate/all-intro-tlet.pf
+++ b/test/should-validate/all-intro-tlet.pf
@@ -1,0 +1,8 @@
+// all intro
+theorem allIntroTLet:
+	(define R = all P: bool. if P then P; R)
+proof
+	arbitrary P: bool
+	assume: P
+	recall P
+end

--- a/test/should-validate/and-elim-tlet.pf
+++ b/test/should-validate/and-elim-tlet.pf
@@ -1,0 +1,10 @@
+// and elim
+theorem andElimTLet: all P : bool.
+  if (define R = true and P; R) then 
+  P
+proof
+  arbitrary P : bool
+  assume prem
+  have _ : P by conjunct 1 of prem
+  recall P
+end

--- a/test/should-validate/cases-tlet.pf
+++ b/test/should-validate/cases-tlet.pf
@@ -1,0 +1,10 @@
+// cases 
+theorem casesTLet: all P:bool, Q:bool.
+	if (define R = true or Q; R) then (true or Q)
+proof
+	arbitrary P:bool, Q:bool
+	assume prem
+	cases prem
+	case t: true { t }
+	case q: Q { q }
+end

--- a/test/should-validate/contradict-tlet.pf
+++ b/test/should-validate/contradict-tlet.pf
@@ -1,0 +1,9 @@
+// modus ponens and (contradict)
+theorem contradictTLet: all P:bool, Q:bool. if (define p = P; p) and (define np = not P; np) then Q
+proof
+  arbitrary P:bool, Q:bool
+  assume prem
+  have p: (define p = P; p) by prem
+  have np: (define np = not P; np) by prem
+  conclude Q by contradict p, np
+end

--- a/test/should-validate/extensionality-tlet.pf
+++ b/test/should-validate/extensionality-tlet.pf
@@ -1,0 +1,19 @@
+// extensionality
+define func1 = fun x:bool { x }
+define func2 = fun x:bool { x }
+
+theorem extensionalityTLet1: (define f = func1; f) = (define g = func2; g)
+proof
+	extensionality
+	arbitrary x:bool
+	expand func1 | func2
+	.
+end
+
+theorem extensionalityTLet2: (define f = func1 = func2; f)
+proof
+	extensionality
+	arbitrary x:bool
+	expand func1 | func2
+	.
+end

--- a/test/should-validate/imp-intro-tlet.pf
+++ b/test/should-validate/imp-intro-tlet.pf
@@ -1,0 +1,8 @@
+// imp intro
+theorem impIntroTLet : all P: bool.
+	(define R = if P then P; R)
+proof
+	arbitrary P:bool
+	assume prem
+	prem
+end

--- a/test/should-validate/induction-tlet.pf
+++ b/test/should-validate/induction-tlet.pf
@@ -1,0 +1,13 @@
+// induction
+union UnionBlah {
+	A
+	B
+}
+
+theorem inductionTLet: (define R = all U: UnionBlah.
+	U = A or U = B; R)
+proof
+	induction UnionBlah
+	case A { . }
+	case B { . }
+end

--- a/test/should-validate/injective-tlet.pf
+++ b/test/should-validate/injective-tlet.pf
@@ -1,0 +1,13 @@
+// injective (already works)
+union UnionBleh {
+	B
+	C(UnionBleh)
+}
+
+theorem injectiveTLet: all a:UnionBleh, b:UnionBleh.
+	if (define R = C(a) = C(b); R) then a = b
+proof
+	arbitrary a:UnionBleh, b:UnionBleh
+	assume prem
+	injective C prem
+end

--- a/test/should-validate/modus-ponens-tlet.pf
+++ b/test/should-validate/modus-ponens-tlet.pf
@@ -1,0 +1,11 @@
+// modus ponens
+// (this already worked before since we just reduce imp)
+theorem modusPonensTLet: all P:bool, Q:bool.
+	if P and (define R = if P then Q; R) then Q
+proof
+	arbitrary P:bool, Q:bool
+	assume G
+	have p: P by G
+	have r: (define R = (if P then Q); R) by G
+	apply r to p
+end

--- a/test/should-validate/obtain-tlet.pf
+++ b/test/should-validate/obtain-tlet.pf
@@ -1,0 +1,13 @@
+import UInt
+
+// obtain
+theorem obtainTLet: all n:UInt. 
+  if (define R = some x:UInt. n = 4 * x; R) then (some x:UInt. n = 2 * x)
+proof
+  arbitrary n:UInt
+  assume prem: (define R = some x:UInt. n = 4 * x; R)
+  obtain x where n_4x: n = 4 * x from prem
+  choose 2 * x
+  show n = 2 * (2 * x)
+  replace n_4x.
+end

--- a/test/should-validate/some-intro-tlet.pf
+++ b/test/should-validate/some-intro-tlet.pf
@@ -1,0 +1,7 @@
+// some intro
+import UInt
+theorem someIntroTlet: (define R = some x:UInt. 6 = 2 * x; R)
+proof
+  choose 3
+  conclude 6 = 2 * 3   by .
+end

--- a/test/should-validate/switch-tlet.pf
+++ b/test/should-validate/switch-tlet.pf
@@ -1,0 +1,9 @@
+// switch
+theorem switch_proof_example: all x:bool. define g=x; g = true or g = false
+proof
+  arbitrary x:bool
+  switch x {
+    case true { . }
+    case false { . }
+  }
+end

--- a/test/should-validate/symmetric-tlet.pf
+++ b/test/should-validate/symmetric-tlet.pf
@@ -1,0 +1,9 @@
+// symmetric (already works)
+theorem symmetricTLet: all P:bool, Q:bool.
+	if (define R = P = Q; R) then Q = P
+proof
+	arbitrary P:bool, Q:bool
+	assume G
+	replace symmetric G
+	.
+end

--- a/test/should-validate/transitive-tlet.pf
+++ b/test/should-validate/transitive-tlet.pf
@@ -1,0 +1,10 @@
+// transitive (already works)
+theorem test: all P:bool, Q:bool, R:bool.
+	if P = Q and Q = R then P = R
+proof
+	arbitrary P:bool, Q:bool, R:bool
+	assume prem
+	have pq: (define a = P = Q; a) by prem
+	have qr: (define b = Q = R; b) by prem
+	transitive pq qr
+end


### PR DESCRIPTION
Partially solves #252.

- I **did not** add extra documentation because I don't think there's anything special we need to do to handle defines in proofs now. You can just go about your proof normally and every case should just be able to work around `TLet`.
- Added a function to `TLet` to reduce only the let through substitutions while leaving the inner expression unreduced. A la head normal form.
  - To reduce the `TLet` I need to pass the environment along to the new expression that gets created. This caused me to have to add an extra variable to a couple functions to pass the current environment: `split_equation` and `collect_all_if_then`. The functionality of these functions remains unchanged, its just something to remember to pass.
- Added this `reduceLets` call to the following AST nodes:
  -  `extensionality` : hence modifying `split_equation`
  - `reflexive`, `symmetric`, and `transitive` : although these might have already worked before.
  - `contradict` : hence modifying `collect_all_if_then`
  - `PAndElim`
  - `AllIntro`
  - `AllElim`
  - `AllElimTypes`
  - `SomeIntro`
  - `SomeElim`
  - `ImpIntro`
  - `Cases` : changed from a straight up call to `reduce`
    - I changed this from a call to `reduce` since before you could have a premise be `prem: true or P` and have `cases prem` error since `true or P` reduces to just `P` which isn't an or.
  - `Induction`
- Added tests for all of these