### PR TITLE
Phase 1 / Step 8: latency benchmark for check_file

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 in progress — Steps 1–7 done.
+**Status:** Phase 1 complete — Steps 1–8 done.
 
 ## Goals
 
@@ -59,8 +59,16 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
   - *Acceptance:* (a) unit tests via the `mcp` SDK's in-memory test client; (b) end-to-end smoke from Claude Code on a real proof.
   - *Implementation:* `lsp/mcp_server.py` with FastMCP. Four tools (`check_file`, `goal_at`, `definition_of`, `list_symbols`) wrap the corresponding `lsp.query` functions; each reads the file from disk, calls the query helper, and lets FastMCP serialize. Stdio transport via `python3 -m lsp.mcp_server`. Standard library at `lib/` is auto-prepended as the prelude unless `DEDUCE_NO_STDLIB=1`; `DEDUCE_ROOT` overrides where the server looks for `lib/`. **Required contract change** (justified): `lsp.query` functions gained an optional `prelude` parameter (default `()`) so the server can pass the stdlib through; the Step 2 signature test was updated, and a new test pins the default at `()` so existing Step 3-5 callers keep working unchanged. `list_symbols` filters out auto-prepended prelude imports so the outline shows only what the user wrote. 8-case acceptance test in `test/lsp/test_mcp_server.py` exercises tool registration, valid/error file checking, goal lookup with and without active proof, definition lookup with whitespace fallback, and the symbol outline. End-to-end smoke from Claude Code is left for the user to verify with `requirements-lsp.txt` installed.
 
-- [ ] **Step 8: Phase 1 latency benchmark.** Measure MCP `check` latency (warm daemon) against baseline `python deduce.py file.pf` latency on a representative set of files. Expected: ~10× speedup (~30s → ~3s).
+- [x] **Step 8: Phase 1 latency benchmark.** Measure MCP `check` latency (warm daemon) against baseline `python deduce.py file.pf` latency on a representative set of files. Expected: ~10× speedup (~30s → ~3s).
   - *Acceptance:* benchmark script that reports a side-by-side table for several files. Decision point — if the speedup is well below expected, identify the bottleneck (prelude not actually cached? per-call work that should be amortized?) and address before continuing to Phase 2.
