### PR TITLE
Phase 2 of Deduce-to-C compiler (steps 7, 8, 9, 11)

### DIFF
--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -83,6 +83,12 @@ def closure_convert(p: ir.Program) -> ir.Program:
             case ir.Match(subj, arms):
                 new_arms = [ir.MatchArm(arm.pattern, go(arm.body)) for arm in arms]
                 return ir.Match(go(subj), new_arms)
+            case ir.Eq(l, r):
+                return ir.Eq(go(l), go(r))
+            case ir.MakeArray(s):
+                return ir.MakeArray(go(s))
+            case ir.ArrayGet(s, i):
+                return ir.ArrayGet(go(s), go(i))
         raise AssertionError(f"closure_convert: unknown term {type(t).__name__}")
 
     new_decls: List[ir.TopLevel] = []

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -135,10 +135,11 @@ def emit_program(p: ir.Program) -> str:
             pass
     out.append("")
 
-    # Global variables
+    # Global variables. Same reasoning as the function declarations:
+    # not `static`, so unused globals don't trip -Wunused-variable.
     for d in p.decls:
         if isinstance(d, ir.Global):
-            out.append(f"static deduce_value {_global_id(d.name)};")
+            out.append(f"deduce_value {_global_id(d.name)};")
     out.append("")
 
     # Function bodies
@@ -179,7 +180,12 @@ def emit_program(p: ir.Program) -> str:
 
 
 def _emit_fn_decl(f: ir.Function) -> str:
-    return f"static deduce_value {_func_id(f.name)}(deduce_value* env, deduce_value* args)"
+    # Not `static`: a function may be unused at runtime if it's only
+    # referenced by an erased proof (e.g. used inside a `terminates`
+    # block that compiled to nothing). `static` would trip
+    # -Wunneeded-internal-declaration; an extern function is silently
+    # dropped by the linker if nothing references it.
+    return f"deduce_value {_func_id(f.name)}(deduce_value* env, deduce_value* args)"
 
 
 def _emit_function(f: ir.Function, ctx: EmitCtx) -> str:
@@ -194,8 +200,10 @@ def _emit_function(f: ir.Function, ctx: EmitCtx) -> str:
         body_stmts.append("    (void)env;")
     for i, p in enumerate(f.params):
         body_stmts.append(f"    deduce_value {_local_id(p)} = args[{i}];")
+        body_stmts.append(f"    (void){_local_id(p)};")
     for i, c in enumerate(f.captures):
         body_stmts.append(f"    deduce_value {_local_id(c)} = env[{i}];")
+        body_stmts.append(f"    (void){_local_id(c)};")
     stmts, expr = _emit_term(f.body, ctx, in_scope)
     for s in stmts:
         body_stmts.append("    " + s)
@@ -418,10 +426,13 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                     stmts.append(f"case {_ctor_id_macro(pc.ctor)}: {{")
                     inner_scope = locals_in_scope | set(pc.binds)
                     for i, b in enumerate(pc.binds):
+                        # Cast to (void) to silence -Wunused on bindings
+                        # the case body happens to ignore.
                         stmts.append(
                             f"    deduce_value {_local_id(b)} = "
                             f"deduce_ctor_field({subj_var}, {i});"
                         )
+                        stmts.append(f"    (void){_local_id(b)};")
                     bs, be = _emit_term(arm.body, ctx, inner_scope)
                     for s in bs:
                         stmts.append("    " + s)
@@ -430,6 +441,35 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                     stmts.append("}")
                 stmts.append("default: deduce_panic(\"non-exhaustive match\");")
                 stmts.append("}")
+            return stmts, tmp
+
+        case ir.Eq(l, r):
+            sl, el = _emit_term(l, ctx, locals_in_scope)
+            sr, er = _emit_term(r, ctx, locals_in_scope)
+            stmts = list(sl) + list(sr)
+            tmp = ctx.fresh_tmp()
+            stmts.append(
+                f"deduce_value {tmp} = deduce_make_bool(deduce_equal({el}, {er}));"
+            )
+            return stmts, tmp
+
+        case ir.MakeArray(s):
+            ssub, esub = _emit_term(s, ctx, locals_in_scope)
+            stmts = list(ssub)
+            tmp = ctx.fresh_tmp()
+            stmts.append(
+                f"deduce_value {tmp} = deduce_make_array_from_list({esub});"
+            )
+            return stmts, tmp
+
+        case ir.ArrayGet(s, i):
+            ssub, esub = _emit_term(s, ctx, locals_in_scope)
+            sidx, eidx = _emit_term(i, ctx, locals_in_scope)
+            stmts = list(ssub) + list(sidx)
+            tmp = ctx.fresh_tmp()
+            stmts.append(
+                f"deduce_value {tmp} = deduce_array_get({esub}, {eidx});"
+            )
             return stmts, tmp
 
         case ir.Lam(_, _):

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -114,7 +114,36 @@ class Match:
     arms: List[MatchArm]
 
 
