### PR TITLE
Site live code bug fix

### DIFF
--- a/live_code_vercel_api/api.py
+++ b/live_code_vercel_api/api.py
@@ -39,7 +39,7 @@ def deduce_req():
     
     try:    
         with redirect_stdout(io.StringIO()) as stdout:
-            deduce_file(f"/tmp/{unique_id}.pf", False)
+            deduce_file(f"/tmp/{unique_id}.pf", error_expected=False, tracing_functions=[])
         deduce_output = stdout.getvalue()
     except Exception as e:
         deduce_output = str(e)


### PR DESCRIPTION
Addresses #253 

There was just a missing param to the `deduce_file` call in the api since we added tracing functions.