### PR TITLE
Add Tactics Cheat Sheet to user documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,10 @@ Per `docs/knowledge-base/what-to-update.md`, a syntax change touches: `Deduce.la
 
 `lib/README.md`: theorem names are lowercase snake_case; first word is the type (`uint`, `nat`, `list`, …), second the main operator/function, third the secondary one if any, then a descriptor.
 
+## Writing proofs
+
+When the task is to write or modify a `.pf` proof, read [`gh_pages/doc/TacticsCheatSheet.md`](gh_pages/doc/TacticsCheatSheet.md) first — it lists every tactic with a one-line meaning and documents the syntactic pitfalls (auto-rule goal collapse, `lemma` privacy, `replace` direction, `ℕ0`/`zero` non-unification, conjunction destructuring with `conjunct N of`, etc.) that otherwise have to be discovered by trial. The companion [`gh_pages/doc/CheatSheet.md`](gh_pages/doc/CheatSheet.md) gives goal-shape-keyed strategy advice; [`gh_pages/doc/Reference.md`](gh_pages/doc/Reference.md) is the long-form reference manual.
+
 ## Profiling
 
 `./profile.sh file.pf` runs cProfile + gprof2dot and opens a PNG (requires `dot`).

--- a/docs/knowledge-base/what-to-update.md
+++ b/docs/knowledge-base/what-to-update.md
@@ -20,6 +20,9 @@ Any changes to the Deduce syntax should be reflected in the following places:
 - `Reference.md`: add or update the alphabetical entry for the new construct, and cross-reference touches in any related entries.
 - `SyntaxGrammar.md`: keep the `## Statements` list current when introducing a new top-level statement form.
 - `CheatSheet.md`: add a row to the "Formula / Prove / Use" table when a new formula shape gains a canonical proof or elimination form.
