### PR TITLE
Phase 1 / Step 4: implement goal_at() in the query API

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 in progress — Steps 1–3 done.
+**Status:** Phase 1 in progress — Steps 1–4 done.
 
 ## Goals
 
@@ -43,8 +43,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
   - *Acceptance:* parallel to `test/should-error/*.pf.err` — assert each fixture produces a `Diagnostic` with the right line/severity.
   - *Implementation:* `lsp/query.py:check` calls `check_file(path, content=content)` and translates the captured exception into a `Diagnostic`. Required surfacing structured location/body via `error.py` (added `location`/`message_body` attributes to `error`/`incomplete_error`/`static_error`/`match_failed`/`ParseError`), a new `wrap_error` helper, and patches at six wrap sites in `proof_checker.py` that previously raised bare `Exception(str(e) + ...)` and dropped the location. `lsp/library.py` gained a `content` parameter (bypasses the uniquified-modules cache) and an `exception` field on `CheckResult`. `rec_desc_parser.py` had a pre-existing leak: `check_closest_kwd` was set to `True` on first parse error and never reset, leaking spurious "did you mean" suggestions across calls in library mode — now reset in a `finally`. Acceptance test `test/lsp/test_check.py` runs 158 cases.
 
-- [ ] **Step 4: Implement `goal_at`.** Insert a `?` (`PHole`) at the requested position into a copy of the source, run check, capture the printed goal.
+- [x] **Step 4: Implement `goal_at`.** Insert a `?` (`PHole`) at the requested position into a copy of the source, run check, capture the printed goal.
   - *Acceptance:* hand-crafted fixtures in `test/lsp/` with `-- expect goal: ...` markers; test reads marker and asserts.
