### PR TITLE
Phase 1 of Deduce-to-C compiler: minimum viable backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ tests-lib:
 
 tests: tests-should-validate tests-should-error
 
+tests-compile:
+	$(PYTHON) ./test/compile/run_lower.py
+	$(PYTHON) ./test/compile/run_e2e.py
+
 package:
 	$(PYTHON) ./deduce.py ./lib
 	mkdir deduce
@@ -46,3 +50,4 @@ clean:
 	rm -f ./lib/*.thm
 	rm -f ./test/should-validate/*.thm
 	rm -f deduce-release.zip
+	rm -f ./test/compile/lower/*.c ./test/compile/e2e/*.c

--- a/compiler/__init__.py
+++ b/compiler/__init__.py
@@ -1,0 +1,1 @@
+# Deduce-to-C compiler. See docs/compile-plan.md.

--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -1,0 +1,116 @@
+"""Closure conversion: hoist every `Lam` to a top-level `Function`.
+
+Input: an `ir.Program` produced by lowering, possibly containing
+`Lam` nodes inside function/global/print/assert bodies.
+
+Output: an `ir.Program` with no `Lam` nodes. Each lambda becomes:
+  - a fresh top-level `Function` whose `captures` list records the
+    free variables that were in scope at the lambda's site, and
+  - an `MkClosure(fn_name, [Var(fv) for fv in captures])` at the
+    lambda's original position.
+
+Top-level user-defined functions remain as they were — they cannot be
+captured and never gain a `captures` list. References to top-level
+names appearing as the rator of `App` are direct calls; references to
+top-level names used as first-class values are not yet supported and
+raise `CompileError` in the emitter, not here.
+
+Pure rewriting; no I/O, no globals.
+"""
+
+from __future__ import annotations
+
+from typing import List, Set
+
+from compiler import ir
+
+
+def closure_convert(p: ir.Program) -> ir.Program:
+    top_names: Set[str] = set()
+    for d in p.decls:
+        if isinstance(d, (ir.Function, ir.Global)):
+            top_names.add(d.name)
+        elif isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                top_names.add(c.name)
+
+    # The `lifted` list collects new top-level Functions produced by
+    # hoisting lambdas. Generated names use `$lam<n>` so they cannot
+    # collide with Deduce's uniquified names (which never contain `$`).
+    lifted: List[ir.Function] = []
+    counter = [0]
+
+    def fresh_lam_name() -> str:
+        counter[0] += 1
+        return f"$lam{counter[0]}"
+
+    def go(t: ir.Term) -> ir.Term:
+        match t:
+            case ir.Var(_) | ir.Bool(_) | ir.Int(_):
+                return t
+            case ir.Lam(params, body):
+                # Convert the body first so any nested Lam is hoisted
+                # and the body is now lambda-free.
+                new_body = go(body)
+                # Free vars of the original lambda; deterministic order
+                # (sorted) so the generated `captures` list and the
+                # corresponding `MkClosure` args are stable across runs.
+                fvs = sorted(ir.free_vars(t) - top_names)
+                fn_name = fresh_lam_name()
+                lifted.append(ir.Function(
+                    name=fn_name,
+                    params=list(params),
+                    body=new_body,
+                    captures=list(fvs),
+                ))
+                return ir.MkClosure(
+                    fn_name=fn_name,
+                    captures=[ir.Var(fv) for fv in fvs],
+                )
+            case ir.MkClosure(fn, caps):
+                # Already converted; recurse into capture expressions
+                # in case some are themselves complex terms (current
+                # converter only puts Vars there, but be defensive).
+                return ir.MkClosure(fn, [go(c) for c in caps])
+            case ir.App(rator, args):
+                return ir.App(go(rator), [go(a) for a in args])
+            case ir.Let(name, rhs, body):
+                return ir.Let(name, go(rhs), go(body))
+            case ir.If(c, th, el):
+                return ir.If(go(c), go(th), go(el))
+            case ir.Con(ctor, args):
+                return ir.Con(ctor, [go(a) for a in args])
+            case ir.Match(subj, arms):
+                new_arms = [ir.MatchArm(arm.pattern, go(arm.body)) for arm in arms]
+                return ir.Match(go(subj), new_arms)
+        raise AssertionError(f"closure_convert: unknown term {type(t).__name__}")
+
+    new_decls: List[ir.TopLevel] = []
+    for d in p.decls:
+        match d:
+            case ir.UnionDecl():
+                new_decls.append(d)
+            case ir.Function(name, params, body, captures):
+                if captures:
+                    raise AssertionError(
+                        "closure_convert: input already has lifted functions; "
+                        "refusing to convert a converted program"
+                    )
+                new_decls.append(ir.Function(
+                    name=name, params=list(params),
+                    body=go(body), captures=[],
+                ))
+            case ir.Global(name, body):
+                new_decls.append(ir.Global(name=name, body=go(body)))
+            case ir.Print(t):
+                new_decls.append(ir.Print(go(t)))
+            case ir.AssertEq(l, r):
+                new_decls.append(ir.AssertEq(go(l), go(r)))
+            case ir.AssertBool(t):
+                new_decls.append(ir.AssertBool(go(t)))
+            case _:
+                raise AssertionError(
+                    f"closure_convert: unknown top-level {type(d).__name__}"
+                )
+
+    return ir.Program(decls=new_decls + lifted)

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -1,0 +1,440 @@
+"""Emit C source from a closure-converted IR program.
+
+The output `#include`s `deduce.h` (the runtime header). Every Deduce
+value is a `deduce_value` (opaque pointer); every function takes
+`(deduce_value* env, deduce_value* args)` and returns `deduce_value`.
+
+Top-level functions are emitted as `static deduce_value F_<mangled>(...)`.
+Top-level globals are emitted as `static deduce_value G_<mangled>;` and
+their initialisation is appended to `deduce_program_main`. Print and
+assert statements are appended to `deduce_program_main` in source order.
+
+Emit is purely functional in the IR: walks the program once, builds a
+list of strings, joins. No global state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Set, Tuple
+
+from compiler import ir
+
+
+class EmitError(Exception):
+    pass
+
+
+# --------------------------------------------------------------------------
+# Name mangling
+# --------------------------------------------------------------------------
+
+def _mangle(name: str) -> str:
+    """Turn a Deduce uniquified name (which may contain `.`, `<`, `>`,
+    digits, operator characters) into a valid C identifier suffix."""
+    out: List[str] = []
+    for c in name:
+        if c.isalnum() or c == "_":
+            out.append(c)
+        elif c == ".":
+            out.append("_")
+        elif c == "$":
+            out.append("__")  # generated names like `$lam1`
+        else:
+            out.append(f"_x{ord(c):02x}")
+    s = "".join(out)
+    # First char must be a letter or underscore. Prefix if needed.
+    if not (s and (s[0].isalpha() or s[0] == "_")):
+        s = "_" + s
+    return s
+
+
+def _func_id(name: str) -> str:
+    return "F_" + _mangle(name)
+
+
+def _global_id(name: str) -> str:
+    return "G_" + _mangle(name)
+
+
+def _local_id(name: str) -> str:
+    return "v_" + _mangle(name)
+
+
+def _ctor_id_macro(name: str) -> str:
+    return "CTOR_" + _mangle(name)
+
+
+def _base_name(name: str) -> str:
+    """Strip the uniquify suffix. Mirrors `abstract_syntax.base_name`
+    but local so emit_c.py has no dependency on the AST module."""
+    return name.split(".", 1)[0]
+
+
+def _c_string(s: str) -> str:
+    out = ['"']
+    for ch in s:
+        b = ch.encode("utf-8")
+        for byte in b:
+            if 0x20 <= byte < 0x7f and byte not in (ord('"'), ord("\\")):
+                out.append(chr(byte))
+            else:
+                out.append("\\x%02x" % byte)
+    out.append('"')
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------
+# Emit context
+# --------------------------------------------------------------------------
+
+@dataclass
+class EmitCtx:
+    top_funcs: Dict[str, int] = field(default_factory=dict)   # name -> arity
+    top_globals: Set[str] = field(default_factory=set)
+    ctor_ids: Dict[str, int] = field(default_factory=dict)
+    ctor_arities: Dict[str, int] = field(default_factory=dict)
+    tmp_counter: int = 0
+
+    def fresh_tmp(self) -> str:
+        n = self.tmp_counter
+        self.tmp_counter += 1
+        return f"t{n}"
+
+
+def emit_program(p: ir.Program) -> str:
+    ctx = EmitCtx()
+    next_ctor_id = 0
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                ctx.ctor_ids[c.name] = next_ctor_id
+                ctx.ctor_arities[c.name] = c.arity
+                next_ctor_id += 1
+        elif isinstance(d, ir.Function):
+            ctx.top_funcs[d.name] = len(d.params)
+        elif isinstance(d, ir.Global):
+            ctx.top_globals.add(d.name)
+
+    out: List[str] = []
+    out.append('#include "deduce.h"')
+    out.append("")
+
+    # Constructor id macros
+    for name, cid in ctx.ctor_ids.items():
+        out.append(f"#define {_ctor_id_macro(name)} {cid}")
+    out.append("")
+
+    # Forward declarations
+    for d in p.decls:
+        if isinstance(d, ir.Function):
+            out.append(_emit_fn_decl(d) + ";")
+    for d in p.decls:
+        if isinstance(d, ir.Function) and getattr(d, "captures", None):
+            # Already declared above; here we'd handle the lifted case.
+            pass
+    out.append("")
+
+    # Global variables
+    for d in p.decls:
+        if isinstance(d, ir.Global):
+            out.append(f"static deduce_value {_global_id(d.name)};")
+    out.append("")
+
+    # Function bodies
+    for d in p.decls:
+        if isinstance(d, ir.Function):
+            out.append(_emit_function(d, ctx))
+            out.append("")
+
+    # The single program-entry function with globals + prints + asserts
+    # in source order.
+    out.append("void deduce_program_main(void) {")
+    for d in p.decls:
+        if isinstance(d, ir.Global):
+            tmp = ctx.fresh_tmp()
+            stmts, expr = _emit_term(d.body, ctx, locals_in_scope=set())
+            for s in stmts:
+                out.append("    " + s)
+            out.append(f"    {_global_id(d.name)} = {expr};")
+        elif isinstance(d, ir.Print):
+            stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
+            for s in stmts:
+                out.append("    " + s)
+            out.append(f"    deduce_println({expr});")
+        elif isinstance(d, ir.AssertEq):
+            sl, el = _emit_term(d.lhs, ctx, locals_in_scope=set())
+            sr, er = _emit_term(d.rhs, ctx, locals_in_scope=set())
+            for s in sl + sr:
+                out.append("    " + s)
+            out.append(f"    deduce_assert_eq({el}, {er}, NULL);")
+        elif isinstance(d, ir.AssertBool):
+            stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
+            for s in stmts:
+                out.append("    " + s)
+            out.append(f"    deduce_assert_bool({expr}, NULL);")
+    out.append("}")
+
+    return "\n".join(out) + "\n"
+
+
+def _emit_fn_decl(f: ir.Function) -> str:
+    return f"static deduce_value {_func_id(f.name)}(deduce_value* env, deduce_value* args)"
+
+
+def _emit_function(f: ir.Function, ctx: EmitCtx) -> str:
+    # Locals in scope inside the body include the params (bound from
+    # args[]) and the captures (bound from env[]).
+    in_scope: Set[str] = set(f.params) | set(f.captures)
+    body_stmts: List[str] = []
+    body_stmts.append(_emit_fn_decl(f) + " {")
+    if not f.params:
+        body_stmts.append("    (void)args;")
+    if not f.captures:
+        body_stmts.append("    (void)env;")
+    for i, p in enumerate(f.params):
+        body_stmts.append(f"    deduce_value {_local_id(p)} = args[{i}];")
+    for i, c in enumerate(f.captures):
+        body_stmts.append(f"    deduce_value {_local_id(c)} = env[{i}];")
+    stmts, expr = _emit_term(f.body, ctx, in_scope)
+    for s in stmts:
+        body_stmts.append("    " + s)
+    body_stmts.append(f"    return {expr};")
+    body_stmts.append("}")
+    return "\n".join(body_stmts)
+
+
+# --------------------------------------------------------------------------
+# Term emission
+# --------------------------------------------------------------------------
+#
+# Returns (statements, expr): statements run before the expression is
+# evaluated; expr is a deduce_value-typed C expression. The caller is
+# free to use `expr` multiple times if it's a single C variable, but
+# only once otherwise (avoiding double-evaluation of side effects).
+# The current emitter always assigns multi-step results to a fresh tmp,
+# so callers can treat `expr` as side-effect-free.
+
+def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[List[str], str]:
+    match t:
+        case ir.Var(name):
+            if name in locals_in_scope:
+                return [], _local_id(name)
+            if name in ctx.top_globals:
+                return [], _global_id(name)
+            if name in ctx.top_funcs:
+                # First-class top-level function reference: build a
+                # closure with empty env. Phase 1 doesn't exercise this,
+                # but supporting it is a few lines.
+                arity = ctx.top_funcs[name]
+                stmts = []
+                tmp = ctx.fresh_tmp()
+                stmts.append(
+                    f"deduce_value {tmp} = deduce_make_closure("
+                    f"{_func_id(name)}, {_c_string(_base_name(name))}, "
+                    f"{arity}, 0, NULL);"
+                )
+                return stmts, tmp
+            if name in ctx.ctor_ids:
+                # Bare constructor reference (rare; usually constructors
+                # appear as Con(...) in the IR). Phase 1 doesn't expect
+                # this; surface the case as an error so we notice.
+                raise EmitError(
+                    f"constructor {name} used as a value; not yet supported"
+                )
+            raise EmitError(f"unbound name in emission: {name}")
+
+        case ir.Bool(b):
+            return [], f"deduce_make_bool({'true' if b else 'false'})"
+
+        case ir.Int(v):
+            return [], f"deduce_make_int({v})"
+
+        case ir.If(cond, thn, els):
+            scond, econd = _emit_term(cond, ctx, locals_in_scope)
+            sthn, ethn = _emit_term(thn, ctx, locals_in_scope)
+            sels, eels = _emit_term(els, ctx, locals_in_scope)
+            tmp = ctx.fresh_tmp()
+            stmts: List[str] = []
+            stmts.extend(scond)
+            stmts.append(f"deduce_value {tmp};")
+            stmts.append(f"if (deduce_get_bool({econd})) {{")
+            for s in sthn:
+                stmts.append("    " + s)
+            stmts.append(f"    {tmp} = {ethn};")
+            stmts.append("} else {")
+            for s in sels:
+                stmts.append("    " + s)
+            stmts.append(f"    {tmp} = {eels};")
+            stmts.append("}")
+            return stmts, tmp
+
+        case ir.Let(name, rhs, body):
+            srhs, erhs = _emit_term(rhs, ctx, locals_in_scope)
+            stmts: List[str] = []
+            stmts.extend(srhs)
+            stmts.append(f"deduce_value {_local_id(name)} = {erhs};")
+            sbody, ebody = _emit_term(body, ctx, locals_in_scope | {name})
+            stmts.extend(sbody)
+            return stmts, ebody
+
+        case ir.Con(ctor, args):
+            if ctor not in ctx.ctor_ids:
+                raise EmitError(f"unknown constructor: {ctor}")
+            arg_stmts: List[str] = []
+            arg_exprs: List[str] = []
+            for a in args:
+                sa, ea = _emit_term(a, ctx, locals_in_scope)
+                arg_stmts.extend(sa)
+                arg_exprs.append(ea)
+            stmts = list(arg_stmts)
+            if arg_exprs:
+                arr = ctx.fresh_tmp() + "_args"
+                stmts.append(
+                    f"deduce_value {arr}[] = {{ {', '.join(arg_exprs)} }};"
+                )
+                arr_arg = arr
+            else:
+                arr_arg = "NULL"
+            tmp = ctx.fresh_tmp()
+            stmts.append(
+                f"deduce_value {tmp} = deduce_make_ctor("
+                f"{_ctor_id_macro(ctor)}, {_c_string(_base_name(ctor))}, "
+                f"{len(args)}, {arr_arg});"
+            )
+            return stmts, tmp
+
+        case ir.MkClosure(fn, caps):
+            if fn not in ctx.top_funcs:
+                raise EmitError(f"closure refers to unknown function: {fn}")
+            arity = ctx.top_funcs[fn]
+            cap_stmts: List[str] = []
+            cap_exprs: List[str] = []
+            for c in caps:
+                sc, ec = _emit_term(c, ctx, locals_in_scope)
+                cap_stmts.extend(sc)
+                cap_exprs.append(ec)
+            stmts = list(cap_stmts)
+            if cap_exprs:
+                arr = ctx.fresh_tmp() + "_env"
+                stmts.append(
+                    f"deduce_value {arr}[] = {{ {', '.join(cap_exprs)} }};"
+                )
+                arr_arg = arr
+            else:
+                arr_arg = "NULL"
+            tmp = ctx.fresh_tmp()
+            stmts.append(
+                f"deduce_value {tmp} = deduce_make_closure("
+                f"{_func_id(fn)}, {_c_string(_base_name(fn))}, {arity}, "
+                f"{len(caps)}, {arr_arg});"
+            )
+            return stmts, tmp
+
+        case ir.App(rator, args):
+            arg_stmts: List[str] = []
+            arg_exprs: List[str] = []
+            for a in args:
+                sa, ea = _emit_term(a, ctx, locals_in_scope)
+                arg_stmts.extend(sa)
+                arg_exprs.append(ea)
+            stmts = list(arg_stmts)
+
+            # Direct call to a top-level function: no env, args[].
+            if isinstance(rator, ir.Var) \
+               and rator.name in ctx.top_funcs \
+               and rator.name not in locals_in_scope:
+                if ctx.top_funcs[rator.name] != len(args):
+                    raise EmitError(
+                        f"arity mismatch calling {rator.name}: "
+                        f"declared {ctx.top_funcs[rator.name]}, called with {len(args)}"
+                    )
+                if arg_exprs:
+                    arr = ctx.fresh_tmp() + "_args"
+                    stmts.append(
+                        f"deduce_value {arr}[] = {{ {', '.join(arg_exprs)} }};"
+                    )
+                    arr_arg = arr
+                else:
+                    arr_arg = "NULL"
+                tmp = ctx.fresh_tmp()
+                stmts.append(
+                    f"deduce_value {tmp} = {_func_id(rator.name)}(NULL, {arr_arg});"
+                )
+                return stmts, tmp
+
+            # Closure call: dispatch via runtime.
+            srator, erator = _emit_term(rator, ctx, locals_in_scope)
+            stmts = srator + stmts
+            if arg_exprs:
+                arr = ctx.fresh_tmp() + "_args"
+                stmts.append(
+                    f"deduce_value {arr}[] = {{ {', '.join(arg_exprs)} }};"
+                )
+                arr_arg = arr
+            else:
+                arr_arg = "NULL"
+            tmp = ctx.fresh_tmp()
+            stmts.append(
+                f"deduce_value {tmp} = deduce_call({erator}, {len(args)}, {arr_arg});"
+            )
+            return stmts, tmp
+
+        case ir.Match(subj, arms):
+            ssubj, esubj = _emit_term(subj, ctx, locals_in_scope)
+            stmts = list(ssubj)
+            subj_var = ctx.fresh_tmp()
+            stmts.append(f"deduce_value {subj_var} = {esubj};")
+            tmp = ctx.fresh_tmp()
+            stmts.append(f"deduce_value {tmp};")
+
+            # Detect bool vs ctor patterns. Mixing is not allowed in
+            # Deduce source so we don't try to handle it.
+            is_bool = any(isinstance(arm.pattern, ir.PatBool) for arm in arms)
+
+            if is_bool:
+                stmts.append(f"if (deduce_get_bool({subj_var})) {{")
+                # Separate true/false branches; pattern order may vary.
+                true_arm = next((a for a in arms if isinstance(a.pattern, ir.PatBool) and a.pattern.value), None)
+                false_arm = next((a for a in arms if isinstance(a.pattern, ir.PatBool) and not a.pattern.value), None)
+                if true_arm is None or false_arm is None:
+                    raise EmitError("bool match must have both true and false arms")
+                ts, te = _emit_term(true_arm.body, ctx, locals_in_scope)
+                for s in ts:
+                    stmts.append("    " + s)
+                stmts.append(f"    {tmp} = {te};")
+                stmts.append("} else {")
+                fs, fe = _emit_term(false_arm.body, ctx, locals_in_scope)
+                for s in fs:
+                    stmts.append("    " + s)
+                stmts.append(f"    {tmp} = {fe};")
+                stmts.append("}")
+            else:
+                stmts.append(f"switch (deduce_ctor_id({subj_var})) {{")
+                for arm in arms:
+                    if not isinstance(arm.pattern, ir.PatCon):
+                        raise EmitError("expected constructor pattern in ctor match")
+                    pc: ir.PatCon = arm.pattern
+                    stmts.append(f"case {_ctor_id_macro(pc.ctor)}: {{")
+                    inner_scope = locals_in_scope | set(pc.binds)
+                    for i, b in enumerate(pc.binds):
+                        stmts.append(
+                            f"    deduce_value {_local_id(b)} = "
+                            f"deduce_ctor_field({subj_var}, {i});"
+                        )
+                    bs, be = _emit_term(arm.body, ctx, inner_scope)
+                    for s in bs:
+                        stmts.append("    " + s)
+                    stmts.append(f"    {tmp} = {be};")
+                    stmts.append("    break;")
+                    stmts.append("}")
+                stmts.append("default: deduce_panic(\"non-exhaustive match\");")
+                stmts.append("}")
+            return stmts, tmp
+
+        case ir.Lam(_, _):
+            raise EmitError(
+                "Lam reached emit_c; closure conversion should have lifted it"
+            )
+
+    raise EmitError(f"emit: unknown term {type(t).__name__}")

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -1,0 +1,301 @@
+"""Intermediate representation for the Deduce compiler.
+
+This is a small functional core in the spirit of an ANF/SSA cousin:
+- Types are erased. Generics, type-instantiations, and type annotations
+  do not appear here. A backend treats every value uniformly.
+- Proofs are erased. Theorems, holes, marks etc. never reach the IR.
+- Names are the uniquified names that the type-checker produced. The IR
+  inherits the global-uniqueness invariant; backends can rely on it.
+
+A program is a flat list of top-level declarations: union types,
+functions, and statements (`print`, `assert`). After Phase 1 step 3
+(closure conversion) every `Lam` has been hoisted to the top level and
+the only remaining lambdas are `MkClosure` placeholders. Pre-closure-
+conversion the IR still contains nested `Lam` nodes; that's fine — the
+shape is stable, only the population of nodes changes.
+
+The pretty-printer's output is the contract that lowering tests assert
+against; keep it stable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple, Union
+
+
+# ---------- terms ----------
+
+@dataclass
+class Var:
+    """Reference to any in-scope name: parameter, let-binding, top-level."""
+    name: str
+
+
+@dataclass
+class Bool:
+    value: bool
+
+
+@dataclass
+class Int:
+    value: int
+
+
+@dataclass
+class Lam:
+    """Anonymous function. Eliminated by closure conversion (Step 3).
+    After closure conversion only `MkClosure` remains."""
+    params: List[str]
+    body: "Term"
+
+
+@dataclass
+class MkClosure:
+    """Created by closure conversion. `fn_name` refers to a top-level
+    `Function`; `captures` are the values of the lambda's free variables
+    at the point the closure was constructed."""
+    fn_name: str
+    captures: List["Term"]
+
+
+@dataclass
+class App:
+    """Apply a value (closure or top-level function) to arguments."""
+    rator: "Term"
+    args: List["Term"]
+
+
+@dataclass
+class Let:
+    name: str
+    rhs: "Term"
+    body: "Term"
+
+
+@dataclass
+class If:
+    cond: "Term"
+    thn: "Term"
+    els: "Term"
+
+
+@dataclass
+class Con:
+    """Constructor application. Nullary constructors have args=[]."""
+    ctor: str
+    args: List["Term"]
+
+
+@dataclass
+class PatCon:
+    """Match a constructor and bind its parameters to fresh names."""
+    ctor: str
+    binds: List[str]
+
+
+@dataclass
+class PatBool:
+    value: bool
+
+
+Pattern = Union[PatCon, PatBool]
+
+
+@dataclass
+class MatchArm:
+    pattern: Pattern
+    body: "Term"
+
+
+@dataclass
+class Match:
+    subject: "Term"
+    arms: List[MatchArm]
+
+
+Term = Union[Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match]
+
+
+# ---------- top-level ----------
+
+@dataclass
+class Constructor:
+    name: str
+    arity: int
+
+
+@dataclass
+class UnionDecl:
+    name: str
+    ctors: List[Constructor]
+
+
+@dataclass
+class Function:
+    """A top-level function.
+
+    After closure conversion (Step 3), `captures` lists the names that
+    are bound from the closure's environment at function entry, in the
+    order they appear in the matching `MkClosure(fn_name, ...)`. The
+    body refers to captures by name, like any other variable; the
+    backend is responsible for materialising those bindings on entry.
+
+    Functions originating from top-level user `Define`/`RecFun` decls
+    are never captured by closures and have `captures=[]`. Lambda-lifted
+    functions produced by closure conversion have `captures=[fv0, ...]`."""
+    name: str
+    params: List[str]
+    body: Term
+    captures: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Global:
+    """A top-level non-function binding. Initialised at program start."""
+    name: str
+    body: Term
+
+
+@dataclass
+class Print:
+    term: Term
+
+
+@dataclass
+class AssertEq:
+    """`assert lhs = rhs` — runtime structural equality check."""
+    lhs: Term
+    rhs: Term
+
+
+@dataclass
+class AssertBool:
+    """`assert <bool-typed-term>` — runtime check that it evaluates to true."""
+    term: Term
+
+
+TopLevel = Union[UnionDecl, Function, Global, Print, AssertEq, AssertBool]
+
+
+@dataclass
+class Program:
+    """A complete IR program. `decls` is in source order; backends
+    typically emit unions and functions first, then `main`-like glue
+    that runs the globals/prints/asserts in order."""
+    decls: List[TopLevel] = field(default_factory=list)
+
+
+# ---------- pretty printer ----------
+#
+# The printer's output is the regression-test contract for lowering:
+# stable, parseable-by-eye, no source locations. One declaration per
+# block of lines.
+
+def pp_program(p: Program) -> str:
+    return "\n".join(pp_top(d) for d in p.decls) + ("\n" if p.decls else "")
+
+
+def pp_top(d: TopLevel) -> str:
+    match d:
+        case UnionDecl(name, ctors):
+            body = ", ".join(f"{c.name}/{c.arity}" for c in ctors)
+            return f"union {name} {{{body}}}"
+        case Function(name, params, body, captures):
+            head = f"fn {name}"
+            if captures:
+                head += "[" + ", ".join(captures) + "]"
+            head += "(" + ", ".join(params) + ")"
+            return head + " = " + pp_term(body, 2)
+        case Global(name, body):
+            return f"global {name} = " + pp_term(body, 2)
+        case Print(t):
+            return "print " + pp_term(t, 2)
+        case AssertEq(l, r):
+            return "assert_eq " + pp_term(l, 2) + " == " + pp_term(r, 2)
+        case AssertBool(t):
+            return "assert " + pp_term(t, 2)
+    raise AssertionError(f"pp_top: unknown decl {type(d).__name__}")
+
+
+def pp_term(t: Term, indent: int) -> str:
+    match t:
+        case Var(name):
+            return name
+        case Bool(b):
+            return "true" if b else "false"
+        case Int(v):
+            return str(v)
+        case Lam(params, body):
+            return "λ(" + ", ".join(params) + "). " + pp_term(body, indent)
+        case MkClosure(fn, caps):
+            return f"closure[{fn}]({', '.join(pp_term(c, indent) for c in caps)})"
+        case App(rator, args):
+            return pp_term(rator, indent) + "(" + ", ".join(pp_term(a, indent) for a in args) + ")"
+        case Let(name, rhs, body):
+            return f"let {name} = " + pp_term(rhs, indent) + " in " + pp_term(body, indent)
+        case If(c, th, el):
+            return "if " + pp_term(c, indent) + " then " + pp_term(th, indent) + " else " + pp_term(el, indent)
+        case Con(ctor, []):
+            return ctor
+        case Con(ctor, args):
+            return ctor + "(" + ", ".join(pp_term(a, indent) for a in args) + ")"
+        case Match(subj, arms):
+            arm_strs = []
+            for arm in arms:
+                match arm.pattern:
+                    case PatBool(v):
+                        ps = "true" if v else "false"
+                    case PatCon(c, []):
+                        ps = c
+                    case PatCon(c, binds):
+                        ps = c + "(" + ", ".join(binds) + ")"
+                    case _:
+                        raise AssertionError("pp_term: bad pattern")
+                arm_strs.append("| " + ps + " -> " + pp_term(arm.body, indent))
+            return "match " + pp_term(subj, indent) + " { " + " ".join(arm_strs) + " }"
+    raise AssertionError(f"pp_term: unknown term {type(t).__name__}")
+
+
+# ---------- traversal helpers ----------
+#
+# Used by closure conversion (free-variable analysis) and by emitters.
+# Kept here so the contract is local to the IR module.
+
+def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
+    match t:
+        case Var(name):
+            return set() if name in bound else {name}
+        case Bool(_) | Int(_):
+            return set()
+        case Lam(params, body):
+            return free_vars(body, bound | set(params))
+        case MkClosure(_, caps):
+            out: set = set()
+            for c in caps:
+                out |= free_vars(c, bound)
+            return out
+        case App(rator, args):
+            out = free_vars(rator, bound)
+            for a in args:
+                out |= free_vars(a, bound)
+            return out
+        case Let(name, rhs, body):
+            return free_vars(rhs, bound) | free_vars(body, bound | {name})
+        case If(c, th, el):
+            return free_vars(c, bound) | free_vars(th, bound) | free_vars(el, bound)
+        case Con(_, args):
+            out = set()
+            for a in args:
+                out |= free_vars(a, bound)
+            return out
+        case Match(subj, arms):
+            out = free_vars(subj, bound)
+            for arm in arms:
+                match arm.pattern:
+                    case PatCon(_, binds):
+                        out |= free_vars(arm.body, bound | set(binds))
+                    case PatBool(_):
+                        out |= free_vars(arm.body, bound)
+            return out
+    raise AssertionError(f"free_vars: unknown term {type(t).__name__}")

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -1,0 +1,359 @@
+"""Lower a checked Deduce AST to the compiler IR.
+
+Input: the post-uniquify, post-typecheck list of `Statement`s that the
+proof checker would otherwise hand to `check_proofs`. We rely on
+`Var.resolved_names` having been filled in.
+
+Output: an `ir.Program`. Anything outside the executable fragment
+(theorems, postulates, predicates, holes, ...) is dropped or rejected
+explicitly — there is no silent fallthrough.
+
+Phase 1 supports: Bool, Int literals; Var; Conditional; TLet; Lambda;
+Generic; TermInst; TAnnote; Mark; Call (function or constructor);
+Switch (PatternCons / PatternBool); Define; RecFun; Union; Print;
+Assert. MakeArray/ArrayGet/GenRecFun/Array etc. raise CompileError.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Set
+
+import abstract_syntax as ast
+
+from compiler import ir
+
+
+class CompileError(Exception):
+    """Raised when lowering hits a node that the compiler does not yet
+    handle. Carries the AST node's location when available so the
+    front-end can format it like any other Deduce error."""
+
+    def __init__(self, location, message: str):
+        self.location = location
+        self.message = message
+        super().__init__(_format_loc(location) + message)
+
+
+def _format_loc(loc) -> str:
+    if loc is None:
+        return ""
+    try:
+        if getattr(loc, "empty", True):
+            return ""
+        return f"{loc.filename}:{loc.line}: "
+    except Exception:
+        return ""
+
+
+# --------------------------------------------------------------------------
+# Top-level lowering
+# --------------------------------------------------------------------------
+
+def lower_program(stmts: List[ast.Statement]) -> ir.Program:
+    """Entry point. Walks the top-level statement list once to collect
+    constructor names (so `Call(Var(ctor), ...)` can become `Con` rather
+    than `App`), then lowers each statement."""
+    ctors: Set[str] = set()
+    arities: Dict[str, int] = {}
+    for s in stmts:
+        if isinstance(s, ast.Union):
+            for c in s.alternatives:
+                ctors.add(c.name)
+                arities[c.name] = len(c.parameters)
+
+    lc = LoweringCtx(ctors=ctors, ctor_arities=arities)
+    out: List[ir.TopLevel] = []
+    for s in stmts:
+        d = lc.lower_stmt(s)
+        if d is not None:
+            if isinstance(d, list):
+                out.extend(d)
+            else:
+                out.append(d)
+    return ir.Program(decls=out)
+
+
+class LoweringCtx:
+    def __init__(self, ctors: Set[str], ctor_arities: Dict[str, int]):
+        self.ctors = ctors
+        self.ctor_arities = ctor_arities
+        self._gensym = 0
+
+    def fresh(self, hint: str = "_t") -> str:
+        n = self._gensym
+        self._gensym += 1
+        # `$` in the prefix avoids collision with Deduce uniquified names,
+        # which use `.` and digits but not `$`.
+        return f"${hint}{n}"
+
+    # ---- statements --------------------------------------------------
+
+    def lower_stmt(self, s: ast.Statement):
+        if isinstance(s, ast.Theorem) or isinstance(s, ast.Postulate) \
+           or isinstance(s, ast.Predicate) or isinstance(s, ast.Auto) \
+           or isinstance(s, ast.Inductive) or isinstance(s, ast.Module) \
+           or isinstance(s, ast.Export) or isinstance(s, ast.Associative) \
+           or isinstance(s, ast.Trace):
+            return None
+        if isinstance(s, ast.Import):
+            # Imports are lowered to a flat statement list upstream
+            # (the proof checker walks them via `Import.ast`); the
+            # caller decides whether to splice them in. Here we treat
+            # an `Import` as "no top-level code", which is the right
+            # answer if the caller already inlined imports. If the
+            # caller did NOT inline imports the compiler will simply
+            # be missing definitions; that fails later with a clearer
+            # "undefined name" error.
+            return None
+        if isinstance(s, ast.Union):
+            return ir.UnionDecl(
+                name=s.name,
+                ctors=[ir.Constructor(c.name, len(c.parameters))
+                       for c in s.alternatives],
+            )
+        if isinstance(s, ast.Define):
+            return self.lower_define(s)
+        if isinstance(s, ast.RecFun):
+            return self.lower_recfun(s)
+        if isinstance(s, ast.GenRecFun):
+            raise CompileError(
+                s.location,
+                "GenRecFun (recfun with measure) is not supported in Phase 1; "
+                "see docs/compile-plan.md Step 7",
+            )
+        if isinstance(s, ast.Print):
+            return ir.Print(self.lower_term(s.term))
+        if isinstance(s, ast.Assert):
+            return self.lower_assert(s)
+        raise CompileError(
+            getattr(s, "location", None),
+            f"compiler does not yet support top-level: {type(s).__name__}",
+        )
+
+    def lower_define(self, d: ast.Define):
+        body = d.body
+        # `define f = generic <T> { fun x { ... } }` and
+        # `define f = fun x { ... }` should both become a top-level
+        # function rather than a global pointing at a closure. This
+        # unwraps Generic to expose the inner Lambda.
+        unwrapped = body
+        if isinstance(unwrapped, ast.Generic):
+            unwrapped = unwrapped.body
+        if isinstance(unwrapped, ast.Lambda):
+            params = [x for (x, _t) in unwrapped.vars]
+            return ir.Function(
+                name=d.name,
+                params=params,
+                body=self.lower_term(unwrapped.body),
+            )
+        return ir.Global(name=d.name, body=self.lower_term(body))
+
+    def lower_recfun(self, r: ast.RecFun):
+        if len(r.cases) == 0:
+            raise CompileError(r.location, "RecFun with no cases")
+
+        n_args = len(r.params)
+        scrutinee = self.fresh("scr")
+        # The other parameter names come from the first case; we then
+        # rename later cases' parameter lists to match.
+        first = r.cases[0]
+        other_params = [p for p in first.parameters]
+        # Sanity: the FunCase contract is N total args, where the first
+        # is matched and the rest are named in `parameters`. Confirm
+        # arity lines up with the RecFun's declared parameter count.
+        if 1 + len(other_params) != n_args:
+            raise CompileError(
+                r.location,
+                f"RecFun {r.name} arity mismatch: header expects {n_args} "
+                f"but first case names {1 + len(other_params)}",
+            )
+
+        arms: List[ir.MatchArm] = []
+        for case in r.cases:
+            # Rename this case's `parameters` to the canonical names
+            # taken from the first case.
+            sub: Dict[str, str] = {}
+            for old, new in zip(case.parameters, other_params):
+                if old != new:
+                    sub[old] = new
+            body = self.lower_term(case.body)
+            if sub:
+                body = subst_vars(body, sub)
+            pat = self.lower_pattern(case.pattern)
+            arms.append(ir.MatchArm(pat, body))
+
+        match = ir.Match(ir.Var(scrutinee), arms)
+        return ir.Function(
+            name=r.name,
+            params=[scrutinee] + other_params,
+            body=match,
+        )
+
+    def lower_assert(self, s: ast.Assert):
+        # `assert lhs = rhs` becomes a structural-equality check;
+        # everything else (incl. `assert b` for a bool b) becomes
+        # AssertBool.
+        f = s.formula
+        if isinstance(f, ast.Call) and isinstance(f.rator, ast.Var) \
+           and ast.base_name(f.rator.name) == "=" and len(f.args) == 2:
+            return ir.AssertEq(
+                self.lower_term(f.args[0]),
+                self.lower_term(f.args[1]),
+            )
+        return ir.AssertBool(self.lower_term(f))
+
+    # ---- terms -------------------------------------------------------
+
+    def lower_term(self, t: ast.Term) -> ir.Term:
+        # Strip transparent wrappers first.
+        if isinstance(t, ast.TAnnote):
+            return self.lower_term(t.subject)
+        if isinstance(t, ast.Mark):
+            return self.lower_term(t.subject)
+        if isinstance(t, ast.TermInst):
+            return self.lower_term(t.subject)
+        if isinstance(t, ast.Generic):
+            return self.lower_term(t.body)
+
+        if isinstance(t, ast.Bool):
+            return ir.Bool(t.value)
+        if isinstance(t, ast.Int):
+            return ir.Int(t.value)
+        if isinstance(t, ast.Var):
+            name = self._resolve(t)
+            if name in self.ctors and self.ctor_arities.get(name, 0) == 0:
+                # Nullary constructor used as a value.
+                return ir.Con(name, [])
+            return ir.Var(name)
+        if isinstance(t, ast.Conditional):
+            return ir.If(
+                self.lower_term(t.cond),
+                self.lower_term(t.thn),
+                self.lower_term(t.els),
+            )
+        if isinstance(t, ast.TLet):
+            return ir.Let(
+                t.var,
+                self.lower_term(t.rhs),
+                self.lower_term(t.body),
+            )
+        if isinstance(t, ast.Lambda):
+            params = [x for (x, _t) in t.vars]
+            return ir.Lam(params, self.lower_term(t.body))
+        if isinstance(t, ast.Call):
+            return self.lower_call(t)
+        if isinstance(t, ast.Switch):
+            return self.lower_switch(t)
+        if isinstance(t, ast.Hole) or isinstance(t, ast.Omitted):
+            raise CompileError(
+                t.location,
+                "hole/omitted term reached compilation; the proof "
+                "checker should have rejected this earlier",
+            )
+        if isinstance(t, ast.MakeArray) or isinstance(t, ast.ArrayGet) \
+           or isinstance(t, ast.Array):
+            raise CompileError(
+                t.location,
+                "arrays are not yet supported by the compiler "
+                "(Phase 2 step 8)",
+            )
+        raise CompileError(
+            getattr(t, "location", None),
+            f"compiler does not yet support term: {type(t).__name__}",
+        )
+
+    def lower_call(self, c: ast.Call) -> ir.Term:
+        rator = c.rator
+        # Peel TermInst: the type instantiation is irrelevant at runtime.
+        while isinstance(rator, ast.TermInst):
+            rator = rator.subject
+        if isinstance(rator, ast.Var):
+            name = self._resolve(rator)
+            if name in self.ctors:
+                return ir.Con(name, [self.lower_term(a) for a in c.args])
+        return ir.App(
+            self.lower_term(c.rator),
+            [self.lower_term(a) for a in c.args],
+        )
+
+    def lower_switch(self, sw: ast.Switch) -> ir.Term:
+        arms: List[ir.MatchArm] = []
+        for case in sw.cases:
+            arms.append(ir.MatchArm(
+                self.lower_pattern(case.pattern),
+                self.lower_term(case.body),
+            ))
+        return ir.Match(self.lower_term(sw.subject), arms)
+
+    def lower_pattern(self, p: ast.Pattern) -> ir.Pattern:
+        if isinstance(p, ast.PatternBool):
+            return ir.PatBool(p.value)
+        if isinstance(p, ast.PatternCons):
+            ctor = p.constructor
+            # The constructor field is typically a Var; sometimes a
+            # bare string slips through. Either way we want the
+            # uniquified name.
+            if isinstance(ctor, ast.Var):
+                name = self._resolve(ctor)
+            else:
+                name = str(ctor)
+            return ir.PatCon(name, list(p.parameters))
+        raise CompileError(
+            getattr(p, "location", None),
+            f"compiler does not support pattern: {type(p).__name__}",
+        )
+
+    # ---- helpers -----------------------------------------------------
+
+    def _resolve(self, v: ast.Var) -> str:
+        # `resolved_names` is filled in by uniquify and may contain
+        # multiple entries when the name is overloaded. After
+        # type-checking, the first entry is the resolved overload.
+        if v.resolved_names:
+            return v.resolved_names[0]
+        return v.name
+
+
+# --------------------------------------------------------------------------
+# IR-level variable substitution
+# --------------------------------------------------------------------------
+
+def subst_vars(t: ir.Term, sub: Dict[str, str]) -> ir.Term:
+    """Rename free variable occurrences according to `sub`. Respects
+    binders (Lam params, Let names, Match arm pattern binds)."""
+
+    def go(t: ir.Term, blocked: Set[str]) -> ir.Term:
+        match t:
+            case ir.Var(name):
+                if name in blocked:
+                    return t
+                return ir.Var(sub.get(name, name))
+            case ir.Bool(_) | ir.Int(_):
+                return t
+            case ir.Lam(params, body):
+                inner = blocked | set(params)
+                return ir.Lam(params, go(body, inner))
+            case ir.MkClosure(fn, caps):
+                return ir.MkClosure(fn, [go(c, blocked) for c in caps])
+            case ir.App(rator, args):
+                return ir.App(go(rator, blocked), [go(a, blocked) for a in args])
+            case ir.Let(name, rhs, body):
+                new_rhs = go(rhs, blocked)
+                inner = blocked | {name}
+                return ir.Let(name, new_rhs, go(body, inner))
+            case ir.If(c, th, el):
+                return ir.If(go(c, blocked), go(th, blocked), go(el, blocked))
+            case ir.Con(ctor, args):
+                return ir.Con(ctor, [go(a, blocked) for a in args])
+            case ir.Match(subj, arms):
+                new_arms = []
+                for arm in arms:
+                    if isinstance(arm.pattern, ir.PatCon):
+                        inner = blocked | set(arm.pattern.binds)
+                    else:
+                        inner = blocked
+                    new_arms.append(ir.MatchArm(arm.pattern, go(arm.body, inner)))
+                return ir.Match(go(subj, blocked), new_arms)
+        raise AssertionError(f"subst_vars: unknown {type(t).__name__}")
+
+    return go(t, set())

--- a/compiler/runtime/deduce.c
+++ b/compiler/runtime/deduce.c
@@ -1,0 +1,201 @@
+/* Deduce-to-C runtime, Phase 1. See deduce.h. */
+
+#include "deduce.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct deduce_obj {
+    deduce_tag tag;
+    union {
+        bool b;
+        int64_t i;
+        struct {
+            int id;
+            const char* name;   /* statically-allocated, do not free */
+            int n_fields;
+            /* fields[] is allocated separately to avoid mixing
+             * flexible arrays with a union. */
+            deduce_value* fields;
+        } ctor;
+        struct {
+            deduce_value (*fn)(deduce_value* env, deduce_value* args);
+            const char* name;
+            int arity;
+            int n_env;
+            deduce_value* env;
+        } closure;
+    } u;
+};
+
+void* deduce_alloc(size_t size) {
+    void* p = calloc(1, size);
+    if (!p) {
+        fprintf(stderr, "deduce: out of memory\n");
+        exit(1);
+    }
+    return p;
+}
+
+deduce_value deduce_make_bool(bool b) {
+    deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
+    v->tag = D_BOOL;
+    v->u.b = b;
+    return v;
+}
+
+deduce_value deduce_make_int(int64_t i) {
+    deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
+    v->tag = D_INT;
+    v->u.i = i;
+    return v;
+}
+
+deduce_value deduce_make_ctor(int ctor_id, const char* name,
+                              int n_fields, deduce_value* fields) {
+    deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
+    v->tag = D_CTOR;
+    v->u.ctor.id = ctor_id;
+    v->u.ctor.name = name;
+    v->u.ctor.n_fields = n_fields;
+    if (n_fields > 0) {
+        v->u.ctor.fields = deduce_alloc(sizeof(deduce_value) * (size_t)n_fields);
+        memcpy(v->u.ctor.fields, fields, sizeof(deduce_value) * (size_t)n_fields);
+    } else {
+        v->u.ctor.fields = NULL;
+    }
+    return v;
+}
+
+deduce_value deduce_make_closure(deduce_value (*fn)(deduce_value*, deduce_value*),
+                                 const char* name, int arity,
+                                 int n_env, deduce_value* env_vals) {
+    deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
+    v->tag = D_CLOSURE;
+    v->u.closure.fn = fn;
+    v->u.closure.name = name;
+    v->u.closure.arity = arity;
+    v->u.closure.n_env = n_env;
+    if (n_env > 0) {
+        v->u.closure.env = deduce_alloc(sizeof(deduce_value) * (size_t)n_env);
+        memcpy(v->u.closure.env, env_vals, sizeof(deduce_value) * (size_t)n_env);
+    } else {
+        v->u.closure.env = NULL;
+    }
+    return v;
+}
+
+deduce_tag deduce_tag_of(deduce_value v) {
+    return v->tag;
+}
+
+bool deduce_get_bool(deduce_value v) {
+    if (v->tag != D_BOOL) deduce_panic("expected bool");
+    return v->u.b;
+}
+
+int64_t deduce_get_int(deduce_value v) {
+    if (v->tag != D_INT) deduce_panic("expected int");
+    return v->u.i;
+}
+
+int deduce_ctor_id(deduce_value v) {
+    if (v->tag != D_CTOR) deduce_panic("expected constructor");
+    return v->u.ctor.id;
+}
+
+deduce_value deduce_ctor_field(deduce_value v, int i) {
+    if (v->tag != D_CTOR) deduce_panic("expected constructor");
+    if (i < 0 || i >= v->u.ctor.n_fields) deduce_panic("ctor field out of range");
+    return v->u.ctor.fields[i];
+}
+
+deduce_value deduce_call(deduce_value clo, int n_args, deduce_value* args) {
+    if (clo->tag != D_CLOSURE) deduce_panic("call: not a function");
+    if (clo->u.closure.arity != n_args) deduce_panic("call: arity mismatch");
+    return clo->u.closure.fn(clo->u.closure.env, args);
+}
+
+bool deduce_equal(deduce_value a, deduce_value b) {
+    if (a == b) return true;
+    if (a->tag != b->tag) return false;
+    switch (a->tag) {
+        case D_BOOL:    return a->u.b == b->u.b;
+        case D_INT:     return a->u.i == b->u.i;
+        case D_CTOR: {
+            if (a->u.ctor.id != b->u.ctor.id) return false;
+            if (a->u.ctor.n_fields != b->u.ctor.n_fields) return false;
+            for (int i = 0; i < a->u.ctor.n_fields; ++i) {
+                if (!deduce_equal(a->u.ctor.fields[i], b->u.ctor.fields[i]))
+                    return false;
+            }
+            return true;
+        }
+        case D_CLOSURE: return false;
+    }
+    return false;
+}
+
+void deduce_println(deduce_value v) {
+    deduce_print(v);
+    fputc('\n', stdout);
+}
+
+void deduce_print(deduce_value v) {
+    switch (v->tag) {
+        case D_BOOL:
+            fputs(v->u.b ? "true" : "false", stdout);
+            return;
+        case D_INT:
+            printf("%lld", (long long)v->u.i);
+            return;
+        case D_CTOR:
+            fputs(v->u.ctor.name, stdout);
+            if (v->u.ctor.n_fields > 0) {
+                fputc('(', stdout);
+                for (int i = 0; i < v->u.ctor.n_fields; ++i) {
+                    if (i > 0) fputs(", ", stdout);
+                    deduce_print(v->u.ctor.fields[i]);
+                }
+                fputc(')', stdout);
+            }
+            return;
+        case D_CLOSURE:
+            printf("<closure %s>", v->u.closure.name ? v->u.closure.name : "?");
+            return;
+    }
+}
+
+void deduce_assert_eq(deduce_value lhs, deduce_value rhs, const char* loc) {
+    if (deduce_equal(lhs, rhs)) return;
+    /* Match the interpreter, which routes assert failures through the
+     * normal Deduce error path (ends up on stdout via deduce.py). */
+    printf("%s: assertion failed:\n\t", loc ? loc : "?");
+    deduce_print(lhs);
+    fputs(" \xe2\x89\xa0 ", stdout);
+    deduce_print(rhs);
+    fputc('\n', stdout);
+    exit(1);
+}
+
+void deduce_assert_bool(deduce_value b, const char* loc) {
+    if (b->tag != D_BOOL) {
+        printf("%s: assertion expected Boolean result\n", loc ? loc : "?");
+        exit(1);
+    }
+    if (!b->u.b) {
+        printf("%s: assertion failed\n", loc ? loc : "?");
+        exit(1);
+    }
+}
+
+void deduce_panic(const char* msg) {
+    fprintf(stderr, "deduce: %s\n", msg);
+    exit(1);
+}
+
+int main(void) {
+    deduce_program_main();
+    return 0;
+}