+- `TacticsCheatSheet.md`: add or update the corresponding row for any new or renamed tactic, and revise the "Common pitfalls" section if the change introduces a new gotcha.
+
+When adding a new top-level documentation page under `gh_pages/doc/`, also add an entry for it to all four dictionaries in `gh_pages/scripts/convert.py` (`mdToHtmlName`, `mdToTitle`, `mdToDescription`, `mdToDeduceCode`), and link it from `Index.md`.
 
 **External:**
 - [deduce-mode (vscode)](https://github.com/HalflingHelper/deduce-mode#): Deduce extension for vscode.

--- a/gh_pages/doc/Index.md
+++ b/gh_pages/doc/Index.md
@@ -164,6 +164,7 @@ The Cheat Sheet gives some advice regarding proof strategy and which Deduce keyw
 <!-- buttons -->
 [Reference Manual](./pages/reference.html)
 [Cheat Sheet](./pages/cheat-sheet.html)
+[Tactics Cheat Sheet](./pages/tactics-cheat-sheet.html)
 <!-- end buttons -->
 <!-- end block -->
 <!-- end section -->

--- a/gh_pages/doc/TacticsCheatSheet.md
+++ b/gh_pages/doc/TacticsCheatSheet.md
@@ -1,0 +1,110 @@
+# Tactics Cheat Sheet
+
+A dense reference for the proof-language constructs in Deduce — every tactic with a one-line meaning, plus the syntactic pitfalls that catch beginners.
+
+This page complements two other documents:
+
+- The [Cheat Sheet](./CheatSheet.md) — strategy advice keyed by the *shape of the goal* ("if my goal is `P and Q`, what do I do?").
+- The [Reference Manual](./Reference.md) — the full alphabetical entry for each construct.
+
+If a name on this page is unfamiliar, follow the link in the Reference column for the long-form description.
+
+## Top-level statement forms
+
+| Form | Meaning |
+| --- | --- |
+| `theorem name: P proof ... end` | A named proof of `P`. **Visible across module boundaries.** |
+| `lemma name: P proof ... end` | A named proof of `P`. **Module-private** — references from another module fail with "undefined proof variable". |
+| `postulate name: P` | Assume `P` without proof. |
+| `auto name` | Register an equation `name : LHS = RHS` as an automatic rewrite. Subsequent goals are simplified silently using it. |
+| `associative operator* in T` | Register `*` as associative for `T`; `replace` and `evaluate` will renormalize accordingly. |
+
+## Proof structure
+
+| Form | Effect on the goal |
+| --- | --- |
+| `arbitrary x:T, y:T` | Introduce universal variables: `∀x:T,y:T. P` becomes `P`. |
+| `assume name: P`&nbsp;/&nbsp;`suppose name: P` | Discharge an antecedent: `if P then Q` becomes `Q`, with `name : P` in scope. The two keywords are synonyms. |
+| `have name: P by proof` | Add `name : P` to scope without changing the goal. |
+| `show P` | Restate the current goal verbatim (must already match — useful for documenting where you are). |
+| `suffices Q by reason` | Replace the goal with `Q`, where `reason` is a proof of `Q → original_goal`. Often `Q` is the goal *after* a `replace` or `expand` you want to make explicit. |
+| `conclude P by proof` | Discharge the goal `P` with `proof`. Like `have` but the formula must equal the current goal. |
+
+## Equality tactics
+
+| Form | Effect |
+| --- | --- |
+| `.` (period) | Close the goal trivially: definitional equality, reflexivity, or `true`. |
+| `evaluate` | Reduce both sides of the goal to normal form. |
+| `expand f \| g` | Unfold the definitions of `f` and `g` in the goal. |
+| `replace eq` | Rewrite the **goal** left-to-right using `eq : LHS = RHS`. |
+| `replace eq in p` | Rewrite within proof `p`'s formula and return a new proof of the rewritten formula. |
+| `replace eq1 \| eq2 \| ...` | Apply rewrites in sequence. |
+| `symmetric p` | If `p : a = b`, returns a proof of `b = a`. |
+| `transitive p1 p2` | `p1 : a = b` together with `p2 : b = c` gives a proof of `a = c`. |
+| `equations a = b by r1   ... = c by r2   ... = d by r3` | Equational chain — a readable form of nested `transitive`. |
+
+## Applying lemmas
+
+| Form | Meaning |
+| --- | --- |
+| `lemma[t1, t2]` | Instantiate the leading `∀` variables. Produces a proof term. |
+| `apply lemma to p` | Modus ponens: given `lemma : if P then Q` and `p : P`, returns a proof of `Q`. |
+| `apply lemma to p1, p2` | Same, when the antecedent is `P1 and P2` — the comma builds the conjunction. |
+| `apply lemma[t] to p` | Combined instantiation and modus ponens. |
+| `recall P` | Refer to an in-scope hypothesis by its formula `P` instead of by label. |
+
+## Case analysis and quantifier elimination
+
+| Form | Use |
+| --- | --- |
+| `switch x { case ctor(args) { ... } ... }` | Pattern-match on a value of a union type. |
+| `switch x { case ctor(args) assume eq { ... } }` | Same, with `eq : x = ctor(args)` available in the branch. |
+| `cases p case name: Pi { ... } ...` | Disjunction elimination on `p : P1 or P2 or ...`. |
+| `induction T case ctor(args) assume IH { ... }` | Structural induction over the union type `T`. |
+| `obtain x where eq: P from p` | Existential elimination: `p : ∃x. P` introduces a fresh `x` together with `eq : P`. |
+
+## Connective introductions
+
+| Goal shape | How to prove |
+| --- | --- |
+| `P and Q` | Comma: `(proof_of_P, proof_of_Q)`. |
+| `P or Q` | Provide a proof of `P` (or of `Q`); the coercion is implicit. `conclude A or B by proof_of_A` works. |
+| `if P then Q` | `assume name: P` then prove `Q`. |
+| `not P` | `assume name: P` then prove `false`. |
+| `false` | `contradict p, np` where `p : P` and `np : not P`. |
+| `∀x:T. P` | `arbitrary x:T` then prove `P`. |
+| `∃x:T. P` | `choose t` (or `choose t1, t2` for nested existentials) then prove `P[x:=t]`. |
+
+## Destructuring conjunctions
+
+| Form | Meaning |
+| --- | --- |
+| `conjunct 0 of p` | First conjunct of `p : A and B and C ...` (zero-indexed). |
+| `conjunct 1 of p` | Second, etc. |
+
+Use these when `apply lemma to p` doesn't typecheck because `p` is a wider conjunction than the lemma's antecedent expects.
+
+## Common pitfalls
+
+1. **`auto` rules silently change the goal.** A "could not find any matches in `true`" error usually means an auto rule from the prelude (or earlier in the file) has already collapsed the goal. Either drop the now-redundant rewrite or use `suffices` to land on a goal the auto rule won't touch.
+
+2. **`lemma` is private.** A `lemma` in another module is not in scope here, even though it is in `lib/`. Promote it to `theorem` or move the call site into the same module.
+
+3. **`replace` only rewrites left-to-right.** To rewrite `RHS → LHS`, use `replace symmetric eq` — or restate the goal so the equation matches its natural direction.
+
+4. **`replace eq` vs `replace eq in p`.** Without `in`, the rewrite applies to the *goal*. With `in p`, it applies inside the formula carried by proof term `p` and produces a new proof term.
+
+5. **`ℕ0`, `lit(zero)`, and `zero` are not always interchangeable.** They denote the same value but are not always *structurally identical*, and `apply` unifies structurally. When a Nat-level lemma fails to apply, check which form the lemma was stated in and bridge with a local `have ... by evaluate`. (Example: `mult_to_zero` is stated with `zero`, `pos_mult_both_sides_of_less` with `ℕ0`.)
+
+6. **Building vs. destructuring conjunctions.** `apply X to A, B` *constructs* the conjunction `A and B` from two separate proofs — no parentheses needed. To go the other way (decompose a hypothesis already of shape `A and B`), use `conjunct 0/1 of`.
+
+7. **Numeric literals don't always reduce eagerly.** `0:UInt` parses as `fromNat(lit(zero))`, so `toNat(0:UInt)` is not definitionally `ℕ0` — it requires `evaluate` or `expand` to bridge. A common pattern: stash `have toNat_zero: toNat((0:UInt)) = ℕ0 by evaluate` near the top of the proof.
+
+## Working tips
+
+- **Read the failure message carefully.** It prints the *current* goal at the point of failure — which may have been transformed by `auto` rules or `suffices` and so differ from what you literally wrote.
+- **When stuck on syntax, search the standard library.** `grep` for the lemma you want to invoke, or for a similar tactic, in `lib/*.pf` and copy the working pattern.
+- **`?` as a proof** prints the current goal and a suggested next step. A cheap way to inspect the proof state mid-construction.
+- **`help L`** on a hypothesis label `L` prints what it can be used for.
+- **Both parsers must agree.** When changing parsing or AST, run with both `--recursive-descent` (default) and `--lalr`.

--- a/gh_pages/scripts/convert.py
+++ b/gh_pages/scripts/convert.py
@@ -14,6 +14,7 @@ html_dir = './gh_pages/pages'
 
 mdToHtmlName = {
     'CheatSheet' : 'cheat-sheet',
+    'TacticsCheatSheet' : 'tactics-cheat-sheet',
     'FunctionalProgramming' : 'deduce-programming',
     'ProofIntro' : 'deduce-proofs',
     'Reference' : 'reference',
@@ -25,6 +26,7 @@ mdToHtmlName = {
 
 mdToTitle = {
     'CheatSheet' : 'Cheat Sheet',
+    'TacticsCheatSheet' : 'Tactics Cheat Sheet',
     'FunctionalProgramming' : 'Programming',
     'ProofIntro' : 'Proofs',
     'Reference' : 'Reference Manual',
@@ -36,6 +38,7 @@ mdToTitle = {
 
 mdToDescription = {
     'CheatSheet' : 'Cheat sheet for advice on deduce proofs.',
+    'TacticsCheatSheet' : 'Concise reference for every Deduce tactic, with common pitfalls.',
     'FunctionalProgramming' : 'A guide on deduce programming with exercises.',
     'ProofIntro' : 'A guide on writing proofs in deduce with exercises.',
     'Reference' : 'Full reference manual for the deduce language.',
@@ -47,6 +50,7 @@ mdToDescription = {
 
 mdToDeduceCode = {
     'CheatSheet' : 'cheat-sheet',
+    'TacticsCheatSheet' : 'tactics-cheat-sheet',
     'FunctionalProgramming' : 'programming',
     'ProofIntro' : 'proof',
     'Reference' : 'reference',


### PR DESCRIPTION
## Summary

Adds a new user-facing doc page, [`TacticsCheatSheet.md`](gh_pages/doc/TacticsCheatSheet.md), with one-line semantics for every proof-language construct in Deduce plus a "Common pitfalls" section covering the things you have to discover by trial otherwise (silent `auto`-rule goal collapse, `lemma` privacy, `replace` direction, `ℕ0`/`zero`/`lit(zero)` non-unification, conjunction building vs destructuring, numeric-literal reduction).

It complements rather than overlaps the two existing docs:

- [CheatSheet.md](gh_pages/doc/CheatSheet.md) — strategy advice keyed by goal shape.
- [Reference.md](gh_pages/doc/Reference.md) — long-form alphabetical entries.

## What's wired up

- `gh_pages/scripts/convert.py` — `TacticsCheatSheet` registered in all four metadata dicts so the site build emits `tactics-cheat-sheet.html`.
- `gh_pages/doc/Index.md` — new "Tactics Cheat Sheet" button next to "Cheat Sheet" in the "Need Help?" block.
- `docs/knowledge-base/what-to-update.md` — added a row for keeping `TacticsCheatSheet.md` in sync, plus a paragraph documenting what to do when adding any new top-level page (the four convert.py dicts plus an Index.md link), so this isn't accidentally rediscovered next time.
- `CLAUDE.md` — new "Writing proofs" section points future agents at the three docs in the right order.

## Notes for reviewer

- No existing docs were edited beyond `Index.md` (one new button) and the internal `what-to-update.md`.
- Tone is user-neutral; nothing in the doc presupposes Claude as the audience.
- The "Common pitfalls" section names specific stdlib lemmas as concrete examples (`mult_to_zero`, `pos_mult_both_sides_of_less`). If you'd rather keep those examples generic to avoid coupling docs to specific lemma names, easy to drop.

## Test plan

- [x] `python3 gh_pages/scripts/convert.py` rebuilds successfully and emits `tactics-cheat-sheet.html`.
- [x] `python3 test-deduce.py --site` passes — the entangled-code generator produces an empty `doc_tactics-cheat-sheet.pf` (matching the existing `doc_cheat-sheet.pf` pattern, since neither markdown file has `{.deduce^...}` blocks).
- [ ] Visual check: render `tactics-cheat-sheet.html` locally and confirm tables look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)