### PR TITLE
Fix false postulate uint_log_add_le_log_mult (#294)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -262,14 +262,18 @@ end
 
 theorem log_sum_less_equal_product:
   all f:fn UInt -> UInt, g:fn UInt -> UInt.
-  log(f) + log(g) ≲ log(f * g)
+  if (all n:UInt. 0 < f(n)) and (all n:UInt. 0 < g(n))
+  then log(f) + log(g) ≲ log(f * g)
 proof
   arbitrary f:fn UInt -> UInt, g:fn UInt -> UInt
+  assume fg_pos
   expand operator≲ | operator+ | operator* | log
   choose 0, 1
   arbitrary n:UInt
   assume _
-  uint_log_add_le_log_mult
+  have f_pos: 0 < f(n) by fg_pos
+  have g_pos: 0 < g(n) by fg_pos
+  apply uint_log_add_le_log_mult to f_pos, g_pos
 end
 
 theorem log_product_equiv_sum:
@@ -281,7 +285,20 @@ proof
   assume fg_gt_1
   expand operator≈
   have A: log(f * g) ≲ log(f) + log(g) by apply log_product_less_equal_sum[f,g] to fg_gt_1
-  have B: log(f) + log(g) ≲ log(f * g) by log_sum_less_equal_product
+  have f_pos: all n:UInt. 0 < f(n) by {
+    arbitrary n:UInt
+    have one_lt_f: 1 < f(n) by fg_gt_1
+    have zero_lt_one: (0:UInt) < 1 by .
+    apply uint_less_trans to zero_lt_one, one_lt_f
+  }
+  have g_pos: all n:UInt. 0 < g(n) by {
+    arbitrary n:UInt
+    have one_lt_g: 1 < g(n) by fg_gt_1
+    have zero_lt_one: (0:UInt) < 1 by .
+    apply uint_less_trans to zero_lt_one, one_lt_g
+  }
+  have B: log(f) + log(g) ≲ log(f * g)
+    by apply log_sum_less_equal_product[f,g] to f_pos, g_pos
   A, B
 end
 

--- a/lib/UIntPowLog.pf
+++ b/lib/UIntPowLog.pf
@@ -558,10 +558,11 @@ proof
   }
 end
 
-// This postulate is false in general: e.g., m = 0, n = 4 gives
+// Without positivity premises this is false: e.g., m = 0, n = 4 gives
 //   log(0) + log(4) = 0 + 2 = 2, log(0 * 4) = log(0) = 0, but 2 ≤ 0 is false.
-// It would be true with the premise 0 < m and 0 < n.
-postulate uint_log_add_le_log_mult: all m:UInt, n:UInt. log(m) + log(n) ≤ log(m * n)
+postulate uint_log_add_le_log_mult: all m:UInt, n:UInt.
+  if 0 < m and 0 < n
+  then log(m) + log(n) ≤ log(m * n)
 
 // Difficult: a proof would proceed by case analysis on m = 0 and n = 0,
 // then for both positive use less_pow_log to bound m * n < 2^(2 + log(m) + log(n))


### PR DESCRIPTION
## Summary
- Add `0 < m and 0 < n` premise to the previously-false postulate `uint_log_add_le_log_mult` in `lib/UIntPowLog.pf`. Counterexample without the premise: `m = 0, n = 4` gives `log(0) + log(4) = 2` but `log(0 * 4) = 0`.
- Update the downstream `log_sum_less_equal_product` in `lib/BigO.pf` to require `(all n. 0 < f(n)) and (all n. 0 < g(n))`, since its previous proof relied on the unsound postulate.
- Propagate the new premise through `log_product_equiv_sum`, deriving `0 < f(n)` from the existing `1 < f(n)` hypothesis via `uint_less_trans`.

Closes #294.

## Test plan
- [x] `python3 test-deduce.py` passes (lib + should-validate + should-error + prelude, both `--recursive-descent` and `--lalr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)