### PR TITLE
Return post-typecheck AST from check_file (closes #305)

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -52,10 +52,15 @@ class CheckResult:
                           without re-parsing strings. ``None`` when ok.
         module_name:      Module name derived from the filename
                           (``Path(filename).stem``).
-        ast:              Post-uniquify AST. Populated on success and on
-                          failures that occur after parse + uniquify
-                          (e.g. type-check failures). ``None`` on parse
-                          or uniquify failure.
+        ast:              On success, the **post-typecheck** AST: the
+                          form returned by ``proof_checker.check_deduce``
+                          after type checking has resolved overloaded
+                          ``Var.resolved_names`` to the single chosen
+                          name. On failure, the post-uniquify AST that
+                          existed before the error (still with
+                          unresolved overload candidates) when parse +
+                          uniquify succeeded; ``None`` on parse or
+                          uniquify failure. See issue #305.
     """
 
     ok: bool
@@ -138,14 +143,20 @@ def check_file(
             if use_cache:
                 add_uniquified_module(module_name, ast)
 
-        check_deduce(ast, module_name, True, list(tracing_functions))
+        # check_deduce returns the post-typecheck AST (ast3 internally)
+        # so callers like the Deduce-to-C compiler see overload-resolved
+        # Var.resolved_names. On failure the variable retains the
+        # post-uniquify ast for best-effort partial info.
+        typechecked_ast = check_deduce(
+            ast, module_name, True, list(tracing_functions)
+        )
         return CheckResult(
             ok=True,
             error_message=None,
             error_traceback=None,
             exception=None,
             module_name=module_name,
-            ast=ast,
+            ast=typechecked_ast,
         )
     except Exception as e:
         return CheckResult(

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -4544,4 +4544,8 @@ def check_deduce(ast, module_name, modified, tracing_functions):
       env = collect_env(s, env)
       if needs_checking[0]:
         check_proofs(s, env)
-    checked_modules.add(module_name)  
+    checked_modules.add(module_name)
+  # Return the post-typecheck AST so callers (lsp.library.check_file,
+  # the Deduce-to-C compiler) can read the overload-resolved form.
+  # See issue #305.
+  return ast3

--- a/test/compile-allowlist.txt
+++ b/test/compile-allowlist.txt
@@ -11,13 +11,10 @@
 test/should-validate/bintree.pf
 test/should-validate/empty_file.pf
 test/should-validate/not_equal.pf
+test/should-validate/overload1.pf
 test/should-validate/overload3.pf
+test/should-validate/overload5.pf
 test/should-validate/private_union.pf
 test/should-validate/rec1.pf
 test/should-validate/rec2.pf
 test/should-validate/switch_term.pf
-
-# Known limitation: overload1.pf and overload5.pf fail because the
-# compiler uses `Var.resolved_names[0]` rather than the type-checker's
-# chosen overload (post-typecheck AST is not returned by `check_file`
-# today — see lsp/library.py). Track in Phase 2 follow-up.


### PR DESCRIPTION
Closes [#305](https://github.com/jsiek/deduce/issues/305).

## What this is
`proof_checker.check_deduce` now returns its internal `ast3` (the AST after `type_check_stmt` has resolved overloaded `Var.resolved_names` to the single chosen name). `lsp.library.check_file` surfaces that on `CheckResult.ast`.

Going with **Option B** from the issue — replace `ast` rather than add a new field. Three real consumers of `result.ast` today and none want the pre-typecheck form:
- `print_theorems` walks declarations (works on either; post-typecheck has type-checked formulas).
- The Deduce-to-C compiler (`lower.lower_program`) — needs post-typecheck per #305.
- Step 5's upcoming `definition_of` will want resolved overloads.

The `CheckResult.ast` docstring is updated to document the new contract: post-typecheck on success; post-uniquify on failure (or `None` if parse/uniquify failed).

## Compile allowlist
`test/should-validate/overload1.pf` and `overload5.pf` are activated in `test/compile-allowlist.txt`; the `# Known limitation` comment block is removed. The compiler now picks the right overload at every call site.

## Test plan
- [x] `python3 -m pytest test/lsp/` — 485 passed, no regressions.
- [x] `python3 test-deduce.py` (default) — clean.
- [x] `python3 test-deduce.py --errors` — `.err` fixtures untouched.
- [x] `python3 test-deduce.py --parser` — clean.
- [x] `python3 ./test/compile/run_e2e.py` — **14/14** (was 12/12 plus a 2-file known-limitation block). Both `overload1.pf` and `overload5.pf` now compile and round-trip correctly.
- [x] `python3 ./test/compile/run_lower.py` — clean.