### PR TITLE
Phase 3 (steps 13 + 14): nullary ctor unboxing and source maps

### DIFF
--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -80,17 +80,17 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 return ir.If(go(c), go(th), go(el))
             case ir.Con(ctor, args):
                 return ir.Con(ctor, [go(a) for a in args])
-            case ir.Match(subj, arms):
+            case ir.Match(subj, arms, loc):
                 new_arms = [ir.MatchArm(arm.pattern, go(arm.body)) for arm in arms]
-                return ir.Match(go(subj), new_arms)
+                return ir.Match(go(subj), new_arms, loc=loc)
             case ir.Eq(l, r):
                 return ir.Eq(go(l), go(r))
-            case ir.Panic(_):
+            case ir.Panic(_, _):
                 return t
-            case ir.MakeArray(s):
-                return ir.MakeArray(go(s))
-            case ir.ArrayGet(s, i):
-                return ir.ArrayGet(go(s), go(i))
+            case ir.MakeArray(s, loc):
+                return ir.MakeArray(go(s), loc=loc)
+            case ir.ArrayGet(s, i, loc):
+                return ir.ArrayGet(go(s), go(i), loc=loc)
         raise AssertionError(f"closure_convert: unknown term {type(t).__name__}")
 
     new_decls: List[ir.TopLevel] = []
@@ -98,7 +98,7 @@ def closure_convert(p: ir.Program) -> ir.Program:
         match d:
             case ir.UnionDecl():
                 new_decls.append(d)
-            case ir.Function(name, params, body, captures):
+            case ir.Function(name, params, body, captures, loc):
                 if captures:
                     raise AssertionError(
                         "closure_convert: input already has lifted functions; "
@@ -106,7 +106,7 @@ def closure_convert(p: ir.Program) -> ir.Program:
                     )
                 new_decls.append(ir.Function(
                     name=name, params=list(params),
-                    body=go(body), captures=[],
+                    body=go(body), captures=[], loc=loc,
                 ))
             case ir.Global(name, body):
                 new_decls.append(ir.Global(name=name, body=go(body)))

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -65,6 +65,12 @@ def _ctor_id_macro(name: str) -> str:
     return "CTOR_" + _mangle(name)
 
 
+def _ctor_singleton(name: str) -> str:
+    """Per-ctor static value for nullary constructors. Allocated once
+    at program startup and reused at every `Con(c, [])` site."""
+    return "C_" + _mangle(name)
+
+
 def _base_name(name: str) -> str:
     """Strip the uniquify suffix. Mirrors `abstract_syntax.base_name`
     but local so emit_c.py has no dependency on the AST module."""
@@ -116,6 +122,16 @@ def emit_program(p: ir.Program) -> str:
         elif isinstance(d, ir.Global):
             ctx.top_globals.add(d.name)
 
+    # Collect every nullary constructor that survives pruning. Each
+    # gets a single `C_<mangled>` storage location allocated once at
+    # startup; `print zero` ends up doing zero per-call allocations
+    # after the first. (Bool literals are interned in the runtime
+    # itself, no codegen needed.)
+    nullary_ctors = [
+        c.name for d in p.decls if isinstance(d, ir.UnionDecl)
+        for c in d.ctors if c.arity == 0
+    ]
+
     out: List[str] = []
     out.append('#include "deduce.h"')
     out.append("")
@@ -129,10 +145,11 @@ def emit_program(p: ir.Program) -> str:
     for d in p.decls:
         if isinstance(d, ir.Function):
             out.append(_emit_fn_decl(d) + ";")
-    for d in p.decls:
-        if isinstance(d, ir.Function) and getattr(d, "captures", None):
-            # Already declared above; here we'd handle the lifted case.
-            pass
+    out.append("")
+
+    # Singleton storage for nullary ctors.
+    for name in nullary_ctors:
+        out.append(f"deduce_value {_ctor_singleton(name)};")
     out.append("")
 
     # Global variables. Same reasoning as the function declarations:
@@ -151,6 +168,14 @@ def emit_program(p: ir.Program) -> str:
     # The single program-entry function with globals + prints + asserts
     # in source order.
     out.append("void deduce_program_main(void) {")
+    # Initialise the nullary-ctor singletons. Must run before any
+    # global initialiser because user-level Globals like
+    # `define two = suc(suc(zero))` reference these.
+    for name in nullary_ctors:
+        out.append(
+            f"    {_ctor_singleton(name)} = deduce_make_ctor("
+            f"{_ctor_id_macro(name)}, {_c_string(_base_name(name))}, 0, NULL);"
+        )
     for d in p.decls:
         if isinstance(d, ir.Global):
             tmp = ctx.fresh_tmp()
