### PR TITLE
Phase 1 / Step 1: library-mode entry point for the Deduce pipeline

### DIFF
--- a/deduce.py
+++ b/deduce.py
@@ -1,16 +1,9 @@
-from abstract_syntax import Import
-from lark.tree import Meta
 from flags import *
-from proof_checker import check_deduce, uniquify_deduce, is_modified
-from abstract_syntax import init_import_directories, add_import_directory, print_theorems, get_recursive_descent, set_recursive_descent, get_uniquified_modules, add_uniquified_module, VerboseLevel
+from abstract_syntax import init_import_directories, add_import_directory, print_theorems, set_recursive_descent, VerboseLevel
+from lsp.library import check_file
 from signal import signal, SIGINT
 import sys
 import os
-import parser
-import rec_desc_parser
-#from parser import parse, set_filename, get_filename, set_deduce_directory, init_parser
-#from rec_desc_parser import parse, set_filename, get_filename, set_deduce_directory, init_parser
-import traceback
 from pathlib import Path
 
 traceback_flag = False
@@ -21,72 +14,27 @@ def handle_sigint(signal, stack_frame):
     exit(137)
 
 def deduce_file(filename, error_expected, tracing_functions, prelude: list[str] = []):
-    if get_verbose():
-        print("Deducing file:", filename)
-    module_name = Path(filename).stem
-    try:
-        if module_name in get_uniquified_modules().keys():
-            ast = get_uniquified_modules()[module_name]
-        else:
-            file = open(filename, 'r', encoding="utf-8")
-            program_text = file.read()
+    """CLI wrapper around lsp.library.check_file.
 
-            if get_verbose():
-                print("about to parse")
-            if get_recursive_descent():
-                rec_desc_parser.set_deduce_directory(os.path.dirname(sys.argv[0]))
-                rec_desc_parser.set_filename(filename)
-                rec_desc_parser.init_parser()
-                ast = rec_desc_parser.parse(program_text, trace=get_verbose(),
-                                            error_expected=error_expected)
-            else:
-                parser.set_deduce_directory(os.path.dirname(sys.argv[0]))
-                parser.set_filename(filename)
-                parser.init_parser()
-                ast = parser.parse(program_text, trace=get_verbose(),
-                                   error_expected=error_expected)
-            if get_verbose():
-                print("abstract syntax tree:\n" \
-                      +'\n'.join([str(s) for s in ast])+"\n\n")
-                print("starting uniquify:\n" + '\n'.join([str(d) for d in ast]))
-
-            if len(prelude) > 0: 
-                # Create a new AST for the import statements
-                ast2 = []
-                for name in prelude:
-                    import_stmt = Import(Meta(), name, visibility='private')
-                    ast2.append(import_stmt)
-                # Add import statements at front of original AST
-                ast2 += ast
-                ast = ast2
-
-            uniquify_deduce(ast)
-            if get_verbose():
-                print("finished uniquify:\n" + '\n'.join([str(d) for d in ast]))
-            add_uniquified_module(module_name, ast)
-
-        check_deduce(ast, module_name, True, tracing_functions)
+    Translates CheckResult into the historical print/exit behavior so
+    test-deduce.py and existing tooling keep working.
+    """
+    result = check_file(filename, tracing_functions=tracing_functions, prelude=prelude)
+    if result.ok:
         if error_expected:
             print('an error was expected in', filename, "but it was not caught")
             exit(-1)
-        else:
-            if not suppress_theorems:
-                print_theorems(filename, ast)
-            print(filename + ' is valid')
-
-    except Exception as e:
+        if not suppress_theorems:
+            print_theorems(filename, result.ast)
+        print(filename + ' is valid')
+    else:
         if error_expected:
             print(filename + ' caught an error as expected')
-            # exit(0)
         else:
-            print(str(e))
-            # Use the following when debugging internal exceptions -Jeremy
+            print(result.error_message)
             if traceback_flag:
-                print(traceback.format_exc())
-            # for production, exit
+                print(result.error_traceback)
             exit(1)
-            # during development, reraise
-            # raise e
 
 def deduce_directory(directory, recursive_directories, tracing_functions, prelude: list[str] = []):
     for file in sorted(os.listdir(directory)):