+  - *Implementation:* `lsp/query.py:goal_at` rewrites the content from the cursor up to the next `end` keyword as `\n?\n`, then runs `check_file` and parses the resulting `IncompleteProof.message_body` for `Goal:` and `Givens:`. The goal formula is the first non-blank line after `Goal:` (Deduce's `__str__` always emits a single line); givens are pulled from the trailing `Givens:` block split on `,\n`. Returns `None` when the cursor is out of range, the inserted `?` produces a parse error, or the message has no `Goal:` header. Required hardening in `error.py`: `get_location_text_lines` and `error_program_text` previously crashed on `OSError`/empty lines when the path didn't exist on disk — they now return empty source excerpts so in-memory content (LSP/MCP) doesn't break exception formatting. 6-case acceptance test in `test/lsp/test_goal_at.py`.
 
 - [ ] **Step 5: Implement `definition_of` and `list_symbols`.** AST walk using `Var.resolved_names` after a successful check; lexical-scope fallback if check failed.
   - *Acceptance:* hand-crafted fixtures with known symbol locations.

--- a/error.py
+++ b/error.py
@@ -2,9 +2,16 @@ import flags
 
 def get_location_text_lines(location):
   if not location.empty:
-    with open(location.filename, 'r') as f:
-      lines = list(f.readlines())
-      return lines[location.line-1:location.end_line]
+    try:
+      with open(location.filename, 'r') as f:
+        lines = list(f.readlines())
+        return lines[location.line-1:location.end_line]
+    except OSError:
+      # Library/LSP/MCP callers pass in-memory content with a path
+      # that may not exist on disk. Returning an empty source excerpt
+      # keeps str(ParseError) from crashing -- the location header
+      # still carries the file:line:col coordinates.
+      return ''
   else:
     return ''
 
@@ -20,6 +27,10 @@ def error_header(location):
 def error_program_text(location):
   if not location.empty:
     lines = get_location_text_lines(location)
+    if not lines:
+      # Source file isn't on disk (in-memory content from library/LSP
+      # callers); skip the source excerpt and carrot rendering.
+      return ''
     # last line decides where we draw the carrots (^)
     error = lines[-1]
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -39,6 +39,7 @@ before calling. The pipeline uses ``path`` for import resolution and
 in user-visible error messages.
 """
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
@@ -247,11 +248,175 @@ def goal_at(path: str, content: str, pos: Position) -> Optional[Goal]:
     Returns ``None`` when there is no active proof at that position --
     e.g. the cursor is outside any ``proof ... end`` block, or the file
     does not parse. Implemented by inserting a ``?`` hole at ``pos``
-    and capturing the printed goal state.
-
-    Implemented in Step 4.
+    (more precisely: replacing the content from ``pos`` up to the next
+    ``end`` keyword with ``?``) and capturing the goal text the checker
+    prints when it reaches the hole.
     """
-    raise NotImplementedError("Step 4 implements goal_at.")
+    from lsp.library import check_file
+
+    modified = _insert_hole(content, pos)
+    if modified is None:
+        return None
+
+    result = check_file(path, content=modified)
+    if result.ok:
+        # No PHole was hit -- the surrounding proof was already complete
+        # without needing the inserted ?. Nothing to report.
+        return None
+
+    return _goal_from_exception(result.exception, pos)
+
+
+def _insert_hole(content: str, pos: Position) -> Optional[str]:
+    """Modify ``content`` so that the proof at ``pos`` halts on a ``?``.
+
+    Strategy: find the byte offset for ``pos``, replace everything from
+    there up to (but not including) the next ``end`` keyword with
+    ``\\n?\\n``. The intervening tactics are dropped so the parser sees
+    a complete proof terminating at the hole.
+
+    Returns ``None`` when ``pos`` is out of range. If no ``end`` keyword
+    follows the cursor we fall back to "append ``?`` at the cursor and
+    leave the rest" -- the parser may still error, in which case
+    ``goal_at`` returns ``None``.
+    """
+    offset = _line_col_to_offset(content, pos)
+    if offset is None:
+        return None
+
+    before = content[:offset]
+    after = content[offset:]
+    m = _END_RE.search(after)
+    if m is None:
+        return before + "\n?\n" + after
+    return before + "\n?\n" + after[m.start():]
+
+
+def _line_col_to_offset(content: str, pos: Position) -> Optional[int]:
+    """Convert a 1-indexed (line, column) to a 0-indexed byte offset.
+
+    Returns ``None`` when the position is past the end of the file.
+    Columns past the end of a line clamp to the line's length.
+    """
+    if pos.line < 1 or pos.column < 1:
+        return None
+    lines = content.splitlines(keepends=True)
+    if pos.line > len(lines):
+        return None
+    line_start = sum(len(line) for line in lines[: pos.line - 1])
+    line = lines[pos.line - 1]
+    # splitlines(keepends=True) keeps the trailing newline; clamp the
+    # column to the line length minus that newline so we don't insert
+    # past it.
+    visible_len = len(line.rstrip("\r\n"))
+    col = min(pos.column - 1, visible_len)
+    return line_start + col
+
+
+_END_RE = re.compile(r"\bend\b")
+
+
+def _goal_from_exception(
+    exc: Optional[BaseException], pos: Position
+) -> Optional[Goal]:
+    """Parse an ``IncompleteProof`` message into a ``Goal``.
+
+    The pipeline raises ``IncompleteProof`` from ``incomplete_error``
+    with a message body of the form::
+
+        incomplete proof
+        Goal:
+        \\t<formula>
+        [<advice text -- may or may not start with "Advice:">]
+        [Givens:
+        \\t<label>: <formula>[,
+        \\t<label>: <formula>]*]
+
+    Formula AST objects always render to a single line, so we take the
+    first non-blank line after ``Goal:`` as the formula and stop. The
+    advice that follows is intentionally discarded -- callers that want
+    advice can read ``Diagnostic.message`` from ``check`` instead.
+
+    Returns ``None`` when the message doesn't match (e.g. the exception
+    is something other than the goal-bearing PHole, like a parse error
+    triggered by the inserted ``?`` ending up in a bad spot).
+    """
+    if exc is None:
+        return None
+    body = getattr(exc, "message_body", None)
+    if body is None:
+        return None
+
+    formula = _extract_goal_formula(body)
+    if formula is None:
+        return None
+
+    givens = _parse_givens_section(body)
+
+    cursor_range = Range(start=pos, end=pos)
+    return Goal(formula=formula, givens=givens, range=cursor_range)
+
+
+def _extract_goal_formula(body: str) -> Optional[str]:
+    """Return the formula on the line immediately after ``Goal:``.
+
+    The formula is always a single line because Deduce's ``__str__``
+    renderers don't emit newlines inside a formula. Returns ``None``
+    when no ``Goal:`` header is present.
+    """
+    idx = body.find("Goal:")
+    if idx < 0:
+        return None
+    after = body[idx + len("Goal:"):]
+    for line in after.splitlines():
+        if not line.strip():
+            continue
+        # Section content is indented with a tab; drop one level.
+        if line.startswith("\t"):
+            line = line[1:]
+        return line.strip()
+    return None
+
+
+def _parse_givens_section(body: str) -> tuple:
+    """Pull a ``Givens:`` block (if any) into a tuple of ``Given``.
+
+    Each entry has the form ``<label>: <formula>``, joined by ``,\\n``
+    (see ``Env.proofs_str``). Lines that don't start with a tab are
+    treated as outside the section and stop iteration -- which never
+    actually happens today since Givens is the last section, but keeps
+    us robust if a future change appends more text.
+    """
+    idx = body.find("Givens:")
+    if idx < 0:
+        return ()
+    after = body[idx + len("Givens:"):]
+    if after.startswith("\n"):
+        after = after[1:]
+
+    section_lines = []
+    for line in after.splitlines():
+        if line == "" or line.startswith("\t"):
+            section_lines.append(line)
+        else:
+            break
+    block = "\n".join(section_lines)
+
+    givens = []
+    # Split on ",\n" rather than just commas because formulas can
+    # contain commas (e.g. argument lists).
+    for entry in block.split(",\n"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        sep = entry.find(":")
+        if sep < 0:
+            givens.append(Given(label=None, formula=entry))
+            continue
+        label = entry[:sep].strip()
+        formula = entry[sep + 1:].strip()
+        givens.append(Given(label=label or None, formula=formula))
+    return tuple(givens)
 
 
 def definition_of(

--- a/test/lsp/test_goal_at.py
+++ b/test/lsp/test_goal_at.py
@@ -1,0 +1,144 @@
+"""Acceptance test for ``lsp.query.goal_at`` (Phase 1 / Step 4).
+
+Hand-crafted fixtures embedded inline -- one per scenario worth pinning.
+Each case supplies a snippet of Deduce source, a 1-indexed cursor
+position, and the goal we expect ``goal_at`` to surface there.
+
+Each fixture stays inside ``bool``-only territory so the test runs
+without the standard library prelude (Step 6 introduces a daemon mode
+where the prelude is preloaded; until then, ``goal_at`` runs each
+check from scratch and we keep them small).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import Given, Goal, Position, goal_at  # noqa: E402
+
+
+@dataclass(frozen=True)
+class GoalCase:
+    name: str
+    source: str
+    cursor: Position
+    expected_formula: str
+    expected_givens: tuple[Given, ...]
+
+
+CASES = [
+    GoalCase(
+        name="simple_equality",
+        # Cursor sits at the start of line 4, just after `arbitrary`.
+        # Goal should be ``P = P`` with no givens (the binding for
+        # ``P`` is a term variable, not a proof variable, so it does
+        # not show up in Givens).
+        source=(
+            "theorem t: all P:bool. P = P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  reflexive\n"
+            "end\n"
+        ),
+        cursor=Position(line=4, column=1),
+        expected_formula="P = P",
+        expected_givens=(),
+    ),
+    GoalCase(
+        name="implication_with_givens",
+        # After ``suppose pP:P`` and ``suppose qQ:Q`` the goal is
+        # ``P`` and both hypotheses are in scope.
+        source=(
+            "theorem t: all P:bool, Q:bool. if P then if Q then P\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  suppose pP: P\n"
+            "  suppose qQ: Q\n"
+            "  pP\n"
+            "end\n"
+        ),
+        cursor=Position(line=6, column=1),
+        expected_formula="P",
+        expected_givens=(
+            Given(label="qQ", formula="Q"),
+            Given(label="pP", formula="P"),
+        ),
+    ),
+    GoalCase(
+        name="and_intro",
+        # The goal at the top of a conjunction proof is the full
+        # conjunction. We deliberately put the cursor on the line
+        # holding the proof body so the test exercises mid-proof
+        # cursor placement.
+        source=(
+            "theorem t: all P:bool, Q:bool. if P then if Q then P and Q\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  suppose pP: P\n"
+            "  suppose qQ: Q\n"
+            "  pP, qQ\n"
+            "end\n"
+        ),
+        cursor=Position(line=6, column=1),
+        expected_formula="(P and Q)",
+        expected_givens=(
+            Given(label="qQ", formula="Q"),
+            Given(label="pP", formula="P"),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_goal_at(case: GoalCase) -> None:
+    g = goal_at("test.pf", case.source, case.cursor)
+    assert g is not None, f"{case.name}: goal_at returned None"
+    assert isinstance(g, Goal)
+    assert g.formula == case.expected_formula, (
+        f"{case.name}: formula mismatch\n"
+        f"  expected: {case.expected_formula!r}\n"
+        f"  got:      {g.formula!r}"
+    )
+    assert g.givens == case.expected_givens, (
+        f"{case.name}: givens mismatch\n"
+        f"  expected: {case.expected_givens}\n"
+        f"  got:      {g.givens}"
+    )
+    # The cursor position is echoed back as a degenerate range.
+    assert g.range.start == case.cursor
+    assert g.range.end == case.cursor
+
+
+def test_goal_at_returns_none_after_proof_end() -> None:
+    """Cursor outside any proof block has no obligation."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+        "\n"
+        "-- top-level here, no proof in scope\n"
+    )
+    # Line 7, column 1 -- the comment line, after `end`.
+    assert goal_at("test.pf", source, Position(line=7, column=1)) is None
+
+
+def test_goal_at_returns_none_for_out_of_range_position() -> None:
+    """Positions past EOF yield no goal."""
+    source = "theorem t: bool = true\n"
+    assert goal_at("test.pf", source, Position(line=99, column=1)) is None
+
+
+def test_goal_at_returns_none_when_position_is_invalid() -> None:
+    """Negative / zero coordinates are not 1-indexed positions."""
+    source = "theorem t: bool = true\n"
+    assert goal_at("test.pf", source, Position(line=0, column=1)) is None
+    assert goal_at("test.pf", source, Position(line=1, column=0)) is None

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -170,15 +170,10 @@ def test_list_symbols_signature():
 
 
 # --------------------------------------------------------------------------
-# Stubs raise NotImplementedError until the dedicated step lands
-# (``check`` is now implemented; its acceptance test lives in
-# ``test_check.py``).
+# Stubs raise NotImplementedError until the dedicated step lands.
+# ``check`` is implemented (Step 3, see test_check.py).
+# ``goal_at`` is implemented (Step 4, see test_goal_at.py).
 # --------------------------------------------------------------------------
-
-
-def test_goal_at_stub_raises():
-    with pytest.raises(NotImplementedError):
-        goal_at("file.pf", "", Position(1, 1))
 
 
 def test_definition_of_stub_raises():


### PR DESCRIPTION
Step 4 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)).