+  - *Implementation:* `lsp/benchmark.py` runs each fixture once via subprocess (cold path) and after a single in-process bootstrap (warm path), 3 runs per phase, median reported. Default fixtures cover small/medium/large should-validate files compatible with the auto-prelude.
+  - *Results (with `lib/*.thm` cache present, the typical developer state, on Python 3.13):*
+    - Cold subprocess: 0.88–1.41s per file (mostly fixed Python+lark+`.thm`-read startup).
+    - Warm via daemon: 0.19–0.75s per file.
+    - Bootstrap: ~0.75s one-time per process.
+    - Per-call speedup: **2–5×**, dominant for small files where startup dwarfs the actual checking work.
+  - *Results (no `.thm` cache, fresh checkout, single fixture):* cold 13.8s, bootstrap 13.9s, subsequent warm 0.26s — **~53× per-call speedup** after bootstrap. The plan's ~10× target was based on this baseline; .thm caching was already pre-paying most of the prelude cost in the typical case.
+  - *Decision:* proceed to Phase 2. The 2–5× speedup is meaningful for editor latency, the daemon is required for any LSP server architecturally (Step 6's state isolation), and the warm-path cost is independent of `.thm` staleness so the daemon stays fast even when the on-disk caches are invalidated.
 
 **Milestone:** MCP works for Claude at the expected speedup. Shippable. Stop and use it for ~1 week before continuing — usage will tell you which queries actually matter.
 

--- a/lsp/benchmark.py
+++ b/lsp/benchmark.py
@@ -1,0 +1,191 @@
+"""Latency benchmark for ``check_file`` (Phase 1 / Step 8).
+
+Compares two ways of running the Deduce pipeline on a fixture:
+
+* **Cold subprocess** -- ``python3 deduce.py file.pf``, which is what
+  the CLI does and what the proof-writing inner loop pays today.
+  Each invocation re-launches the interpreter, re-parses the
+  standard library prelude, and runs the user file.
+
+* **Warm in-process** -- ``lsp.query.check`` after the prelude has
+  been loaded once (the snapshot/restore mechanism from Step 6).
+  Each call only re-parses + re-checks the user file; the lib
+  modules are reused.
+
+The benchmark prints a side-by-side table and reports the speedup
+factor for each fixture. The first MCP call per process is the
+prelude bootstrap and is reported separately -- it's a one-time
+cost a long-running daemon (the MCP server) only pays at startup.
+
+Note about ``.thm`` caching
+---------------------------
+
+Both the cold and warm paths benefit from ``lib/*.thm`` files
+generated during the first ``make tests-lib`` run -- they let the
+proof checker skip re-proving the standard library. With the .thm
+cache present (the typical developer state) cold latency is ~1s
+per file. Without it (fresh checkout), cold latency is closer to
+~13s, and the daemon bootstrap pays the same one-time cost. The
+warm-path latency is ~0.2-0.7s in either case because the
+in-memory snapshot doesn't depend on .thm files.
+
+Run::
+
+    python3 lsp/benchmark.py
+    python3 lsp/benchmark.py path/to/file.pf path/to/another.pf
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Default fixtures: small/medium/large by line count, all inside
+# test/should-validate so they're known to validate cleanly with the
+# stdlib auto-prelude. (Files that redefine ``Nat`` etc. -- e.g.
+# after.pf -- clash with the auto-prelude and are skipped.)
+DEFAULT_FIXTURES: tuple[str, ...] = (
+    "test/should-validate/IntTests.pf",
+    "test/should-validate/NatTests.pf",
+    "test/should-validate/ListTests.pf",
+    "test/should-validate/LogTests.pf",
+    "test/should-validate/UIntLogTests.pf",
+)
+
+# How many timing samples to take per phase. Median is reported so
+# outliers (GC pauses, OS scheduling) don't skew the headline.
+RUNS = 3
+
+
+def _median(samples: list[float]) -> float:
+    return statistics.median(samples)
+
+
+def _measure(label: str, fn: Callable[[], None], runs: int = RUNS) -> float:
+    """Time ``fn`` ``runs`` times, return the median seconds."""
+    times: list[float] = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return _median(times)
+
+
+def _cold_run(fixture: str) -> None:
+    """Run ``deduce.py`` on ``fixture`` in a fresh subprocess."""
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "deduce.py"),
+        "--quiet",
+        "--suppress-theorems",
+        fixture,
+    ]
+    result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True)
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"\n[benchmark] WARNING: cold run for {fixture} exited with "
+            f"{result.returncode}:\n{result.stderr.decode(errors='replace')}\n"
+        )
+
+
+def _set_up_query_environment() -> tuple[Callable[[str], None], tuple[str, ...]]:
+    """Configure Deduce for in-process use and return ``(check, prelude)``.
+
+    Mirrors what ``deduce.py``'s ``__main__`` and ``lsp.mcp_server``
+    do at startup -- import directories, recursion limit, quiet mode
+    -- so the warm-path measurement matches what the MCP server
+    actually pays per call.
+    """
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.argv = [str(REPO_ROOT / "deduce.py")] + sys.argv[1:]
+    sys.setrecursionlimit(10000)
+
+    from abstract_syntax import (
+        add_import_directory,
+        init_import_directories,
+    )
+    from flags import set_quiet_mode
+
+    set_quiet_mode(True)
+    init_import_directories()
+    add_import_directory(str(REPO_ROOT / "lib"))
+    add_import_directory(str(REPO_ROOT / "test" / "test-imports"))
+
+    from lsp.query import check as query_check
+
+    lib_dir = REPO_ROOT / "lib"
+    prelude = tuple(sorted(p.stem for p in lib_dir.glob("*.pf")))
+
+    def runner(path: str) -> None:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+        diagnostics = query_check(path, content, prelude=prelude)
+        # Sanity: the fixtures are in should-validate so they should
+        # produce no diagnostics. Don't fail the benchmark if one
+        # slips through, just flag it.
+        if diagnostics:
+            sys.stderr.write(
+                f"\n[benchmark] WARNING: warm run for {path} returned "
+                f"{len(diagnostics)} diagnostic(s)\n"
+            )
+
+    return runner, prelude
+
+
+def _format_seconds(s: float) -> str:
+    return f"{s:5.2f}s"
+
+
+def main(argv: list[str]) -> int:
+    fixtures = argv if argv else list(DEFAULT_FIXTURES)
+    abs_fixtures: list[Path] = []
+    for f in fixtures:
+        p = Path(f)
+        if not p.is_absolute():
+            p = (REPO_ROOT / f).resolve()
+        if not p.exists():
+            sys.stderr.write(f"[benchmark] missing fixture: {f}\n")
+            return 1
+        abs_fixtures.append(p)
+
+    print(f"Repo root:  {REPO_ROOT}")
+    print(f"Python:     {sys.version.split()[0]}")
+    print(f"Runs/phase: {RUNS} (median reported)\n")
+
+    runner, prelude = _set_up_query_environment()
+    print(f"Prelude size: {len(prelude)} modules from lib/\n")
+
+    # The very first warm call bootstraps the prelude. Time it
+    # separately so the per-fixture warm rows are post-bootstrap.
+    print("Bootstrapping prelude (one-time per daemon)...")
+    bootstrap = _measure("bootstrap", lambda: runner(str(abs_fixtures[0])), runs=1)
+    print(f"  bootstrap+first check on {abs_fixtures[0].name}: {_format_seconds(bootstrap)}\n")
+
+    header = f"{'File':<48}{'Cold':>10}{'Warm':>10}{'Speedup':>12}"
+    sep = "-" * len(header)
+    print(header)
+    print(sep)
+
+    for fixture in abs_fixtures:
+        rel = fixture.relative_to(REPO_ROOT)
+        cold = _measure(f"cold:{rel}", lambda f=fixture: _cold_run(str(f)))
+        warm = _measure(f"warm:{rel}", lambda f=fixture: runner(str(f)))
+        speedup = cold / warm if warm > 0 else float("inf")
+        print(
+            f"{str(rel):<48}{_format_seconds(cold):>10}"
+            f"{_format_seconds(warm):>10}{speedup:>11.1f}x"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Step 8 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)). The Phase 1 milestone — measure whether Step 6's caching delivers the speedup the plan predicted.

## Results
On Python 3.13, with `lib/*.thm` cache present (typical developer state), 3 runs per phase, median reported:

| File | Cold (`deduce.py`) | Warm (MCP) | Speedup |
|------|-------------------:|-----------:|--------:|
| `IntTests.pf` | 0.88s | 0.19s | **4.7×** |
| `NatTests.pf` | 0.89s | 0.22s | **4.0×** |
| `ListTests.pf` | 0.90s | 0.23s | **4.0×** |
| `LogTests.pf` | 1.05s | 0.37s | **2.8×** |
| `UIntLogTests.pf` | 1.41s | 0.75s | **1.9×** |

Bootstrap (one-time per process): **~0.75s**.

Without `lib/*.thm` cache (fresh-checkout simulation, single fixture): cold **13.8s**, bootstrap **13.9s**, subsequent warm **0.26s** — **~53× per-call speedup** after bootstrap.

## Interpretation
The plan's "~30s baseline, ~10× speedup" target was based on a fresh checkout. With `.thm` files present (typical developer state) most of the prelude cost is already pre-paid by an earlier `make tests-lib`, so per-call cold latency is ~1s and the daemon's headline speedup is 2–5× rather than 10×.

Either way, the warm-path latency is **independent** of `.thm` staleness because the in-memory snapshot doesn't read `.thm` files, so the daemon stays fast even when the on-disk caches are invalidated by edits to `lib/`.

## Decision: proceed to Phase 2
- The 2–5× per-call speedup is meaningful for editor latency.
- The daemon model is required for any LSP server **architecturally**, regardless of the speed number — Step 6's state isolation is what makes a long-lived check loop deterministic in the first place.
- The warm path is robust to `.thm` cache state, so the daemon is the right backend for an LSP server even on a freshly-cloned repo.

## Test plan
- [x] `python3 lsp/benchmark.py` — 5 fixtures, all valid, output matches the table above.
- [x] No production code touched; no test impact.

## Phase 1 status
| Step | Status |
|---|---|
| 1–8 | ✅ |

Phase 2 next: LSP adapter (Step 9) → process-lifecycle hardening (Step 10) → multi-error collection (Step 11). Phase 3 (incrementality) is optional and gated on the warm-path latency being insufficient — based on these numbers it isn't.