### PR TITLE
Phase 1 / Step 7: MCP adapter for the Deduce query API

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 in progress — Steps 1–6 done.
+**Status:** Phase 1 in progress — Steps 1–7 done.
 
 ## Goals
 
@@ -55,8 +55,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
   - *Acceptance:* (a) call `check` on the same file twice in one process, results identical; (b) `check(A); check(B); check(A)` — third call matches first.
   - *Implementation:* `lsp/library.py` gained a snapshot/restore layer over the pipeline's module-level containers. On the first call with a given prelude, the old containers are cleared, the prelude bootstraps via `_check_file_impl` on an empty buffer, and the resulting post-prelude state is shallow-copied into `_prelude_snapshot`. Subsequent calls with the same prelude restore from the snapshot — much faster than re-running `lib/`. Counters (e.g. `name_id`) are intentionally **not** restored: letting them increase monotonically guarantees freshly generated names never collide with cached prelude names. Tracked containers are `uniquified_modules`, `_predicate_decls_by_unique_name`, `collected_imports`, `reduce_only`, `reduced_defs` (from `abstract_syntax`); `imported_modules`, `checked_modules`, `modules`, `dirty_files` (from `proof_checker`). The conftest `_reset_state` hack is gone — `check_file` is now self-contained — and a new `reset_prelude_cache()` helper lets long-running daemons or tests force a reload. 6-case acceptance test in `test/lsp/test_state_isolation.py` covers idempotency, interleaving, snapshot reuse, and the reset helper.
 
-- [ ] **Step 7: MCP adapter.** `lsp/mcp_server.py` using the Python `mcp` SDK. Each tool is a thin wrapper around a query API function. Stdio transport.
+- [x] **Step 7: MCP adapter.** `lsp/mcp_server.py` using the Python `mcp` SDK. Each tool is a thin wrapper around a query API function. Stdio transport.
   - *Acceptance:* (a) unit tests via the `mcp` SDK's in-memory test client; (b) end-to-end smoke from Claude Code on a real proof.
