### PR TITLE
Reject non-positive recursive union types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Deduce is a proof checker and small functional language for teaching logic, written in Python. Source `.pf` files contain definitions, theorems, and proofs; running `deduce.py file.pf` either prints `... is valid` or fails with an error. The standard library lives in `lib/` and is auto-imported as a prelude unless `--no-stdlib` is passed.
+
+Single dependency: `lark==1.2.2` (Python 3.11+, CI uses 3.12, Makefile uses 3.13).
+
+## Running and testing
+
+```sh
+# Check a single file (uses recursive-descent parser by default)
+python deduce.py path/to/file.pf
+
+# Pick a parser explicitly
+python deduce.py --recursive-descent file.pf
+python deduce.py --lalr file.pf
+
+# Make targets run BOTH parsers across the test/lib tree
+make tests        # should-validate + should-error
+make tests-lib    # checks the stdlib itself
+make              # tests + tests-lib (default)
+```
+
+`test-deduce.py` is the higher-level harness used in CI:
+
+```sh
+python test-deduce.py                  # default: lib + should-validate + should-error + prelude
+python test-deduce.py --lib            # only ./lib
+python test-deduce.py --passable       # only test/should-validate
+python test-deduce.py --errors         # only test/should-error (diff vs .err files)
+python test-deduce.py --parser         # only test/parse (parser-error fixtures)
+python test-deduce.py --site           # generates and checks doc code from gh_pages/doc
+
+# Regenerate the expected stderr fixture for a should-error test
+python test-deduce.py --generate-error test/should-error/foo.pf
+python test-deduce.py --regenerate-errors      # all of them
+```
+
+The test harness auto-discovers a python3.11–3.14 with `lark` installed. Both parsers must pass — when changing parsing or AST, run with `--lalr` and `--recursive-descent`.
+
+Useful `deduce.py` flags while debugging: `--verbose` (or `--verbose full`), `--unique-names`, `--trace <function>`, `--traceback`, `--quiet`, `--suppress-theorems`, `-r` (recurse into directories).
+
+## Architecture
+
+The pipeline lives in five Python files. The flow for one file is in `deduce.py:deduce_file`:
+
+1. **Parse** — either `parser.py` (lark, grammar in `Deduce.lark`) or `rec_desc_parser.py` (hand-written recursive descent). Both produce the same AST. The default is recursive descent (`flags.py:recursive_descent = True`); `--lalr` switches to lark.
+2. **uniquify** (`proof_checker.uniquify_deduce`) — alpha-rename every binding to a globally unique name. `Var.resolved_names` is filled in here (a list, because of overloading).
+3. **process_declarations** — collect the type environment for top-level statements.
+4. **type_check_stmt** — type-check function bodies; resolve overloads using types.
+5. **collect_env** — build the proof environment (label → formula) and runtime environment (name → value).
+6. **check_proofs** — verify proofs against the rules of logic; execute `print`/`assert`.
+
+Steps 3–6 all run inside `proof_checker.check_deduce`. The four-phase comment at the top of `proof_checker.py` is the canonical reference.
+
+`abstract_syntax.py` (~5000 lines) defines every AST node as a dataclass under base classes `AST`, `Type`, `Term` (with `Formula` as a subclass), `Proof`, `Statement`, plus `Pattern`. Each node implements `copy`, `uniquify`, `substitute`, `reduce` as needed. `docs/knowledge-base/abstract-syntax.md` documents the major nodes.
+
+`flags.py` holds all global compiler state (verbosity, unique-name display, parser choice, import directories, quiet mode). `error.py` defines the exception types (`Exception` for normal errors, `IncompleteProof`, `StaticError`, `MatchFailed`, `ParseError`) and the location-prefixed message format.
+
+### Imports and the prelude
+
+`init_import_directories` seeds `.` plus anything in `~/.config/deduce/libraries`. `--dir <path>` adds another. The stdlib at `lib/` is auto-added unless the file being checked already lives in `lib/` (handled by `check_in_prelude`) or `--no-stdlib` is passed; when included, every `.pf` file in `lib/` is prepended as a private `Import` statement (the prelude) before checking. `lib/*.thm` and `test/**/*.thm` are generated artifacts — they are gitignored and `make clean` removes them.
+
+### Tests directory layout
+
+- `test/should-validate/` — must check successfully.
+- `test/should-error/` — must produce an error whose stdout matches the sibling `*.pf.err` file (diffed with `--ignore-space-change`). Update fixtures via `--generate-error`.
+- `test/parse/` — same idea but for parser-error messages (only run via `--parser`).
+- `test/test-imports/` — auxiliary modules referenced by `should-validate`/`should-error` tests; passed in as `--dir` so cross-module behavior can be exercised.
+- `test/prelude/` — files that exercise the auto-prelude behavior.
+
+## When changing syntax
+
+Per `docs/knowledge-base/what-to-update.md`, a syntax change touches: `Deduce.lark`, `parser.py`, `rec_desc_parser.py`, `abstract_syntax.py`, `gh_pages/scripts/keywords.py`, `gh_pages/js/codeUtils.js`, `gh_pages/js/sandbox.js`. The two external editor modes (`deduce-mode` for VS Code and Emacs) also need updates but live in separate repos.
+
+## Stdlib naming convention
+
+`lib/README.md`: theorem names are lowercase snake_case; first word is the type (`uint`, `nat`, `list`, …), second the main operator/function, third the secondary one if any, then a descriptor.
+
+## Profiling
+
+`./profile.sh file.pf` runs cProfile + gprof2dot and opens a PNG (requires `dot`).

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2414,7 +2414,7 @@ def validate_union_type(ty, params, env):
         validate_union_type(t, [], env)
       validate_union_type(ty, type_args, env)
       pass
