### PR TITLE
Phase 1 / Step 2: lock the protocol-neutral query API surface

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 in progress — Step 1 done.
+**Status:** Phase 1 in progress — Steps 1–2 done.
 
 ## Goals
 
@@ -35,8 +35,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
   - *Acceptance:* `pytest` that runs the library API across `test/should-validate/` and `test/should-error/` and asserts the same outcomes the existing `test-deduce.py` harness produces.
   - *Implementation:* `lsp/library.py` (`check_file`, `CheckResult`); CLI wrapper in `deduce.py`; one parser fix in `parser.py` (replace `print + exit` on parse error with `raise` so library callers aren't killed); 302-test pytest at `test/lsp/test_library.py`.
 
-- [ ] **Step 2: Query API surface, no implementations.** Create `lsp/query.py` with dataclasses and function stubs (`check`, `goal_at`, `definition_of`, `list_symbols`). Bodies raise `NotImplementedError`. Lock the contract.
+- [x] **Step 2: Query API surface, no implementations.** Create `lsp/query.py` with dataclasses and function stubs (`check`, `goal_at`, `definition_of`, `list_symbols`). Bodies raise `NotImplementedError`. Lock the contract.
   - *Acceptance:* import test verifying signatures. After this step, any change to `query.py` signatures requires explicit justification in the PR.
+  - *Implementation:* `lsp/query.py` with 9 frozen dataclasses/enums (`Position`, `Range`, `Location`, `Diagnostic`, `Given`, `Goal`, `SymbolInfo`, `Severity`, `SymbolKind`) and 4 stub functions; `__all__` declared. `test/lsp/test_query.py` (21 tests) locks signatures, parameter names, return annotations, frozen-ness, `__all__` membership, stub-raises behavior, and statically asserts no protocol imports (`pygls`/`mcp`/`lsprotocol`/`anthropic`). Position convention: 1-indexed (matches Deduce error messages and lark Meta).
 
 - [ ] **Step 3: Implement `check`.** Convert raised `Exception` / `StaticError` / `IncompleteProof` into `Diagnostic` objects. Single-diagnostic mode is fine; multi-error collection is Step 10.
   - *Acceptance:* parallel to `test/should-error/*.pf.err` — assert each fixture produces a `Diagnostic` with the right line/severity.

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -1,0 +1,241 @@
+"""Protocol-neutral query API for the Deduce LSP/MCP servers.
+
+This module is the contract between the Deduce pipeline (``lsp.library``)
+and the protocol-specific adapters (``lsp.mcp_server`` from Step 7,
+``lsp.lsp_server`` from Step 9). It MUST NOT import ``pygls``, ``mcp``,
+or any other protocol library; both adapters translate to/from these
+types at their own boundary.
+
+The function signatures here are load-bearing. Per
+``docs/lsp-plan.md``, changes to ``__all__`` or to any signature in
+this module require an explicit justification in the PR description --
+the adapters are very thin and their wire-format mappings depend on
+the shapes here.
+
+Implementations are deferred to Steps 3-5; Step 2 only locks the
+surface, and every function below raises ``NotImplementedError`` when
+called.
+
+Position convention
+-------------------
+Positions are 1-indexed: line and column both start at 1. This matches
+the locations Deduce already prints in error messages and the lark
+``Meta`` objects produced by both parsers, so MCP callers see line
+numbers identical to ``deduce.py``'s output. The LSP adapter converts
+to LSP's 0-indexed convention at the wire boundary -- a single
+subtraction per coordinate.
+
+Range convention
+----------------
+Ranges are inclusive-start, exclusive-end -- the same convention as
+lark Meta and LSP. ``end`` points one position past the last covered
+character.
+
+Path convention
+---------------
+``path`` is a string filesystem path (absolute or relative to the
+working directory). Adapters that receive URIs convert to plain paths
+before calling. The pipeline uses ``path`` for import resolution and
+in user-visible error messages.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+__all__ = [
+    # Enums
+    "Severity",
+    "SymbolKind",
+    # Data types
+    "Position",
+    "Range",
+    "Location",
+    "Diagnostic",
+    "Given",
+    "Goal",
+    "SymbolInfo",
+    # Query functions
+    "check",
+    "goal_at",
+    "definition_of",
+    "list_symbols",
+]
+
+
+class Severity(Enum):
+    """Diagnostic severity level.
+
+    Adapters map this to their wire-format equivalents:
+    LSP uses integer ``DiagnosticSeverity`` (Error=1, Warning=2,
+    Information=3, Hint=4); MCP exposes the string ``value``.
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+    HINT = "hint"
+
+
+class SymbolKind(Enum):
+    """Kind of top-level Deduce declaration."""
+
+    THEOREM = "theorem"
+    LEMMA = "lemma"
+    FUNCTION = "function"
+    DEFINE = "define"
+    UNION = "union"
+    PREDICATE = "predicate"
+    POSTULATE = "postulate"
+    IMPORT = "import"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class Position:
+    """A 1-indexed (line, column) position in a source file."""
+
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
+class Range:
+    """An inclusive-start, exclusive-end range in a source file.
+
+    ``start`` and ``end`` refer to positions in the same file.
+    """
+
+    start: Position
+    end: Position
+
+
+@dataclass(frozen=True)
+class Location:
+    """A range tagged with the source file it lives in."""
+
+    path: str
+    range: Range
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """A single problem found while checking a file."""
+
+    severity: Severity
+    range: Range
+    message: str
+    # Optional short error code (e.g. ``"incomplete-proof"``). Reserved
+    # so adapters can plumb it through; the checker does not yet emit
+    # codes.
+    code: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Given:
+    """A bound hypothesis available at a proof point.
+
+    ``label`` is ``None`` for anonymous givens (premises without an
+    explicit label). ``formula`` is rendered text -- the same string
+    Deduce's printer would produce -- not an AST node, so the type
+    survives serialization across the MCP boundary.
+    """
+
+    label: Optional[str]
+    formula: str
+
+
+@dataclass(frozen=True)
+class Goal:
+    """The proof obligation visible at a source position.
+
+    Returned by :func:`goal_at`. ``formula`` is the goal as rendered
+    text. ``givens`` is a tuple (not list) so ``Goal`` stays hashable.
+    ``range`` is the source range the goal corresponds to -- typically
+    where the cursor or hole sits.
+    """
+
+    formula: str
+    givens: tuple
+    range: Range
+
+
+@dataclass(frozen=True)
+class SymbolInfo:
+    """A top-level declaration in a source file.
+
+    ``signature`` is rendered text suitable for editor hover or LSP
+    ``SignatureInformation``; ``None`` when not applicable (e.g. for
+    imports).
+    """
+
+    name: str
+    kind: SymbolKind
+    location: Location
+    signature: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Query functions
+# ---------------------------------------------------------------------------
+#
+# Each query takes both ``path`` and ``content``. Passing ``content``
+# explicitly means the LSP adapter can ship unsaved buffer contents
+# without writing to a temp file, while the MCP adapter just reads from
+# disk before calling. ``path`` is still required because import
+# resolution and error messages depend on it.
+
+
+def check(path: str, content: str) -> list[Diagnostic]:
+    """Run the full Deduce pipeline on ``content`` (treated as if it
+    were the contents of ``path``) and return all diagnostics found.
+
+    An empty list means the file is valid. The current pipeline raises
+    on the first error, so today the list will have at most one entry;
+    Step 11 (multi-error collection) will lift that limit without
+    changing this signature.
+
+    Implemented in Step 3.
+    """
+    raise NotImplementedError("Step 3 implements check.")
+
+
+def goal_at(path: str, content: str, pos: Position) -> Optional[Goal]:
+    """Return the proof obligation visible at ``pos``.
+
+    Returns ``None`` when there is no active proof at that position --
+    e.g. the cursor is outside any ``proof ... end`` block, or the file
+    does not parse. Implemented by inserting a ``?`` hole at ``pos``
+    and capturing the printed goal state.
+
+    Implemented in Step 4.
+    """
+    raise NotImplementedError("Step 4 implements goal_at.")
+
+
+def definition_of(
+    path: str, content: str, pos: Position
+) -> Optional[Location]:
+    """Return the source location of the symbol under ``pos``.
+
+    Returns ``None`` when there is no resolvable symbol at ``pos``
+    (whitespace, keyword, unparseable region) or when the definition
+    is outside any source file the server can see.
+
+    Implemented in Step 5.
+    """
+    raise NotImplementedError("Step 5 implements definition_of.")
+
+
+def list_symbols(path: str, content: str) -> list[SymbolInfo]:
+    """Return all top-level declarations in ``content``.
+
+    Used for editor outline views and the MCP ``list_symbols`` tool.
+    Includes theorems, lemmas, functions, defines, unions, predicates,
+    postulates, and imports; does not descend into nested definitions
+    inside proofs.
+
+    Implemented in Step 5.
+    """
+    raise NotImplementedError("Step 5 implements list_symbols.")

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -1,0 +1,194 @@
+"""Stub-level test that locks the protocol-neutral query API surface.
+
+Phase 1 / Step 2 of the LSP/MCP plan. The implementations come in
+Steps 3-5; this test pins the *signature* so an accidental edit to
+``lsp/query.py`` shows up as a test failure rather than a quietly
+broken adapter contract. It checks:
+
+* every public function raises ``NotImplementedError`` until its
+  dedicated step lands (the adapters can therefore be written against
+  these signatures today)
+* parameter names, return-type annotations, and ``__all__`` match
+  what the plan documents
+* the data types are frozen so adapters can't accidentally mutate
+  returned values
+* ``lsp/query.py`` imports nothing protocol-specific (no pygls, mcp,
+  lsprotocol, anthropic) -- if it ever does, the boundary is broken
+"""
+
+import inspect
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp import query  # noqa: E402
+from lsp.query import (  # noqa: E402
+    Diagnostic,
+    Given,
+    Goal,
+    Location,
+    Position,
+    Range,
+    Severity,
+    SymbolInfo,
+    SymbolKind,
+    check,
+    definition_of,
+    goal_at,
+    list_symbols,
+)
+
+
+# --------------------------------------------------------------------------
+# Module surface
+# --------------------------------------------------------------------------
+
+
+EXPECTED_PUBLIC = {
+    "Severity",
+    "SymbolKind",
+    "Position",
+    "Range",
+    "Location",
+    "Diagnostic",
+    "Given",
+    "Goal",
+    "SymbolInfo",
+    "check",
+    "goal_at",
+    "definition_of",
+    "list_symbols",
+}
+
+
+def test_all_matches_expected():
+    assert set(query.__all__) == EXPECTED_PUBLIC, (
+        "lsp/query.py __all__ has drifted from the plan; if this is "
+        "intentional, update docs/lsp-plan.md and the test together"
+    )
+
+
+def test_no_protocol_imports():
+    forbidden = ("pygls", "mcp", "lsprotocol", "anthropic")
+    source = Path(query.__file__).read_text()
+    for name in forbidden:
+        assert f"import {name}" not in source, (
+            f"lsp/query.py imports {name!r} -- breaks protocol neutrality"
+        )
+        assert f"from {name}" not in source, (
+            f"lsp/query.py imports from {name!r} -- breaks protocol neutrality"
+        )
+
+
+# --------------------------------------------------------------------------
+# Data-type shape
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [Position, Range, Location, Diagnostic, Given, Goal, SymbolInfo],
+)
+def test_dataclasses_are_frozen(cls):
+    """All public data types must be frozen so callers can't mutate
+    returned values in place."""
+    assert cls.__dataclass_params__.frozen, (
+        f"{cls.__name__} is not frozen; the API contract requires it"
+    )
+
+
+def test_severity_values():
+    # Strings rather than ints so MCP exposes a self-explanatory name.
+    assert {s.value for s in Severity} == {"error", "warning", "info", "hint"}
+
+
+def test_symbol_kinds_cover_top_level_forms():
+    expected = {
+        "theorem",
+        "lemma",
+        "function",
+        "define",
+        "union",
+        "predicate",
+        "postulate",
+        "import",
+        "other",
+    }
+    assert {k.value for k in SymbolKind} == expected
+
+
+def test_position_is_one_indexed_by_construction():
+    # Not enforced at runtime, but the docstring promises 1-indexed,
+    # and Position(1, 1) (the smallest valid value) must construct.
+    p = Position(1, 1)
+    assert p.line == 1 and p.column == 1
+
+
+def test_goal_givens_is_a_tuple():
+    """``Goal`` is hashable -- givens must be a tuple, not a list."""
+    g = Goal(formula="P", givens=(), range=Range(Position(1, 1), Position(1, 2)))
+    hash(g)  # hashable iff all fields are hashable
+
+
+# --------------------------------------------------------------------------
+# Query function signatures
+# --------------------------------------------------------------------------
+
+
+def _check_sig(func, expected_params, expected_return):
+    sig = inspect.signature(func)
+    actual_params = [p.name for p in sig.parameters.values()]
+    assert actual_params == expected_params, (
+        f"{func.__name__} parameter names drifted: "
+        f"expected {expected_params}, got {actual_params}"
+    )
+    assert sig.return_annotation == expected_return, (
+        f"{func.__name__} return annotation drifted: "
+        f"expected {expected_return!r}, got {sig.return_annotation!r}"
+    )
+
+
+def test_check_signature():
+    _check_sig(check, ["path", "content"], list[Diagnostic])
+
+
+def test_goal_at_signature():
+    _check_sig(goal_at, ["path", "content", "pos"], Optional[Goal])
+
+
+def test_definition_of_signature():
+    _check_sig(definition_of, ["path", "content", "pos"], Optional[Location])
+
+
+def test_list_symbols_signature():
+    _check_sig(list_symbols, ["path", "content"], list[SymbolInfo])
+
+
+# --------------------------------------------------------------------------
+# Stubs raise NotImplementedError until the dedicated step lands
+# --------------------------------------------------------------------------
+
+
+def test_check_stub_raises():
+    with pytest.raises(NotImplementedError):
+        check("file.pf", "")
+
+
+def test_goal_at_stub_raises():
+    with pytest.raises(NotImplementedError):
+        goal_at("file.pf", "", Position(1, 1))
+
+
+def test_definition_of_stub_raises():
+    with pytest.raises(NotImplementedError):
+        definition_of("file.pf", "", Position(1, 1))
+
+
+def test_list_symbols_stub_raises():
+    with pytest.raises(NotImplementedError):
+        list_symbols("file.pf", "")


