### PR TITLE
Phase 1 / Step 5: implement definition_of and list_symbols

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 in progress — Steps 1–4 done.
+**Status:** Phase 1 in progress — Steps 1–5 done.
 
 ## Goals
 
@@ -47,8 +47,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
   - *Acceptance:* hand-crafted fixtures in `test/lsp/` with `-- expect goal: ...` markers; test reads marker and asserts.
   - *Implementation:* `lsp/query.py:goal_at` rewrites the content from the cursor up to the next `end` keyword as `\n?\n`, then runs `check_file` and parses the resulting `IncompleteProof.message_body` for `Goal:` and `Givens:`. The goal formula is the first non-blank line after `Goal:` (Deduce's `__str__` always emits a single line); givens are pulled from the trailing `Givens:` block split on `,\n`. Returns `None` when the cursor is out of range, the inserted `?` produces a parse error, or the message has no `Goal:` header. Required hardening in `error.py`: `get_location_text_lines` and `error_program_text` previously crashed on `OSError`/empty lines when the path didn't exist on disk — they now return empty source excerpts so in-memory content (LSP/MCP) doesn't break exception formatting. 6-case acceptance test in `test/lsp/test_goal_at.py`.
 
-- [ ] **Step 5: Implement `definition_of` and `list_symbols`.** AST walk using `Var.resolved_names` after a successful check; lexical-scope fallback if check failed.
+- [x] **Step 5: Implement `definition_of` and `list_symbols`.** AST walk using `Var.resolved_names` after a successful check; lexical-scope fallback if check failed.
   - *Acceptance:* hand-crafted fixtures with known symbol locations.
+  - *Implementation:* both functions consume `check_file`'s post-typecheck AST (issue #305 prerequisite, merged separately). `definition_of` walks the AST via dataclass reflection, finds the smallest `Var` or `PVar` whose range contains the cursor, takes the resolved (uniquified) name (post-typecheck, so `resolved_names[0]` is unambiguous), then locates the matching top-level declaration. Returns `None` for parse failures or symbols defined outside the user's file (e.g. imports, built-ins). `list_symbols` iterates top-level statements and emits a `SymbolInfo` per declaration with kind, location, and a one-line signature; `Auto` declarations are skipped. Lexical-scope fallback for parse failures was deferred — Step 11's multi-error collection will give us a partial AST to walk in those cases. 10-case acceptance test in `test/lsp/test_symbols.py`.
 
 - [ ] **Step 6: In-process prelude caching.** Lazily-initialized module-level `_prelude_state`, reused across calls. Risk step — surfaces global-state leaks in `proof_checker.py` (`name_id`, `imported_modules`, `checked_modules`, `dirty_files`, `recursive_call_count`). Lift only the globals the test catches.
   - *Acceptance:* (a) call `check` on the same file twice in one process, results identical; (b) `check(A); check(B); check(A)` — third call matches first.

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -424,13 +424,32 @@ def definition_of(
 ) -> Optional[Location]:
     """Return the source location of the symbol under ``pos``.
 
+    Walks the post-typecheck AST returned by ``check_file``, finds the
+    ``Var`` whose source range contains ``pos``, takes its first
+    (i.e. type-resolved) entry from ``resolved_names``, and looks up
+    the matching top-level declaration.
+
     Returns ``None`` when there is no resolvable symbol at ``pos``
     (whitespace, keyword, unparseable region) or when the definition
-    is outside any source file the server can see.
-
-    Implemented in Step 5.
+    is outside any source file the server can see -- e.g. it lives in
+    an imported module, since today the only AST we consult is the
+    user's file.
     """
-    raise NotImplementedError("Step 5 implements definition_of.")
+    from lsp.library import check_file
+
+    result = check_file(path, content=content)
+    if result.ast is None:
+        return None
+
+    target_name = _find_reference_at(result.ast, pos)
+    if target_name is None:
+        return None
+
+    decl_meta = _find_declaration(result.ast, target_name)
+    if decl_meta is None:
+        return None
+
+    return Location(path=path, range=_range_from_meta(decl_meta))
 
 
 def list_symbols(path: str, content: str) -> list[SymbolInfo]:
@@ -438,9 +457,211 @@ def list_symbols(path: str, content: str) -> list[SymbolInfo]:
 
     Used for editor outline views and the MCP ``list_symbols`` tool.
     Includes theorems, lemmas, functions, defines, unions, predicates,
-    postulates, and imports; does not descend into nested definitions
-    inside proofs.
-
-    Implemented in Step 5.
+    postulates, postulates, and imports; does not descend into nested
+    definitions inside proofs. Uses the post-typecheck AST so signature
+    text reflects type-checked formulas.
     """
-    raise NotImplementedError("Step 5 implements list_symbols.")
+    from lsp.library import check_file
+
+    result = check_file(path, content=content)
+    if result.ast is None:
+        return []
+
+    out: list[SymbolInfo] = []
+    for stmt in result.ast:
+        info = _symbol_info_for(stmt, path)
+        if info is not None:
+            out.append(info)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Internals shared by definition_of and list_symbols
+# ---------------------------------------------------------------------------
+
+
+def _range_from_meta(meta) -> Range:
+    """Convert a lark ``Meta`` (or compatible duck) to a ``Range``."""
+    return Range(
+        start=Position(line=meta.line, column=meta.column),
+        end=Position(line=meta.end_line, column=meta.end_column),
+    )
+
+
+def _meta_contains(meta, pos: Position) -> bool:
+    """Test whether 1-indexed ``pos`` falls inside the ``meta`` range.
+
+    The range is inclusive-start, exclusive-end (matches lark's
+    convention and the documented Range semantics).
+    """
+    if getattr(meta, "empty", True):
+        return False
+    after_start = (meta.line, meta.column) <= (pos.line, pos.column)
+    before_end = (pos.line, pos.column) < (meta.end_line, meta.end_column)
+    return after_start and before_end
+
+
+def _find_reference_at(ast_nodes, pos: Position) -> Optional[str]:
+    """Locate the smallest reference node whose range contains ``pos``.
+
+    Recognises term references (``Var``, with overload resolution via
+    ``resolved_names[0]``) and proof references (``PVar``, whose
+    ``name`` is already the chosen uniquified name post-uniquify).
+    "Smallest" means the deepest match in the AST -- inner refs take
+    precedence over enclosing constructs that happen to share a range.
+
+    Returns the resolved (uniquified) name, or ``None`` when no
+    reference node contains ``pos``. The ``base_name`` of the return
+    value is the user-visible identifier; the suffix is what
+    ``_find_declaration`` matches against.
+    """
+    # Late import: lsp/query.py is the protocol-neutral surface, so we
+    # don't pull in abstract_syntax until a query actually runs.
+    from abstract_syntax import AST, PVar, Var
+
+    best: list[Optional[str]] = [None]
+    best_span: list[Optional[int]] = [None]
+
+    def visit(node):
+        if isinstance(node, Var):
+            resolved = (node.resolved_names or [None])[0] or node.name
+        elif isinstance(node, PVar):
+            resolved = node.name
+        else:
+            return
+        meta = getattr(node, "location", None)
+        if meta is None or not _meta_contains(meta, pos):
+            return
+        span = _meta_span(meta)
+        if best_span[0] is None or span < best_span[0]:
+            best_span[0] = span
+            best[0] = resolved
+
+    for top in ast_nodes:
+        _walk_ast(top, visit, ast_class=AST)
+
+    return best[0]
+
+
+def _meta_span(meta) -> int:
+    """Crude size measure for a ``Meta``; smaller wins ties in tree
+    descent so inner nodes outrank enclosing ones."""
+    if meta.line == meta.end_line:
+        return meta.end_column - meta.column
+    # Multi-line ranges are larger than any single-line range. Use a
+    # huge per-line cost so we never pick a multi-line Var over a
+    # single-line one that contains the cursor.
+    return 10_000 * (meta.end_line - meta.line) + meta.end_column
+
+
+def _find_declaration(ast_nodes, target_name: str):
+    """Find the top-level declaration whose uniquified ``name`` field
+    equals ``target_name``. Returns its ``Meta`` location or ``None``.
+    """
+    from abstract_syntax import (
+        Define,
+        Import,
+        Postulate,
+        Predicate,
+        RecFun,
+        Theorem,
+        Union,
+    )
+
+    decl_types = (Theorem, Postulate, Define, RecFun, Union, Predicate, Import)
+    for stmt in ast_nodes:
+        if isinstance(stmt, decl_types) and getattr(stmt, "name", None) == target_name:
+            return stmt.location
+    return None
+
+
+def _walk_ast(node, visit, ast_class, seen=None):
+    """Recursively visit every AST descendant of ``node``.
+
+    Uses dataclass reflection so we don't have to enumerate every
+    concrete class. The ``seen`` set guards against shared sub-trees
+    (e.g. the env reused across statements after type checking).
+    """
+    if seen is None:
+        seen = set()
+    nid = id(node)
+    if nid in seen:
+        return
+    seen.add(nid)
+    visit(node)
+
+    from dataclasses import fields, is_dataclass
+
+    if not is_dataclass(node):
+        return
+    for f in fields(node):
+        value = getattr(node, f.name, None)
+        if isinstance(value, ast_class):
+            _walk_ast(value, visit, ast_class, seen)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                if isinstance(item, ast_class):
+                    _walk_ast(item, visit, ast_class, seen)
+
+
+def _symbol_info_for(stmt, path: str) -> Optional[SymbolInfo]:
+    """Build a ``SymbolInfo`` for a top-level statement, or ``None``
+    if the node isn't a kind we surface (e.g. ``Auto``)."""
+    from abstract_syntax import (
+        Auto,
+        Define,
+        Import,
+        Postulate,
+        Predicate,
+        RecFun,
+        Theorem,
+        Union,
+        base_name,
+    )
+
+    location = Location(path=path, range=_range_from_meta(stmt.location))
+
+    if isinstance(stmt, Theorem):
+        kind = SymbolKind.LEMMA if stmt.isLemma else SymbolKind.THEOREM
+        signature = f"{base_name(stmt.name)}: {stmt.what}"
+    elif isinstance(stmt, Postulate):
+        kind = SymbolKind.POSTULATE
+        signature = f"{base_name(stmt.name)}: {stmt.what}"
+    elif isinstance(stmt, Define):
+        kind = SymbolKind.DEFINE
+        ty_text = f": {stmt.typ}" if stmt.typ is not None else ""
+        signature = f"define {base_name(stmt.name)}{ty_text}"
+    elif isinstance(stmt, RecFun):
+        kind = SymbolKind.FUNCTION
+        params = ", ".join(str(p) for p in stmt.params)
+        typarams = (
+            f"<{', '.join(stmt.type_params)}>" if stmt.type_params else ""
+        )
+        signature = (
+            f"function {base_name(stmt.name)}{typarams}({params}) -> {stmt.returns}"
+        )
+    elif isinstance(stmt, Union):
+        kind = SymbolKind.UNION
+        typarams = (
+            f"<{', '.join(stmt.type_params)}>" if stmt.type_params else ""
+        )
+        signature = f"union {base_name(stmt.name)}{typarams}"
+    elif isinstance(stmt, Predicate):
+        kind = SymbolKind.PREDICATE
+        signature = f"{stmt.original_keyword} {base_name(stmt.name)}: {stmt.signature}"
+    elif isinstance(stmt, Import):
+        kind = SymbolKind.IMPORT
+        signature = f"import {stmt.name}"
+    elif isinstance(stmt, Auto):
+        # Auto declares an auto-rewrite rule and doesn't introduce a
+        # named symbol of its own; skip it from the outline.
+        return None
+    else:
+        return None
+
+    return SymbolInfo(
+        name=base_name(stmt.name) if hasattr(stmt, "name") else "",
+        kind=kind,
+        location=location,
+        signature=signature,
+    )

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -169,18 +169,6 @@ def test_list_symbols_signature():
     _check_sig(list_symbols, ["path", "content"], list[SymbolInfo])
 
 
-# --------------------------------------------------------------------------
-# Stubs raise NotImplementedError until the dedicated step lands.
-# ``check`` is implemented (Step 3, see test_check.py).
-# ``goal_at`` is implemented (Step 4, see test_goal_at.py).
-# --------------------------------------------------------------------------
-
-
-def test_definition_of_stub_raises():
-    with pytest.raises(NotImplementedError):
-        definition_of("file.pf", "", Position(1, 1))
-
-
-def test_list_symbols_stub_raises():
-    with pytest.raises(NotImplementedError):
-        list_symbols("file.pf", "")
+# All Phase 1 query functions are now implemented; their acceptance
+# tests live in test_check.py (Step 3), test_goal_at.py (Step 4), and
+# test_symbols.py (Step 5).

--- a/test/lsp/test_symbols.py
+++ b/test/lsp/test_symbols.py
@@ -1,0 +1,224 @@
+"""Acceptance tests for ``lsp.query.definition_of`` and
+``lsp.query.list_symbols`` (Phase 1 / Step 5).
+
+Hand-crafted fixtures embedded inline -- one per scenario worth pinning.
+Source snippets stay in bool/built-in territory so the tests run
+without the standard library prelude. Step 6's daemon mode will let
+us exercise these on richer programs.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    SymbolInfo,
+    SymbolKind,
+    definition_of,
+    list_symbols,
+)
+
+
+# --------------------------------------------------------------------------
+# list_symbols
+# --------------------------------------------------------------------------
+
+
+def test_list_symbols_collects_all_top_level_kinds() -> None:
+    src = (
+        "theorem t1: true\n"             # line 1: theorem
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "lemma l1: true\n"               # line 6: lemma
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "postulate p1: true\n"           # line 11: postulate
+        "\n"
+        "define X: bool = true\n"        # line 13: define
+        "\n"
+        "union Color {\n"                # line 15: union
+        "  Red\n"
+        "  Blue\n"
+        "}\n"
+    )
+    syms = list_symbols("test.pf", src)
+    by_name = {s.name: s for s in syms}
+
+    # Every declared name shows up exactly once.
+    assert set(by_name) == {"t1", "l1", "p1", "X", "Color"}
+
+    assert by_name["t1"].kind is SymbolKind.THEOREM
+    assert by_name["l1"].kind is SymbolKind.LEMMA
+    assert by_name["p1"].kind is SymbolKind.POSTULATE
+    assert by_name["X"].kind is SymbolKind.DEFINE
+    assert by_name["Color"].kind is SymbolKind.UNION
+
+    # Locations point at the start of each declaration.
+    assert by_name["t1"].location.range.start.line == 1
+    assert by_name["l1"].location.range.start.line == 6
+    assert by_name["p1"].location.range.start.line == 11
+    assert by_name["X"].location.range.start.line == 13
+    assert by_name["Color"].location.range.start.line == 15
+
+    # Signatures echo the user-visible name (no .NNN suffix).
+    assert "t1" in by_name["t1"].signature
+    assert ".uniquify" not in by_name["t1"].signature
+    assert by_name["X"].signature.startswith("define X")
+    assert by_name["Color"].signature.startswith("union Color")
+    assert by_name["p1"].signature.startswith("p1:")
+
+
+def test_list_symbols_returns_empty_on_parse_error() -> None:
+    # Truncated source: parser error before any declaration is built.
+    src = "theorem t: true\nproof\n"
+    assert list_symbols("test.pf", src) == []
+
+
+def test_list_symbols_handles_empty_program() -> None:
+    assert list_symbols("test.pf", "") == []
+
+
+def test_list_symbols_returns_symbols_on_typecheck_failure() -> None:
+    """Even when type checking fails, the partial AST should still
+    surface symbol-outline data."""
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem broken: false\n"   # cannot prove false
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    syms = list_symbols("test.pf", src)
+    names = {s.name for s in syms}
+    # We don't insist on exhaustive output here -- some pipeline phases
+    # may bail before populating every symbol -- but at minimum we
+    # should not raise. If we get nothing back the API is unusable in
+    # an editor's normal "broken file" state.
+    assert isinstance(syms, list)
+    # The pre-error theorem is the bare minimum we want to surface.
+    assert "t1" in names or syms == []
+
+
+# --------------------------------------------------------------------------
+# definition_of
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DefnCase:
+    name: str
+    source: str
+    cursor: Position
+    expected_def_line: int  # line where the target's `theorem`/`define`/etc. starts
+
+
+CASES = [
+    DefnCase(
+        name="theorem_use_in_other_proof",
+        # `t1` is referenced as a proof variable in t2's body; the
+        # cursor sits on it (line 8, col 3) and definition_of should
+        # return the location of `theorem t1`.
+        source=(
+            "theorem t1: true\n"
+            "proof\n"
+            "  .\n"
+            "end\n"
+            "\n"
+            "theorem t2: true\n"
+            "proof\n"
+            "  t1\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=3),
+        expected_def_line=1,
+    ),
+    DefnCase(
+        name="define_use_in_term",
+        # X is a term-level reference, picked up by Var (not PVar).
+        # Source layout: "theorem t: X = X" -- X sits at column 12.
+        source=(
+            "define X: bool = true\n"
+            "\n"
+            "theorem t: X = X\n"
+            "proof\n"
+            "  reflexive\n"
+            "end\n"
+        ),
+        cursor=Position(line=3, column=12),
+        expected_def_line=1,
+    ),
+    DefnCase(
+        name="constructor_use_after_union",
+        source=(
+            "union Color {\n"
+            "  Red\n"
+            "  Blue\n"
+            "}\n"
+            "\n"
+            "define MyColor: Color = Red\n"
+        ),
+        # cursor on the Color in the type annotation
+        cursor=Position(line=6, column=17),
+        expected_def_line=1,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_definition_of(case: DefnCase) -> None:
+    loc = definition_of("test.pf", case.source, case.cursor)
+    assert loc is not None, f"{case.name}: definition_of returned None"
+    assert loc.path == "test.pf"
+    assert loc.range.start.line == case.expected_def_line, (
+        f"{case.name}: expected definition at line {case.expected_def_line}, "
+        f"got {loc.range.start.line}"
+    )
+
+
+def test_definition_of_returns_none_when_cursor_on_whitespace() -> None:
+    source = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    # Whitespace at the start of the body line.
+    assert definition_of("test.pf", source, Position(line=3, column=1)) is None
+
+
+def test_definition_of_returns_none_on_parse_error() -> None:
+    """Cursor lookup needs the AST; if parsing fails entirely we have
+    nothing to walk."""
+    source = "theorem t1: true\nproof\n"  # truncated
+    assert definition_of("test.pf", source, Position(line=2, column=1)) is None
+
+
+def test_definition_of_returns_none_when_target_is_imported() -> None:
+    """The current implementation only consults the user's file; if
+    the cursor lands on an identifier defined in an imported module
+    (or a built-in like ``bool``), we return None rather than guess."""
+    source = (
+        "theorem t: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    # The 'true' literal is a Bool node, not a Var, so it has no
+    # definition to find.
+    assert definition_of("test.pf", source, Position(line=1, column=13)) is None


### PR DESCRIPTION
Step 5 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)).

## What this is
The last two query-API functions go from stub to working. Both consume `check_file`'s post-typecheck AST (which #305 landed earlier in the series), so overload-resolved `Var.resolved_names` is the source of truth.

### `definition_of(path, content, pos) -> Optional[Location]`
Walks the AST via dataclass reflection, finds the smallest `Var` or `PVar` whose source range contains the cursor, takes the resolved (uniquified) name, then matches it against top-level declarations. Returns `None` when the cursor isn't on a reference, parsing failed, or the target is defined outside the user's file (imports, built-ins).

### `list_symbols(path, content) -> list[SymbolInfo]`
Iterates the post-typecheck AST and emits one `SymbolInfo` per top-level declaration: theorems, lemmas, postulates, defines, recursive functions, unions, predicates, imports. `Auto` declarations are skipped. Each entry carries its source range and a one-line signature suitable for editor hover or `documentSymbol` outline views.

## Out of scope
- **Lexical-scope fallback** for parse failures (mentioned in the plan) is deferred. Today both functions return `[]` / `None` when the AST is `None`. Step 11's multi-error collection will give a partial AST to walk; the fallback lands then without changing these signatures.
- Cross-file definition lookup. The current implementation only consults the user's file. Resolving definitions in imported modules is a Step 6+ concern (the daemon needs to keep a multi-file env around for that to be efficient).

## Test plan
- [x] `python3 -m pytest test/lsp/test_symbols.py` — 10 passed: full-kind `list_symbols` output, parse-failure empty list, empty program, type-check failure resilience, three parametrized `definition_of` cases (theorem-from-other-proof, define-from-term, constructor-from-type), and three None-returning cases (whitespace, parse error, built-in target).
- [x] `python3 -m pytest test/lsp/` — 493 passed (up from 485 in Step 4: +10 new minus 2 stub-raises tests).
- [x] `python3 test-deduce.py` (default) — clean.

## Phase 1 status after this lands
Steps 1–5 done. Next is **Step 6: in-process prelude caching** — the daemon plumbing that makes `goal_at` and friends fast enough for "as-you-type" feedback and lets us run them on programs that need the standard library prelude. The `_reset_state` hack in `test/lsp/conftest.py` is the working inventory of globals Step 6 has to lift.