-Term = Union[Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match]
+@dataclass
+class Eq:
+    """Structural equality, the only built-in primitive in the IR.
+    Comes from `Call(Var('='), [a, b])` in the source. Closures
+    compare by pointer identity (matches the runtime `deduce_equal`)."""
+    lhs: "Term"
+    rhs: "Term"
+
+
+@dataclass
+class MakeArray:
+    """Convert a `List<T>`-shaped value (a chain of `node(_, _)` ending
+    in `empty`) into a runtime array. Uses base-name dispatch at the
+    runtime, matching the interpreter's `isNodeList` semantics — any
+    union with constructors named `empty`/`node` works."""
+    subject: "Term"
+
+
+@dataclass
+class ArrayGet:
+    """Read an array element by index. The index is a Nat or UInt;
+    the runtime decodes it by inspecting constructor names. Out-of-
+    bounds returns the original ArrayGet — matches the interpreter
+    convention of not raising on OOB. (We diverge: the compiled
+    binary aborts via `deduce_panic` instead.)"""
+    subject: "Term"
+    index: "Term"
+
+
+Term = Union[Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match, Eq, MakeArray, ArrayGet]
 
 
 # ---------- top-level ----------
@@ -254,6 +283,12 @@ def pp_term(t: Term, indent: int) -> str:
                         raise AssertionError("pp_term: bad pattern")
                 arm_strs.append("| " + ps + " -> " + pp_term(arm.body, indent))
             return "match " + pp_term(subj, indent) + " { " + " ".join(arm_strs) + " }"
+        case Eq(l, r):
+            return "(" + pp_term(l, indent) + " == " + pp_term(r, indent) + ")"
+        case MakeArray(s):
+            return "array(" + pp_term(s, indent) + ")"
+        case ArrayGet(s, i):
+            return pp_term(s, indent) + "[" + pp_term(i, indent) + "]"
     raise AssertionError(f"pp_term: unknown term {type(t).__name__}")
 
 
@@ -261,6 +296,96 @@ def pp_term(t: Term, indent: int) -> str:
 #
 # Used by closure conversion (free-variable analysis) and by emitters.
 # Kept here so the contract is local to the IR module.
+
+def verify(p: Program) -> None:
+    """Walk an IR program and assert every node is a known IR class.
+
+    This is a safety net: it would fire if a future change to lowering
+    accidentally embedded an `abstract_syntax.*` AST node (a Type, or a
+    Term that wasn't translated) inside an IR term. The IR has no
+    field that holds a type — there is nothing to "erase" at this
+    layer; the check enforces that the layer below us did its job.
+
+    Raises `AssertionError` on the first stray node it finds, with the
+    enclosing decl name in the message so the failure is locatable."""
+    top_classes = (UnionDecl, Function, Global, Print, AssertEq, AssertBool)
+    term_classes = (
+        Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match, Eq,
+        MakeArray, ArrayGet,
+    )
+
+    def check_term(t: object, ctx: str) -> None:
+        if not isinstance(t, term_classes):
+            raise AssertionError(
+                f"verify: non-IR term {type(t).__name__} in {ctx}"
+            )
+        match t:
+            case Var(_) | Bool(_) | Int(_):
+                return
+            case Lam(_, body):
+                check_term(body, ctx)
+            case MkClosure(_, caps):
+                for c in caps:
+                    check_term(c, ctx)
+            case App(rator, args):
+                check_term(rator, ctx)
+                for a in args:
+                    check_term(a, ctx)
+            case Let(_, rhs, body):
+                check_term(rhs, ctx)
+                check_term(body, ctx)
+            case If(c, th, el):
+                check_term(c, ctx)
+                check_term(th, ctx)
+                check_term(el, ctx)
+            case Con(_, args):
+                for a in args:
+                    check_term(a, ctx)
+            case Match(subj, arms):
+                check_term(subj, ctx)
+                for arm in arms:
+                    if not isinstance(arm, MatchArm):
+                        raise AssertionError(
+                            f"verify: non-MatchArm in {ctx}"
+                        )
+                    if not isinstance(arm.pattern, (PatBool, PatCon)):
+                        raise AssertionError(
+                            f"verify: non-IR pattern in {ctx}"
+                        )
+                    check_term(arm.body, ctx)
+            case Eq(l, r):
+                check_term(l, ctx)
+                check_term(r, ctx)
+            case MakeArray(s):
+                check_term(s, ctx)
+            case ArrayGet(s, i):
+                check_term(s, ctx)
+                check_term(i, ctx)
+
+    if not isinstance(p, Program):
+        raise AssertionError(f"verify: not a Program: {type(p).__name__}")
+    for d in p.decls:
+        if not isinstance(d, top_classes):
+            raise AssertionError(
+                f"verify: non-IR top-level {type(d).__name__}"
+            )
+        match d:
+            case UnionDecl(_, ctors):
+                for c in ctors:
+                    if not isinstance(c, Constructor):
+                        raise AssertionError("verify: non-IR ctor")
+            case Function(name, _, body, _):
+                check_term(body, f"function {name}")
+            case Global(name, body):
+                check_term(body, f"global {name}")
+            case Print(t):
+                check_term(t, "print")
+            case AssertEq(l, r):
+                check_term(l, "assert_eq")
+                check_term(r, "assert_eq")
+            case AssertBool(t):
+                check_term(t, "assert_bool")
+
 
 def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
     match t:
@@ -298,4 +423,10 @@ def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
                     case PatBool(_):
                         out |= free_vars(arm.body, bound)
             return out
+        case Eq(l, r):
+            return free_vars(l, bound) | free_vars(r, bound)
+        case MakeArray(s):
+            return free_vars(s, bound)
+        case ArrayGet(s, i):
+            return free_vars(s, bound) | free_vars(i, bound)
     raise AssertionError(f"free_vars: unknown term {type(t).__name__}")

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -116,11 +116,7 @@ class LoweringCtx:
         if isinstance(s, ast.RecFun):
             return self.lower_recfun(s)
         if isinstance(s, ast.GenRecFun):
-            raise CompileError(
-                s.location,
-                "GenRecFun (recfun with measure) is not supported in Phase 1; "
-                "see docs/compile-plan.md Step 7",
-            )
+            return self.lower_genrecfun(s)
         if isinstance(s, ast.Print):
             return ir.Print(self.lower_term(s.term))
         if isinstance(s, ast.Assert):
@@ -189,6 +185,20 @@ class LoweringCtx:
             body=match,
         )
 
+    def lower_genrecfun(self, r: ast.GenRecFun):
+        """Recfun-with-measure: a single-body recursive function. The
+        measure expression and the `terminates` proof are erased — the
+        compiler does no termination checking, just like the Deduce
+        interpreter at runtime. The user already proved termination at
+        check time, so a non-terminating compiled binary is on us only
+        if the proof checker accepted a buggy proof."""
+        params = [x for (x, _t) in r.vars]
+        return ir.Function(
+            name=r.name,
+            params=params,
+            body=self.lower_term(r.body),
+        )
+
     def lower_assert(self, s: ast.Assert):
         # `assert lhs = rhs` becomes a structural-equality check;
         # everything else (incl. `assert b` for a bool b) becomes
@@ -231,6 +241,29 @@ class LoweringCtx:
                 self.lower_term(t.thn),
                 self.lower_term(t.els),
             )
+        if isinstance(t, ast.IfThen):
+            # `if P then Q` (formula form) is `(not P) or Q`. As a
+            # boolean term: `if P then Q else true`.
+            return ir.If(
+                self.lower_term(t.premise),
+                self.lower_term(t.conclusion),
+                ir.Bool(True),
+            )
+        if isinstance(t, ast.And):
+            # n-ary short-circuit AND, right-folded.
+            if not t.args:
+                return ir.Bool(True)
+            result = self.lower_term(t.args[-1])
+            for a in reversed(t.args[:-1]):
+                result = ir.If(self.lower_term(a), result, ir.Bool(False))
+            return result
+        if isinstance(t, ast.Or):
+            if not t.args:
+                return ir.Bool(False)
+            result = self.lower_term(t.args[-1])
+            for a in reversed(t.args[:-1]):
+                result = ir.If(self.lower_term(a), ir.Bool(True), result)
+            return result
         if isinstance(t, ast.TLet):
             return ir.Let(
                 t.var,
@@ -250,12 +283,20 @@ class LoweringCtx:
                 "hole/omitted term reached compilation; the proof "
                 "checker should have rejected this earlier",
             )
-        if isinstance(t, ast.MakeArray) or isinstance(t, ast.ArrayGet) \
-           or isinstance(t, ast.Array):
+        if isinstance(t, ast.MakeArray):
+            return ir.MakeArray(self.lower_term(t.subject))
+        if isinstance(t, ast.ArrayGet):
+            return ir.ArrayGet(
+                self.lower_term(t.subject),
+                self.lower_term(t.position),
+            )
+        if isinstance(t, ast.Array):
+            # `Array` only appears in source as the result of reducing
+            # `MakeArray` (literal `array([…])` uses the latter). The
+            # post-uniquify AST should not contain `Array` directly.
             raise CompileError(
                 t.location,
-                "arrays are not yet supported by the compiler "
-                "(Phase 2 step 8)",
+                "Array term reached compilation; expected MakeArray instead",
             )
         raise CompileError(
             getattr(t, "location", None),
@@ -269,6 +310,16 @@ class LoweringCtx:
             rator = rator.subject
         if isinstance(rator, ast.Var):
             name = self._resolve(rator)
+            base = ast.base_name(name)
+            # Built-in equality. `=` is not a Deduce-source-level
+            # function — it's parsed as `Call(Var('='), [a, b])` and
+            # the type checker accepts it for any pair of same-typed
+            # values. The runtime decides via `deduce_equal`.
+            if base == "=" and len(c.args) == 2:
+                return ir.Eq(
+                    self.lower_term(c.args[0]),
+                    self.lower_term(c.args[1]),
+                )
             if name in self.ctors:
                 return ir.Con(name, [self.lower_term(a) for a in c.args])
         return ir.App(
@@ -354,6 +405,12 @@ def subst_vars(t: ir.Term, sub: Dict[str, str]) -> ir.Term:
                         inner = blocked
                     new_arms.append(ir.MatchArm(arm.pattern, go(arm.body, inner)))
                 return ir.Match(go(subj, blocked), new_arms)
+            case ir.Eq(l, r):
+                return ir.Eq(go(l, blocked), go(r, blocked))
+            case ir.MakeArray(s):
+                return ir.MakeArray(go(s, blocked))
+            case ir.ArrayGet(s, i):
+                return ir.ArrayGet(go(s, blocked), go(i, blocked))
         raise AssertionError(f"subst_vars: unknown {type(t).__name__}")
 
     return go(t, set())

--- a/compiler/runtime/deduce.c
+++ b/compiler/runtime/deduce.c
@@ -26,6 +26,10 @@ struct deduce_obj {
             int n_env;
             deduce_value* env;
         } closure;
+        struct {
+            int n;
+            deduce_value* elements;
+        } array;
     } u;
 };
 
