### PR TITLE
Phase 1 / Step 3: implement check() in the query API

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 in progress — Steps 1–2 done.
+**Status:** Phase 1 in progress — Steps 1–3 done.
 
 ## Goals
 
@@ -39,8 +39,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
   - *Acceptance:* import test verifying signatures. After this step, any change to `query.py` signatures requires explicit justification in the PR.
   - *Implementation:* `lsp/query.py` with 9 frozen dataclasses/enums (`Position`, `Range`, `Location`, `Diagnostic`, `Given`, `Goal`, `SymbolInfo`, `Severity`, `SymbolKind`) and 4 stub functions; `__all__` declared. `test/lsp/test_query.py` (21 tests) locks signatures, parameter names, return annotations, frozen-ness, `__all__` membership, stub-raises behavior, and statically asserts no protocol imports (`pygls`/`mcp`/`lsprotocol`/`anthropic`). Position convention: 1-indexed (matches Deduce error messages and lark Meta).
 
-- [ ] **Step 3: Implement `check`.** Convert raised `Exception` / `StaticError` / `IncompleteProof` into `Diagnostic` objects. Single-diagnostic mode is fine; multi-error collection is Step 10.
+- [x] **Step 3: Implement `check`.** Convert raised `Exception` / `StaticError` / `IncompleteProof` into `Diagnostic` objects. Single-diagnostic mode is fine; multi-error collection is Step 10.
   - *Acceptance:* parallel to `test/should-error/*.pf.err` — assert each fixture produces a `Diagnostic` with the right line/severity.
+  - *Implementation:* `lsp/query.py:check` calls `check_file(path, content=content)` and translates the captured exception into a `Diagnostic`. Required surfacing structured location/body via `error.py` (added `location`/`message_body` attributes to `error`/`incomplete_error`/`static_error`/`match_failed`/`ParseError`), a new `wrap_error` helper, and patches at six wrap sites in `proof_checker.py` that previously raised bare `Exception(str(e) + ...)` and dropped the location. `lsp/library.py` gained a `content` parameter (bypasses the uniquified-modules cache) and an `exception` field on `CheckResult`. `rec_desc_parser.py` had a pre-existing leak: `check_closest_kwd` was set to `True` on first parse error and never reset, leaking spurious "did you mean" suggestions across calls in library mode — now reset in a `finally`. Acceptance test `test/lsp/test_check.py` runs 158 cases.
 
 - [ ] **Step 4: Implement `goal_at`.** Insert a `?` (`PHole`) at the requested position into a copy of the source, run check, capture the printed goal.
   - *Acceptance:* hand-crafted fixtures in `test/lsp/` with `-- expect goal: ...` markers; test reads marker and asserts.

--- a/error.py
+++ b/error.py
@@ -51,6 +51,11 @@ def error(location, msg):
   exc = Exception(error_header(location) + msg)
   # exc = Exception(error_header(location) + '\n\n' + error_program_text(location) + '\n\n' + msg)
   exc.depth = 0
+  # Attach structured fields so library/LSP/MCP callers can build
+  # Diagnostic objects without regex-parsing str(exc). The CLI ignores
+  # these attributes; existing print(str(exc)) output is unchanged.
+  exc.location = location
+  exc.message_body = msg
   raise exc
 
 class IncompleteProof(Exception):
@@ -59,24 +64,57 @@ class IncompleteProof(Exception):
 def incomplete_error(location, msg):
   exc = IncompleteProof(error_header(location) + msg)
   exc.depth = 0
+  exc.location = location
+  exc.message_body = msg
   raise exc
 
 def warning(location, msg):
   print(error_header(location) + msg)
 
+def wrap_error(inner, context):
+  """Return a new Exception that re-raises ``inner`` with ``context``
+  appended to the message, preserving the structured ``location`` and
+  ``message_body`` attributes set by error()/incomplete_error()/
+  static_error()/match_failed().
+
+  Callers that catch a structured exception and want to add trailing
+  context should use this helper instead of ``raise Exception(str(e)
+  + context)`` -- the bare-Exception form drops the location, which
+  the LSP/MCP query API needs for Diagnostic.range.
+
+  ``str()`` of the returned exception equals ``str(inner) + context``,
+  so user-visible error text (and the should-error/*.pf.err fixtures)
+  is unchanged.
+  """
+  new_exc = Exception(str(inner) + context)
+  inner_loc = getattr(inner, 'location', None)
+  if inner_loc is not None:
+    new_exc.location = inner_loc
+  inner_body = getattr(inner, 'message_body', None)
+  if inner_body is None:
+    inner_body = str(inner)
+  new_exc.message_body = inner_body + context
+  return new_exc
+
 class StaticError(Exception):
   pass
 
 def static_error(location, msg):