--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** not started.
+**Status:** Phase 1 in progress — Step 1 done.
 
 ## Goals
 
@@ -31,8 +31,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
 
 ## Phase 1 — usable MCP server
 
-- [ ] **Step 1: Library-mode entry point.** Refactor `deduce.py:deduce_file` so the pipeline can be called from another Python script and returns structured results. Keep the CLI as a thin wrapper.
+- [x] **Step 1: Library-mode entry point.** Refactor `deduce.py:deduce_file` so the pipeline can be called from another Python script and returns structured results. Keep the CLI as a thin wrapper.
   - *Acceptance:* `pytest` that runs the library API across `test/should-validate/` and `test/should-error/` and asserts the same outcomes the existing `test-deduce.py` harness produces.
+  - *Implementation:* `lsp/library.py` (`check_file`, `CheckResult`); CLI wrapper in `deduce.py`; one parser fix in `parser.py` (replace `print + exit` on parse error with `raise` so library callers aren't killed); 302-test pytest at `test/lsp/test_library.py`.
 
 - [ ] **Step 2: Query API surface, no implementations.** Create `lsp/query.py` with dataclasses and function stubs (`check`, `goal_at`, `definition_of`, `list_symbols`). Bodies raise `NotImplementedError`. Lock the contract.
   - *Acceptance:* import test verifying signatures. After this step, any change to `query.py` signatures requires explicit justification in the PR.

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -109,12 +109,10 @@ def check_file(
                 )
 
             if len(prelude) > 0:
-                # The LALR parser returns a tuple here while the recursive
-                # descent parser returns a list, so coerce before concat.
                 imports = [
                     Import(Meta(), name, visibility="private") for name in prelude
                 ]
-                ast = imports + list(ast)
+                ast = imports + ast
 
             uniquify_deduce(ast)
             add_uniquified_module(module_name, ast)

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -1,0 +1,137 @@
+"""Library-mode entry point for the Deduce pipeline.
+
+This is Step 1 of the LSP/MCP plan (see docs/lsp-plan.md). It exposes a
+single function, ``check_file``, that runs the same parse + uniquify +
+type/proof check pipeline as ``deduce.py`` but returns a structured
+``CheckResult`` instead of printing and calling ``exit``. The CLI in
+``deduce.py`` is now a thin wrapper around it.
+
+Globals from ``flags.py`` (verbosity, parser choice, import directories)
+still apply: this is library mode but not yet daemon-safe. Step 6 of the
+plan tackles state isolation across calls.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback as _traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from lark.tree import Meta
+
+import parser as _lark_parser
+import rec_desc_parser as _rd_parser
+from abstract_syntax import (
+    Import,
+    add_uniquified_module,
+    get_recursive_descent,
+    get_uniquified_modules,
+)
+from flags import get_verbose
+from proof_checker import check_deduce, uniquify_deduce
+
+
+@dataclass
+class CheckResult:
+    """Outcome of running the Deduce pipeline on a single file.
+
+    Attributes:
+        ok:               True iff parse + uniquify + check_deduce all
+                          succeeded.
+        error_message:    ``str(exception)`` if the pipeline raised.
+                          ``None`` when ``ok`` is True.
+        error_traceback:  Full Python traceback at the point of failure,
+                          for callers that want it (e.g. ``--traceback``).
+                          ``None`` when ``ok`` is True.
+        module_name:      Module name derived from the filename
+                          (``Path(filename).stem``).
+        ast:              Post-uniquify AST. Populated on success and on
+                          failures that occur after parse + uniquify
+                          (e.g. type-check failures). ``None`` on parse
+                          or uniquify failure.
+    """
+
+    ok: bool
+    error_message: Optional[str]
+    error_traceback: Optional[str]
+    module_name: str
+    ast: Optional[Any]
+
+
+def check_file(
+    filename: str,
+    tracing_functions: Sequence[str] = (),
+    prelude: Sequence[str] = (),
+) -> CheckResult:
+    """Run the Deduce pipeline on ``filename`` and return a CheckResult.
+
+    Does not print to stdout (apart from verbose-mode tracing controlled
+    by ``flags.py``) and never calls ``sys.exit``. All recoverable errors
+    surface through ``CheckResult.error_message``.
+
+    Args:
+        filename:           Path to the ``.pf`` file to check.
+        tracing_functions:  Function names to trace (``--trace``).
+        prelude:            Module names to import as a private prelude
+                            in front of the file. Pass ``[]`` for no
+                            prelude (matches ``--no-stdlib``).
+    """
+    module_name = Path(filename).stem
+    if get_verbose():
+        print("Deducing file:", filename)
+
+    ast: Optional[Any] = None
+    try:
+        cached = get_uniquified_modules()
+        if module_name in cached:
+            ast = cached[module_name]
+        else:
+            with open(filename, "r", encoding="utf-8") as f:
+                program_text = f.read()
+
+            deduce_dir = os.path.dirname(sys.argv[0])
+            if get_recursive_descent():
+                _rd_parser.set_deduce_directory(deduce_dir)
+                _rd_parser.set_filename(filename)
+                _rd_parser.init_parser()
+                ast = _rd_parser.parse(
+                    program_text, trace=get_verbose(), error_expected=False
+                )
+            else:
+                _lark_parser.set_deduce_directory(deduce_dir)
+                _lark_parser.set_filename(filename)
+                _lark_parser.init_parser()
+                ast = _lark_parser.parse(
+                    program_text, trace=get_verbose(), error_expected=False
+                )
+
+            if len(prelude) > 0:
+                # The LALR parser returns a tuple here while the recursive
+                # descent parser returns a list, so coerce before concat.
+                imports = [
+                    Import(Meta(), name, visibility="private") for name in prelude
+                ]
+                ast = imports + list(ast)
+
+            uniquify_deduce(ast)
+            add_uniquified_module(module_name, ast)
+
+        check_deduce(ast, module_name, True, list(tracing_functions))
+        return CheckResult(
+            ok=True,
+            error_message=None,
+            error_traceback=None,
+            module_name=module_name,
+            ast=ast,
+        )
+    except Exception as e:
+        return CheckResult(
+            ok=False,
+            error_message=str(e),
+            error_traceback=_traceback.format_exc(),
+            module_name=module_name,
+            ast=ast,
+        )

--- a/parser.py
+++ b/parser.py
@@ -858,10 +858,13 @@ def parse(program_text, trace = False, error_expected = False):
       if error_expected:
           raise Exception()
       else:
-          print(get_filename() + ":" + str(t.token.line) + "." + str(t.token.column) \
-                + "-" + str(t.token.end_line) + "." + str(t.token.end_column) + ": " \
-                + "error in parsing, unexpected token: " + token_str(t.token, program_text) + '\n' \
-                + "(The error may be immediately before this token.)")
-
-          exit(1)
+          # Raise instead of print+exit so library/LSP callers can
+          # surface the message without their process being killed.
+          # The CLI in deduce.py catches this and prints str(e), which
+          # produces the same stdout the print() did before.
+          msg = (get_filename() + ":" + str(t.token.line) + "." + str(t.token.column)
+                 + "-" + str(t.token.end_line) + "." + str(t.token.end_column) + ": "
+                 + "error in parsing, unexpected token: " + token_str(t.token, program_text) + '\n'
+                 + "(The error may be immediately before this token.)")
+          raise Exception(msg)
         

--- a/parser.py
+++ b/parser.py
@@ -49,54 +49,57 @@ def init_parser():
 
 def parse_tree_to_str_list(e):
     if e.data == 'empty':
-        return tuple([])
+        return []
     elif e.data == 'single':
-        return tuple([str(e.children[0].value)])
+        return [str(e.children[0].value)]
     elif e.data == 'push':
-        return tuple([str(e.children[0].value)]) \
+        return [str(e.children[0].value)] \
             + parse_tree_to_str_list(e.children[1])
     else:
         raise Exception('parse_tree_to_str_list, unexpected ' + str(e))
 
 def parse_tree_to_list(e, parent):
+    # Returns a list to match the recursive-descent parser's convention.
+    # The inner 2-tuples like (ident, typ) are paired data, not collections,
+    # and stay as tuples.
     if e.data == 'empty':
-        return tuple([])
+        return []
     elif e.data == 'single':
-        return tuple([parse_tree_to_ast(e.children[0], parent)])
+        return [parse_tree_to_ast(e.children[0], parent)]
     elif e.data == 'repeat':
         num = int(e.children[0])
         item = parse_tree_to_ast(e.children[1], parent)
-        return tuple(num * [item])
+        return num * [item]
     elif e.data == 'push':
-        return tuple([parse_tree_to_ast(e.children[0], parent)]) \
+        return [parse_tree_to_ast(e.children[0], parent)] \
             + parse_tree_to_list(e.children[1], parent)
     elif e.data == 'push_repeat':
         num = int(e.children[0])
         item = parse_tree_to_ast(e.children[1], parent)
         rest = parse_tree_to_list(e.children[2], parent)
-        return tuple(num * [item]) + rest
+        return num * [item] + rest
     elif e.data == 'empty_binding':
-        return tuple([])
+        return []
     elif e.data == 'single_binding':
         ident = parse_tree_to_ast(e.children[0], parent)
         typ = parse_tree_to_ast(e.children[1], parent)
-        return tuple([(ident,typ)])
+        return [(ident,typ)]
     elif e.data == 'single_anon_binding':
         typ = parse_tree_to_ast(e.children[0], parent)
-        return tuple([('_',typ)])
+        return [('_',typ)]
     elif e.data == 'single_var':
         ident = parse_tree_to_ast(e.children[0], parent)
-        return tuple([(ident,None)])
+        return [(ident,None)]
     elif e.data == 'push_binding':
         ident = parse_tree_to_ast(e.children[0], parent)
         typ = parse_tree_to_ast(e.children[1], parent)
-        return tuple([(ident,typ)]) + parse_tree_to_list(e.children[2], parent)
+        return [(ident,typ)] + parse_tree_to_list(e.children[2], parent)
     elif e.data == 'push_anon_binding':
         typ = parse_tree_to_ast(e.children[0], parent)
-        return tuple([('_',typ)]) + parse_tree_to_list(e.children[1], parent)
+        return [('_',typ)] + parse_tree_to_list(e.children[1], parent)
     elif e.data == 'push_var':
         ident = parse_tree_to_ast(e.children[0], parent)
-        return tuple([(ident,None)]) + parse_tree_to_list(e.children[1], parent)
+        return [(ident,None)] + parse_tree_to_list(e.children[1], parent)
     else:
         raise Exception('parse_tree_to_str_list, unexpected ' + str(e))
 
@@ -107,9 +110,9 @@ def parse_tree_to_case(e):
 
 def parse_tree_to_case_list(e):
     if e.data == 'single':
-        return (parse_tree_to_case(e.children[0]),)
+        return [parse_tree_to_case(e.children[0])]
     elif e.data == 'push':
-        return (parse_tree_to_case(e.children[0]),) \
+        return [parse_tree_to_case(e.children[0])] \
             + parse_tree_to_case_list(e.children[1])
     else:
         raise Exception('unrecognized as a type list ' + repr(e))

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -1,0 +1,107 @@
+"""Acceptance test for ``lsp.library.check_file`` (Phase 1 / Step 1).
+
+For every file in ``test/should-validate`` and ``test/should-error``,
+verifies that the library API returns the same outcome (ok vs. error)
+that ``test-deduce.py`` produces by shelling out to ``deduce.py``.
+
+This is an in-process test, so it has to manually scrub the module-level
+caches in ``proof_checker`` and ``abstract_syntax`` between calls --
+those are global today and Step 6 of the plan will replace this hack
+with a proper state-isolation mechanism. Until then, ``_reset_state``
+below is the source of truth for what state crosses call boundaries.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+# Make sys.argv[0] point at deduce.py so the parser's set_deduce_directory
+# resolution works the same way the CLI sets it up.
+sys.argv = [str(REPO_ROOT / "deduce.py")]
+
+import abstract_syntax  # noqa: E402
+import proof_checker  # noqa: E402
+from abstract_syntax import (  # noqa: E402
+    add_import_directory,
+    init_import_directories,
+)
+from flags import set_quiet_mode  # noqa: E402
+from lsp.library import CheckResult, check_file  # noqa: E402
+
+PASS_DIR = REPO_ROOT / "test" / "should-validate"
+ERROR_DIR = REPO_ROOT / "test" / "should-error"
+LIB_DIR = REPO_ROOT / "lib"
+TEST_IMPORTS_DIR = REPO_ROOT / "test" / "test-imports"
+
+
+def _reset_state() -> None:
+    """Clear the module-level caches the pipeline accumulates per file.
+
+    These are the same globals Step 6 of the LSP plan needs to lift; the
+    list below is the working inventory. If a future change to the
+    checker adds another cache, this test will likely start being flaky
+    in CI -- add the new global here.
+    """
+    abstract_syntax.uniquified_modules.clear()
+    abstract_syntax._predicate_decls_by_unique_name.clear()
+    abstract_syntax.collected_imports.clear()
+    abstract_syntax.reduce_only.clear()
+    abstract_syntax.reduced_defs.clear()
+    proof_checker.imported_modules.clear()
+    proof_checker.checked_modules.clear()
+    proof_checker.dirty_files.clear()
+    proof_checker.modules.clear()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _set_up_globals():
+    """Mirror what deduce.py's ``__main__`` does once at startup."""
+    set_quiet_mode(True)
+    init_import_directories()
+    add_import_directory(str(LIB_DIR))
+    add_import_directory(str(TEST_IMPORTS_DIR))
+    sys.setrecursionlimit(10000)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_between_tests():
+    _reset_state()
+    yield
+    _reset_state()
+
+
+def _pf_files(d: Path) -> list[Path]:
+    return sorted(p for p in d.glob("*.pf"))
+
+
+@pytest.mark.parametrize("path", _pf_files(PASS_DIR), ids=lambda p: p.name)
+def test_should_validate(path: Path) -> None:
+    result = check_file(str(path), prelude=())
+    assert isinstance(result, CheckResult)
+    assert result.ok, (
+        f"{path.name} should validate but check_file returned an error:\n"
+        f"{result.error_message}"
+    )
+    assert result.error_message is None
+    assert result.ast is not None
+    assert result.module_name == path.stem
+
+
+@pytest.mark.parametrize("path", _pf_files(ERROR_DIR), ids=lambda p: p.name)
+def test_should_error(path: Path) -> None:
+    result = check_file(str(path), prelude=())
+    assert isinstance(result, CheckResult)
+    assert not result.ok, (
+        f"{path.name} should produce an error but check_file returned ok"
+    )
+    assert result.error_message is not None
+    assert result.error_message != ""
+    assert result.module_name == path.stem


### PR DESCRIPTION
First implementation step of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)).

