### PR TITLE
Allow operator names in predicate / relation declarations

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -288,8 +288,8 @@ ident: IDENT              -> ident
 ?pred_rule_list:                                           -> empty
     | pred_rule pred_rule_list                             -> push
 
-?predicate_decl: visibility "predicate" IDENT type_params_opt ":" type "{" pred_rule_list "}" -> predicate_decl
-?relation_decl:  visibility "relation"  IDENT type_params_opt ":" type "{" pred_rule_list "}" -> relation_decl
+?predicate_decl: visibility "predicate" ident type_params_opt ":" type "{" pred_rule_list "}" -> predicate_decl
+?relation_decl:  visibility "relation"  ident type_params_opt ":" type "{" pred_rule_list "}" -> relation_decl
 
 ?pattern: ident                                  -> pattern_id
     | "0"                                        -> pattern_zero

--- a/parser.py
+++ b/parser.py
@@ -645,7 +645,7 @@ def parse_tree_to_ast(e, parent):
     elif e.data == 'predicate_decl' or e.data == 'relation_decl':
         keyword = 'predicate' if e.data == 'predicate_decl' else 'relation'
         visibility = parse_tree_to_ast(e.children[0], e)
-        name = str(e.children[1].value)
+        name = parse_tree_to_ast(e.children[1], e)
         typarams = parse_tree_to_list(e.children[2], e)
         signature = parse_tree_to_ast(e.children[3], e)
         rules = parse_tree_to_list(e.children[4], e)

--- a/test/should-validate/relation_operator_name.pf
+++ b/test/should-validate/relation_operator_name.pf
@@ -1,0 +1,22 @@
+// A relation can be declared with an operator-symbol name. Tests run
+// with --no-stdlib, so `≤` is not already in scope.
+
+union Nat {
+  zero
+  suc(Nat)
+}
+
+relation operator ≤ : fn Nat, Nat -> bool {
+  le_zero : all n:Nat. zero ≤ n
+  le_suc  : all m:Nat, n:Nat. if m ≤ n then suc(m) ≤ suc(n)
+}
+
+theorem zero_le_zero : zero ≤ zero
+proof
+  le_zero[zero]
+end
+
+theorem one_le_two : suc(zero) ≤ suc(suc(zero))
+proof
+  apply le_suc[zero, suc(zero)] to le_zero[suc(zero)]
+end


### PR DESCRIPTION
## Summary

- The lark grammar was using `IDENT` directly for `predicate_decl` and `relation_decl`, so a declaration like `relation operator ≤ : ...` was rejected at parse time even though the recursive-descent parser (`parse_identifier()` at [rec_desc_parser.py:122](rec_desc_parser.py:122)) already accepted operator-name forms.
- Switch both rules to the `ident` non-terminal (the form used by `function` and `recursive`) and adjust [parser.py](parser.py) to convert the resulting subtree the same way `fun` / `rec_fun` already do.
- Add a should-validate test that declares `relation operator ≤` over a local `Nat` union. The existing no-overload rule still prevents shadowing stdlib operators like `≤` on UInt/Nat, but the test runs under `--no-stdlib` so the namespace is clean.

## Test plan

- [x] `python deduce.py --no-stdlib --recursive-descent test/should-validate/relation_operator_name.pf` — valid
- [x] `python deduce.py --no-stdlib --lalr test/should-validate/relation_operator_name.pf` — valid
- [x] `python test-deduce.py` — passes (lib + should-validate + should-error + prelude, both parsers, exit 0)
- [ ] `python test-deduce.py --parser` — pre-existing unrelated diff on `test/parse/all_dot.pf` reproduces on `main`, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)