### PR TITLE
Detect non-positive nesting via per-parameter polarity inference

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2430,17 +2430,37 @@ def validate_union_type(ty, params, env):
 # Strict-positivity check for inductive (union) types.
 #
 # A constructor parameter type is strictly positive in the union being defined
-# (`union_name`) if the union name does not appear in any "negative position",
+# (`union_name`) if `union_name` does not appear in any "negative position",
 # i.e. to the left of an arrow in a `FunctionType`. Without this restriction
 # the type theory is inconsistent: `union Bad { Wrap(fn Bad -> bool) }` admits
 # Russell's paradox via `R = Wrap(fun x { not unwrap(x)(x) })`.
 #
-# This check only handles direct self-reference. It does NOT catch nested
-# non-positivity introduced by another generic union whose type parameter is
-# itself used non-positively (e.g. `union B { Mk(Set<B>) }`, where `Set<X>` is
-# defined as `char_fun(fn X -> bool)`). Detecting that case requires a polarity
-# analysis of every generic union's parameters, which would currently reject
-# the stdlib's `Set` and `MultiSet`.
+# When walking through a `TypeInst(D, args)` of some other generic union `D`,
+# the polarity for each arg is adjusted by the polarity that `D` uses for that
+# parameter. Per-parameter polarities for each generic union are inferred by
+# `infer_param_polarities` and stored on the `Union` AST node before this
+# check runs. This catches "nested" non-positivity such as
+# `union B { Mk(Set<B>) }`, where `Set<X>` is `char_fun(fn X -> bool)` — `Set`'s
+# parameter `X` is negative, so `B` ends up in a negative position.
+#
+# Deduce does not allow forward references between unions, so polarities can be
+# computed in source order.
+def _flip_polarity(pol):
+  return '-' if pol == '+' else '+'
+
+def _lookup_param_polarities(head, env):
+  """If `head` resolves to a Union, return its inferred per-parameter polarities
+  (or None if not yet inferred)."""
+  if not isinstance(head, Var):
+    return None
+  try:
+    head_def = env.get_def_of_type_var(head)
+  except Exception:
+    return None
+  if isinstance(head_def, Union):
+    return getattr(head_def, 'param_polarities', None)
+  return None
+
 def check_strict_positivity(ty, union_name, env, forbidden=False):
   match ty:
     case Var(loc, _, name, rns):
@@ -2453,8 +2473,15 @@ def check_strict_positivity(ty, union_name, env, forbidden=False):
               f"inconsistent (Russell's paradox)")
     case TypeInst(loc, head, type_args):
       check_strict_positivity(head, union_name, env, forbidden)
-      for t in type_args:
-        check_strict_positivity(t, union_name, env, forbidden)
+      head_pols = _lookup_param_polarities(head, env)
+      for i, t in enumerate(type_args):
+        if head_pols is not None and i < len(head_pols) and head_pols[i] == '-':
+          # Sticky: passing through a negative parameter forbids occurrences
+          # in this arg, even under further negations.
+          eff_forbidden = True
+        else:
+          eff_forbidden = forbidden
+        check_strict_positivity(t, union_name, env, eff_forbidden)
     case FunctionType(loc, ty_params, param_types, return_type):
       for t in param_types:
         check_strict_positivity(t, union_name, env, forbidden=True)
@@ -2463,6 +2490,58 @@ def check_strict_positivity(ty, union_name, env, forbidden=False):
       check_strict_positivity(elt_ty, union_name, env, forbidden)
     case _:
       pass
+
+# Infer per-parameter polarities for `union_decl` and stash them on the AST
+# node as `param_polarities`. The list is mutable and used in-place during a
+# fixpoint iteration so self-references read the in-progress polarities. This
+# converges in at most |type_params| iterations because polarity is monotone
+# (only goes '+' -> '-').
+def infer_param_polarities(union_decl, env):
+  if not union_decl.type_params:
+    union_decl.param_polarities = []
+    return
+
+  polarities = ['+'] * len(union_decl.type_params)
+  union_decl.param_polarities = polarities  # exposed in-place for self-refs
+
+  type_param_names = set(union_decl.type_params)
+
+  def walk(ty, current):
+    match ty:
+      case Var(loc, _, name, rns):
+        ref_name = rns[0] if rns else name
+        if ref_name in type_param_names:
+          idx = union_decl.type_params.index(ref_name)
+          if current == '-':
+            polarities[idx] = '-'
+      case TypeInst(loc, head, type_args):
+        walk(head, current)
+        head_pols = _lookup_param_polarities(head, env)
+        for i, arg in enumerate(type_args):
+          if head_pols is not None and i < len(head_pols) and head_pols[i] == '-':
+            # Sticky: descending through a negative parameter records this arg
+            # as negative regardless of how deeply further function arrows
+            # nest. This matches Coq's strict positivity (no parity flipping).
+            eff = '-'
+          else:
+            eff = current
+          walk(arg, eff)
+      case FunctionType(loc, ty_params, param_types, return_type):
+        for t in param_types:
+          walk(t, '-')
+        walk(return_type, current)
+      case ArrayType(loc, elt_ty):
+        walk(elt_ty, current)
+      case _:
+        pass
+
+  while True:
+    before = list(polarities)
+    for con in union_decl.alternatives:
+      for ty in con.parameters:
+        walk(ty, '+')
+    if before == polarities:
+      break
 
 def process_declaration_visibility(decl : Declaration, env: Env, module_chain, downstream_needs_checking):
   match decl:
@@ -2531,6 +2610,9 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
       union_type = Var(loc, None, name, [name])
       body_env = env.declare_type_vars(loc, typarams)
       body_union_type = union_type