-  raise StaticError(error_header(location) + msg)
+  exc = StaticError(error_header(location) + msg)
   # raise StaticError(error_header(location) + '\n\n' + error_program_text(location) + '\n\n' + msg)
+  exc.location = location
+  exc.message_body = msg
+  raise exc
 
 class MatchFailed(Exception):
   pass
 
 def match_failed(location, msg):
-  raise MatchFailed(error_header(location) + msg)
+  exc = MatchFailed(error_header(location) + msg)
   # raise MatchFailed(error_header(location) + '\n\n' + error_program_text(location) + '\n\n' + msg)
+  exc.location = location
+  exc.message_body = msg
+  raise exc
 
 MAX_ERR_DEPTH = 2
 
@@ -89,6 +127,12 @@ class ParseError(Exception):
     self.missing = missing
     self.last = last
     self.trace = []
+    # Aliases that match the attribute names attached to Exception by
+    # error()/incomplete_error()/static_error()/match_failed(), so the
+    # query API can read e.location / e.message_body uniformly across
+    # exception types.
+    self.location = loc
+    self.message_body = msg
 
   def extend(self, loc, msg):
     self.trace.append(ParseError(loc, msg))

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -46,6 +46,10 @@ class CheckResult:
         error_traceback:  Full Python traceback at the point of failure,
                           for callers that want it (e.g. ``--traceback``).
                           ``None`` when ``ok`` is True.
+        exception:        The raised exception object, preserved so
+                          structured callers (``lsp.query.check``) can
+                          read ``e.location`` / ``e.message_body``
+                          without re-parsing strings. ``None`` when ok.
         module_name:      Module name derived from the filename
                           (``Path(filename).stem``).
         ast:              Post-uniquify AST. Populated on success and on
@@ -57,6 +61,7 @@ class CheckResult:
     ok: bool
     error_message: Optional[str]
     error_traceback: Optional[str]
+    exception: Optional[BaseException]
     module_name: str
     ast: Optional[Any]
 
@@ -65,6 +70,7 @@ def check_file(
     filename: str,
     tracing_functions: Sequence[str] = (),
     prelude: Sequence[str] = (),
+    content: Optional[str] = None,
 ) -> CheckResult:
     """Run the Deduce pipeline on ``filename`` and return a CheckResult.
 
@@ -78,6 +84,13 @@ def check_file(
         prelude:            Module names to import as a private prelude
                             in front of the file. Pass ``[]`` for no
                             prelude (matches ``--no-stdlib``).
+        content:            If given, parsed instead of reading
+                            ``filename`` from disk. Use this to check
+                            an unsaved editor buffer. ``filename`` is
+                            still used for import resolution and
+                            error messages. Bypasses the
+                            ``uniquified_modules`` cache, since the
+                            cached AST corresponds to disk content.
     """
     module_name = Path(filename).stem
     if get_verbose():