-    case FunctionType(loc, ty_params, param_types, return_type):  
+    case FunctionType(loc, ty_params, param_types, return_type):
       for t in param_types:
         validate_union_type(t, [], env)
       validate_union_type(return_type, [], env)
@@ -2426,6 +2426,43 @@ def validate_union_type(ty, params, env):
       validate_union_type(elt_ty, [], env)
     case _:
       error(ty.location, f"Unhandled case '{type(ty)}' in 'validate_union_type")
+
+# Strict-positivity check for inductive (union) types.
+#
+# A constructor parameter type is strictly positive in the union being defined
+# (`union_name`) if the union name does not appear in any "negative position",
+# i.e. to the left of an arrow in a `FunctionType`. Without this restriction
+# the type theory is inconsistent: `union Bad { Wrap(fn Bad -> bool) }` admits
+# Russell's paradox via `R = Wrap(fun x { not unwrap(x)(x) })`.
+#
+# This check only handles direct self-reference. It does NOT catch nested
+# non-positivity introduced by another generic union whose type parameter is
+# itself used non-positively (e.g. `union B { Mk(Set<B>) }`, where `Set<X>` is
+# defined as `char_fun(fn X -> bool)`). Detecting that case requires a polarity
+# analysis of every generic union's parameters, which would currently reject
+# the stdlib's `Set` and `MultiSet`.
+def check_strict_positivity(ty, union_name, env, forbidden=False):
+  match ty:
+    case Var(loc, _, name, rns):
+      ref_name = rns[0] if rns else name
+      if forbidden and ref_name == union_name:
+        error(loc,
+              f"the union '{base_name(union_name)}' must not occur in a "
+              f"negative position (to the left of '->') of its own "
+              f"constructor parameters; this would make the logic "
+              f"inconsistent (Russell's paradox)")
+    case TypeInst(loc, head, type_args):
+      check_strict_positivity(head, union_name, env, forbidden)
+      for t in type_args:
+        check_strict_positivity(t, union_name, env, forbidden)
+    case FunctionType(loc, ty_params, param_types, return_type):
+      for t in param_types:
+        check_strict_positivity(t, union_name, env, forbidden=True)
+      check_strict_positivity(return_type, union_name, env, forbidden)
+    case ArrayType(loc, elt_ty):
+      check_strict_positivity(elt_ty, union_name, env, forbidden)
+    case _:
+      pass
 
 def process_declaration_visibility(decl : Declaration, env: Env, module_chain, downstream_needs_checking):
   match decl:
@@ -2505,6 +2542,7 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
           for ty in constr.parameters:
             check_type(ty, body_env)
             validate_union_type(ty, [], body_env)
+            check_strict_positivity(ty, name, body_env)
           constr_type = FunctionType(constr.location, typarams,
                                      constr.parameters, return_type)
         elif len(typarams) > 0:

--- a/test/should-error/union_non_positive.pf
+++ b/test/should-error/union_non_positive.pf
@@ -1,0 +1,3 @@
+union Bad {
+  Wrap(fn Bad -> bool)
+}

--- a/test/should-error/union_non_positive.pf.err
+++ b/test/should-error/union_non_positive.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/union_non_positive.pf:2.11-2.14: the union 'Bad' must not occur in a negative position (to the left of '->') of its own constructor parameters; this would make the logic inconsistent (Russell's paradox)


### PR DESCRIPTION
## Summary

- Adds a strict-positivity check on `union` constructor parameters that rejects definitions where the union being defined appears to the left of an arrow (a negative position).
- Without this check, `union Bad { Wrap(fn Bad -> bool) }` was accepted and admitted Russell's paradox (`R = Wrap(fun x { not unwrap(x)(x) })`), making the logic inconsistent. Reproduced before this change in #272.
- The check is intentionally conservative: it only catches **direct** self-reference. Nested non-positivity through another generic union whose type parameter is used non-positively (e.g. `union B { Mk(Set<B>) }` where `Set<X>` is `char_fun(fn X -> bool)`) is **not yet detected**, since a per-parameter polarity analysis would currently reject the stdlib's `Set` and `MultiSet`. That's left as a follow-up.

## Implementation

`check_strict_positivity(ty, union_name, env, forbidden)` in `proof_checker.py` walks the constructor parameter type with a `forbidden` flag. The flag flips on at `FunctionType.param_types`; when a `Var` whose resolved name equals the union being defined is reached with `forbidden=True`, an error is emitted. Called from the `Union` case of `process_declaration` alongside the existing `validate_union_type`.

## Test plan

- [x] `make tests-lib` (stdlib still validates under both parsers)
- [x] `make tests` (full should-validate + should-error suite passes)
- [x] `python test-deduce.py` (default lib + passable + errors + prelude run passes)
- [x] New fixture `test/should-error/union_non_positive.pf` rejects `union Bad { Wrap(fn Bad -> bool) }` with a clear error message; `.err` file generated via `--generate-error`.
- [x] Manual check: a self-referential union in positive position (`union Tree { Leaf(Tree) }`-style) is unaffected; the fixture is the only new should-error case.

Refs #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)