--- a/compiler/runtime/deduce.h
+++ b/compiler/runtime/deduce.h
@@ -1,0 +1,78 @@
+/* Deduce-to-C runtime, Phase 1.
+ *
+ * Single uniform value representation (boxed). No GC: the runtime
+ * mallocs and never frees. That's fine for short-lived test programs
+ * and keeps the runtime under 200 lines. Phase 4 of the compile plan
+ * is where memory management gets revisited.
+ *
+ * Every Deduce value is a `deduce_value` (an opaque pointer). The
+ * concrete shape depends on the tag stored at offset 0; do not access
+ * fields directly — use the helpers below.
+ */
+
+#ifndef DEDUCE_RUNTIME_H
+#define DEDUCE_RUNTIME_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct deduce_obj* deduce_value;
+
+typedef enum {
+    D_BOOL,
+    D_INT,
+    D_CTOR,
+    D_CLOSURE
+} deduce_tag;
+
+/* The actual struct shape is hidden in deduce.c. */
+
+/* Allocation. */
+void* deduce_alloc(size_t size);
+
+/* Constructors for the four value kinds. `env_vals` and `fields` are
+ * copied; the caller does not need to keep the array alive. */
+deduce_value deduce_make_bool(bool b);
+deduce_value deduce_make_int(int64_t i);
+deduce_value deduce_make_ctor(int ctor_id, const char* name,
+                              int n_fields, deduce_value* fields);
+deduce_value deduce_make_closure(deduce_value (*fn)(deduce_value* env,
+                                                     deduce_value* args),
+                                 const char* name,
+                                 int arity,
+                                 int n_env,
+                                 deduce_value* env_vals);
+
+/* Accessors (with tag checks; abort on mismatch). */
+deduce_tag deduce_tag_of(deduce_value v);
+bool        deduce_get_bool(deduce_value v);
+int64_t     deduce_get_int(deduce_value v);
+int         deduce_ctor_id(deduce_value v);
+deduce_value deduce_ctor_field(deduce_value v, int i);
+
+/* Closure call: dispatches through the closure's function pointer. */
+deduce_value deduce_call(deduce_value clo, int n_args, deduce_value* args);
+
+/* Structural equality. Closures compare by pointer identity (the
+ * surface language has no closure-equality primitive at runtime, but
+ * `assert lhs = rhs` may end up comparing them anyway — pointer is the
+ * least-bad answer). */
+bool deduce_equal(deduce_value a, deduce_value b);
+
+/* Pretty-print to stdout, no trailing newline. */
+void deduce_print(deduce_value v);
+
+/* Pretty-print followed by a newline. Generated programs use this for
+ * top-level `print`. */
+void deduce_println(deduce_value v);
+
+/* Diagnostics. `loc` is a "file:line" string; OK to be NULL. */
+void deduce_assert_eq(deduce_value lhs, deduce_value rhs, const char* loc);
+void deduce_assert_bool(deduce_value b, const char* loc);
+void deduce_panic(const char* msg) __attribute__((noreturn));
+
+/* Generated programs call this from main(). */
+void deduce_program_main(void);
+
+#endif