@@ -86,11 +99,18 @@ def check_file(
     ast: Optional[Any] = None
     try:
         cached = get_uniquified_modules()
-        if module_name in cached:
+        # The cache is keyed by module name and corresponds to a
+        # specific on-disk state. When the caller passes in-memory
+        # content, the cache may be stale, so we bypass it and re-parse.
+        use_cache = content is None
+        if use_cache and module_name in cached:
             ast = cached[module_name]
         else:
-            with open(filename, "r", encoding="utf-8") as f:
-                program_text = f.read()
+            if content is None:
+                with open(filename, "r", encoding="utf-8") as f:
+                    program_text = f.read()
+            else:
+                program_text = content
 
             deduce_dir = os.path.dirname(sys.argv[0])
             if get_recursive_descent():
@@ -115,13 +135,15 @@ def check_file(
                 ast = imports + ast
 
             uniquify_deduce(ast)
-            add_uniquified_module(module_name, ast)
+            if use_cache:
+                add_uniquified_module(module_name, ast)
 
         check_deduce(ast, module_name, True, list(tracing_functions))
         return CheckResult(
             ok=True,
             error_message=None,
             error_traceback=None,
+            exception=None,
             module_name=module_name,
             ast=ast,
         )
@@ -130,6 +152,7 @@ def check_file(
             ok=False,
             error_message=str(e),
             error_traceback=_traceback.format_exc(),
+            exception=e,
             module_name=module_name,
             ast=ast,
         )

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -195,10 +195,50 @@ def check(path: str, content: str) -> list[Diagnostic]:
     on the first error, so today the list will have at most one entry;
     Step 11 (multi-error collection) will lift that limit without
     changing this signature.
-
-    Implemented in Step 3.
     """
-    raise NotImplementedError("Step 3 implements check.")
+    # Imported here, not at module top, so this module stays free of
+    # any pipeline import while it is just a stub at module-load time.
+    # That keeps the protocol-neutral boundary cheap to enforce.
+    from lsp.library import check_file
+
+    result = check_file(path, content=content)
+    if result.ok:
+        return []
+
+    return [_diagnostic_from_exception(result.exception, str_fallback=result.error_message)]
+
+
+def _diagnostic_from_exception(
+    exc: Optional[BaseException], str_fallback: Optional[str]
+) -> Diagnostic:
+    """Build a Diagnostic from an exception raised by the pipeline.
+
+    Reads ``exc.location`` and ``exc.message_body`` if present
+    (attached by ``error.py`` for all error/incomplete/static/match/
+    parse errors). Falls back to ``str_fallback`` plus a sentinel
+    range when the exception is unstructured -- which only happens
+    for unexpected internal exceptions.
+    """
+    sentinel = Range(Position(1, 1), Position(1, 1))
+
+    if exc is None:
+        # Should not happen in practice; defensive fallback.
+        return Diagnostic(Severity.ERROR, sentinel, str_fallback or "unknown error")
+
+    location = getattr(exc, "location", None)
+    if location is not None and not getattr(location, "empty", True):
+        rng = Range(
+            start=Position(location.line, location.column),
+            end=Position(location.end_line, location.end_column),
+        )
+    else:
+        rng = sentinel
+
+    body = getattr(exc, "message_body", None)
+    if body is None:
+        body = str_fallback if str_fallback is not None else str(exc)
+
+    return Diagnostic(severity=Severity.ERROR, range=rng, message=body)
 
 
 def goal_at(path: str, content: str, pos: Position) -> Optional[Goal]:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -23,7 +23,7 @@
 #    reduce some formulas and terms automatically.
 
 from abstract_syntax import *
-from error import error, incomplete_error, warning, error_header, IncompleteProof, match_failed, MatchFailed
+from error import error, incomplete_error, warning, error_header, IncompleteProof, match_failed, MatchFailed, wrap_error
 from flags import get_verbose, set_verbose, print_verbose, VerboseLevel
 
 imported_modules = set()
@@ -50,20 +50,20 @@ def check_implies(loc, frm1, frm2):
         for arg2 in args:
           check_implies(loc, frm1, arg2)
       except Exception as e:
-          msg = str(e) + '\n\nWhile trying to prove that\n\t' + str(frm1) \
+          context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
               + '\nimplies\n'\
               + '\t' + str(frm2)
-          raise Exception(msg)
-        
+          raise wrap_error(e, context) from e
+
     case(Or(loc1, tyof1, args1), _):
       for arg1 in args1:
         try:
           check_implies(loc, arg1, frm2)
         except Exception as e:
-          msg = str(e) + '\n\nWhile trying to prove that\n\t' + str(frm1) \
+          context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
               + '\nimplies\n'\
               + '\t' + str(frm2)
-          raise Exception(msg)
+          raise wrap_error(e, context) from e
       
     case (Bool(loc2, tyof2, False), _):
       return
@@ -111,21 +111,21 @@ def check_implies(loc, frm1, frm2):
         check_implies(loc, prem2, prem1)
         check_implies(loc, conc1, conc2)
       except Exception as e:
-        msg = str(e) + '\n\nWhile trying to prove that\n\t' + str(frm1) \
+        context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
             + '\nimplies\n'\
             + '\t' + str(frm2)
-        raise Exception(msg)
-      
+        raise wrap_error(e, context) from e
+
     case (All(loc1, tyof1, var1, _, body1), All(loc2, tyof2, var2, _, body2)):
       try:
           sub = { var2[0]: Var(loc2, var1[1], var1[0], []) }
           body2a = body2.substitute(sub)
           check_implies(loc, body1, body2a)
       except Exception as e:
-        msg = str(e) + '\n\nWhile trying to prove that\n\t' + str(frm1) \
+        context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
             + '\nimplies\n'\
             + '\t' + str(frm2)
-        raise Exception(msg)
+        raise wrap_error(e, context) from e
 
     case (All(loc1, tyof1, vars1, _, body1), _):
        matching = {}
@@ -1293,7 +1293,7 @@ def check_proof_of(proof, formula, env):
             try:
               check_implies(loc, red_claim, new_formula)
             except Exception as e:
-              raise Exception(str(e) + '\nGivens:\n' + env.proofs_str())
+              raise wrap_error(e, '\nGivens:\n' + env.proofs_str()) from e
             check_proof_of(rest, new_claim, env)
       else:
         new_claim = type_check_term(claim, BoolType(loc), env, None, [])
@@ -1639,14 +1639,14 @@ def check_proof_of(proof, formula, env):
       except IncompleteProof as e:
         raise e
       except Exception as e:
-        msg = str(e)
         # It could be that form is never reduced, such as in a PHelpUse
         # In that case, we don't give 'replace' advice
-        try: 
-          if is_equation(form_red): 
-            msg += '\nDid you mean `replace ' + str(proof) + '`?'
+        replace_advice = ''
+        try:
+          if is_equation(form_red):
+            replace_advice = '\nDid you mean `replace ' + str(proof) + '`?'
         finally:
-          raise(Exception(msg))
+          raise wrap_error(e, replace_advice) from e
 
 
 def expand_definitions(loc, formula, defs, env):
@@ -1814,12 +1814,12 @@ def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
             type_match(loc, type_params, param_type, new_arg.typeof, matching)
           new_args.append(new_arg)
     except Exception as e:
-        new_msg = str(e) + '\n\n\t' + 'in context of call ' + str(call) + '\n' \
+        context = '\n\n\t' + 'in context of call ' + str(call) + '\n' \
             + '\tfunction type: ' + str(FunctionType(loc, typarams, param_types,
                                                      return_type)) + '\n' \
             + '\tinferred type arguments: ' \
             + ', '.join([base_name(x) + ' := ' + str(ty) for (x,ty) in matching.items()])
-        raise Exception(new_msg)
+        raise wrap_error(e, context) from e
     
     # Were all the type parameters deduced?
     for x in typarams:

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -93,30 +93,39 @@ check_closest_kwd = False
 
 def parse(program_text, trace = False, error_expected = False):
   global token_list, current_position, check_closest_kwd
-  lexed = lark_parser.lex(program_text)
-  token_list = []
-  current_position = 0
-  for token in lexed:
-    if trace:
-      print(repr(token))
-    token_list.append(token)
+  try:
+    lexed = lark_parser.lex(program_text)
+    token_list = []
+    current_position = 0
+    for token in lexed:
+      if trace:
+        print(repr(token))
+      token_list.append(token)
 
-  stmts = []
-  while not end_of_file():
-    try:
-      stmt = parse_statement()
-    except ParseError as e:
-      if not check_closest_kwd:
-        check_closest_kwd = True
-        parse(program_text, trace, error_expected)
-      else:
+    stmts = []
+    while not end_of_file():
+      try:
+        stmt = parse_statement()
+      except ParseError as e:
+        if not check_closest_kwd:
+          check_closest_kwd = True
+          parse(program_text, trace, error_expected)
+        else:
+          raise e
+      except Exception as e:
         raise e
-    except Exception as e:
-      raise e
 
-        
-    stmts.append(stmt)
-  return stmts
+
+      stmts.append(stmt)
+    return stmts
+  finally:
+    # check_closest_kwd is set to True when a first-pass parse error
+    # triggers a "did you mean" retry. Without this reset, the True
+    # value leaks into subsequent parses (e.g. of imported library
+    # files in library mode) and produces spurious keyword-closeness
+    # suggestions. The CLI never noticed because each invocation is
+    # a fresh process.
+    check_closest_kwd = False
 
 
 def parse_identifier():

--- a/test/lsp/conftest.py
+++ b/test/lsp/conftest.py
@@ -1,0 +1,71 @@
+"""Shared pytest fixtures for the lsp/ test suite.
+
+The Deduce pipeline keeps a lot of module-level state in
+``proof_checker`` and ``abstract_syntax`` (caches keyed by module name,
+counters, sets of "already checked" modules, etc.). The CLI doesn't
+care because each invocation runs in a fresh process, but the in-process
+tests below run many checks back-to-back. ``_reset_state`` is the
+working inventory of those globals; Step 6 of the LSP plan replaces
+this hack with proper per-call isolation.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+# Make sys.argv[0] point at deduce.py so set_deduce_directory resolves
+# imports the same way the CLI does. Has to happen before any test
+# module imports the pipeline.
+sys.argv = [str(REPO_ROOT / "deduce.py")]
+
+import abstract_syntax  # noqa: E402
+import proof_checker  # noqa: E402
+from abstract_syntax import (  # noqa: E402
+    add_import_directory,
+    init_import_directories,
+)
+from flags import set_quiet_mode  # noqa: E402
+
+
+LIB_DIR = REPO_ROOT / "lib"
+TEST_IMPORTS_DIR = REPO_ROOT / "test" / "test-imports"
+
+
+def _reset_state() -> None:
+    """Clear the module-level caches the pipeline accumulates per file.
+
+    If a future change to the checker adds another cache, the in-process
+    tests will go flaky -- add the new global here.
+    """
+    abstract_syntax.uniquified_modules.clear()
+    abstract_syntax._predicate_decls_by_unique_name.clear()
+    abstract_syntax.collected_imports.clear()
+    abstract_syntax.reduce_only.clear()
+    abstract_syntax.reduced_defs.clear()
+    proof_checker.imported_modules.clear()
+    proof_checker.checked_modules.clear()
+    proof_checker.dirty_files.clear()
+    proof_checker.modules.clear()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _set_up_globals():
+    """Mirror what ``deduce.py``'s ``__main__`` does once at startup."""
+    set_quiet_mode(True)
+    init_import_directories()
+    add_import_directory(str(LIB_DIR))
+    add_import_directory(str(TEST_IMPORTS_DIR))
+    sys.setrecursionlimit(10000)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_between_tests():
+    _reset_state()
+    yield
+    _reset_state()

--- a/test/lsp/test_check.py
+++ b/test/lsp/test_check.py
@@ -1,0 +1,110 @@
+"""Acceptance test for ``lsp.query.check`` (Phase 1 / Step 3).
+
+For every ``test/should-error/*.pf`` fixture, verifies that ``check``
+returns a single ``Diagnostic`` with ``Severity.ERROR`` whose start
+line and column match the location reported in the sibling ``.err``
+fixture. For a sample of ``test/should-validate/`` files, verifies
+``check`` returns an empty list.
+
+The .err files are produced by running ``deduce.py`` and capturing
+stdout, so they contain the same location text the user sees today;
+this test pins the new structured ``Diagnostic.range`` to that text,
+catching any regression where the LSP/MCP boundary reports a
+different line than the CLI does.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import Diagnostic, Position, Severity, check  # noqa: E402
+
+ERROR_DIR = REPO_ROOT / "test" / "should-error"
+PASS_DIR = REPO_ROOT / "test" / "should-validate"
+
+
+# Matches Deduce's location header anywhere in a .err file. Some parse
+# errors print the source excerpt first, then the header on a later
+# line, so we scan instead of inspecting just the first line.
+_LOC_HEADER_RE = re.compile(
+    r"(?P<path>[^\s:]+):(?P<line>\d+)\.(?P<col>\d+)-(?P<eline>\d+)\.(?P<ecol>\d+):"
+)
+
+
+def _expected_positions(err_path: Path) -> list[Position]:
+    """Pull every ``file:L.C-L.C:`` location out of a .err file.
+
+    Some fixtures print just one location; parse errors print a trace
+    (broader context, then the specific failure); structural errors
+    like overload clashes print the primary location followed by a
+    referential one (e.g. "previously defined here"). The Diagnostic's
+    ``e.location`` matches *some* of these, depending on which path
+    raised; we accept any match.
+    """
+    text = err_path.read_text()
+    return [
+        Position(line=int(m.group("line")), column=int(m.group("col")))
+        for m in _LOC_HEADER_RE.finditer(text)
+    ]
+
+
+def _error_pf_files() -> list[Path]:
+    return sorted(p for p in ERROR_DIR.glob("*.pf"))
+
+
+# A handful of should-validate files; the full corpus is already
+# covered by test_library.py at the CheckResult level. These confirm
+# the query API's empty-list contract.
+_SAMPLE_VALID = [
+    "after.pf",
+    "all-elim-tlet.pf",
+    "ImportTests.pf",
+    "ListTests.pf",
+    "NatTests.pf",
+]
+
+
+@pytest.mark.parametrize("pf_path", _error_pf_files(), ids=lambda p: p.name)
+def test_check_reports_error_at_expected_location(pf_path: Path) -> None:
+    err_path = pf_path.with_suffix(pf_path.suffix + ".err")
+    expected_positions = _expected_positions(err_path)
+    if not expected_positions:
+        pytest.skip(f"{err_path.name} has no parseable location header")
+
+    content = pf_path.read_text()
+    diagnostics = check(str(pf_path), content)
+
+    assert isinstance(diagnostics, list)
+    assert len(diagnostics) == 1, (
+        f"{pf_path.name}: expected 1 diagnostic, got {len(diagnostics)}"
+    )
+
+    diag = diagnostics[0]
+    assert isinstance(diag, Diagnostic)
+    assert diag.severity is Severity.ERROR
+
+    actual = diag.range.start
+    assert actual in expected_positions, (
+        f"{pf_path.name}: Diagnostic at {actual.line}.{actual.column} "
+        f"doesn't match any location in {err_path.name} "
+        f"({[f'{p.line}.{p.column}' for p in expected_positions]})"
+    )
+    assert diag.message, f"{pf_path.name}: diagnostic message is empty"
+
+
+@pytest.mark.parametrize("name", _SAMPLE_VALID)
+def test_check_returns_empty_for_valid_files(name: str) -> None:
+    path = PASS_DIR / name
+    content = path.read_text()
+    diagnostics = check(str(path), content)
+    assert diagnostics == [], (
+        f"{name} should validate but check returned {len(diagnostics)} "
+        f"diagnostic(s): {[d.message for d in diagnostics]}"
+    )

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -4,16 +4,12 @@ For every file in ``test/should-validate`` and ``test/should-error``,
 verifies that the library API returns the same outcome (ok vs. error)
 that ``test-deduce.py`` produces by shelling out to ``deduce.py``.
 
-This is an in-process test, so it has to manually scrub the module-level
-caches in ``proof_checker`` and ``abstract_syntax`` between calls --
-those are global today and Step 6 of the plan will replace this hack
-with a proper state-isolation mechanism. Until then, ``_reset_state``
-below is the source of truth for what state crosses call boundaries.
+The session/state fixtures live in ``conftest.py`` so the Step 3
+acceptance test can share them.
 """
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -22,60 +18,10 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-# Make sys.argv[0] point at deduce.py so the parser's set_deduce_directory
-# resolution works the same way the CLI sets it up.
-sys.argv = [str(REPO_ROOT / "deduce.py")]
-
-import abstract_syntax  # noqa: E402
-import proof_checker  # noqa: E402
-from abstract_syntax import (  # noqa: E402
-    add_import_directory,
-    init_import_directories,
-)
-from flags import set_quiet_mode  # noqa: E402
 from lsp.library import CheckResult, check_file  # noqa: E402
 
 PASS_DIR = REPO_ROOT / "test" / "should-validate"
 ERROR_DIR = REPO_ROOT / "test" / "should-error"
-LIB_DIR = REPO_ROOT / "lib"
-TEST_IMPORTS_DIR = REPO_ROOT / "test" / "test-imports"
-
-
-def _reset_state() -> None:
-    """Clear the module-level caches the pipeline accumulates per file.
-
-    These are the same globals Step 6 of the LSP plan needs to lift; the
-    list below is the working inventory. If a future change to the
-    checker adds another cache, this test will likely start being flaky
-    in CI -- add the new global here.
-    """
-    abstract_syntax.uniquified_modules.clear()
-    abstract_syntax._predicate_decls_by_unique_name.clear()
-    abstract_syntax.collected_imports.clear()
-    abstract_syntax.reduce_only.clear()
-    abstract_syntax.reduced_defs.clear()
-    proof_checker.imported_modules.clear()
-    proof_checker.checked_modules.clear()
-    proof_checker.dirty_files.clear()
-    proof_checker.modules.clear()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _set_up_globals():
-    """Mirror what deduce.py's ``__main__`` does once at startup."""
-    set_quiet_mode(True)
-    init_import_directories()
-    add_import_directory(str(LIB_DIR))
-    add_import_directory(str(TEST_IMPORTS_DIR))
-    sys.setrecursionlimit(10000)
-    yield
-
-
-@pytest.fixture(autouse=True)
-def _reset_between_tests():
-    _reset_state()
-    yield
-    _reset_state()
 
 
 def _pf_files(d: Path) -> list[Path]:
@@ -91,6 +37,7 @@ def test_should_validate(path: Path) -> None:
         f"{result.error_message}"
     )
     assert result.error_message is None
+    assert result.exception is None
     assert result.ast is not None
     assert result.module_name == path.stem
 
@@ -104,4 +51,5 @@ def test_should_error(path: Path) -> None:
     )
     assert result.error_message is not None
     assert result.error_message != ""
