### PR TITLE
Regenerate stale parse-error fixtures and gate CI on --parser

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -26,3 +26,4 @@ jobs:
         run: |
           python test-deduce.py --site
           python test-deduce.py
+          python test-deduce.py --parser

--- a/test/parse/all_dot.pf.err
+++ b/test/parse/all_dot.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/all_dot.pf:3.12-3.26: 
 while parsing
 	term ::= "all" var_list "." term
+
+theorem T: all x : bool x = x 
+                        ^
+
 ./test/parse/all_dot.pf:3.25-3.26: expected "." after parameters of "all", not
 	x

--- a/test/parse/apply.pf.err
+++ b/test/parse/apply.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/apply.pf:1.1-6.10: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  rewrite prem
+          ^^^^
+
 ./test/parse/apply.pf:6.11-6.15: expected keyword "end" after proof of theorem, not
 	prem

--- a/test/parse/array1.pf.err
+++ b/test/parse/array1.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/array1.pf:13.9-13.18: while parsing array access
 	term ::= term "[" term "]"
 
+
+assert A[1] = false
+^^^^^^
+
 ./test/parse/array1.pf:14.1-14.7: expected closing bracket "]" , not
 	assert

--- a/test/parse/array2.pf.err
+++ b/test/parse/array2.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/array2.pf:12.12-12.17: while parsing array creation
 	term ::= "array" "(" term ")"
 
+
+define A = array L
+                 ^
+
 ./test/parse/array2.pf:12.18-12.19: expected open parenthesis "(" , not
 	L

--- a/test/parse/array3.pf.err
+++ b/test/parse/array3.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/array3.pf:12.12-12.19: while parsing array creation
 	term ::= "array" "(" term ")"
 
+
+assert A[2] = true
+^^^^^^
+
 ./test/parse/array3.pf:14.1-14.7: expected closing parenthesis ")" , not
 	assert

--- a/test/parse/call1.pf.err
+++ b/test/parse/call1.pf.err
@@ -4,6 +4,10 @@
 ./test/parse/call1.pf:4.7-4.13: while parsing function call
 	term ::= term "(" term_list ")"
 
+
+print f(false)
+^^^^^
+
 ./test/parse/call1.pf:5.1-5.6: expected closing parenthesis ")" , not
 	print
 Perhaps you forgot a comma?

--- a/test/parse/call2_comma.pf.err
+++ b/test/parse/call2_comma.pf.err
@@ -4,6 +4,10 @@
 ./test/parse/call2_comma.pf:6.7-6.13: while parsing function call
 	term ::= term "(" term_list ")"
 
+
+print f(true false)
+             ^^^^^
+
 ./test/parse/call2_comma.pf:6.14-6.19: expected closing parenthesis ")" , not
 	false
 Perhaps you forgot a comma?

--- a/test/parse/cases1.pf.err
+++ b/test/parse/cases1.pf.err
@@ -4,5 +4,9 @@
 
 ./test/parse/cases1.pf:6.3-6.14: while parsing:
 	"case" label ":" formula "{" proof "}"
+
+  case a    . }
+            ^
+
 ./test/parse/cases1.pf:6.13-6.14: expected "{" after assumption of "case", not
 	.

--- a/test/parse/cases2.pf.err
+++ b/test/parse/cases2.pf.err
@@ -4,5 +4,9 @@
 
 ./test/parse/cases2.pf:6.3-7.7: while parsing:
 	"case" label ":" formula "{" proof "}"
+
+  case b : false { . }
+  ^^^^
+
 ./test/parse/cases2.pf:7.3-7.7: expected "}" after body of "case", not
 	case

--- a/test/parse/conclude.pf.err
+++ b/test/parse/conclude.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/conclude.pf:6.3-6.61: while parsing
 	conclusion ::= "conclude" formula "by" proof
 
+
+    definition { const_t2,  const_t1 }
+    ^^^^^^^^^^
+
 ./test/parse/conclude.pf:7.5-7.15: expected the keyword "by" or "proof" at beginning of a reason, not
 	definition

--- a/test/parse/conjunct1.pf.err
+++ b/test/parse/conjunct1.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/conjunct1.pf:1.1-6.11: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  conjunct not_number of prem
+           ^^^^^^^^^^
+
 ./test/parse/conjunct1.pf:6.12-6.22: expected an int literal after "conjunct", not
 	not_number

--- a/test/parse/conjunct2.pf.err
+++ b/test/parse/conjunct2.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/conjunct2.pf:1.1-6.13: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  conjunct 0  prem
+              ^^^^
+
 ./test/parse/conjunct2.pf:6.15-6.19: expected keyword "of" after index of "conjunct", not
 	prem