@@ -117,6 +121,79 @@ deduce_value deduce_call(deduce_value clo, int n_args, deduce_value* args) {
     return clo->u.closure.fn(clo->u.closure.env, args);
 }
 
+/* --- arrays ----------------------------------------------------------- */
+
+/* Count list length by walking node(_, rest) until empty. */
+static int list_length(deduce_value v) {
+    int n = 0;
+    while (1) {
+        if (v->tag != D_CTOR) deduce_panic("array: subject is not a list");
+        const char* name = v->u.ctor.name;
+        if (strcmp(name, "empty") == 0 || strcmp(name, "[]") == 0) return n;
+        if (strcmp(name, "node") != 0)
+            deduce_panic("array: list constructor not empty/node");
+        if (v->u.ctor.n_fields != 2)
+            deduce_panic("array: node arity != 2");
+        n++;
+        v = v->u.ctor.fields[1];
+    }
+}
+
+deduce_value deduce_make_array_from_list(deduce_value list) {
+    int n = list_length(list);
+    deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
+    v->tag = D_ARRAY;
+    v->u.array.n = n;
+    if (n > 0) {
+        v->u.array.elements = deduce_alloc(sizeof(deduce_value) * (size_t)n);
+        deduce_value cur = list;
+        for (int i = 0; i < n; ++i) {
+            v->u.array.elements[i] = cur->u.ctor.fields[0];
+            cur = cur->u.ctor.fields[1];
+        }
+    } else {
+        v->u.array.elements = NULL;
+    }
+    return v;
+}
+
+/* Decode a Nat (zero / suc) or UInt (bzero / dub_inc / inc_dub) value
+ * to a non-negative C int. `lit` (and any wrapper that the user may
+ * have defined for literal-display purposes) is unwrapped silently. */
+static int64_t decode_index(deduce_value v) {
+    while (1) {
+        if (v->tag != D_CTOR) deduce_panic("array index is not Nat/UInt");
+        const char* n = v->u.ctor.name;
+        if (strcmp(n, "zero") == 0) return 0;
+        if (strcmp(n, "bzero") == 0) return 0;
+        if (strcmp(n, "suc") == 0) {
+            if (v->u.ctor.n_fields != 1) deduce_panic("suc arity != 1");
+            return 1 + decode_index(v->u.ctor.fields[0]);
+        }
+        if (strcmp(n, "dub_inc") == 0) {
+            if (v->u.ctor.n_fields != 1) deduce_panic("dub_inc arity != 1");
+            return 2 * (1 + decode_index(v->u.ctor.fields[0]));
+        }
+        if (strcmp(n, "inc_dub") == 0) {
+            if (v->u.ctor.n_fields != 1) deduce_panic("inc_dub arity != 1");
+            return 1 + 2 * decode_index(v->u.ctor.fields[0]);
+        }
+        if (strcmp(n, "lit") == 0 || strcmp(n, "fromNat") == 0) {
+            if (v->u.ctor.n_fields != 1) deduce_panic("lit/fromNat arity != 1");
+            v = v->u.ctor.fields[0];
+            continue;
+        }
+        deduce_panic("array index: unrecognized constructor");
+    }
+}
+
+deduce_value deduce_array_get(deduce_value arr, deduce_value idx) {
+    if (arr->tag != D_ARRAY) deduce_panic("array get: not an array");
+    int64_t i = decode_index(idx);
+    if (i < 0 || i >= arr->u.array.n) deduce_panic("array index out of range");
+    return arr->u.array.elements[(int)i];
+}
+
 bool deduce_equal(deduce_value a, deduce_value b) {
     if (a == b) return true;
     if (a->tag != b->tag) return false;
@@ -128,6 +205,15 @@ bool deduce_equal(deduce_value a, deduce_value b) {
             if (a->u.ctor.n_fields != b->u.ctor.n_fields) return false;
             for (int i = 0; i < a->u.ctor.n_fields; ++i) {
                 if (!deduce_equal(a->u.ctor.fields[i], b->u.ctor.fields[i]))
+                    return false;
+            }
+            return true;
+        }
+        case D_ARRAY: {
+            if (a->u.array.n != b->u.array.n) return false;
+            for (int i = 0; i < a->u.array.n; ++i) {
+                if (!deduce_equal(a->u.array.elements[i],
+                                  b->u.array.elements[i]))
                     return false;
             }
             return true;
@@ -163,6 +249,14 @@ void deduce_print(deduce_value v) {
             return;
         case D_CLOSURE:
             printf("<closure %s>", v->u.closure.name ? v->u.closure.name : "?");
+            return;
+        case D_ARRAY:
+            fputs("array(", stdout);
+            for (int i = 0; i < v->u.array.n; ++i) {
+                if (i > 0) fputs(", ", stdout);
+                deduce_print(v->u.array.elements[i]);
+            }
+            fputc(')', stdout);
             return;
     }
 }

--- a/compiler/runtime/deduce.h
+++ b/compiler/runtime/deduce.h
@@ -23,7 +23,8 @@ typedef enum {
     D_BOOL,
     D_INT,
     D_CTOR,
-    D_CLOSURE
+    D_CLOSURE,
+    D_ARRAY
 } deduce_tag;
 
 /* The actual struct shape is hidden in deduce.c. */
@@ -53,6 +54,19 @@ deduce_value deduce_ctor_field(deduce_value v, int i);
 
 /* Closure call: dispatches through the closure's function pointer. */
 deduce_value deduce_call(deduce_value clo, int n_args, deduce_value* args);
+
+/* `array(<list>)` — walk a `node(_, _)` … `empty` chain and pack into
+ * a flat array. Dispatches by the constructor's stored base name, so
+ * any union with `empty` and `node` constructors works (matches the
+ * interpreter's `isNodeList` semantics). Aborts on a non-list value. */
+deduce_value deduce_make_array_from_list(deduce_value list);
+
+/* `arr[idx]` — read an element. The index must be a Nat or UInt; the
+ * runtime decodes by inspecting constructor base names (`zero`/`suc`
+ * for Nat, `bzero`/`dub_inc`/`inc_dub` for UInt). Out-of-bounds
+ * aborts; the interpreter's behaviour of leaving the term un-reduced
+ * has no compiled-program analogue. */
+deduce_value deduce_array_get(deduce_value arr, deduce_value idx);
 
 /* Structural equality. Closures compare by pointer identity (the
  * surface language has no closure-equality primitive at runtime, but

--- a/deduce.py
+++ b/deduce.py
@@ -53,7 +53,9 @@ def compile_file(filename: str, output: str, prelude: list[str]) -> None:
             print(result.error_traceback)
         exit(1)
     program = lower.lower_program(result.ast)
+    ir.verify(program)
     program = _closure.closure_convert(program)
+    ir.verify(program)
     src = emit_c.emit_program(program)
     if output == "-":
         sys.stdout.write(src)

--- a/test/compile-allowlist.txt
+++ b/test/compile-allowlist.txt
@@ -1,0 +1,23 @@
+# Phase 1+2 allowlist for `make tests-compile`.
+#
+# Each non-empty, non-comment line is a path to a `.pf` file (relative
+# to repo root) that the e2e harness will compile, run, and diff
+# against the interpreter's output. Files are required to be
+# compatible with `--no-stdlib` (Phase 1+2 has no prelude support).
+#
+# Files in `test/compile/lower/` are picked up automatically and need
+# not be listed here.
+
+test/should-validate/bintree.pf
+test/should-validate/empty_file.pf
+test/should-validate/not_equal.pf
+test/should-validate/overload3.pf
+test/should-validate/private_union.pf
+test/should-validate/rec1.pf
+test/should-validate/rec2.pf
+test/should-validate/switch_term.pf
+
+# Known limitation: overload1.pf and overload5.pf fail because the
+# compiler uses `Var.resolved_names[0]` rather than the type-checker's
+# chosen overload (post-typecheck AST is not returned by `check_file`
+# today — see lsp/library.py). Track in Phase 2 follow-up.

--- a/test/compile/lower/array.cir
+++ b/test/compile/lower/array.cir
@@ -1,0 +1,11 @@
+union MyNat.0 {zero.1/0, suc.2/1}
+union List.3 {empty.5/0, node.6/2}
+global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
+global A.8 = array(ns.7)
+print A.8
+print A.8[zero.1]
+print A.8[suc.2(zero.1)]
+print A.8[suc.2(suc.2(zero.1))]
+assert_eq A.8[zero.1] == zero.1
+assert_eq A.8[suc.2(zero.1)] == suc.2(zero.1)
+assert_eq A.8[suc.2(suc.2(zero.1))] == suc.2(suc.2(zero.1))

--- a/test/compile/lower/array.ir
+++ b/test/compile/lower/array.ir
@@ -1,0 +1,11 @@
+union MyNat.0 {zero.1/0, suc.2/1}
+union List.3 {empty.5/0, node.6/2}
+global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
+global A.8 = array(ns.7)
+print A.8
+print A.8[zero.1]
+print A.8[suc.2(zero.1)]
+print A.8[suc.2(suc.2(zero.1))]
+assert_eq A.8[zero.1] == zero.1
+assert_eq A.8[suc.2(zero.1)] == suc.2(zero.1)
+assert_eq A.8[suc.2(suc.2(zero.1))] == suc.2(suc.2(zero.1))

--- a/test/compile/lower/array.pf
+++ b/test/compile/lower/array.pf
@@ -1,0 +1,26 @@
+// Phase 2 step 8: MakeArray and ArrayGet. Custom List<T> and a
+// custom Nat suffice; the runtime dispatches by the constructors'
+// base names (`empty`/`node` for the list, `zero`/`suc` for the
+// index), matching the interpreter's `isNodeList`/`isNat` helpers.
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+union List<T> {
+  empty
+  node(T, List<T>)
+}
+
+define ns : List<MyNat> = node(zero, node(suc(zero), node(suc(suc(zero)), empty)))
+define A = array(ns)
+
+print A
+print A[zero]
+print A[suc(zero)]
+print A[suc(suc(zero))]
+
+assert A[zero] = zero
+assert A[suc(zero)] = suc(zero)
+assert A[suc(suc(zero))] = suc(suc(zero))

--- a/test/compile/lower/basic.cir
+++ b/test/compile/lower/basic.cir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
-assert_eq add.3(two.7, zero.1) == two.7
+union MyNat.9 {zero.10/0, suc.11/1}
+fn add.12($scr0, m.13) = match $scr0 { | zero.10 -> m.13 | suc.11(n.14) -> suc.11(add.12(n.14, m.13)) }
+global two.16 = suc.11(suc.11(zero.10))
+fn add_two.18(x.17) = add.12(two.16, x.17)
+fn pick.22(b.19, x.20, y.21) = if b.19 then x.20 else y.21
+print add_two.18(suc.11(zero.10))
+print pick.22(true, two.16, zero.10)
+assert_eq add.12(two.16, zero.10) == two.16

--- a/test/compile/lower/basic.ir
+++ b/test/compile/lower/basic.ir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
-assert_eq add.3(two.7, zero.1) == two.7
+union MyNat.9 {zero.10/0, suc.11/1}
+fn add.12($scr0, m.13) = match $scr0 { | zero.10 -> m.13 | suc.11(n.14) -> suc.11(add.12(n.14, m.13)) }
+global two.16 = suc.11(suc.11(zero.10))
+fn add_two.18(x.17) = add.12(two.16, x.17)
+fn pick.22(b.19, x.20, y.21) = if b.19 then x.20 else y.21
+print add_two.18(suc.11(zero.10))
+print pick.22(true, two.16, zero.10)
+assert_eq add.12(two.16, zero.10) == two.16

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,5 +1,5 @@
-union MyNat.14 {zero.15/0, suc.16/1}
-fn add.17($scr0, m.18) = match $scr0 { | zero.15 -> m.18 | suc.16(n.19) -> suc.16(add.17(n.19, m.18)) }
-fn adder.23(x.21) = closure[$lam1](x.21)
-print adder.23(suc.16(zero.15))(suc.16(suc.16(zero.15)))
-fn $lam1[x.21](y.22) = add.17(x.21, y.22)
+union MyNat.23 {zero.24/0, suc.25/1}
+fn add.26($scr0, m.27) = match $scr0 { | zero.24 -> m.27 | suc.25(n.28) -> suc.25(add.26(n.28, m.27)) }
+fn adder.32(x.30) = closure[$lam1](x.30)
+print adder.32(suc.25(zero.24))(suc.25(suc.25(zero.24)))
+fn $lam1[x.30](y.31) = add.26(x.30, y.31)

--- a/test/compile/lower/closure.ir
+++ b/test/compile/lower/closure.ir
@@ -1,4 +1,4 @@
-union MyNat.14 {zero.15/0, suc.16/1}
-fn add.17($scr0, m.18) = match $scr0 { | zero.15 -> m.18 | suc.16(n.19) -> suc.16(add.17(n.19, m.18)) }
-fn adder.23(x.21) = λ(y.22). add.17(x.21, y.22)
-print adder.23(suc.16(zero.15))(suc.16(suc.16(zero.15)))
+union MyNat.23 {zero.24/0, suc.25/1}
+fn add.26($scr0, m.27) = match $scr0 { | zero.24 -> m.27 | suc.25(n.28) -> suc.25(add.26(n.28, m.27)) }
+fn adder.32(x.30) = λ(y.31). add.26(x.30, y.31)
+print adder.32(suc.25(zero.24))(suc.25(suc.25(zero.24)))

--- a/test/compile/lower/generic.cir
+++ b/test/compile/lower/generic.cir
@@ -1,0 +1,7 @@
+union Box.33 {box.35/1}
+fn unbox.39(b.37) = match b.37 { | box.35(x.38) -> x.38 }
+fn id.43(x.42) = x.42
+union MyNat.44 {zero.45/0, suc.46/1}
+print id.43(suc.46(zero.45))
+print unbox.39(box.35(suc.46(suc.46(zero.45))))
+assert_eq id.43(zero.45) == zero.45

--- a/test/compile/lower/generic.ir
+++ b/test/compile/lower/generic.ir
@@ -1,0 +1,7 @@
+union Box.33 {box.35/1}
+fn unbox.39(b.37) = match b.37 { | box.35(x.38) -> x.38 }
+fn id.43(x.42) = x.42
+union MyNat.44 {zero.45/0, suc.46/1}
+print id.43(suc.46(zero.45))
+print unbox.39(box.35(suc.46(suc.46(zero.45))))
+assert_eq id.43(zero.45) == zero.45

--- a/test/compile/lower/generic.pf
+++ b/test/compile/lower/generic.pf
@@ -1,0 +1,23 @@
+// Phase 2 step 9: generics fully erase. The lowered IR contains no
+// type-parameter or type-instantiation residue.
+
+union Box<T> {
+  box(T)
+}
+
+fun unbox<T>(b : Box<T>) {
+  switch b {
+    case box(x) { x }
+  }
+}
+
+define id : fn <T> T -> T = generic T { fun x : T { x } }
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+print id(suc(zero))
+print unbox(box(suc(suc(zero))))
+assert id(zero) = zero

--- a/test/compile/lower/genrecfun.cir
+++ b/test/compile/lower/genrecfun.cir
@@ -1,0 +1,6 @@
+union MyNat.47 {zero.48/0, suc.49/1}
+fn iszero.52(n.50) = match n.50 { | zero.48 -> true | suc.49(n'.51) -> false }
+fn pred.55(n.53) = match n.53 { | zero.48 -> zero.48 | suc.49(n'.54) -> n'.54 }
+fn <.56($scr0, m.57) = match $scr0 { | zero.48 -> match m.57 { | zero.48 -> false | suc.49(m'.58) -> true } | suc.49(n'.59) -> match m.57 { | zero.48 -> false | suc.49(m'.61) -> <.56(n'.59, m'.61) } }
+fn count_down.69(n.70) = if iszero.52(n.70) then zero.48 else count_down.69(pred.55(n.70))
+print count_down.69(suc.49(suc.49(suc.49(zero.48))))

--- a/test/compile/lower/genrecfun.ir
+++ b/test/compile/lower/genrecfun.ir
@@ -1,0 +1,6 @@
+union MyNat.47 {zero.48/0, suc.49/1}
+fn iszero.52(n.50) = match n.50 { | zero.48 -> true | suc.49(n'.51) -> false }
+fn pred.55(n.53) = match n.53 { | zero.48 -> zero.48 | suc.49(n'.54) -> n'.54 }
+fn <.56($scr0, m.57) = match $scr0 { | zero.48 -> match m.57 { | zero.48 -> false | suc.49(m'.58) -> true } | suc.49(n'.59) -> match m.57 { | zero.48 -> false | suc.49(m'.61) -> <.56(n'.59, m'.61) } }
+fn count_down.69(n.70) = if iszero.52(n.70) then zero.48 else count_down.69(pred.55(n.70))
+print count_down.69(suc.49(suc.49(suc.49(zero.48))))

--- a/test/compile/lower/genrecfun.pf
+++ b/test/compile/lower/genrecfun.pf
@@ -1,0 +1,72 @@
+// Phase 2 step 7: recfun-with-measure (GenRecFun) lowers like a
+// regular function — measure and terminates proof both erase.
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+fun iszero(n : MyNat) {
+  switch n {
+    case zero { true }
+    case suc(n') { false }
+  }
+}
+
+fun pred(n : MyNat) {
+  switch n {
+    case zero { zero }
+    case suc(n') { n' }
+  }
+}
+
+recursive operator <(MyNat, MyNat) -> bool {
+  operator <(zero, m) =
+    switch m {
+      case zero { false }
+      case suc(m') { true }
+    }
+  operator <(suc(n'), m) =
+    switch m {
+      case zero { false }
+      case suc(m') { n' < m' }
+    }
+}
+
+theorem less_suc: all n:MyNat. n < suc(n)
+proof
+  induction MyNat
+  case zero { expand operator<. }
+  case suc(n') assume IH {
+    suffices n' < suc(n')  by expand operator<.
+    IH
+  }
+end
+
+theorem pred_suc_less_suc: all n:MyNat. pred(suc(n)) < suc(n)
+proof
+  arbitrary n:MyNat
+  expand pred
+  less_suc[n]
+end
+
+recfun count_down(n : MyNat) -> MyNat
+  measure n of MyNat
+{
+  if iszero(n) then zero
+  else count_down(pred(n))
+}
+terminates {
+  arbitrary n:MyNat
+  assume nz: not iszero(n)
+  switch n {
+    case zero assume eq {
+      conclude false by apply nz to expand iszero replace eq.
+    }
+    case suc(n') assume eq {
+      pred_suc_less_suc[n']
+    }
+  }
+}
+
+print count_down(suc(suc(suc(zero))))

--- a/test/compile/run_e2e.py
+++ b/test/compile/run_e2e.py
@@ -26,6 +26,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 LOWER_DIR = ROOT / "test" / "compile" / "lower"
 E2E_DIR = ROOT / "test" / "compile" / "e2e"
+ALLOWLIST = ROOT / "test" / "compile-allowlist.txt"
 RUNTIME_DIR = ROOT / "compiler" / "runtime"
 
 
@@ -94,6 +95,16 @@ def main() -> int:
     for d in (E2E_DIR, LOWER_DIR):
         if d.exists():
             fixtures.extend(sorted(d.glob("*.pf")))
+    if ALLOWLIST.exists():
+        for raw in ALLOWLIST.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            p = (ROOT / line).resolve()
+            if not p.exists():
+                print(f"WARN: allowlist entry not found: {line}", file=sys.stderr)
+                continue
+            fixtures.append(p)
     if args.filter:
         fixtures = [f for f in fixtures if args.filter in f.name]
     if not fixtures:

--- a/test/compile/run_lower.py
+++ b/test/compile/run_lower.py
@@ -37,8 +37,10 @@ def lower_file(path: Path) -> tuple[str, str]:
     if not result.ok:
         raise RuntimeError(f"{path}: deduce check failed:\n{result.error_message}")
     program = lower.lower_program(result.ast)
+    ir.verify(program)
     lowered_str = ir.pp_program(program)
     converted = closure.closure_convert(program)
+    ir.verify(converted)
     converted_str = ir.pp_program(converted)
     return lowered_str, converted_str
 


### PR DESCRIPTION
## Summary

Continues the compile-to-C work from #302. Lands steps 7, 8, 9, and 11 of Phase 2 in [docs/compile-plan.md](https://github.com/jsiek/deduce/blob/main/docs/compile-plan.md). **Step 10 (prelude inlining) is deferred to a follow-up PR** — that one's a substantial undertaking (the whole stdlib has to round-trip) and benefits from being its own focused unit.

## What's in this PR

### Step 7 — `GenRecFun` (recfun with measure)
`recfun foo(x : T) -> U measure m of M { … } terminates { … }` now compiles. The measure expression and the `terminates` proof both erase; the body lowers to a regular IR `Function`. Fixture: [test/compile/lower/genrecfun.pf](test/compile/lower/genrecfun.pf).

### Step 8 — Arrays
- New IR nodes `MakeArray` and `ArrayGet`.
- Runtime: new `D_ARRAY` tag plus `deduce_make_array_from_list` (walks `node(_, _)` … `empty` chains by base name, matching the interpreter's `isNodeList` semantics) and `deduce_array_get` (decodes Nat/UInt indices by inspecting constructor base names — `zero`/`suc` for Nat, `bzero`/`dub_inc`/`inc_dub` for UInt). Out-of-bounds aborts via `deduce_panic`.
- Fixture: [test/compile/lower/array.pf](test/compile/lower/array.pf).

### Step 9 — Type erasure verification
New `ir.verify(p)` walks the program after each pass and asserts every node is a known IR class. Wired into both [`deduce.py`](deduce.py)'s `compile_file` and [`test/compile/run_lower.py`](test/compile/run_lower.py). Fixture [test/compile/lower/generic.pf](test/compile/lower/generic.pf) exercises `Generic` and `TermInst` erasure end-to-end.

### Step 11 — Test harness allowlist
New [test/compile-allowlist.txt](test/compile-allowlist.txt) lets the e2e harness pull in fixtures from `test/should-validate/`. Seven existing tests are added: `bintree`, `empty_file`, `not_equal`, `overload3`, `private_union`, `rec1`, `rec2`, `switch_term`.

## Other improvements rolled in (because they were on the path)

- **`IfThen`/`And`/`Or`** lower at the term level, so `not`, `and`, `or`, and `≠` work in compiled code. Was raising `CompileError` before.
- **New `ir.Eq` primitive** for the `=` operator. Emitter calls `deduce_equal`.
- **Drop `static` on emitted functions** to avoid `-Wunneeded-internal-declaration` on functions only referenced by erased proofs (e.g. helpers used inside `terminates` blocks).
- **`(void)` casts** on every binder (params, captures, let-bindings, pattern binds) to silence `-Wunused` on switch arms whose body ignores a binder.

## Known limitation

`overload1.pf` and `overload5.pf` are tagged in the allowlist as known-broken: the compiler uses `Var.resolved_names[0]` rather than the type-checker's chosen overload, because [`lsp/library.py`](lsp/library.py)'s `check_file` returns the post-uniquify AST, not the post-typecheck one. Fixing this is a small change to the library-mode entry point — happy to follow up.

## Test plan

12 fixtures pass `make tests-compile`:
- 5 in `test/compile/lower/` — `basic`, `closure`, `array`, `generic`, `genrecfun`.
- 7 from `test/should-validate/` via the allowlist.

For each fixture the harness:
1. Runs the interpreter and captures stdout.
2. Compiles via `deduce.py --compile`, links against the runtime, runs the binary.
3. Diffs the two stdouts (must match exactly).

`make tests` is unchanged and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)