+    assert result.exception is not None
     assert result.module_name == path.stem

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -171,12 +171,9 @@ def test_list_symbols_signature():
 
 # --------------------------------------------------------------------------
 # Stubs raise NotImplementedError until the dedicated step lands
+# (``check`` is now implemented; its acceptance test lives in
+# ``test_check.py``).
 # --------------------------------------------------------------------------
-
-
-def test_check_stub_raises():
-    with pytest.raises(NotImplementedError):
-        check("file.pf", "")
 
 
 def test_goal_at_stub_raises():


### PR DESCRIPTION
Step 3 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)).

## What this is
A working `lsp.query.check(path, content)` that returns `list[Diagnostic]`. Builds on Steps 1 and 2 (which are already on main).

## Required changes outside `lsp/`
The Step 3 pipeline needs structured location info for `Diagnostic.range`, which today is buried inside the location prefix of `str(exception)`. Three small surgeries upstream:

1. **`error.py`**: `error` / `incomplete_error` / `static_error` / `match_failed` / `ParseError` now attach `.location` and `.message_body` to the raised exception. `str(e)` and the `.err` fixture text are unchanged. Adds a `wrap_error()` helper for the "catch + re-raise with trailing context" pattern that previously dropped these attributes.

2. **`proof_checker.py`**: six wrap sites in `check_implies`, `check_proof_of`, and `type_check_call_funty` raised bare `Exception(str(e) + context)`, dropping the structured location. Each switched to `wrap_error(e, ...)`. Behavior of `str(e)` (and therefore `.err` fixtures) is preserved.