--- a/test/parse/define_1.pf.err
+++ b/test/parse/define_1.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/define_1.pf:1.1-1.9: while parsing
 	proof_stmt ::= "define" identifier "=" term
 
+
+define a 3
+         ^
+
 ./test/parse/define_1.pf:1.10-1.11: expected "=" after name in "define", not
 	3

--- a/test/parse/define_term1.pf.err
+++ b/test/parse/define_term1.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/define_term1.pf:2.3-2.11: while parsing
 	term ::= "define" identifier "=" term ";" term
 
+
+  define H  a and c;
+            ^
+
 ./test/parse/define_term1.pf:2.13-2.14: expected "=" after name in "define", not
 	a

--- a/test/parse/define_term2.pf.err
+++ b/test/parse/define_term2.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/define_term2.pf:2.3-2.21: while parsing
 	term ::= "define" identifier "=" term ";" term
 
+
+  H or not a or not c
+  ^
+
 ./test/parse/define_term2.pf:3.3-3.4: expected ";" after right-hand side of "define", not
 	H

--- a/test/parse/eof_def.pf.err
+++ b/test/parse/eof_def.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/eof_def.pf:1.1-1.7: while parsing
 	proof_stmt ::= "define" identifier "=" term
 
+
+define
+^^^^^^
+
 ./test/parse/eof_def.pf:1.1-1.7: expected an identifier, not end of file

--- a/test/parse/eof_def_1.pf.err
+++ b/test/parse/eof_def_1.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/eof_def_1.pf:1.1-1.9: while parsing
 	proof_stmt ::= "define" identifier "=" term
 
+
+define a
+       ^
+
 ./test/parse/eof_def_1.pf:1.8-1.9: Expected a token, got end of file

--- a/test/parse/eof_have_0.pf.err
+++ b/test/parse/eof_have_0.pf.err
@@ -4,4 +4,8 @@
 	proof_stmt ::= "have" identifier ":" formula "by" proof
 	proof_stmt ::= "have" ":" formula "by" proof
 
+
+  have 
+  ^^^^
+
 ./test/parse/eof_have_0.pf:3.3-3.7: expected an identifier or colon after "have", not end of file

--- a/test/parse/eof_have_1.pf.err
+++ b/test/parse/eof_have_1.pf.err
@@ -4,4 +4,8 @@
 	proof_stmt ::= "have" identifier ":" formula "by" proof
 	proof_stmt ::= "have" ":" formula "by" proof
 
+
+  have :
+       ^
+
 ./test/parse/eof_have_1.pf:3.8-3.9: expected a term, not end of file

--- a/test/parse/eof_have_2.pf.err
+++ b/test/parse/eof_have_2.pf.err
@@ -4,4 +4,8 @@
 	proof_stmt ::= "have" identifier ":" formula "by" proof
 	proof_stmt ::= "have" ":" formula "by" proof
 
+
+  have asdf
+  ^^^^
+
 ./test/parse/eof_have_2.pf:3.3-3.7: expected a colon after label of "have", not end of file

--- a/test/parse/eof_have_3.pf.err
+++ b/test/parse/eof_have_3.pf.err
@@ -4,4 +4,8 @@
 	proof_stmt ::= "have" identifier ":" formula "by" proof
 	proof_stmt ::= "have" ":" formula "by" proof
 
+
+  have asdf : true
+              ^^^^
+
 ./test/parse/eof_have_3.pf:3.15-3.19: Expected a token, got end of file

--- a/test/parse/eof_proof.pf.err
+++ b/test/parse/eof_proof.pf.err
@@ -1,3 +1,7 @@
 ./test/parse/eof_proof.pf:1.1-2.6: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+proof 
+^^^^^
+
 ./test/parse/eof_proof.pf:2.1-2.6: expected a proof, not end of file

--- a/test/parse/eof_term.pf.err
+++ b/test/parse/eof_term.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/eof_term.pf:1.1-1.11: while parsing
 	proof_stmt ::= "define" identifier "=" term
 
+
+define a = 
+         ^
+
 ./test/parse/eof_term.pf:1.10-1.11: expected a term, not end of file

--- a/test/parse/fun_1.pf.err
+++ b/test/parse/fun_1.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/fun_1.pf:1.1-2.9: while parsing
 	proof_stmt ::= "define" identifier ":" type "=" term
 
+
+ = fun x x
+         ^
+
 ./test/parse/fun_1.pf:2.10-2.11: expected "{" after parameters of fun, not
 	x