+      # Infer per-parameter polarities first so check_strict_positivity (and
+      # any future checks on later unions) can consult them.
+      infer_param_polarities(decl, body_env)
       new_alts = []
       for constr in alts:
         if len(constr.parameters) > 0:

--- a/test/should-error/union_non_positive_double.pf
+++ b/test/should-error/union_non_positive_double.pf
@@ -1,0 +1,11 @@
+// Double-negation in the parameter is still non-strictly-positive.
+// `M ≅ DN<M> ≅ (M -> bool) -> bool` has no fixpoint either, so the
+// definition must be rejected.
+
+union DN<T> {
+  D(fn (fn T -> bool) -> bool)
+}
+
+union M {
+  W(DN<M>)
+}

--- a/test/should-error/union_non_positive_double.pf.err
+++ b/test/should-error/union_non_positive_double.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/union_non_positive_double.pf:10.8-10.9: the union 'M' must not occur in a negative position (to the left of '->') of its own constructor parameters; this would make the logic inconsistent (Russell's paradox)

--- a/test/should-error/union_non_positive_nested.pf
+++ b/test/should-error/union_non_positive_nested.pf
@@ -1,0 +1,12 @@
+// `Container<T>` is harmless on its own (no recursive use of Container),
+// but its parameter `T` is used in a negative position. Wrapping the
+// type being defined inside `Container` should therefore be rejected:
+// `B ≅ Container<B> ≅ B -> bool` is the Russell setup again.
+
+union Container<T> {
+  C(fn T -> bool)
+}
+
+union B {
+  W(Container<B>)
+}

--- a/test/should-error/union_non_positive_nested.pf.err
+++ b/test/should-error/union_non_positive_nested.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/union_non_positive_nested.pf:11.15-11.16: the union 'B' must not occur in a negative position (to the left of '->') of its own constructor parameters; this would make the logic inconsistent (Russell's paradox)

--- a/test/should-validate/union_positive_nested.pf
+++ b/test/should-validate/union_positive_nested.pf
@@ -1,0 +1,11 @@
+import List
+
+// `List<T>` uses `T` strictly positively, so wrapping the type being
+// defined inside `List` is fine: `Tree ≅ Leaf | Node(List<Tree>)`.
+
+union Tree {
+  Leaf
+  Node(List<Tree>)
+}
+
+define t : Tree = Node([Leaf, Node([]), Leaf])


### PR DESCRIPTION
Stacked on top of #273.

## Summary

- For each generic union, infer the polarity (`+` or `-`) of each type parameter from its constructors and stash it on the AST node as `param_polarities`.
- Use those polarities in `check_strict_positivity` so that descending into `TypeInst(D, args)` of another union accounts for how `D` uses each of its parameters.
- This closes the limitation noted in #273: nested non-positivity through another generic union (e.g. `union B { Mk(Set<B>) }` where `Set<X>` is `char_fun(fn X -> bool)`) is now rejected.

## What this changes vs. #273

#273 only checks direct self-reference: a Var whose name matches the union being defined, sitting under a `FunctionType` parameter, errors. It walks `TypeInst` args without paying any attention to how the head's parameters are used. So `Set<B>` slipped through.

This PR adds the missing piece. When walking `TypeInst(D, args)`, we look up `D.param_polarities`. For each arg whose corresponding parameter is `'-'`, we mark this arg's recursion as forbidden. Downstream occurrences of the union being defined under that arg are rejected.

The same machinery is used both during polarity *inference* (to compute per-parameter polarity from the constructors) and during the *gate check* (to reject definitions). Both follow Coq-style strict positivity: descending under any function-arrow LHS, or through a parameter another union has marked negative, makes the position permanently negative — no parity flipping. (Parity flipping would let `(T -> bool) -> bool` slip through, but `M ≅ (M -> bool) -> bool` has no fixpoint either.)

## Why this works without mutual-recursion plumbing

Deduce does not allow forward references between unions — `union A { Mk(B) }` followed by `union B {...}` errors with `undefined variable: B`. So polarities can be computed in source order:

1. Each generic union's polarities are inferred eagerly when its `Union` declaration is processed.
2. By the time we check a later union that mentions an earlier one's `TypeInst`, the earlier union's polarities are already on its AST node.
3. Self-references during inference read the in-progress polarity list (mutated in place); the iteration is monotone (`+` -> `-` only) so a single fixpoint loop converges in at most `|type_params|` steps.

## Stdlib

Unaffected. `Set<T>` and `MultiSet<T>` simply get `param_polarities = ['-']` and remain valid declarations; only downstream definitions that fold the type being defined through one of their negative parameters are now rejected.

## Test plan

- [x] `make tests-lib` (stdlib still validates under both parsers)
- [x] `make tests` (full should-validate + should-error suite passes)
- [x] `python test-deduce.py` (default lib + passable + errors + prelude)
- [x] New fixtures:
  - `test/should-error/union_non_positive_nested.pf` — `union B { W(Container<B>) }` with `Container<T> = C(fn T -> bool)` (the original limitation)
  - `test/should-error/union_non_positive_double.pf` — `union M { W(DN<M>) }` with double-negation (verifies sticky semantics)
  - `test/should-validate/union_positive_nested.pf` — `union Tree { Leaf | Node(List<Tree>) }` (verifies positive nesting still works)

## What's still not handled

This PR catches non-positivity through *generic* unions whose parameters are non-strictly-positive in their own bodies. It still does not catch non-positivity introduced through arbitrary type aliases or other non-union constructs — Deduce currently has none of those for type-level abstraction, so this hasn't been an issue in practice. If a future PR adds type aliases that abstract over types, the alias would need its own polarity inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)