### PR TITLE
Phase 2 step 10: compile against the prelude

### DIFF
--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -85,6 +85,8 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 return ir.Match(go(subj), new_arms)
             case ir.Eq(l, r):
                 return ir.Eq(go(l), go(r))
+            case ir.Panic(_):
+                return t
             case ir.MakeArray(s):
                 return ir.MakeArray(go(s))
             case ir.ArrayGet(s, i):

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -250,7 +250,17 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                 raise EmitError(
                     f"constructor {name} used as a value; not yet supported"
                 )
-            raise EmitError(f"unbound name in emission: {name}")
+            # Reference to a name we never produced a definition for —
+            # almost always because a Predicate / theorem / `some`/`all`
+            # in the source code reduced to a name that the compiler
+            # can't materialise. Emit a runtime panic so the binary
+            # still builds; if pruning kept this code path it'll abort
+            # with a clear message.
+            tmp = ctx.fresh_tmp()
+            return [
+                f"deduce_value {tmp} = deduce_unreachable_value("
+                f"{_c_string(f'undefined name: {name}')});"
+            ], tmp
 
         case ir.Bool(b):
             return [], f"deduce_make_bool({'true' if b else 'false'})"
@@ -452,6 +462,12 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                 f"deduce_value {tmp} = deduce_make_bool(deduce_equal({el}, {er}));"
             )
             return stmts, tmp
+
+        case ir.Panic(msg):
+            tmp = ctx.fresh_tmp()
+            return [
+                f"deduce_value {tmp} = deduce_unreachable_value({_c_string(msg)});"
+            ], tmp
 
         case ir.MakeArray(s):
             ssub, esub = _emit_term(s, ctx, locals_in_scope)

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -115,6 +115,20 @@ class Match:
 
 
 @dataclass
+class Panic:
+    """Stand-in for a non-computational term (e.g. a `some`/`all`
+    formula in a `fun` body) or a reference to a name we couldn't
+    lower. Emits a `deduce_unreachable_value` call at the C level —
+    the compiled program aborts if execution actually reaches it.
+
+    The whole point is to let the rest of the function lower
+    successfully so the pruner can drop it if it isn't reached at
+    runtime. If pruning keeps it, the user gets a clear runtime
+    message naming what went wrong."""
+    msg: str
+
+
+@dataclass
 class Eq:
     """Structural equality, the only built-in primitive in the IR.
     Comes from `Call(Var('='), [a, b])` in the source. Closures
@@ -143,7 +157,7 @@ class ArrayGet:
     index: "Term"
 
 
-Term = Union[Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match, Eq, MakeArray, ArrayGet]
+Term = Union[Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match, Eq, Panic, MakeArray, ArrayGet]
 
 
 # ---------- top-level ----------
@@ -285,6 +299,8 @@ def pp_term(t: Term, indent: int) -> str:
             return "match " + pp_term(subj, indent) + " { " + " ".join(arm_strs) + " }"
         case Eq(l, r):
             return "(" + pp_term(l, indent) + " == " + pp_term(r, indent) + ")"
+        case Panic(msg):
+            return f"panic({msg!r})"
         case MakeArray(s):
             return "array(" + pp_term(s, indent) + ")"
         case ArrayGet(s, i):
@@ -311,7 +327,7 @@ def verify(p: Program) -> None:
     top_classes = (UnionDecl, Function, Global, Print, AssertEq, AssertBool)
     term_classes = (
         Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match, Eq,
-        MakeArray, ArrayGet,
+        Panic, MakeArray, ArrayGet,
     )
 
     def check_term(t: object, ctx: str) -> None:
@@ -356,6 +372,8 @@ def verify(p: Program) -> None:
             case Eq(l, r):
                 check_term(l, ctx)
                 check_term(r, ctx)
+            case Panic(_):
+                pass
             case MakeArray(s):
                 check_term(s, ctx)
             case ArrayGet(s, i):
@@ -425,6 +443,8 @@ def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
             return out
         case Eq(l, r):
             return free_vars(l, bound) | free_vars(r, bound)
+        case Panic(_):
+            return set()
         case MakeArray(s):
             return free_vars(s, bound)
         case ArrayGet(s, i):

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -50,12 +50,22 @@ def _format_loc(loc) -> str:
 # --------------------------------------------------------------------------
 
 def lower_program(stmts: List[ast.Statement]) -> ir.Program:
-    """Entry point. Walks the top-level statement list once to collect
-    constructor names (so `Call(Var(ctor), ...)` can become `Con` rather
-    than `App`), then lowers each statement."""
+    """Entry point. Walks the top-level statement list, recursing into
+    each `Import.ast` so the imported module's declarations end up in
+    the same flat list. Each module is recursed into at most once
+    (matching how the interpreter populates `imported_modules`).
+    Then collects constructor names (so `Call(Var(ctor), ...)` can
+    become `Con` rather than `App`) and lowers each statement.
+
+    Pruning (compiler/prune.py) downstream removes everything that
+    isn't transitively reached from the user's `print` statements;
+    this lets us inline the entire prelude without paying for the
+    parts the user doesn't touch."""
+    flat = _flatten_imports(stmts)
+
     ctors: Set[str] = set()
     arities: Dict[str, int] = {}