--- a/test/parse/fun_2.pf.err
+++ b/test/parse/fun_2.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/fun_2.pf:1.1-2.13: while parsing
 	proof_stmt ::= "define" identifier ":" type "=" term
 
+
+assert true
+^^^^^^
+
 ./test/parse/fun_2.pf:4.1-4.7: expected "}" after body of fun, not
 	assert

--- a/test/parse/generic_1.pf.err
+++ b/test/parse/generic_1.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/generic_1.pf:1.1-2.14: while parsing
 	proof_stmt ::= "define" identifier ":" type "=" term
 
+
+  = generic E  fun x, y, p { if p then x else y }
+               ^^^
+
 ./test/parse/generic_1.pf:2.16-2.19: expected "{" after parameters of "generic", not
 	fun

--- a/test/parse/generic_2.pf.err
+++ b/test/parse/generic_2.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/generic_2.pf:1.1-2.51: while parsing
 	proof_stmt ::= "define" identifier ":" type "=" term
 
+
+print true
+^^^^^
+
 ./test/parse/generic_2.pf:4.1-4.6: expected "}" after body of "generic", not
 	print

--- a/test/parse/hash_term.pf.err
+++ b/test/parse/hash_term.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/hash_term.pf:1.1-1.13: while parsing
 	statement ::= "print" term
 
+
+print false
+^^^^^
+
 ./test/parse/hash_term.pf:2.1-2.6: expected closing hash "#" , not
 	print

--- a/test/parse/have_no_by.pf.err
+++ b/test/parse/have_no_by.pf.err
@@ -4,5 +4,9 @@
 	proof_stmt ::= "have" identifier ":" formula "by" proof
 	proof_stmt ::= "have" ":" formula "by" proof
 
+
+  have t : true . 
+                ^
+
 ./test/parse/have_no_by.pf:3.17-3.18: expected the keyword "by" or "proof" at beginning of a reason, not
 	.

--- a/test/parse/have_no_colon.pf.err
+++ b/test/parse/have_no_colon.pf.err
@@ -4,5 +4,9 @@
 	proof_stmt ::= "have" identifier ":" formula "by" proof
 	proof_stmt ::= "have" ":" formula "by" proof
 
+
+  have t  true by . 
+          ^^^^
+
 ./test/parse/have_no_colon.pf:3.11-3.15: expected a colon after label of "have", not
 	true

--- a/test/parse/id_eof_thm.pf.err
+++ b/test/parse/id_eof_thm.pf.err
@@ -1,3 +1,7 @@
 ./test/parse/id_eof_thm.pf:1.1-1.8: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+theorem 
+^^^^^^^
+
 ./test/parse/id_eof_thm.pf:1.1-1.8: expected name of theorem, not end of file

--- a/test/parse/id_miss.pf.err
+++ b/test/parse/id_miss.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/id_miss.pf:1.1-1.8: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+theorem 42
+        ^^
+
 ./test/parse/id_miss.pf:1.9-1.11: expected name of theorem, not:
 	42

--- a/test/parse/if_no_then.pf.err
+++ b/test/parse/if_no_then.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/if_no_then.pf:3.5-3.16: 
 while parsing
 	formula ::= "if" formula "then" formula
+
+    if x  false else true
+          ^^^^^
+
 ./test/parse/if_no_then.pf:3.11-3.16: expected keyword "then" after premise of "if" formula, not
 	false

--- a/test/parse/inst-term-angle-bracket.pf.err
+++ b/test/parse/inst-term-angle-bracket.pf.err
@@ -2,5 +2,9 @@
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
 ./test/parse/inst-term-angle-bracket.pf:8.3-8.18: while trying to parse type arguments for instantiation of an "all" formula:
 	proof ::= proof "<" type_list ">"
+
+  prem<Nat><node(1,empty)>
+                ^
+
 ./test/parse/inst-term-angle-bracket.pf:8.17-8.18: expected a closing ">" , not
 	(

--- a/test/parse/instant1.pf.err
+++ b/test/parse/instant1.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/instant1.pf:9.18-9.22: 
 while parsing
 	term ::= "@" term "<" type_list ">"
+
+assert @[]<A> = (@[])
+                    ^
+
 ./test/parse/instant1.pf:9.21-9.22: expected "<" after subject of instantiation ("@"), not
 	)

--- a/test/parse/instant2.pf.err
+++ b/test/parse/instant2.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/instant2.pf:9.17-9.22: while parsing parenthesized term
 	term ::= "(" term ")"
 