--- a/deduce.py
+++ b/deduce.py
@@ -36,6 +36,31 @@ def deduce_file(filename, error_expected, tracing_functions, prelude: list[str] 
                 print(result.error_traceback)
             exit(1)
 
+def compile_file(filename: str, output: str, prelude: list[str]) -> None:
+    """Compile a checked .pf file to a single .c source file.
+
+    Phase 1 of docs/compile-plan.md: parse + uniquify + type-check via
+    the existing pipeline, then run lower → closure-convert → emit_c.
+    The runtime in compiler/runtime/ supplies the matching deduce.h /
+    deduce.c that callers must compile alongside the generated source.
+    """
+    from compiler import closure as _closure, emit_c, ir, lower
+
+    result = check_file(filename, tracing_functions=(), prelude=prelude)
+    if not result.ok:
+        print(result.error_message)
+        if traceback_flag:
+            print(result.error_traceback)
+        exit(1)
+    program = lower.lower_program(result.ast)
+    program = _closure.closure_convert(program)
+    src = emit_c.emit_program(program)
+    if output == "-":
+        sys.stdout.write(src)
+    else:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(src)
+
 def deduce_directory(directory, recursive_directories, tracing_functions, prelude: list[str] = []):
     for file in sorted(os.listdir(directory)):
         fpath = os.path.join(directory, file)
@@ -72,6 +97,8 @@ if __name__ == "__main__":
     error_expected = False
     recursive_directories = False
     already_processed_next = False
+    compile_target = None
+    compile_output = None
     init_import_directories()
 
     # TODO: Cleanup 
@@ -120,6 +147,11 @@ if __name__ == "__main__":
             exit(0)
         elif argument == '--no-check-imports':
             set_check_imports(False)
+        elif argument == '--compile':
+            compile_target = '__pending__'
+        elif argument == '-o' and i + 1 < len(sys.argv):
+            compile_output = sys.argv[i + 1]
+            already_processed_next = True
         else:
             deducables.append(argument)
     
@@ -150,13 +182,20 @@ if __name__ == "__main__":
         # If a file is in the prelude and we include the prelude
         # Then we'll process the file twice, hence using an empty "prelude"
         # For said file
-        
+
         if check_in_prelude(deducable, stdlib_dir):
             deducable_prelude = []
         else:
             deducable_prelude = prelude
-        
-        if os.path.isfile(deducable):
+
+        if compile_target is not None:
+            if not os.path.isfile(deducable):
+                print(deducable, "was not found!")
+                exit(1)
+            out = compile_output if compile_output is not None \
+                else os.path.splitext(deducable)[0] + ".c"
+            compile_file(deducable, out, deducable_prelude)
+        elif os.path.isfile(deducable):
             deduce_file(deducable, error_expected, tracing_functions, deducable_prelude)
         elif os.path.isdir(deducable):
             deduce_directory(deducable, recursive_directories, tracing_functions, deducable_prelude)

--- a/test/compile/lower/basic.cir
+++ b/test/compile/lower/basic.cir
@@ -1,0 +1,8 @@
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+global two.7 = suc.2(suc.2(zero.1))
+fn add_two.9(x.8) = add.3(two.7, x.8)
+fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
+print add_two.9(suc.2(zero.1))
+print pick.13(true, two.7, zero.1)
+assert_eq add.3(two.7, zero.1) == two.7

--- a/test/compile/lower/basic.ir
+++ b/test/compile/lower/basic.ir
@@ -1,0 +1,8 @@
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+global two.7 = suc.2(suc.2(zero.1))
+fn add_two.9(x.8) = add.3(two.7, x.8)
+fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
+print add_two.9(suc.2(zero.1))
+print pick.13(true, two.7, zero.1)
+assert_eq add.3(two.7, zero.1) == two.7

--- a/test/compile/lower/basic.pf
+++ b/test/compile/lower/basic.pf
@@ -1,0 +1,23 @@
+// Phase-1 lowering smoke test. Uses no prelude so the IR fixture
+// stays small and human-readable.
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+recursive add(MyNat, MyNat) -> MyNat {
+  add(zero, m) = m
+  add(suc(n), m) = suc(add(n, m))
+}
+
+define two : MyNat = suc(suc(zero))
+
+define add_two : fn MyNat -> MyNat = λ x { add(two, x) }
+
+define pick : fn bool, MyNat, MyNat -> MyNat
+  = λ b:bool, x:MyNat, y:MyNat { if b then x else y }
+
+print add_two(suc(zero))
+print pick(true, two, zero)
+assert add(two, zero) = two

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,0 +1,5 @@
+union MyNat.14 {zero.15/0, suc.16/1}
+fn add.17($scr0, m.18) = match $scr0 { | zero.15 -> m.18 | suc.16(n.19) -> suc.16(add.17(n.19, m.18)) }
+fn adder.23(x.21) = closure[$lam1](x.21)
+print adder.23(suc.16(zero.15))(suc.16(suc.16(zero.15)))
+fn $lam1[x.21](y.22) = add.17(x.21, y.22)

--- a/test/compile/lower/closure.ir
+++ b/test/compile/lower/closure.ir
@@ -1,0 +1,4 @@
+union MyNat.14 {zero.15/0, suc.16/1}
+fn add.17($scr0, m.18) = match $scr0 { | zero.15 -> m.18 | suc.16(n.19) -> suc.16(add.17(n.19, m.18)) }
+fn adder.23(x.21) = λ(y.22). add.17(x.21, y.22)
+print adder.23(suc.16(zero.15))(suc.16(suc.16(zero.15)))

--- a/test/compile/lower/closure.pf
+++ b/test/compile/lower/closure.pf
@@ -1,0 +1,17 @@
+// Exercises closure conversion: a top-level function returns a lambda
+// that captures the outer parameter.
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+recursive add(MyNat, MyNat) -> MyNat {
+  add(zero, m) = m
+  add(suc(n), m) = suc(add(n, m))
+}
+
+define adder : fn MyNat -> (fn MyNat -> MyNat)
+  = λ x : MyNat { λ y : MyNat { add(x, y) } }
+
+print adder(suc(zero))(suc(suc(zero)))

--- a/test/compile/run_e2e.py
+++ b/test/compile/run_e2e.py
@@ -1,0 +1,135 @@
+"""End-to-end test for the Deduce-to-C compiler.
+
+For each `.pf` fixture in `test/compile/e2e/` (and the lowering
+fixtures in `test/compile/lower/`):
+1. Run it under the interpreter and capture stdout.
+2. Compile it via `deduce.py --compile` to a `.c` file.
+3. Compile that with the system `cc` and link against the runtime.
+4. Run the binary and compare stdout to (1).
+
+Skips the whole run with a clear message if `cc` is not available.
+
+Run from the repo root:
+    python3 test/compile/run_e2e.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+LOWER_DIR = ROOT / "test" / "compile" / "lower"
+E2E_DIR = ROOT / "test" / "compile" / "e2e"
+RUNTIME_DIR = ROOT / "compiler" / "runtime"
+
+
+def find_cc() -> str | None:
+    return shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+
+
+def run_interpreter(pf: Path) -> str:
+    """Returns the interpreter's stdout (excluding the trailing
+    `... is valid` line)."""
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "deduce.py"), "--no-stdlib",
+         "--suppress-theorems", "--quiet", str(pf)],
+        cwd=str(ROOT),
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"interpreter failed on {pf.name}:\n{proc.stdout}\n{proc.stderr}")
+    lines = proc.stdout.splitlines()
+    if lines and lines[-1].endswith("is valid"):
+        lines = lines[:-1]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def run_compiled(pf: Path, cc: str, tmp: Path) -> str:
+    c_path = tmp / (pf.stem + ".c")
+    bin_path = tmp / pf.stem
+    subprocess.run(
+        [sys.executable, str(ROOT / "deduce.py"), "--no-stdlib",
+         "--suppress-theorems", "--quiet", "--compile",
+         "-o", str(c_path), str(pf)],
+        cwd=str(ROOT), check=True,
+        # Suppress the interpreter's own print/assert output during
+        # compilation; we only want the compiled program's stdout.
+        capture_output=True, text=True,
+    )
+    subprocess.run(
+        [cc, "-Wall", "-Wextra", "-Werror",
+         "-I", str(RUNTIME_DIR),
+         "-o", str(bin_path),
+         str(c_path), str(RUNTIME_DIR / "deduce.c")],
+        check=True, capture_output=True, text=True,
+    )
+    proc = subprocess.run([str(bin_path)], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{pf.name}: compiled binary exit {proc.returncode}:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return proc.stdout
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--filter", default=None)
+    ap.add_argument("--keep-tmp", action="store_true",
+                    help="don't delete the working directory; print its path")
+    args = ap.parse_args()
+
+    cc = find_cc()
+    if cc is None:
+        print("SKIP: no C compiler (cc/clang/gcc) on PATH", file=sys.stderr)
+        return 0
+
+    fixtures: list[Path] = []
+    for d in (E2E_DIR, LOWER_DIR):
+        if d.exists():
+            fixtures.extend(sorted(d.glob("*.pf")))
+    if args.filter:
+        fixtures = [f for f in fixtures if args.filter in f.name]
+    if not fixtures:
+        print("no fixtures found", file=sys.stderr)
+        return 1
+
+    tmp = Path(tempfile.mkdtemp(prefix="deduce-e2e-"))
+    failures: list[str] = []
+    for pf in fixtures:
+        try:
+            interp_out = run_interpreter(pf)
+            compiled_out = run_compiled(pf, cc, tmp)
+        except Exception as e:
+            failures.append(f"{pf.name}: {e}")
+            continue
+        if interp_out != compiled_out:
+            failures.append(
+                f"{pf.name}: stdout mismatch\n"
+                f"--- interpreter ({len(interp_out)} bytes)\n{interp_out}"
+                f"--- compiled ({len(compiled_out)} bytes)\n{compiled_out}"
+            )
+            continue
+        print(f"ok {pf.relative_to(ROOT)}")
+
+    if args.keep_tmp:
+        print(f"workdir: {tmp}")
+    else:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if failures:
+        print("\nFAILURES:")
+        for msg in failures:
+            print(msg)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/compile/run_lower.py
+++ b/test/compile/run_lower.py
@@ -1,0 +1,95 @@
+"""Standalone runner for lowering tests.
+
+For each `*.pf` fixture in `test/compile/lower/`, run the Deduce
+pipeline (parse + uniquify + type-check) without the prelude, then
+hand the post-uniquify AST to `compiler.lower.lower_program` and
+pretty-print the resulting IR. Compare against the sibling `*.ir`
+file, regenerating with `--regenerate` if requested.
+
+Run from the repo root:
+
+    python3 test/compile/run_lower.py
+    python3 test/compile/run_lower.py --regenerate
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Make the repo root importable.
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+
+from compiler import closure, ir, lower  # noqa: E402
+from lsp.library import check_file  # noqa: E402
+
+
+FIXTURE_DIR = ROOT / "test" / "compile" / "lower"
+
+
+def lower_file(path: Path) -> tuple[str, str]:
+    """Returns (post-lower IR, post-closure-conversion IR)."""
+    sys.argv = [str(ROOT / "deduce.py")]  # check_file looks at sys.argv[0]
+    result = check_file(str(path), prelude=[])
+    if not result.ok:
+        raise RuntimeError(f"{path}: deduce check failed:\n{result.error_message}")
+    program = lower.lower_program(result.ast)
+    lowered_str = ir.pp_program(program)
+    converted = closure.closure_convert(program)
+    converted_str = ir.pp_program(converted)
+    return lowered_str, converted_str
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--regenerate", action="store_true",
+                    help="overwrite expected .ir files with current output")
+    ap.add_argument("--filter", default=None,
+                    help="only run fixtures whose name contains this string")
+    args = ap.parse_args()
+
+    fixtures = sorted(FIXTURE_DIR.glob("*.pf"))
+    if args.filter:
+        fixtures = [f for f in fixtures if args.filter in f.name]
+
+    failures: list[str] = []
+    for pf in fixtures:
+        try:
+            lowered, converted = lower_file(pf)
+        except Exception as e:
+            failures.append(f"{pf.name}: lowering raised: {e}")
+            continue
+
+        for stage, actual in (("ir", lowered), ("cir", converted)):
+            expect_path = pf.with_suffix("." + stage)
+            if args.regenerate:
+                expect_path.write_text(actual)
+                print(f"regenerated {expect_path.name}")
+                continue
+            if not expect_path.exists():
+                failures.append(
+                    f"{pf.name}: missing expected file {expect_path.name}"
+                )
+                continue
+            expected = expect_path.read_text()
+            if actual != expected:
+                failures.append(
+                    f"{pf.name} ({stage}): IR mismatch\n"
+                    f"--- expected\n{expected}--- actual\n{actual}"
+                )
+                continue
+            print(f"ok {pf.name} ({stage})")
+
+    if failures:
+        print("\nFAILURES:")
+        for msg in failures:
+            print(msg)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Begins implementing the compile-to-C plan from #291. Delivers Phase 1, steps 1–6: small Deduce programs lower to a small functional IR, get closure-converted, and emit a self-contained `.c` file that — when linked against a tiny runtime — produces the same stdout as the interpreter.