+  - *Implementation:* `lsp/mcp_server.py` with FastMCP. Four tools (`check_file`, `goal_at`, `definition_of`, `list_symbols`) wrap the corresponding `lsp.query` functions; each reads the file from disk, calls the query helper, and lets FastMCP serialize. Stdio transport via `python3 -m lsp.mcp_server`. Standard library at `lib/` is auto-prepended as the prelude unless `DEDUCE_NO_STDLIB=1`; `DEDUCE_ROOT` overrides where the server looks for `lib/`. **Required contract change** (justified): `lsp.query` functions gained an optional `prelude` parameter (default `()`) so the server can pass the stdlib through; the Step 2 signature test was updated, and a new test pins the default at `()` so existing Step 3-5 callers keep working unchanged. `list_symbols` filters out auto-prepended prelude imports so the outline shows only what the user wrote. 8-case acceptance test in `test/lsp/test_mcp_server.py` exercises tool registration, valid/error file checking, goal lookup with and without active proof, definition lookup with whitespace fallback, and the symbol outline. End-to-end smoke from Claude Code is left for the user to verify with `requirements-lsp.txt` installed.
 
 - [ ] **Step 8: Phase 1 latency benchmark.** Measure MCP `check` latency (warm daemon) against baseline `python deduce.py file.pf` latency on a representative set of files. Expected: ~10× speedup (~30s → ~3s).
   - *Acceptance:* benchmark script that reports a side-by-side table for several files. Decision point — if the speedup is well below expected, identify the bottleneck (prelude not actually cached? per-call work that should be amortized?) and address before continuing to Phase 2.

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -1,0 +1,205 @@
+"""MCP adapter for the Deduce query API (Phase 1 / Step 7).
+
+Exposes ``lsp.query``'s four functions as MCP tools over stdio. Each
+tool is a thin wrapper that reads the file from disk, calls the
+underlying query helper, and serializes the result to JSON-friendly
+dicts.
+
+Run directly to start the stdio server::
+
+    python3 -m lsp.mcp_server
+
+Wire it into Claude Code via ``.mcp.json`` (or the user-level
+equivalent)::
+
+    {
+      "mcpServers": {
+        "deduce": {
+          "command": "python3",
+          "args": ["-m", "lsp.mcp_server"]
+        }
+      }
+    }
+
+The standard library at ``lib/`` is auto-prepended as the default
+prelude unless ``DEDUCE_NO_STDLIB=1`` is set in the environment;
+that mirrors ``deduce.py``'s ``--no-stdlib`` flag. Set
+``DEDUCE_ROOT`` to override where the server looks for ``lib/`` and
+``test/test-imports/``; otherwise it falls back to the parent
+directory of this module.
+
+The MCP boundary stays protocol-specific: the only consumer of
+``mcp`` lives here. Everything reachable from tests and the LSP
+adapter (Step 9) goes through ``lsp.query``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: configure the Deduce environment exactly once at import.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_deduce_root() -> Path:
+    env_root = os.environ.get("DEDUCE_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    # ``lsp/mcp_server.py`` lives one directory below the repo root.
+    return Path(__file__).resolve().parent.parent
+
+
+_DEDUCE_ROOT = _resolve_deduce_root()
+_LIB_DIR = _DEDUCE_ROOT / "lib"
+_TEST_IMPORTS_DIR = _DEDUCE_ROOT / "test" / "test-imports"
+
+# ``set_deduce_directory`` -- called by the parsers -- reads
+# ``os.path.dirname(sys.argv[0])`` to find ``Deduce.lark``. Make
+# sure it points at the repo root regardless of how the server
+# was launched.
+_PSEUDO_ENTRY = str(_DEDUCE_ROOT / "deduce.py")
+sys.argv = [_PSEUDO_ENTRY] + sys.argv[1:]
+sys.setrecursionlimit(10000)
+
+# Repo root needs to be on sys.path for ``import abstract_syntax`` etc.
+if str(_DEDUCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_DEDUCE_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    add_import_directory,
+    init_import_directories,
+)
+from flags import set_quiet_mode  # noqa: E402
+
+set_quiet_mode(True)
+init_import_directories()
+add_import_directory(str(_LIB_DIR))
+if _TEST_IMPORTS_DIR.is_dir():
+    add_import_directory(str(_TEST_IMPORTS_DIR))
+
+
+def _default_prelude() -> tuple[str, ...]:
+    """Module names for every ``.pf`` in ``lib/`` -- the standard
+    library prelude, mirroring ``deduce.py`` without ``--no-stdlib``.
+    Returns ``()`` when ``DEDUCE_NO_STDLIB=1`` or ``lib/`` is missing.
+    """
+    if os.environ.get("DEDUCE_NO_STDLIB") == "1":
+        return ()
+    if not _LIB_DIR.is_dir():
+        return ()
+    return tuple(
+        sorted(p.stem for p in _LIB_DIR.glob("*.pf"))
+    )
+
+
+_PRELUDE = _default_prelude()
+
+
+# ---------------------------------------------------------------------------
+# Server definition
+# ---------------------------------------------------------------------------
+
+
+from lsp import query  # noqa: E402
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+
+mcp = FastMCP("deduce-lsp")
+
+
+def _to_serializable(obj: Any) -> Any:
+    """Convert frozen dataclasses (and tuples/enums of them) into
+    plain dicts/lists for the MCP JSON wire format."""
+    if obj is None:
+        return None
+    if is_dataclass(obj):
+        return {k: _to_serializable(v) for k, v in asdict(obj).items()}
+    if isinstance(obj, (list, tuple)):
+        return [_to_serializable(x) for x in obj]
+    if hasattr(obj, "value") and hasattr(obj, "name"):
+        # Enum-ish: surface the .value (e.g. "error" for Severity).
+        return obj.value
+    return obj
+
+
+def _read_file(path: str) -> str:
+    """Read a file with the same encoding ``check_file`` uses."""
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+@mcp.tool()
+def check_file(path: str) -> dict:
+    """Run the Deduce pipeline on ``path`` and return diagnostics.
+
+    The standard library at ``lib/`` is auto-prepended unless the
+    server was started with ``DEDUCE_NO_STDLIB=1``. Returns a dict
+    with a ``diagnostics`` list; an empty list means the file is
+    valid. Diagnostic entries have ``severity``, ``range`` (with
+    1-indexed line/column positions), ``message``, and an optional
+    ``code``.
+    """
+    content = _read_file(path)
+    diagnostics = query.check(path, content, prelude=_PRELUDE)
+    return {"diagnostics": _to_serializable(diagnostics)}
+
+
+@mcp.tool()
+def goal_at(path: str, line: int, column: int) -> Optional[dict]:
+    """Return the proof obligation visible at ``line``:``column``.
+
+    Lines and columns are 1-indexed (matching the location text in
+    Deduce error messages). Returns ``None`` when the cursor is
+    outside any active proof or the file does not parse. The result
+    has ``formula`` (a rendered string), ``givens`` (a list of
+    ``{label, formula}`` pairs in scope), and ``range``.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    goal = query.goal_at(path, content, pos, prelude=_PRELUDE)
+    return _to_serializable(goal)
+
+
+@mcp.tool()
+def definition_of(path: str, line: int, column: int) -> Optional[dict]:
+    """Return the source location of the symbol at ``line``:``column``.
+
+    Returns ``None`` when the cursor isn't on a resolvable symbol or
+    when the definition lives outside the file (an imported module,
+    a built-in). The result has ``path`` and ``range``.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    loc = query.definition_of(path, content, pos, prelude=_PRELUDE)
+    return _to_serializable(loc)
+
+
+@mcp.tool()
+def list_symbols(path: str) -> list[dict]:
+    """Return all top-level declarations in ``path``.
+
+    Includes theorems, lemmas, postulates, defines, recursive
+    functions, unions, predicates, and explicit imports. Auto-
+    prepended prelude imports are filtered out so the outline shows
+    only what the user wrote. Each entry has ``name``, ``kind``
+    (e.g. ``"theorem"``), ``location``, and an optional
+    ``signature``.
+    """
+    content = _read_file(path)
+    syms = query.list_symbols(path, content, prelude=_PRELUDE)
+    return _to_serializable(syms)
+
+
+def main() -> None:
+    """Run the server over stdio. Used as the ``__main__`` entry."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -42,7 +42,7 @@ in user-visible error messages.
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Optional, Sequence
 
 
 __all__ = [
@@ -188,7 +188,9 @@ class SymbolInfo:
 # resolution and error messages depend on it.
 
 
-def check(path: str, content: str) -> list[Diagnostic]:
+def check(
+    path: str, content: str, prelude: Sequence[str] = ()
+) -> list[Diagnostic]:
     """Run the full Deduce pipeline on ``content`` (treated as if it
     were the contents of ``path``) and return all diagnostics found.
 
@@ -196,13 +198,17 @@ def check(path: str, content: str) -> list[Diagnostic]:
     on the first error, so today the list will have at most one entry;
     Step 11 (multi-error collection) will lift that limit without
     changing this signature.
+
+    ``prelude`` is the list of module names auto-imported in front of
+    the file (matching ``deduce.py``'s ``--no-stdlib`` flag: empty by
+    default; the MCP / LSP server passes the standard library here).
     """
     # Imported here, not at module top, so this module stays free of
     # any pipeline import while it is just a stub at module-load time.
     # That keeps the protocol-neutral boundary cheap to enforce.
     from lsp.library import check_file
 
-    result = check_file(path, content=content)
+    result = check_file(path, content=content, prelude=prelude)
     if result.ok:
         return []
 
@@ -242,7 +248,9 @@ def _diagnostic_from_exception(
     return Diagnostic(severity=Severity.ERROR, range=rng, message=body)
 
 
-def goal_at(path: str, content: str, pos: Position) -> Optional[Goal]:
+def goal_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> Optional[Goal]:
     """Return the proof obligation visible at ``pos``.
 
     Returns ``None`` when there is no active proof at that position --
@@ -251,6 +259,8 @@ def goal_at(path: str, content: str, pos: Position) -> Optional[Goal]:
     (more precisely: replacing the content from ``pos`` up to the next
     ``end`` keyword with ``?``) and capturing the goal text the checker
     prints when it reaches the hole.
+
+    ``prelude`` matches the meaning in :func:`check`.
     """
     from lsp.library import check_file
 
@@ -258,7 +268,7 @@ def goal_at(path: str, content: str, pos: Position) -> Optional[Goal]:
     if modified is None:
         return None
 
-    result = check_file(path, content=modified)
+    result = check_file(path, content=modified, prelude=prelude)
     if result.ok:
         # No PHole was hit -- the surrounding proof was already complete
         # without needing the inserted ?. Nothing to report.
@@ -420,7 +430,7 @@ def _parse_givens_section(body: str) -> tuple:
 
 
 def definition_of(
-    path: str, content: str, pos: Position
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
 ) -> Optional[Location]:
     """Return the source location of the symbol under ``pos``.
 
@@ -434,10 +444,12 @@ def definition_of(
     is outside any source file the server can see -- e.g. it lives in
     an imported module, since today the only AST we consult is the
     user's file.
+
+    ``prelude`` matches the meaning in :func:`check`.
     """
     from lsp.library import check_file
 
-    result = check_file(path, content=content)
+    result = check_file(path, content=content, prelude=prelude)
     if result.ast is None:
         return None
 
@@ -452,7 +464,9 @@ def definition_of(
     return Location(path=path, range=_range_from_meta(decl_meta))
 
 
-def list_symbols(path: str, content: str) -> list[SymbolInfo]:
+def list_symbols(
+    path: str, content: str, prelude: Sequence[str] = ()
+) -> list[SymbolInfo]:
     """Return all top-level declarations in ``content``.
 
     Used for editor outline views and the MCP ``list_symbols`` tool.
@@ -460,15 +474,26 @@ def list_symbols(path: str, content: str) -> list[SymbolInfo]:
     postulates, postulates, and imports; does not descend into nested
     definitions inside proofs. Uses the post-typecheck AST so signature
     text reflects type-checked formulas.
+
+    ``prelude`` matches the meaning in :func:`check`. Symbols that
+    come from prelude imports are *not* included in the result --
+    only declarations in ``content`` itself.
     """
     from lsp.library import check_file
 
-    result = check_file(path, content=content)
+    from abstract_syntax import Import as _ImportNode
+
+    result = check_file(path, content=content, prelude=prelude)
     if result.ast is None:
         return []
 
+    prelude_set = set(prelude)
     out: list[SymbolInfo] = []
     for stmt in result.ast:
+        # Skip the auto-prepended prelude imports -- the user didn't
+        # write them, so they shouldn't show up in the outline.
+        if isinstance(stmt, _ImportNode) and stmt.name in prelude_set:
+            continue
         info = _symbol_info_for(stmt, path)
         if info is not None:
             out.append(info)

--- a/requirements-lsp.txt
+++ b/requirements-lsp.txt
@@ -1,0 +1,10 @@
+# Optional dependencies for the Deduce LSP/MCP server (lsp/mcp_server.py).
+#
+# Install with: python3 -m pip install -r requirements-lsp.txt
+#
+# These are NOT required to run deduce.py, test-deduce.py, or the
+# in-process pieces of lsp/ (library, query). Only lsp/mcp_server.py
+# depends on the MCP SDK, and the test_mcp_server.py acceptance suite
+# skips itself when mcp isn't installed.
+
+mcp>=1.27.0

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -1,0 +1,261 @@
+"""End-to-end tests for the MCP adapter (Phase 1 / Step 7).
+
+Each MCP tool is exercised through the SDK's in-memory test client so
+we cover the full path -- input schema, JSON serialization,
+``query.*`` plumbing -- without spawning a stdio subprocess. The
+underlying ``query`` functions are already exhaustively tested in
+``test_check.py`` / ``test_goal_at.py`` / ``test_symbols.py``; the
+job here is to verify the wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+# Skip if mcp isn't installed -- it's an optional dependency and the
+# rest of the LSP suite stays runnable without it.
+mcp = pytest.importorskip("mcp")
+from mcp.shared.memory import (  # noqa: E402
+    create_connected_server_and_client_session,
+)
+
+# Importing the server triggers Deduce environment setup. Ensure no
+# stdlib auto-prepend so test fixtures don't depend on it.
+import os  # noqa: E402
+
+os.environ["DEDUCE_NO_STDLIB"] = "1"
+
+from lsp import mcp_server as _server_module  # noqa: E402
+
+
+VALID_FILE = REPO_ROOT / "test" / "should-validate" / "after.pf"
+ERROR_FILE = REPO_ROOT / "test" / "should-error" / "advice_and.pf"
+
+
+@pytest.fixture
+def server():
+    """The configured FastMCP instance under test."""
+    return _server_module.mcp
+
+
+def _parse_response(result) -> Any:
+    """Decode whatever FastMCP returned for our tool.
+
+    FastMCP picks one of three encodings depending on the tool's return
+    annotation:
+
+    * ``dict`` returns -- one ``TextContent`` holding a JSON object,
+      ``structuredContent`` is ``None``;
+    * ``list[...]`` and ``None`` returns -- ``structuredContent`` is
+      ``{"result": ...}`` (and ``content`` mirrors each list element);
+    * primitives -- similar to lists.
+
+    Prefer structured content when present, fall back to parsing the
+    text body otherwise.
+    """
+    sc = getattr(result, "structuredContent", None)
+    if sc is not None and "result" in sc:
+        return sc["result"]
+    if not result.content:
+        return None
+    return json.loads(result.content[0].text)
+
+
+async def _call(server, name: str, arguments: dict) -> Any:
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        await session.initialize()
+        result = await session.call_tool(name, arguments)
+        assert not result.isError, f"{name} returned error: {result.content}"
+        return _parse_response(result)
+
+
+# --------------------------------------------------------------------------
+# Tool registration
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_all_four_tools_are_registered(server):
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        await session.initialize()
+        listing = await session.list_tools()
+        names = {t.name for t in listing.tools}
+        assert names == {
+            "check_file",
+            "goal_at",
+            "definition_of",
+            "list_symbols",
+        }
+
+
+# --------------------------------------------------------------------------
+# check_file
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_check_file_on_valid_file_returns_no_diagnostics(server):
+    payload = await _call(server, "check_file", {"path": str(VALID_FILE)})
+    assert payload == {"diagnostics": []}
+
+
+@pytest.mark.anyio
+async def test_check_file_on_error_file_returns_one_diagnostic(server):
+    payload = await _call(server, "check_file", {"path": str(ERROR_FILE)})
+    assert "diagnostics" in payload
+    diags = payload["diagnostics"]
+    assert len(diags) == 1
+    diag = diags[0]
+    assert diag["severity"] == "error"
+    assert "range" in diag
+    assert diag["range"]["start"]["line"] == 6
+    assert "incomplete proof" in diag["message"]
+
+
+# --------------------------------------------------------------------------
+# goal_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_goal_at_returns_goal_dict(server, tmp_path):
+    # Self-contained bool-only fixture so we don't need the prelude.
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    fp = tmp_path / "goal.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "goal_at",
+        {"path": str(fp), "line": 4, "column": 1},
+    )
+    assert payload is not None
+    assert payload["formula"] == "P = P"
+    assert payload["givens"] == []
+
+
+@pytest.mark.anyio
+async def test_goal_at_returns_null_outside_proof(server, tmp_path):
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+        "\n"
+        "-- here, after end\n"
+    )
+    fp = tmp_path / "outside.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "goal_at",
+        {"path": str(fp), "line": 7, "column": 1},
+    )
+    assert payload is None
+
+
+# --------------------------------------------------------------------------
+# definition_of
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_definition_of_finds_theorem(server, tmp_path):
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem t2: true\n"
+        "proof\n"
+        "  t1\n"
+        "end\n"
+    )
+    fp = tmp_path / "defn.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "definition_of",
+        {"path": str(fp), "line": 8, "column": 3},
+    )
+    assert payload is not None
+    assert payload["path"] == str(fp)
+    assert payload["range"]["start"]["line"] == 1
+
+
+@pytest.mark.anyio
+async def test_definition_of_returns_null_for_whitespace(server, tmp_path):
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    fp = tmp_path / "ws.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "definition_of",
+        {"path": str(fp), "line": 3, "column": 1},
+    )
+    assert payload is None
+
+
+# --------------------------------------------------------------------------
+# list_symbols
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_symbols_returns_each_top_level_decl(server, tmp_path):
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "define X: bool = true\n"
+        "\n"
+        "union Color {\n"
+        "  Red\n"
+        "  Blue\n"
+        "}\n"
+    )
+    fp = tmp_path / "outline.pf"
+    fp.write_text(src)
+    payload = await _call(server, "list_symbols", {"path": str(fp)})
+    assert isinstance(payload, list)
+    by_name = {s["name"]: s for s in payload}
+    assert set(by_name) == {"t1", "X", "Color"}
+    assert by_name["t1"]["kind"] == "theorem"
+    assert by_name["X"]["kind"] == "define"
+    assert by_name["Color"]["kind"] == "union"
+
+
+# --------------------------------------------------------------------------
+# pytest-anyio plumbing -- pytest.mark.anyio needs an event-loop fixture
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -154,19 +154,39 @@ def _check_sig(func, expected_params, expected_return):
 
 
 def test_check_signature():
-    _check_sig(check, ["path", "content"], list[Diagnostic])
+    _check_sig(check, ["path", "content", "prelude"], list[Diagnostic])
 
 
 def test_goal_at_signature():
-    _check_sig(goal_at, ["path", "content", "pos"], Optional[Goal])
+    _check_sig(
+        goal_at, ["path", "content", "pos", "prelude"], Optional[Goal]
+    )
 
 
 def test_definition_of_signature():
-    _check_sig(definition_of, ["path", "content", "pos"], Optional[Location])
+    _check_sig(
+        definition_of,
+        ["path", "content", "pos", "prelude"],
+        Optional[Location],
+    )
 
 
 def test_list_symbols_signature():
-    _check_sig(list_symbols, ["path", "content"], list[SymbolInfo])
+    _check_sig(
+        list_symbols, ["path", "content", "prelude"], list[SymbolInfo]
+    )
+
+
+def test_prelude_param_has_default():
+    """``prelude`` is optional on every query function so existing
+    Step 3-5 callers (which pass ``path`` and ``content`` only)
+    keep working."""
+    for func in (check, goal_at, definition_of, list_symbols):
+        prelude_param = inspect.signature(func).parameters["prelude"]
+        assert prelude_param.default == (), (
+            f"{func.__name__}.prelude default drifted: "
+            f"got {prelude_param.default!r}"
+        )
 
 
 # All Phase 1 query functions are now implemented; their acceptance


### PR DESCRIPTION
Step 7 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)). Phase 1 reaches its main deliverable.

## What this is
`lsp/mcp_server.py` is a FastMCP server that exposes the four `lsp.query` functions as MCP tools over stdio. Each tool reads the file from disk, calls the query helper, and lets FastMCP handle JSON serialization.

Wire it into Claude Code with:
```json
{
  "mcpServers": {
    "deduce": {
      "command": "python3",
      "args": ["-m", "lsp.mcp_server"]
    }
  }
}
```

The standard library at `lib/` is auto-prepended as the prelude unless `DEDUCE_NO_STDLIB=1`. `DEDUCE_ROOT` overrides where the server looks for `lib/` and `test/test-imports/`.

## Required contract change to `lsp.query`
The four query functions gained an optional `prelude` parameter (default `()`). Step 2 locked the four-parameter signatures; this is justified because the MCP case really wants the stdlib auto-prepended. The new parameter is **optional**, so all Step 3–5 callers still work unchanged, and a new `test_prelude_param_has_default` pins the `()` default so a future PR can't accidentally make it required. `list_symbols` also filters out auto-prepended prelude imports so the outline shows only what the user wrote.

## `mcp` is an optional dependency
`requirements-lsp.txt` lists `mcp>=1.27.0`. The base `requirements.txt` is unchanged; `deduce.py`, `test-deduce.py`, and the in-process pieces of `lsp/` (library, query) all stay runnable on a fresh checkout with just `lark`. `test_mcp_server.py` uses `pytest.importorskip` so the LSP suite degrades gracefully when `mcp` isn't installed.

## Test plan
- [x] `python3 -m pytest test/lsp/test_mcp_server.py` — 8 cases via the SDK's in-memory client (no stdio subprocess required): all four tools register, `check_file` on valid + error fixtures, `goal_at` mid-proof + null outside proof, `definition_of` finds theorem + null on whitespace, `list_symbols` outline.
- [x] `python3 -m pytest test/lsp/` — 508 passed (up from 499 in Step 6: +8 new MCP tests + 1 new prelude-default test).
- [x] `python3 test-deduce.py` (default) — clean.
- [x] Server smoke: `python3 -c "from lsp import mcp_server"` registers the four tools and detects 32 prelude modules from `lib/`.

## Out of scope
- **End-to-end smoke from Claude Code** is the plan's acceptance (b). I can verify in-memory but can't drive Claude Code automatically — left for the user to run with `pip install -r requirements-lsp.txt` and the `.mcp.json` snippet above.
- **Step 8 (latency benchmark)** confirms whether the prelude caching from Step 6 actually delivers the ~10× speedup the plan predicted. That comes next.

## Phase 1 status
| Step | Status |
|---|---|
| 1–7 | ✅ |
| 8 | ⏳ latency benchmark (next, Phase 1 milestone) |