+
+assert @[]<A> = (@<A)
+                    ^
+
 ./test/parse/instant2.pf:9.21-9.22: expected closing ">" after type parameters, not
 	)

--- a/test/parse/list1.pf.err
+++ b/test/parse/list1.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/list1.pf:6.1-6.19: while parsing
 	statement ::= "print" term
 
+
+print [false]
+^^^^^
+
 ./test/parse/list1.pf:8.1-8.6: expected closing bracket "]" at end of list literal, not
 	print

--- a/test/parse/misspell.pf.err
+++ b/test/parse/misspell.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/misspell.pf:3.1-6.15: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  sufices Q   by prem
+  ^^^^^^^
+
 ./test/parse/misspell.pf:7.3-7.10: expected a proof.
 Did you mean "suffices" instead of "sufices"?

--- a/test/parse/no_term.pf.err
+++ b/test/parse/no_term.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/no_term.pf:5.3-5.13: while parsing
 	proof_stmt ::= "define" identifier "=" term
 
+
+  .
+  ^
+
 ./test/parse/no_term.pf:6.3-6.4: expected a term, not
 	"."

--- a/test/parse/paren_term.pf.err
+++ b/test/parse/paren_term.pf.err
@@ -4,5 +4,9 @@
 ./test/parse/paren_term.pf:1.7-3.6: while parsing parenthesized term
 	term ::= "(" term ")"
 
+
+print false
+^^^^^
+
 ./test/parse/paren_term.pf:3.1-3.6: expected closing parenthesis ")" , not
 	print

--- a/test/parse/pf_brace.pf.err
+++ b/test/parse/pf_brace.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/pf_brace.pf:1.1-6.10: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  rewrite prem
+          ^^^^
+
 ./test/parse/pf_brace.pf:6.11-6.15: expected keyword "end" after proof of theorem, not
 	prem

--- a/test/parse/pf_paren.pf.err
+++ b/test/parse/pf_paren.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/pf_paren.pf:1.1-6.10: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  rewrite prem
+          ^^^^
+
 ./test/parse/pf_paren.pf:6.11-6.15: expected keyword "end" after proof of theorem, not
 	prem

--- a/test/parse/plus_int.pf.err
+++ b/test/parse/plus_int.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/plus_int.pf:13.1-13.8: while parsing
 	statement ::= "print" term
 
+
+print + a
+        ^
+
 ./test/parse/plus_int.pf:13.9-13.10: expected an integer not
 	a

--- a/test/parse/proof_args_comma.pf.err
+++ b/test/parse/proof_args_comma.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/proof_args_comma.pf:8.1-12.6: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  P[w z]
+      ^
+
 ./test/parse/proof_args_comma.pf:12.7-12.8: expected a closing "]" , not
 	z
 Perhaps you forgot a comma?

--- a/test/parse/proof_brace.pf.err
+++ b/test/parse/proof_brace.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/proof_brace.pf:1.1-3.5: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+end
+^^^
+
 ./test/parse/proof_brace.pf:4.1-4.4: expected closing "}" around proof, not
 	end

--- a/test/parse/proof_define.pf.err
+++ b/test/parse/proof_define.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/proof_define.pf:3.3-3.11: while parsing
 	proof_stmt ::= "define" identifier "=" term
 
+
+  define t true
+           ^^^^
+
 ./test/parse/proof_define.pf:3.12-3.16: expected "=" after name in "define", not
 	true

--- a/test/parse/proof_paren.pf.err
+++ b/test/parse/proof_paren.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/proof_paren.pf:1.1-3.5: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+end
+^^^
+
 ./test/parse/proof_paren.pf:4.1-4.4: expected closing parenthesis ")" around proof, not
 	end

--- a/test/parse/some_dot.pf.err
+++ b/test/parse/some_dot.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/some_dot.pf:1.1-1.25: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+theorem T: some x : bool x = x
+                         ^
+
 ./test/parse/some_dot.pf:1.26-1.27: expected "." after parameters of "some", not
 	x

--- a/test/parse/suffices1.pf.err
+++ b/test/parse/suffices1.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/suffices1.pf:1.1-3.16: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  suffices true  .
+                 ^
+
 ./test/parse/suffices1.pf:3.18-3.19: expected the keyword "by" or "proof" at beginning of a reason, not
 	.

--- a/test/parse/switch1.pf.err
+++ b/test/parse/switch1.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/switch1.pf:8.1-10.13: while parsing
 	proof_stmt ::= "define" identifier ":" type "=" term
 
+
+      case A { true }
+      ^^^^
+
 ./test/parse/switch1.pf:11.7-11.11: expected "{" after subject of "switch", not
 	case