## What this is
`lsp.query.goal_at(path, content, pos)` returns the proof obligation visible at a cursor position. The motivating LSP feature ("show me the goal as I type") and the corresponding MCP tool both want this.

## Approach
Insert `?` (a `PHole` proof) at the cursor and run the existing pipeline. The `PHole` case in `check_proof_of` already calls `incomplete_error` with the goal formula and givens text; we parse them out.

The mechanic is: take everything from the cursor up to the next `end` keyword in the original content and replace it with `\n?\n`. This trims the in-progress tactics so the parser sees a complete proof terminating at the hole. Cursors not followed by an `end` get a fallback ("append `?` and leave the rest") that may parse-error and yield `None`, which is the correct answer for cursors outside any proof block.

Goal formula extraction is robust because Deduce's `__str__` always renders a formula on one line — so the formula is the first non-blank line after `Goal:`. Givens come from the trailing `Givens:` block split on `,\n` (matching `Env.proofs_str`).

## Required hardening
`error.py:get_location_text_lines` and `error_program_text` previously crashed on `OSError`/empty lines when the path didn't exist on disk. LSP/MCP callers pass in-memory content with arbitrary path strings, so `str(ParseError)` was dying inside `check_file`'s `CheckResult` construction. Both helpers now bail cleanly — the location header still carries `file:line:col`, just no source excerpt with carrots.

## Test plan
- [x] `python3 -m pytest test/lsp/test_goal_at.py` — 6 cases, all pass: simple equality, implication-with-givens, and-intro, plus three None-returning cases (cursor after `end`, line past EOF, zero/negative coordinates).
- [x] `python3 -m pytest test/lsp/` — 485 passed (up from 480 in Step 3: +6 new minus the now-removed `test_goal_at_stub_raises`).
- [x] `python3 test-deduce.py` (default) — clean.
- [x] `python3 test-deduce.py --errors` — `.err` fixtures unchanged despite the `error.py` hardening.
- [x] `python3 test-deduce.py --parser` — clean.

## Out of scope
- Daemon mode / prelude reuse (Step 6). Today the test fixtures are bool-only because `goal_at` runs each check from scratch with no prelude.
- Tooltip-style advice text. The existing `incomplete_error` advice (e.g. "Prove this logical-and...") is dropped from `Goal.formula` deliberately; clients that want it can read `Diagnostic.message` from `check`.