-    for s in stmts:
+    for s in flat:
         if isinstance(s, ast.Union):
             for c in s.alternatives:
                 ctors.add(c.name)
@@ -63,7 +73,7 @@ def lower_program(stmts: List[ast.Statement]) -> ir.Program:
 
     lc = LoweringCtx(ctors=ctors, ctor_arities=arities)
     out: List[ir.TopLevel] = []
-    for s in stmts:
+    for s in flat:
         d = lc.lower_stmt(s)
         if d is not None:
             if isinstance(d, list):
@@ -71,6 +81,31 @@ def lower_program(stmts: List[ast.Statement]) -> ir.Program:
             else:
                 out.append(d)
     return ir.Program(decls=out)
+
+
+def _flatten_imports(stmts: List[ast.Statement]) -> List[ast.Statement]:
+    """Walk `stmts`, splicing each `Import.ast` (the imported module's
+    post-typecheck statement list — see `process_declaration` in
+    proof_checker.py) in place of the import itself. Imports are
+    deduplicated by module name; only the first occurrence's nested
+    statements are emitted, matching `imported_modules` semantics in
+    the interpreter."""
+    seen: Set[str] = set()
+    out: List[ast.Statement] = []
+
+    def walk(items: List[ast.Statement]) -> None:
+        for s in items:
+            if isinstance(s, ast.Import):
+                if s.name in seen:
+                    continue
+                seen.add(s.name)
+                if s.ast is not None:
+                    walk(s.ast)
+            else:
+                out.append(s)
+
+    walk(stmts)
+    return out
 
 
 class LoweringCtx:
@@ -275,6 +310,13 @@ class LoweringCtx:
                 "hole/omitted term reached compilation; the proof "
                 "checker should have rejected this earlier",
             )
+        # Quantifiers are formulas — they show up in `fun`/`define`
+        # bodies in the prelude (e.g. `fun EvenNat(n) { some m. … }`)
+        # but are not computational. Lower to a panic stub; pruning
+        # drops it if no `print`-reachable path actually evaluates it.
+        if isinstance(t, (ast.Some, ast.All)):
+            kind = "some" if isinstance(t, ast.Some) else "all"
+            return ir.Panic(f"non-computational `{kind}` quantifier evaluated")
         if isinstance(t, ast.MakeArray):
             return ir.MakeArray(self.lower_term(t.subject))
         if isinstance(t, ast.ArrayGet):
@@ -399,6 +441,8 @@ def subst_vars(t: ir.Term, sub: Dict[str, str]) -> ir.Term:
                 return ir.Match(go(subj, blocked), new_arms)
             case ir.Eq(l, r):
                 return ir.Eq(go(l, blocked), go(r, blocked))
+            case ir.Panic(_):
+                return t
             case ir.MakeArray(s):
                 return ir.MakeArray(go(s, blocked))
             case ir.ArrayGet(s, i):

--- a/compiler/prune.py
+++ b/compiler/prune.py
@@ -128,6 +128,8 @@ def _referenced(t: ir.Term) -> Set[str]:
             case ir.Eq(l, r):
                 walk(l)
                 walk(r)
+            case ir.Panic(_):
+                pass
             case ir.MakeArray(s):
                 walk(s)
             case ir.ArrayGet(s, i):

--- a/compiler/runtime/deduce.c
+++ b/compiler/runtime/deduce.c
@@ -289,6 +289,10 @@ void deduce_panic(const char* msg) {
     exit(1);
 }
 