--- a/test/parse/switch2.pf.err
+++ b/test/parse/switch2.pf.err
@@ -1,5 +1,9 @@
 ./test/parse/switch2.pf:8.1-13.23: while parsing
 	proof_stmt ::= "define" identifier ":" type "=" term
 
+
+    ]
+    ^
+
 ./test/parse/switch2.pf:14.5-14.6: expected "}" after last case of "switch", not
 	]

--- a/test/parse/switch_pf1.pf.err
+++ b/test/parse/switch_pf1.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/switch_pf1.pf:1.1-4.11: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+    case true assume prop_t { . }
+    ^^^^
+
 ./test/parse/switch_pf1.pf:5.5-5.9: expected "{" after subject of "switch", not
 	case

--- a/test/parse/switch_pf2.pf.err
+++ b/test/parse/switch_pf2.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/switch_pf2.pf:1.1-6.35: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+end
+^^^
+
 ./test/parse/switch_pf2.pf:8.1-8.4: expected "}" after last case of "switch", not
 	end

--- a/test/parse/switch_pf3.pf.err
+++ b/test/parse/switch_pf3.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/switch_pf3.pf:5.5-5.17: while parsing one of the following
 	switch_proof_case ::= "case" pattern "{" proof "}"
 	switch_proof_case ::= "case" pattern "assume" assumption_list "{" proof "}"
+
+    case true  . }
+               ^
+
 ./test/parse/switch_pf3.pf:5.16-5.17: expected "{" after assumption of "case", not
 	.

--- a/test/parse/switch_pf4.pf.err
+++ b/test/parse/switch_pf4.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/switch_pf4.pf:5.5-6.9: while parsing one of the following
 	switch_proof_case ::= "case" pattern "{" proof "}"
 	switch_proof_case ::= "case" pattern "assume" assumption_list "{" proof "}"
+
+    case false assume prop_f { . }
+    ^^^^
+
 ./test/parse/switch_pf4.pf:6.5-6.9: expected "}" after body of "case", not
 	case

--- a/test/parse/switch_pf5.pf.err
+++ b/test/parse/switch_pf5.pf.err
@@ -3,5 +3,9 @@
 ./test/parse/switch_pf5.pf:5.5-5.31: while parsing one of the following
 	switch_proof_case ::= "case" pattern "{" proof "}"
 	switch_proof_case ::= "case" pattern "assume" assumption_list "{" proof "}"
+
+    case true assume prop_t  . }
+                             ^
+
 ./test/parse/switch_pf5.pf:5.30-5.31: expected "{" after assumption of "case", not
 	.

--- a/test/parse/ty_params_1.pf.err
+++ b/test/parse/ty_params_1.pf.err
@@ -1,4 +1,8 @@
 ./test/parse/ty_params_1.pf:16.1-16.18: while parsing
 	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+theorem blah : <T all x : T.
+                  ^^^
+
 ./test/parse/ty_params_1.pf:16.19-16.22: expected closing ">" after type parameters, not
 	all


### PR DESCRIPTION
## Summary

- The 57 `.err` fixtures in `test/parse/` have been stale since [`a1bfbba`](https://github.com/jsiek/deduce/commit/a1bfbba) (Nov 21 2025), which added a source-line + caret snippet to `ParseError.__str__` without regenerating them. `python test-deduce.py --parser` has been red on `main` ever since.
- CI didn't catch it because the default `python test-deduce.py` invocation explicitly skips `parse_dir` (see comment at [test-deduce.py:253](test-deduce.py#L253)).

This PR does two things:

1. **Regenerates every fixture in `test/parse/`** via `--gen-parse`. Diffs are purely additive — each file gains a 4-line block (blank, source line, caret line, blank) between the trace stanzas and the final "expected …" line. Verified mechanically that no diff has any removed or modified lines (a `git diff | grep -c '^-[^-]'` check across all 57 modified fixtures returns 0).
2. **Wires `python test-deduce.py --parser` into the CI workflow** so future error-formatting changes can't silently rot these fixtures.

## Test plan

- [x] `python test-deduce.py --gen-parse` regenerated 57/58 fixtures (the 58th, `weird_if.pf.err`, is an `IncompleteProof` fixture that doesn't go through `ParseError.__str__` and was already current)
- [x] `python test-deduce.py --parser` is green (exit 0) after regen
- [x] Mechanical check: every fixture diff is purely additive, no removals or modifications
- [x] `python test-deduce.py` still passes (default harness, both parsers)
- [ ] CI: confirm the new `--parser` step runs and is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)