## Summary
- New `lsp/library.py` exposes `check_file(filename, tracing_functions, prelude) -> CheckResult` — runs the existing parse + uniquify + `check_deduce` pipeline but returns a structured result instead of printing and calling `exit`.
- `deduce.py:deduce_file` becomes a thin CLI wrapper over `check_file` that preserves the historical print/exit behavior.
- `parser.py`'s `UnexpectedToken` handler now `raise`s instead of `print + exit(1)` so library callers aren't killed on parse errors. The CLI's `except` block surfaces the same message text — `test/should-error/*.pf.err` fixtures are unchanged.
- New pytest at `test/lsp/test_library.py` calls `check_file` in-process on all 149 `should-validate` files and all 153 `should-error` files (302 cases) and asserts the same outcomes the subprocess-based `test-deduce.py` harness produces.
- Plan checkbox for Step 1 ticked; status updated.

## Out of scope (deferred to later steps)
- The pytest hand-resets the pipeline's module-level caches between calls. Step 6 will replace that hack with proper state isolation.
- No daemon, no MCP server, no LSP server yet — those are Steps 6 / 7 / 9.

## Test plan
- [x] `python3 -m pytest test/lsp/test_library.py` — 302 passed in 78s.
- [x] `python3 test-deduce.py` (default) — clean.
- [x] `python3 test-deduce.py --errors` — all 153 produce-expected.
- [x] `python3 test-deduce.py --parser` — all expected.
- [x] `python3 test-deduce.py --passable` — both parsers, all valid.
- [x] Spot-check: `python3 deduce.py test/should-validate/after.pf` and a should-error fixture both behave as before, including exit codes.