+deduce_value deduce_unreachable_value(const char* msg) {
+    deduce_panic(msg);
+}
+
 int main(void) {
     deduce_program_main();
     return 0;

--- a/compiler/runtime/deduce.h
+++ b/compiler/runtime/deduce.h
@@ -86,6 +86,12 @@ void deduce_assert_eq(deduce_value lhs, deduce_value rhs, const char* loc);
 void deduce_assert_bool(deduce_value b, const char* loc);
 void deduce_panic(const char* msg) __attribute__((noreturn));
 
+/* Value-returning panic. Same as `deduce_panic` but its return type
+ * is `deduce_value`, so it can stand in for an expression. The
+ * compiler emits this for IR `Panic` nodes — reachable only if the
+ * pruner couldn't drop the surrounding code. */
+deduce_value deduce_unreachable_value(const char* msg) __attribute__((noreturn));
+
 /* Generated programs call this from main(). */
 void deduce_program_main(void);
 

--- a/test/compile-allowlist.txt
+++ b/test/compile-allowlist.txt
@@ -1,12 +1,15 @@
-# Phase 1+2 allowlist for `make tests-compile`.
+# Allowlist for `make tests-compile`.
 #
 # Each non-empty, non-comment line is a path to a `.pf` file (relative
 # to repo root) that the e2e harness will compile, run, and diff
-# against the interpreter's output. Files are required to be
-# compatible with `--no-stdlib` (Phase 1+2 has no prelude support).
+# against the interpreter's output. The harness auto-detects whether
+# a fixture needs the prelude by scanning for `import` lines, so the
+# two groups below differ only in commentary.
 #
-# Files in `test/compile/lower/` are picked up automatically and need
-# not be listed here.
+# Files in `test/compile/lower/` and `test/compile/prelude/` are
+# picked up automatically and need not be listed here.
+
+# --- Tests that don't import the prelude ---
 
 test/should-validate/bintree.pf
 test/should-validate/empty_file.pf
@@ -18,3 +21,28 @@ test/should-validate/private_union.pf
 test/should-validate/rec1.pf
 test/should-validate/rec2.pf
 test/should-validate/switch_term.pf
+
+# --- Tests that import the prelude ---
+#
+# A scan over `test/should-validate/` after Step 10 landed found 122
+# of 149 files compile and round-trip cleanly through the compiler.
+# The set below is a curated selection covering different feature
+# areas — arrays, integers, lists, generics, simplification, marks.
+# Adding more is a one-line change.
+
+test/should-validate/array1.pf
+test/should-validate/array3.pf
+test/should-validate/generic1.pf
+test/should-validate/generic2.pf
+test/should-validate/inst1.pf
+test/should-validate/int1.pf
+test/should-validate/int_arith.pf
+test/should-validate/list1.pf
+test/should-validate/list2.pf
+test/should-validate/mark1.pf
+test/should-validate/nat_arith.pf
+test/should-validate/nat_literals.pf
+test/should-validate/simplify1.pf
+test/should-validate/theorem_and.pf
+test/should-validate/theorem_or.pf
+test/should-validate/uint_arith.pf

--- a/test/compile/prelude/hello_nat.pf
+++ b/test/compile/prelude/hello_nat.pf
@@ -1,0 +1,9 @@
+// Step 10 acceptance: a file that uses the prelude `Nat` operators.
+// Compiler should inline the prelude, then prune everything not
+// reached from the prints.
+
+import Nat
+
+print ℕ2 + ℕ3
+print pow2(ℕ4)
+print gcd(ℕ12, ℕ8)

--- a/test/compile/run_e2e.py
+++ b/test/compile/run_e2e.py
@@ -26,8 +26,22 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 LOWER_DIR = ROOT / "test" / "compile" / "lower"
 E2E_DIR = ROOT / "test" / "compile" / "e2e"
+PRELUDE_DIR = ROOT / "test" / "compile" / "prelude"
 ALLOWLIST = ROOT / "test" / "compile-allowlist.txt"
 RUNTIME_DIR = ROOT / "compiler" / "runtime"
+
+
+def needs_prelude(pf: Path) -> bool:
+    """A fixture needs the prelude if it has any `import` statement.
+    Cheap textual check — good enough for our fixtures, and avoids
+    trying to parse with two different stdlib settings."""
+    for raw in pf.read_text().splitlines():
+        s = raw.strip()
+        if not s or s.startswith("//") or s.startswith("/*"):
+            continue
+        if s.startswith("import ") or s.startswith("public import "):
+            return True
+    return False
 
 
 def find_cc() -> str | None:
@@ -37,10 +51,12 @@ def find_cc() -> str | None:
 def run_interpreter(pf: Path) -> str:
     """Returns the interpreter's stdout (excluding the trailing
     `... is valid` line)."""
+    cmd = [sys.executable, str(ROOT / "deduce.py"),
+           "--suppress-theorems", "--quiet", str(pf)]
+    if not needs_prelude(pf):
+        cmd.insert(2, "--no-stdlib")
     proc = subprocess.run(
-        [sys.executable, str(ROOT / "deduce.py"), "--no-stdlib",
-         "--suppress-theorems", "--quiet", str(pf)],
-        cwd=str(ROOT),
+        cmd, cwd=str(ROOT),
         capture_output=True, text=True, check=False,
     )
     if proc.returncode != 0:
@@ -54,11 +70,13 @@ def run_interpreter(pf: Path) -> str:
 def run_compiled(pf: Path, cc: str, tmp: Path) -> str:
     c_path = tmp / (pf.stem + ".c")
     bin_path = tmp / pf.stem
+    cmd = [sys.executable, str(ROOT / "deduce.py"),
+           "--suppress-theorems", "--quiet", "--compile",
+           "-o", str(c_path), str(pf)]
+    if not needs_prelude(pf):
+        cmd.insert(2, "--no-stdlib")
     subprocess.run(
-        [sys.executable, str(ROOT / "deduce.py"), "--no-stdlib",
-         "--suppress-theorems", "--quiet", "--compile",
-         "-o", str(c_path), str(pf)],
-        cwd=str(ROOT), check=True,
+        cmd, cwd=str(ROOT), check=True,
         # Suppress the interpreter's own print/assert output during
         # compilation; we only want the compiled program's stdout.
         capture_output=True, text=True,
@@ -92,7 +110,7 @@ def main() -> int:
         return 0
 
     fixtures: list[Path] = []
-    for d in (E2E_DIR, LOWER_DIR):
+    for d in (E2E_DIR, LOWER_DIR, PRELUDE_DIR):
         if d.exists():
             fixtures.extend(sorted(d.glob("*.pf")))
     if ALLOWLIST.exists():


### PR DESCRIPTION
## Summary

Closes the last open Phase 2 step from [docs/compile-plan.md](https://github.com/jsiek/deduce/blob/main/docs/compile-plan.md). With this in, `python3 deduce.py --compile foo.pf` works on a file that imports the stdlib — the entire prelude inlines into the lowered IR and the pruner from #308 keeps only what's reached from the user's `print` statements.

## Acceptance fixture

```deduce
import Nat

print ℕ2 + ℕ3
print pow2(ℕ4)
print gcd(ℕ12, ℕ8)
```

Compiles to 369 lines of self-contained C. Output matches the interpreter exactly:

```
suc(suc(suc(suc(suc(zero)))))
suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(suc(zero))))))))))))))))
suc(suc(suc(suc(zero))))
```

Lives at [test/compile/prelude/hello_nat.pf](test/compile/prelude/hello_nat.pf).

## How it works

By the time `check_file` returns, every `Import` node carries the imported module's post-typecheck statement list in `Import.ast` (populated by `process_declaration` in `proof_checker.py`). Lowering recursively walks those, splicing each module's statements into a single flat list and deduplicating by module name to match the interpreter's `imported_modules` semantics.

Pruning (added in #308) is what makes this practical: the prelude has hundreds of definitions and most user programs touch a fraction of them. A reachable-from-`print` walk drops the rest before emit.

## Surviving non-computational terms

The prelude has `fun EvenNat(n) { some m:Nat. n = ℕ2 * m }` and predicates that get erased. To keep lowering robust:

- New `ir.Panic` IR node lowers `some`/`all` quantifiers and any unhandled term to a runtime panic stub.
- The emitter treats unknown names (predicates that erased, etc.) the same way.
- New runtime helper `deduce_unreachable_value(msg)` — a `__attribute__((noreturn))` function typed as `deduce_value` so it can stand in for an expression.

If pruning drops the stub: nothing happens, the program runs fine. If pruning keeps it (because the user actually called the non-computational thing): the binary aborts with `deduce: undefined name: foo` or `deduce: non-computational \`some\` quantifier evaluated`. Loud, locatable.

## Test harness

The e2e harness auto-detects whether a fixture needs the prelude by scanning for `import` lines (cheap text check), so allowlist entries don't have to flag it. New directory `test/compile/prelude/` for prelude-using fixtures.

## Allowlist expansion

A scan over all 149 `test/should-validate/` files found **122 compile and round-trip cleanly**. Adding all 122 would push `make tests-compile` to ~2 minutes; instead, the allowlist gains a **curated 16** covering arrays, integers, lists, generics, simplification, and marks. Adding more is a one-line change.

## Test plan

- [x] `make tests-compile` — **33/33** green (was 16/16). Includes 16 prelude-using fixtures + the new acceptance test + the existing 16.
- [x] `make tests` — interpreter suite unchanged.
- [x] `python3 deduce.py example.pf` and other interpreter-mode CLI invocations are unaffected.
- [x] `python3 deduce.py --compile --no-prune` keeps unreachable defs (still useful for debugging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)