@@ -193,6 +218,8 @@ def _emit_function(f: ir.Function, ctx: EmitCtx) -> str:
     # args[]) and the captures (bound from env[]).
     in_scope: Set[str] = set(f.params) | set(f.captures)
     body_stmts: List[str] = []
+    if f.loc:
+        body_stmts.append(f"// from {f.loc}")
     body_stmts.append(_emit_fn_decl(f) + " {")
     if not f.params:
         body_stmts.append("    (void)args;")
@@ -299,6 +326,9 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
         case ir.Con(ctor, args):
             if ctor not in ctx.ctor_ids:
                 raise EmitError(f"unknown constructor: {ctor}")
+            # Nullary ctors are pre-allocated singletons.
+            if not args:
+                return [], _ctor_singleton(ctor)
             arg_stmts: List[str] = []
             arg_exprs: List[str] = []
             for a in args:
@@ -306,19 +336,15 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                 arg_stmts.extend(sa)
                 arg_exprs.append(ea)
             stmts = list(arg_stmts)
-            if arg_exprs:
-                arr = ctx.fresh_tmp() + "_args"
-                stmts.append(
-                    f"deduce_value {arr}[] = {{ {', '.join(arg_exprs)} }};"
-                )
-                arr_arg = arr
-            else:
-                arr_arg = "NULL"
+            arr = ctx.fresh_tmp() + "_args"
+            stmts.append(
+                f"deduce_value {arr}[] = {{ {', '.join(arg_exprs)} }};"
+            )
             tmp = ctx.fresh_tmp()
             stmts.append(
                 f"deduce_value {tmp} = deduce_make_ctor("
                 f"{_ctor_id_macro(ctor)}, {_c_string(_base_name(ctor))}, "
-                f"{len(args)}, {arr_arg});"
+                f"{len(args)}, {arr});"
             )
             return stmts, tmp
 
@@ -398,7 +424,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
             )
             return stmts, tmp
 
-        case ir.Match(subj, arms):
+        case ir.Match(subj, arms, match_loc):
             ssubj, esubj = _emit_term(subj, ctx, locals_in_scope)
             stmts = list(ssubj)
             subj_var = ctx.fresh_tmp()
@@ -449,7 +475,10 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                     stmts.append(f"    {tmp} = {be};")
                     stmts.append("    break;")
                     stmts.append("}")
-                stmts.append("default: deduce_panic(\"non-exhaustive match\");")
+                msg = "non-exhaustive match"
+                if match_loc:
+                    msg = f"{match_loc}: {msg}"
+                stmts.append(f"default: deduce_panic({_c_string(msg)});")
                 stmts.append("}")
             return stmts, tmp
 
@@ -463,28 +492,31 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
             )
             return stmts, tmp
 
-        case ir.Panic(msg):
+        case ir.Panic(msg, loc):
             tmp = ctx.fresh_tmp()
+            full = f"{loc}: {msg}" if loc else msg
             return [
-                f"deduce_value {tmp} = deduce_unreachable_value({_c_string(msg)});"
+                f"deduce_value {tmp} = deduce_unreachable_value({_c_string(full)});"
             ], tmp
 
-        case ir.MakeArray(s):
+        case ir.MakeArray(s, loc):
             ssub, esub = _emit_term(s, ctx, locals_in_scope)
             stmts = list(ssub)
             tmp = ctx.fresh_tmp()
+            loc_arg = _c_string(loc) if loc else "NULL"
             stmts.append(
-                f"deduce_value {tmp} = deduce_make_array_from_list({esub});"
+                f"deduce_value {tmp} = deduce_make_array_from_list({esub}, {loc_arg});"
             )
             return stmts, tmp
 
-        case ir.ArrayGet(s, i):
+        case ir.ArrayGet(s, i, loc):
             ssub, esub = _emit_term(s, ctx, locals_in_scope)
             sidx, eidx = _emit_term(i, ctx, locals_in_scope)
             stmts = list(ssub) + list(sidx)
             tmp = ctx.fresh_tmp()
+            loc_arg = _c_string(loc) if loc else "NULL"
             stmts.append(
-                f"deduce_value {tmp} = deduce_array_get({esub}, {eidx});"
+                f"deduce_value {tmp} = deduce_array_get({esub}, {eidx}, {loc_arg});"
             )
             return stmts, tmp
 

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -112,6 +112,7 @@ class MatchArm:
 class Match:
     subject: "Term"
     arms: List[MatchArm]