3. **`rec_desc_parser.py`**: a pre-existing latent leak. `parse()` set the module-global `check_closest_kwd` to `True` on first parse error and never reset it. The CLI never noticed because each invocation is a fresh process; in library mode the `True` value leaked across calls and produced spurious "did you mean" suggestions when imported library files contained similar identifiers. Now reset in `try/finally` around the parse body.

## Inside `lsp/`
- `lsp/library.py`: `check_file` gained a `content` parameter for in-memory buffers (LSP didChange use case). When content is supplied, the `uniquified_modules` cache is bypassed (it corresponds to on-disk state). `CheckResult` gained an `exception` field so structured callers can read `e.location` / `e.message_body` without re-parsing strings.
- `lsp/query.py`: `check()` is a few lines on top of `check_file` plus a small `_diagnostic_from_exception` helper.

## Test changes
- `test/lsp/conftest.py` (new): hoisted session/state fixtures so the new test can reuse them. `_reset_state` remains the working inventory of cross-call globals; Step 6 replaces it with proper isolation.
- `test/lsp/test_check.py` (new): **158 cases**. For every `should-error/*.pf` fixture, asserts `check` returns one `Diagnostic` with `Severity.ERROR` whose start position matches one of the location headers in the sibling `.err`. For five sample `should-validate` files, asserts `check` returns `[]`. The matcher accepts any location in the `.err` text rather than insisting on first or last — parse-error traces put the deepest location last while structural errors (overload clashes, etc.) put the primary location first and references second.
- `test/lsp/test_library.py`: shed the now-duplicated fixtures, added an exception-field assertion.
- `test/lsp/test_query.py`: drop the `check`-stub-raises test now that it's implemented.

## Test plan
- [x] `python3 -m pytest test/lsp/` — 480 passed (302 from Step 1 + 20 from Step 2 + 158 from Step 3).
- [x] `python3 test-deduce.py` (default) — clean.
- [x] `python3 test-deduce.py --errors` — all `.err` fixtures untouched despite `error.py` / `proof_checker.py` changes.
- [x] `python3 test-deduce.py --parser` — clean.