This builds on top of [PR #300](https://github.com/jsiek/deduce/pull/300) (the planning document). It does not depend on that PR landing — the new code is self-contained — but the plan is the design rationale and is worth reviewing first.

## What's in this PR

### `compiler/` (new package)
- **`ir.py`** — small functional core IR. `Var`, `Bool`, `Int`, `Lam`, `MkClosure`, `App`, `Let`, `If`, `Con`, `Match`. Top-level: `UnionDecl`, `Function`, `Global`, `Print`, `AssertEq`, `AssertBool`. Types and proofs are erased before they reach the IR.
- **`lower.py`** — Deduce post-uniquify AST → IR. Handles the executable subset enumerated in [docs/compile-plan.md](https://github.com/jsiek/deduce/blob/main/docs/compile-plan.md). Theorems / postulates / predicates / `auto` / `inductive` etc. are silently dropped. Anything outside the supported subset raises `CompileError` with a location — no silent fallthrough.
- **`closure.py`** — lambda-lifts every `Lam` to a fresh top-level `Function` with a `captures` list; replaces the lambda site with `MkClosure(fn, [...])`.
- **`emit_c.py`** — emits C source. Every value is a `deduce_value`; every function takes `(env, args)`. Direct calls to top-level functions bypass the closure dispatch; everything else goes through `deduce_call`.
- **`runtime/deduce.h`**, **`runtime/deduce.c`** — small C runtime: tagged union for `D_BOOL` / `D_INT` / `D_CTOR` / `D_CLOSURE`; structural equality; pretty-printing; assertion helpers. No GC — mallocs and leaks. Compiles clean with `-Wall -Wextra -Werror`.

### `deduce.py`
Adds `--compile` and `-o <path>` flags. `python3 deduce.py --compile -o foo.c foo.pf` produces `foo.c`; link against `compiler/runtime/deduce.c` to get a binary.

### Tests under `test/compile/`
- **`run_lower.py`** — regression test for the IR. For each `.pf` fixture, dumps post-lowering IR and post-closure-conversion IR; compares against checked-in `.ir` / `.cir` files. `--regenerate` to update.
- **`run_e2e.py`** — end-to-end: for each fixture, runs the interpreter, compiles via `--compile`, runs the binary, diffs stdout. Skips cleanly if no `cc` on PATH.
- **Fixtures**: `basic.pf` (union, recursive function, if, print, assert) and `closure.pf` (returned lambda capturing an outer parameter).

### `Makefile`
New `tests-compile` target. Not added to default `make` since it depends on a C compiler being installed.

## Out of scope (deferred to Phase 2+)

- `MakeArray` / `ArrayGet` / `Array` — raises `CompileError`.
- `GenRecFun` (recfun with measure) — raises `CompileError`.
- Prelude integration — fixtures use `--no-stdlib` for now.
- Performance — see Phase 4 of the plan; peano `Nat` is exponential by design.
- First-class top-level function references appear as a stub in `emit_c.py` but aren't exercised; lambdas are the supported way to pass functions around.

## Test plan

- [ ] `make tests-compile` — both lowering regression and end-to-end pass.
- [ ] `make tests` — no regression to the existing test suite.
- [ ] Eyeball the two fixtures' `.ir` / `.cir` files; confirm the IR shape matches expectations (especially the lifted `$lam1` in `closure.cir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)