### PR TITLE
Refresh Standard Library page and document module conventions

### DIFF
--- a/docs/knowledge-base/what-to-update.md
+++ b/docs/knowledge-base/what-to-update.md
@@ -24,3 +24,10 @@ Any changes to the Deduce syntax should be reflected in the following places:
 **External:**
 - [deduce-mode (vscode)](https://github.com/HalflingHelper/deduce-mode#): Deduce extension for vscode.
 - [deduce-mode (emacs)](https://github.com/mateidragony/deduce-mode#): Deduce package for emacs.
+
+## Adding a new standard-library module
+
+When a new top-level module is added under `lib/`, update:
+
+- `gh_pages/doc/StandardLib.md`: add an entry for the new module (alphabetical order). Only list top-level module files — private helper files (e.g. `UIntAdd.pf`, `NatDiv.pf`) that are `public import`-ed from a main module should not be listed. If the module defines theorems, link both `<Name>.thm` and `<Name>.pf`; otherwise link only `<Name>.pf`.
+- `lib/README.md`: keep the naming-convention notes accurate if the module introduces a new type prefix (e.g. `uint`, `nat`).

--- a/gh_pages/doc/StandardLib.md
+++ b/gh_pages/doc/StandardLib.md
@@ -2,14 +2,16 @@
 
 This section provides links to the theorems defined in the Deduce standard library along with the source files for the Deduce standard library.
 
+Only the top-level module files (such as `UInt.pf`) are listed below. Each module may be split internally across several private helper files (for example, `UIntAdd.pf`, `UIntMult.pf`, ...) that are publicly imported from the main module file; users should import the module by its top-level name.
+
 - ([`Base.thm`](../lib/Base.thm), [`Base.pf`](../lib/Base.pf)): Base proofs about propositional and predicate logic
+- ([`BigO.thm`](../lib/BigO.thm), [`BigO.pf`](../lib/BigO.pf)): Big-O asymptotic analysis on `fn UInt -> UInt`
 - ([`Int.thm`](../lib/Int.thm), [`Int.pf`](../lib/Int.pf)): Integers
 - ([`List.thm`](../lib/List.thm), [`List.pf`](../lib/List.pf)): Lists
-- ([`Log.thm`](../lib/Log.thm), [`Log.pf`](../lib/Log.pf)): Logarithms on natural numbers
 - ([`Maps.thm`](../lib/Maps.thm), [`Maps.pf`](../lib/Maps.pf)): Functional maps
 - ([`MultiSet.thm`](../lib/MultiSet.thm), [`MultiSet.pf`](../lib/MultiSet.pf)): Multisets
 - ([`Nat.thm`](../lib/Nat.thm), [`Nat.pf`](../lib/Nat.pf)): Natural numbers
 - ([`Option.pf`](../lib/Option.pf)): Optional values
 - ([`Pair.pf`](../lib/Pair.pf)): Pairs
 - ([`Set.thm`](../lib/Set.thm), [`Set.pf`](../lib/Set.pf)): Sets
-- ([`Sums.thm`](../lib/Sums.thm), [`Sums.pf`](../lib/Sums.pf)): Proofs of summation formulae
+- ([`UInt.thm`](../lib/UInt.thm), [`UInt.pf`](../lib/UInt.pf)): Unsigned integers

--- a/lib/README.md
+++ b/lib/README.md
@@ -7,3 +7,15 @@
 * The third word is the second function or operator, if applicable.
 * The rest of the name is descriptive.
 
+## Module Files
+
+A module is the top-level file with the module's name (for example, `UInt.pf`).
+Larger modules are split internally across several helper files (for example,
+`UIntDefs.pf`, `UIntAdd.pf`, `UIntMult.pf`, ...) that are `public import`-ed
+from the main module file. Users of the standard library should import only the
+top-level module (e.g. `import UInt`); the helper files are private
+implementation details.
+
+When you add a new top-level module here, also add it to the user-facing list
+in `gh_pages/doc/StandardLib.md`. See `docs/knowledge-base/what-to-update.md`.
+


### PR DESCRIPTION
## Summary

Fixes #285.

- The Standard Library page (`gh_pages/doc/StandardLib.md`) was missing an entry for `UInt` and the newer `BigO` module, and it still linked to the now-removed `Log` and `Sums` modules. Updated the list to match `lib/`.
- Added a note at the top of the page clarifying that only top-level module files are listed; helper files like `UIntAdd.pf`, `UIntMult.pf`, `NatDefs.pf`, etc. are `public import`-ed from a main module file and are private implementation details.
- Added matching reminders in `lib/README.md` (a "Module Files" section) and `docs/knowledge-base/what-to-update.md` (a new "Adding a new standard-library module" section) so future module additions get reflected on the docs page.

## Test plan

- [ ] Verify the rendered Standard Library page on the Deploy-to-GitHub-Pages preview links correctly to `UInt.thm`/`UInt.pf` and `BigO.thm`/`BigO.pf` (these `.thm` files are auto-generated by `gh_pages/scripts/lib_generate.py` at build time).
- [ ] Confirm `Log` and `Sums` no longer appear in the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)