+    loc: "str | None" = None  # source `file:line`, for runtime panic messages
 
 
 @dataclass
@@ -126,6 +127,7 @@ class Panic:
     runtime. If pruning keeps it, the user gets a clear runtime
     message naming what went wrong."""
     msg: str
+    loc: "str | None" = None  # source `file:line`, prepended to msg in output
 
 
 @dataclass
@@ -144,6 +146,7 @@ class MakeArray:
     runtime, matching the interpreter's `isNodeList` semantics — any
     union with constructors named `empty`/`node` works."""
     subject: "Term"
+    loc: "str | None" = None  # source `file:line`, for runtime panic messages
 
 
 @dataclass
@@ -155,6 +158,7 @@ class ArrayGet:
     binary aborts via `deduce_panic` instead.)"""
     subject: "Term"
     index: "Term"
+    loc: "str | None" = None  # source `file:line`, for OOB panic messages
 
 
 Term = Union[Var, Bool, Int, Lam, MkClosure, App, Let, If, Con, Match, Eq, Panic, MakeArray, ArrayGet]
@@ -186,11 +190,16 @@ class Function:
 
     Functions originating from top-level user `Define`/`RecFun` decls
     are never captured by closures and have `captures=[]`. Lambda-lifted
-    functions produced by closure conversion have `captures=[fv0, ...]`."""
+    functions produced by closure conversion have `captures=[fv0, ...]`.
+
+    `loc` is the original `.pf` file:line where the function was
+    declared. Emitted as a `// from foo.pf:42` comment so a debugger
+    or human reader can navigate from the generated C back to source."""
     name: str
     params: List[str]
     body: Term
     captures: List[str] = field(default_factory=list)
+    loc: "str | None" = None
 
 
 @dataclass
@@ -244,7 +253,7 @@ def pp_top(d: TopLevel) -> str:
         case UnionDecl(name, ctors):
             body = ", ".join(f"{c.name}/{c.arity}" for c in ctors)
             return f"union {name} {{{body}}}"
-        case Function(name, params, body, captures):
+        case Function(name, params, body, captures, _):
             head = f"fn {name}"
             if captures:
                 head += "[" + ", ".join(captures) + "]"
@@ -283,7 +292,7 @@ def pp_term(t: Term, indent: int) -> str:
             return ctor
         case Con(ctor, args):
             return ctor + "(" + ", ".join(pp_term(a, indent) for a in args) + ")"
-        case Match(subj, arms):
+        case Match(subj, arms, _):
             arm_strs = []
             for arm in arms:
                 match arm.pattern:
@@ -299,11 +308,11 @@ def pp_term(t: Term, indent: int) -> str:
             return "match " + pp_term(subj, indent) + " { " + " ".join(arm_strs) + " }"
         case Eq(l, r):
             return "(" + pp_term(l, indent) + " == " + pp_term(r, indent) + ")"
-        case Panic(msg):
+        case Panic(msg, _):
             return f"panic({msg!r})"
-        case MakeArray(s):
+        case MakeArray(s, _):
             return "array(" + pp_term(s, indent) + ")"
-        case ArrayGet(s, i):
+        case ArrayGet(s, i, _):
             return pp_term(s, indent) + "[" + pp_term(i, indent) + "]"
     raise AssertionError(f"pp_term: unknown term {type(t).__name__}")
 
@@ -357,7 +366,7 @@ def verify(p: Program) -> None:
             case Con(_, args):
                 for a in args:
                     check_term(a, ctx)
-            case Match(subj, arms):
+            case Match(subj, arms, _):
                 check_term(subj, ctx)
                 for arm in arms:
                     if not isinstance(arm, MatchArm):
@@ -372,11 +381,11 @@ def verify(p: Program) -> None:
             case Eq(l, r):
                 check_term(l, ctx)
                 check_term(r, ctx)
-            case Panic(_):
+            case Panic(_, _):
                 pass
-            case MakeArray(s):
+            case MakeArray(s, _):
                 check_term(s, ctx)
-            case ArrayGet(s, i):
+            case ArrayGet(s, i, _):
                 check_term(s, ctx)
                 check_term(i, ctx)
 
@@ -392,7 +401,7 @@ def verify(p: Program) -> None:
                 for c in ctors:
                     if not isinstance(c, Constructor):
                         raise AssertionError("verify: non-IR ctor")
-            case Function(name, _, body, _):
+            case Function(name, _, body, _, _):
                 check_term(body, f"function {name}")
             case Global(name, body):
                 check_term(body, f"global {name}")
@@ -432,7 +441,7 @@ def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
             for a in args:
                 out |= free_vars(a, bound)
             return out
-        case Match(subj, arms):
+        case Match(subj, arms, _):
             out = free_vars(subj, bound)
             for arm in arms:
                 match arm.pattern:
@@ -443,10 +452,10 @@ def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
             return out
         case Eq(l, r):
             return free_vars(l, bound) | free_vars(r, bound)
-        case Panic(_):
+        case Panic(_, _):
             return set()
-        case MakeArray(s):
+        case MakeArray(s, _):
             return free_vars(s, bound)
-        case ArrayGet(s, i):
+        case ArrayGet(s, i, _):
             return free_vars(s, bound) | free_vars(i, bound)
     raise AssertionError(f"free_vars: unknown term {type(t).__name__}")

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -45,6 +45,20 @@ def _format_loc(loc) -> str:
         return ""
 
 
+def _ast_loc(loc) -> "str | None":
+    """Format a `lark.tree.Meta` location as `file:line`, or None if
+    the location is empty / missing. Used to populate `loc` fields on
+    IR nodes for source-map output."""
+    if loc is None:
+        return None
+    try:
+        if getattr(loc, "empty", True):
+            return None
+        return f"{loc.filename}:{loc.line}"
+    except Exception:
+        return None
+
+
 # --------------------------------------------------------------------------
 # Top-level lowering
 # --------------------------------------------------------------------------
@@ -181,6 +195,7 @@ class LoweringCtx:
                 name=d.name,
                 params=params,
                 body=self.lower_term(unwrapped.body),
+                loc=_ast_loc(d.location),
             )
         return ir.Global(name=d.name, body=self.lower_term(body))
 
@@ -218,11 +233,12 @@ class LoweringCtx:
             pat = self.lower_pattern(case.pattern)
             arms.append(ir.MatchArm(pat, body))
 
-        match = ir.Match(ir.Var(scrutinee), arms)
+        match = ir.Match(ir.Var(scrutinee), arms, loc=_ast_loc(r.location))
         return ir.Function(
             name=r.name,
             params=[scrutinee] + other_params,
             body=match,
+            loc=_ast_loc(r.location),
         )
 
     def lower_genrecfun(self, r: ast.GenRecFun):
@@ -237,6 +253,7 @@ class LoweringCtx:
             name=r.name,
             params=params,
             body=self.lower_term(r.body),
+            loc=_ast_loc(r.location),
         )
 
     # ---- terms -------------------------------------------------------
@@ -316,13 +333,20 @@ class LoweringCtx:
         # drops it if no `print`-reachable path actually evaluates it.
         if isinstance(t, (ast.Some, ast.All)):
             kind = "some" if isinstance(t, ast.Some) else "all"
-            return ir.Panic(f"non-computational `{kind}` quantifier evaluated")
+            return ir.Panic(
+                f"non-computational `{kind}` quantifier evaluated",
+                loc=_ast_loc(t.location),
+            )
         if isinstance(t, ast.MakeArray):
-            return ir.MakeArray(self.lower_term(t.subject))
+            return ir.MakeArray(
+                self.lower_term(t.subject),
+                loc=_ast_loc(t.location),
+            )
         if isinstance(t, ast.ArrayGet):
             return ir.ArrayGet(
                 self.lower_term(t.subject),
                 self.lower_term(t.position),
+                loc=_ast_loc(t.location),
             )
         if isinstance(t, ast.Array):
             # `Array` only appears in source as the result of reducing
@@ -368,7 +392,9 @@ class LoweringCtx:
                 self.lower_pattern(case.pattern),
                 self.lower_term(case.body),
             ))
-        return ir.Match(self.lower_term(sw.subject), arms)
+        return ir.Match(
+            self.lower_term(sw.subject), arms, loc=_ast_loc(sw.location),
+        )
 
     def lower_pattern(self, p: ast.Pattern) -> ir.Pattern:
         if isinstance(p, ast.PatternBool):
@@ -430,7 +456,7 @@ def subst_vars(t: ir.Term, sub: Dict[str, str]) -> ir.Term:
                 return ir.If(go(c, blocked), go(th, blocked), go(el, blocked))
             case ir.Con(ctor, args):
                 return ir.Con(ctor, [go(a, blocked) for a in args])
-            case ir.Match(subj, arms):
+            case ir.Match(subj, arms, loc):
                 new_arms = []
                 for arm in arms:
                     if isinstance(arm.pattern, ir.PatCon):
@@ -438,15 +464,15 @@ def subst_vars(t: ir.Term, sub: Dict[str, str]) -> ir.Term:
                     else:
                         inner = blocked
                     new_arms.append(ir.MatchArm(arm.pattern, go(arm.body, inner)))
-                return ir.Match(go(subj, blocked), new_arms)
+                return ir.Match(go(subj, blocked), new_arms, loc=loc)
             case ir.Eq(l, r):
                 return ir.Eq(go(l, blocked), go(r, blocked))
-            case ir.Panic(_):
+            case ir.Panic(_, _):
                 return t
-            case ir.MakeArray(s):
-                return ir.MakeArray(go(s, blocked))
-            case ir.ArrayGet(s, i):
-                return ir.ArrayGet(go(s, blocked), go(i, blocked))
+            case ir.MakeArray(s, loc):
+                return ir.MakeArray(go(s, blocked), loc=loc)
+            case ir.ArrayGet(s, i, loc):
+                return ir.ArrayGet(go(s, blocked), go(i, blocked), loc=loc)
         raise AssertionError(f"subst_vars: unknown {type(t).__name__}")
 
     return go(t, set())

--- a/compiler/prune.py
+++ b/compiler/prune.py
@@ -119,7 +119,7 @@ def _referenced(t: ir.Term) -> Set[str]:
                 out.add(ctor)
                 for a in args:
                     walk(a)
-            case ir.Match(subj, arms):
+            case ir.Match(subj, arms, _):
                 walk(subj)
                 for arm in arms:
                     if isinstance(arm.pattern, ir.PatCon):
@@ -128,11 +128,11 @@ def _referenced(t: ir.Term) -> Set[str]:
             case ir.Eq(l, r):
                 walk(l)
                 walk(r)
-            case ir.Panic(_):
+            case ir.Panic(_, _):
                 pass
-            case ir.MakeArray(s):
+            case ir.MakeArray(s, _):
                 walk(s)
-            case ir.ArrayGet(s, i):
+            case ir.ArrayGet(s, i, _):
                 walk(s)
                 walk(i)
 

--- a/compiler/runtime/deduce.c
+++ b/compiler/runtime/deduce.c
@@ -33,7 +33,24 @@ struct deduce_obj {
     } u;
 };
 
+/* Total allocations performed by the program. Reported at exit when
+ * DEDUCE_TRACE_ALLOC=1 is in the environment. */
+static long long deduce_alloc_count = 0;
+static int deduce_trace_alloc_enabled = -1;  /* -1 = uninspected */
+
+static void deduce_alloc_atexit(void) {
+    fprintf(stderr, "deduce: %lld allocations\n", deduce_alloc_count);
+}
+
 void* deduce_alloc(size_t size) {
+    if (deduce_trace_alloc_enabled == -1) {
+        const char* env = getenv("DEDUCE_TRACE_ALLOC");
+        deduce_trace_alloc_enabled = (env && env[0] == '1') ? 1 : 0;
+        if (deduce_trace_alloc_enabled) {
+            atexit(deduce_alloc_atexit);
+        }
+    }
+    deduce_alloc_count++;
     void* p = calloc(1, size);
     if (!p) {
         fprintf(stderr, "deduce: out of memory\n");
@@ -42,11 +59,15 @@ void* deduce_alloc(size_t size) {
     return p;
 }
 
+/* Bool values are interned: every `deduce_make_bool(true)` returns
+ * the same pointer, every `deduce_make_bool(false)` returns the
+ * other. Lifts the bool case of constructor unboxing into the
+ * runtime so the codegen doesn't have to special-case it. */
+static struct deduce_obj BOOL_TRUE  = { D_BOOL, { .b = true } };
+static struct deduce_obj BOOL_FALSE = { D_BOOL, { .b = false } };
+
 deduce_value deduce_make_bool(bool b) {
-    deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
-    v->tag = D_BOOL;
-    v->u.b = b;
-    return v;
+    return b ? &BOOL_TRUE : &BOOL_FALSE;
 }
 
 deduce_value deduce_make_int(int64_t i) {
@@ -123,24 +144,35 @@ deduce_value deduce_call(deduce_value clo, int n_args, deduce_value* args) {
 
 /* --- arrays ----------------------------------------------------------- */
 
+/* Format a "<loc>: <msg>" string into a static buffer when `loc` is
+ * non-NULL, else just `<msg>`. The buffer is shared and overwritten
+ * on each call — fine for a panic-and-exit usage. */
+static const char* with_loc(const char* loc, const char* msg) {
+    static char buf[256];
+    if (!loc) return msg;
+    snprintf(buf, sizeof(buf), "%s: %s", loc, msg);
+    return buf;
+}
+
 /* Count list length by walking node(_, rest) until empty. */
-static int list_length(deduce_value v) {
+static int list_length(deduce_value v, const char* loc) {
     int n = 0;
     while (1) {
-        if (v->tag != D_CTOR) deduce_panic("array: subject is not a list");
+        if (v->tag != D_CTOR)
+            deduce_panic(with_loc(loc, "array: subject is not a list"));
         const char* name = v->u.ctor.name;
         if (strcmp(name, "empty") == 0 || strcmp(name, "[]") == 0) return n;
         if (strcmp(name, "node") != 0)
-            deduce_panic("array: list constructor not empty/node");
+            deduce_panic(with_loc(loc, "array: list constructor not empty/node"));
         if (v->u.ctor.n_fields != 2)
-            deduce_panic("array: node arity != 2");
+            deduce_panic(with_loc(loc, "array: node arity != 2"));
         n++;
         v = v->u.ctor.fields[1];
     }
 }
 
-deduce_value deduce_make_array_from_list(deduce_value list) {
-    int n = list_length(list);
+deduce_value deduce_make_array_from_list(deduce_value list, const char* loc) {
+    int n = list_length(list, loc);
     deduce_value v = deduce_alloc(sizeof(struct deduce_obj));
     v->tag = D_ARRAY;
     v->u.array.n = n;
@@ -187,10 +219,12 @@ static int64_t decode_index(deduce_value v) {
     }
 }
 
-deduce_value deduce_array_get(deduce_value arr, deduce_value idx) {
-    if (arr->tag != D_ARRAY) deduce_panic("array get: not an array");
+deduce_value deduce_array_get(deduce_value arr, deduce_value idx, const char* loc) {
+    if (arr->tag != D_ARRAY)
+        deduce_panic(with_loc(loc, "array get: not an array"));
     int64_t i = decode_index(idx);
-    if (i < 0 || i >= arr->u.array.n) deduce_panic("array index out of range");
+    if (i < 0 || i >= arr->u.array.n)
+        deduce_panic(with_loc(loc, "array index out of range"));
     return arr->u.array.elements[(int)i];
 }
 

--- a/compiler/runtime/deduce.h
+++ b/compiler/runtime/deduce.h
@@ -58,15 +58,18 @@ deduce_value deduce_call(deduce_value clo, int n_args, deduce_value* args);
 /* `array(<list>)` — walk a `node(_, _)` … `empty` chain and pack into
  * a flat array. Dispatches by the constructor's stored base name, so
  * any union with `empty` and `node` constructors works (matches the
- * interpreter's `isNodeList` semantics). Aborts on a non-list value. */
-deduce_value deduce_make_array_from_list(deduce_value list);
+ * interpreter's `isNodeList` semantics). Aborts on a non-list value.
+ * `loc` is a `file:line` string used in panic messages; OK to be
+ * NULL. */
+deduce_value deduce_make_array_from_list(deduce_value list, const char* loc);
 
 /* `arr[idx]` — read an element. The index must be a Nat or UInt; the
  * runtime decodes by inspecting constructor base names (`zero`/`suc`
  * for Nat, `bzero`/`dub_inc`/`inc_dub` for UInt). Out-of-bounds
  * aborts; the interpreter's behaviour of leaving the term un-reduced
- * has no compiled-program analogue. */
-deduce_value deduce_array_get(deduce_value arr, deduce_value idx);
+ * has no compiled-program analogue. `loc` is a `file:line` string
+ * used in panic messages; OK to be NULL. */
+deduce_value deduce_array_get(deduce_value arr, deduce_value idx, const char* loc);
 
 /* Structural equality. Closures compare by pointer identity (the
  * surface language has no closure-equality primitive at runtime, but

--- a/test/compile/lower/source_map.cir
+++ b/test/compile/lower/source_map.cir
@@ -1,0 +1,4 @@
+union MyNat.88 {zero.89/0, suc.90/1}
+union List.91 {empty.93/0, node.94/2}
+global A.95 = array(node.94(zero.89, empty.93))
+print A.95[suc.90(zero.89)]

--- a/test/compile/lower/source_map.ir
+++ b/test/compile/lower/source_map.ir
@@ -1,0 +1,4 @@
+union MyNat.88 {zero.89/0, suc.90/1}
+union List.91 {empty.93/0, node.94/2}
+global A.95 = array(node.94(zero.89, empty.93))
+print A.95[suc.90(zero.89)]

--- a/test/compile/lower/source_map.pf
+++ b/test/compile/lower/source_map.pf
@@ -1,0 +1,21 @@
+// Step 14: an array out-of-bounds at runtime panics with a message
+// that includes the original `.pf:line`. Type-checks fine; the
+// interpreter happily leaves the OOB ArrayGet un-reduced (printing
+// `array(zero)[suc(zero)]`), so the compiled binary's behavior
+// diverges. The harness compares only the panic substring.
+//
+// expected-runtime-error: source_map.pf:
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+union List<T> {
+  empty
+  node(T, List<T>)
+}
+
+define A = array(node(zero, empty))
+
+print A[suc(zero)]

--- a/test/compile/lower/source_map.pir
+++ b/test/compile/lower/source_map.pir
@@ -1,0 +1,4 @@
+union MyNat.88 {zero.89/0, suc.90/1}
+union List.91 {empty.93/0, node.94/2}
+global A.95 = array(node.94(zero.89, empty.93))
+print A.95[suc.90(zero.89)]

--- a/test/compile/lower/unbox.cir
+++ b/test/compile/lower/unbox.cir
@@ -1,0 +1,6 @@
+union MyNat.96 {zero.97/0, suc.98/1}
+print zero.97
+print zero.97
+print zero.97
+print zero.97
+print zero.97

--- a/test/compile/lower/unbox.ir
+++ b/test/compile/lower/unbox.ir
@@ -1,0 +1,6 @@
+union MyNat.96 {zero.97/0, suc.98/1}
+print zero.97
+print zero.97
+print zero.97
+print zero.97
+print zero.97

--- a/test/compile/lower/unbox.pf
+++ b/test/compile/lower/unbox.pf
@@ -1,0 +1,16 @@
+// Step 13 acceptance: nullary constructors are emitted as shared
+// singletons. Allocation count via DEDUCE_TRACE_ALLOC=1 stays
+// constant regardless of how many times we print `zero`.
+//
+// expected-allocs: 1
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+print zero
+print zero
+print zero
+print zero
+print zero

--- a/test/compile/lower/unbox.pir
+++ b/test/compile/lower/unbox.pir
@@ -1,0 +1,6 @@
+union MyNat.96 {zero.97/0, suc.98/1}
+print zero.97
+print zero.97
+print zero.97
+print zero.97
+print zero.97

--- a/test/compile/run_e2e.py
+++ b/test/compile/run_e2e.py
@@ -44,6 +44,30 @@ def needs_prelude(pf: Path) -> bool:
     return False
 
 
+def expected_allocs(pf: Path) -> int | None:
+    """Look for an `// expected-allocs: N` directive in the fixture.
+    If present, the e2e runner re-runs the binary with
+    DEDUCE_TRACE_ALLOC=1 and asserts the count matches. Used for the
+    nullary-constructor unboxing acceptance test (Step 13)."""
+    for raw in pf.read_text().splitlines():
+        s = raw.strip()
+        if s.startswith("// expected-allocs:"):
+            return int(s.split(":", 1)[1].strip())
+    return None
+
+
+def expected_runtime_error(pf: Path) -> str | None:
+    """Look for an `// expected-runtime-error: <substring>` directive.
+    If present, the runner inverts its expectations: the binary must
+    exit non-zero and the substring must appear in stderr. Used to
+    exercise the source-map / runtime-panic path (Step 14)."""
+    for raw in pf.read_text().splitlines():
+        s = raw.strip()
+        if s.startswith("// expected-runtime-error:"):
+            return s.split(":", 1)[1].strip()
+    return None
+
+
 def find_cc() -> str | None:
     return shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
 
@@ -89,11 +113,52 @@ def run_compiled(pf: Path, cc: str, tmp: Path) -> str:
         check=True, capture_output=True, text=True,
     )
     proc = subprocess.run([str(bin_path)], capture_output=True, text=True, check=False)
+    err_substring = expected_runtime_error(pf)
+    if err_substring is not None:
+        if proc.returncode == 0:
+            raise RuntimeError(
+                f"{pf.name}: expected runtime error containing "
+                f"{err_substring!r}, but binary exited 0"
+            )
+        if err_substring not in proc.stderr:
+            raise RuntimeError(
+                f"{pf.name}: expected stderr to contain {err_substring!r}, "
+                f"got:\n{proc.stderr}"
+            )
+        # On a deliberate failure, return the captured stdout so the
+        # caller can still diff with the interpreter's output (which
+        # is empty if the proof checker accepts the program).
+        return proc.stdout
     if proc.returncode != 0:
         raise RuntimeError(
             f"{pf.name}: compiled binary exit {proc.returncode}:\n"
             f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
         )
+
+    # If the fixture declares an expected allocation count, re-run
+    # under DEDUCE_TRACE_ALLOC=1 and verify.
+    expected = expected_allocs(pf)
+    if expected is not None:
+        env = {**os.environ, "DEDUCE_TRACE_ALLOC": "1"}
+        traced = subprocess.run(
+            [str(bin_path)], capture_output=True, text=True, check=False, env=env,
+        )
+        # Last stderr line is `deduce: N allocations`.
+        marker = "deduce: "
+        suffix = " allocations"
+        actual = None
+        for line in traced.stderr.splitlines():
+            if line.startswith(marker) and line.endswith(suffix):
+                actual = int(line[len(marker):-len(suffix)])
+        if actual is None:
+            raise RuntimeError(
+                f"{pf.name}: DEDUCE_TRACE_ALLOC=1 produced no count line\n"
+                f"stderr:\n{traced.stderr}"
+            )
+        if actual != expected:
+            raise RuntimeError(
+                f"{pf.name}: expected {expected} allocations, got {actual}"
+            )
     return proc.stdout
 
 
@@ -133,8 +198,15 @@ def main() -> int:
     failures: list[str] = []
     for pf in fixtures:
         try:
-            interp_out = run_interpreter(pf)
             compiled_out = run_compiled(pf, cc, tmp)
+            # Fixtures that deliberately panic at runtime aren't
+            # expected to match the interpreter's stdout — the panic
+            # cuts the program short and the interpreter would have
+            # printed more.
+            if expected_runtime_error(pf) is not None:
+                print(f"ok {pf.relative_to(ROOT)}")
+                continue
+            interp_out = run_interpreter(pf)
         except Exception as e:
             failures.append(f"{pf.name}: {e}")
             continue


### PR DESCRIPTION
## Summary

Two polish items from [docs/compile-plan.md](https://github.com/jsiek/deduce/blob/main/docs/compile-plan.md) Phase 3 — TCO (step 12) is deferred per discussion. They share runtime hooks so they ship together.

## Step 13 — constructor unboxing

**Bool literals** are interned in the runtime: two static `struct deduce_obj` instances cover all `true`/`false` values, so `deduce_make_bool(b)` returns the appropriate pointer without allocating.

**Nullary user constructors** (`zero`, `empty`, `bzero`, …) are emitted as `C_<mangled>` storage allocated once at the top of `deduce_program_main`. Every `Con(c, [])` references the singleton.

**`DEDUCE_TRACE_ALLOC=1`** runtime mode prints `deduce: N allocations` to stderr at exit. New fixture `test/compile/lower/unbox.pf` declares `// expected-allocs: 1` and the e2e harness validates the count — five `print zero` statements all share one allocation.

## Step 14 — source maps

`Function`, `Match`, `MakeArray`, `ArrayGet`, and `Panic` IR nodes now carry an optional `loc` (`file:line`) populated by lowering from the AST node's location.

In the emitted C:
- Each top-level function emits a `// from foo.pf:42` line above its declaration:
  ```c
  // from test/compile/lower/basic.pf:9
  deduce_value F_add_3(deduce_value* env, deduce_value* args) { … }
  ```
- The `default:` clause of a non-exhaustive match panics with the source location prepended.
- `Panic` stubs (from `some`/`all` quantifiers in `fun` bodies) prepend the location.

Runtime helpers `deduce_make_array_from_list` and `deduce_array_get` take a `const char* loc` and prepend it to their panic messages. So array OOB now reports:
```
deduce: test/compile/lower/source_map.pf:21: array index out of range
```

instead of the previous `deduce: array index out of range`.

New fixture `test/compile/lower/source_map.pf` triggers a runtime OOB and verifies the resulting stderr contains the source location, via a new `// expected-runtime-error: <substring>` harness directive (which also skips the stdout diff, since the binary panics before completing the program).

## Test plan

- [x] `make tests-compile` — **35/35** (was 33/33). The two new fixtures cover the new functionality.
- [x] `make tests` — interpreter suite unchanged.
- [x] Spot-checked emitted C: three `// from test/compile/lower/basic.pf:N` comments for `basic.pf`'s three function-shaped definitions.
- [x] `DEDUCE_TRACE_ALLOC=1 ./unbox` reports 1 allocation regardless of how many `print zero` statements are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)