### PR DESCRIPTION
Step 2 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)).

**Stacked on [#298](https://github.com/jsiek/deduce/pull/298)** — base will auto-update to `main` when #298 merges. Review #298 first.

## What this is

Just the API surface — types and stub functions. No implementations; every function raises `NotImplementedError`. Implementations land in Steps 3–5.

## Pinned design choices

All documented in `lsp/query.py`'s module docstring; calling them out here so reviewers can sanity-check before they get baked in:

- **Positions are 1-indexed.** Matches Deduce's existing error messages and lark `Meta` objects, so MCP tool calls see the same line numbers `deduce.py` prints. LSP adapter does a single subtraction at the wire boundary.
- **Ranges are inclusive-start, exclusive-end.** Same convention as lark Meta and LSP.
- **Frozen dataclasses.** Adapters can't accidentally mutate returned values. `Goal.givens` is a `tuple` (not a list) so `Goal` itself stays hashable.
- **String-valued `Severity` / `SymbolKind` enums.** LSP uses integers; the adapter maps.
- **Free functions, not methods.** If Step 6's daemon needs state, we'll wrap into a `Service` class then; the call sites stay the same shape.
- **`__all__` is declared,** and the test asserts it matches the expected set so additions/removals show up as test failures.

## Contract enforcement

`test/lsp/test_query.py` (21 tests) locks all of the above:
- `__all__` matches the documented surface
- a static source scan asserts `lsp/query.py` does not import `pygls`, `mcp`, `lsprotocol`, or `anthropic` (the protocol-neutral boundary)
- every dataclass is frozen (parametrized over the 7 data types)
- enum value sets match the plan
- function signatures: parameter names + return annotations
- every stub raises `NotImplementedError`

## Test plan
- [x] `python3 -m pytest test/lsp/test_query.py` — 21 passed in 0.09s.
- [x] `python3 -m pytest test/lsp/` — 323 passed (Step 1 + Step 2 in 78s).
- [x] No CLI/runtime touched, so `test-deduce.py` still passes (#298's matrix).