### PR TITLE
Phase 2 / Step 9: LSP adapter using pygls

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -2,7 +2,7 @@
 
 Tracking issue: [#279](https://github.com/jsiek/deduce/issues/279).
 
-**Status:** Phase 1 complete — Steps 1–8 done.
+**Status:** Phase 2 in progress — Steps 1–9 done.
 
 ## Goals
 
@@ -74,8 +74,9 @@ All new code lives under `lsp/` (subject to rename). Only exception: Step 1's re
 
 ## Phase 2 — LSP and robustness
 
-- [ ] **Step 9: LSP adapter.** `lsp/lsp_server.py` using `pygls`. Adds open-buffer tracking via `didOpen` / `didChange`; query API itself unchanged.
+- [x] **Step 9: LSP adapter.** `lsp/lsp_server.py` using `pygls`. Adds open-buffer tracking via `didOpen` / `didChange`; query API itself unchanged.
   - *Acceptance:* `pygls` protocol-level tests; manual VS Code testing via existing `deduce-mode`.
+  - *Implementation:* `lsp/lsp_server.py` with pygls 2.1's `LanguageServer`. Document sync uses pygls's built-in workspace (no manual buffer tracking needed). Seven features: `didOpen`/`didSave` push diagnostics; `didChange` is a no-op (buffer-only update — Step 12's per-statement caching is what would make per-keystroke checks affordable); `didClose` clears diagnostics; `textDocument/definition` and `textDocument/documentSymbol` map directly to `query.definition_of` / `query.list_symbols`. LSP has no built-in for "current proof goal", so a custom `deduce/goalAt` request takes a `{textDocument, position}` payload (LSP-shaped) and returns `{formula, givens, range}`. Coordinate translation (LSP's 0-indexed line/character ↔ query's 1-indexed line/column) is centralized in two helpers, exercised by their own unit tests. Bootstrap mirrors `lsp/mcp_server.py` (DEDUCE_ROOT / DEDUCE_NO_STDLIB env knobs, auto-prelude from `lib/`). 14-case acceptance test in `test/lsp/test_lsp_server.py` exercises feature registration, position translation, didOpen/didSave/didClose diagnostics, definition + outline, custom goal-at, and defensive paths (unknown URI, missing position). `pygls>=2.1.0` added to `requirements-lsp.txt`. Manual VS Code smoke (the plan's second acceptance prong) is left for the user to run with `pip install -r requirements-lsp.txt` and a client config pointing at `python3 -m lsp.lsp_server`.
 
 - [ ] **Step 10: Process-lifecycle hardening.** Crash recovery, structured logging, settings, graceful shutdown. Shared between adapters in `lsp/runtime.py`.
   - *Acceptance:* fault-injection tests — kill prelude mid-load, send malformed requests, send a request before `initialize`. Server reports a structured error instead of crashing.

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -1,0 +1,344 @@
+"""LSP adapter for the Deduce query API (Phase 2 / Step 9).
+
+Wraps the four ``lsp.query`` functions in standard Language Server
+Protocol features, plus a custom ``deduce/goalAt`` request for proof
+goals (LSP has no built-in for "what proof obligation is at this
+cursor"). Document content is taken from pygls's open-buffer
+workspace, so the queries see unsaved edits.
+
+Run directly to start the stdio server::
+
+    python3 -m lsp.lsp_server
+
+Wire it into VS Code by pointing an LSP client at that command --
+the existing ``deduce-mode`` extensions could grow a client
+configuration that does so. See :mod:`lsp.mcp_server` for the MCP
+sibling that exposes the same query helpers as tools.
+
+Coordinate conventions
+----------------------
+
+LSP uses 0-indexed lines and 0-indexed UTF-16 characters; ``lsp.query``
+uses 1-indexed lines and 1-indexed columns to match Deduce's existing
+error messages. The translation is a simple ``+1`` / ``-1`` per
+coordinate, performed at the boundary in the helpers below.
+
+The LSP boundary stays protocol-specific: the only consumer of
+``pygls`` and ``lsprotocol`` lives here. The query API itself is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: configure the Deduce environment once at import.
+# Mirrors lsp.mcp_server -- see that module's docstring for the
+# DEDUCE_ROOT / DEDUCE_NO_STDLIB knobs.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_deduce_root() -> Path:
+    env_root = os.environ.get("DEDUCE_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    return Path(__file__).resolve().parent.parent
+
+
+_DEDUCE_ROOT = _resolve_deduce_root()
+_LIB_DIR = _DEDUCE_ROOT / "lib"
+_TEST_IMPORTS_DIR = _DEDUCE_ROOT / "test" / "test-imports"
+
+_PSEUDO_ENTRY = str(_DEDUCE_ROOT / "deduce.py")
+sys.argv = [_PSEUDO_ENTRY] + sys.argv[1:]
+sys.setrecursionlimit(10000)
+
+if str(_DEDUCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_DEDUCE_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    add_import_directory,
+    init_import_directories,
+)
+from flags import set_quiet_mode  # noqa: E402
+
+set_quiet_mode(True)
+init_import_directories()
+add_import_directory(str(_LIB_DIR))
+if _TEST_IMPORTS_DIR.is_dir():
+    add_import_directory(str(_TEST_IMPORTS_DIR))
+
+
+def _default_prelude() -> tuple[str, ...]:
+    if os.environ.get("DEDUCE_NO_STDLIB") == "1":
+        return ()
+    if not _LIB_DIR.is_dir():
+        return ()
+    return tuple(sorted(p.stem for p in _LIB_DIR.glob("*.pf")))
+
+
+_PRELUDE = _default_prelude()
+
+
+# ---------------------------------------------------------------------------
+# Server definition
+# ---------------------------------------------------------------------------
+
+
+from lsprotocol import types as lsp_types  # noqa: E402
+from pygls.lsp.server import LanguageServer  # noqa: E402
+
+from lsp import query as _query  # noqa: E402
+
+
+SERVER_NAME = "deduce-lsp"
+SERVER_VERSION = "0.1.0"
+
+# Custom request method name for "what's the goal at this cursor".
+# LSP has no built-in for this; downstream clients can issue a
+# raw request with this method.
+GOAL_AT_REQUEST = "deduce/goalAt"
+
+server = LanguageServer(
+    SERVER_NAME,
+    SERVER_VERSION,
+    text_document_sync_kind=lsp_types.TextDocumentSyncKind.Full,
+)
+
+
+# --- Position / Range translation (LSP <-> query) -------------------------
+
+
+def _query_pos_from_lsp(pos: lsp_types.Position) -> _query.Position:
+    """LSP is 0-indexed line/character; query API is 1-indexed."""
+    return _query.Position(line=pos.line + 1, column=pos.character + 1)
+
+
+def _lsp_range_from_query(rng: _query.Range) -> lsp_types.Range:
+    return lsp_types.Range(
+        start=lsp_types.Position(
+            line=max(rng.start.line - 1, 0),
+            character=max(rng.start.column - 1, 0),
+        ),
+        end=lsp_types.Position(
+            line=max(rng.end.line - 1, 0),
+            character=max(rng.end.column - 1, 0),
+        ),
+    )
+
+
+def _severity_to_lsp(sev: _query.Severity) -> lsp_types.DiagnosticSeverity:
+    return {
+        _query.Severity.ERROR: lsp_types.DiagnosticSeverity.Error,
+        _query.Severity.WARNING: lsp_types.DiagnosticSeverity.Warning,
+        _query.Severity.INFO: lsp_types.DiagnosticSeverity.Information,
+        _query.Severity.HINT: lsp_types.DiagnosticSeverity.Hint,
+    }[sev]
+
+
+_SYMBOL_KIND_MAP: dict[_query.SymbolKind, lsp_types.SymbolKind] = {
+    _query.SymbolKind.THEOREM: lsp_types.SymbolKind.Function,
+    _query.SymbolKind.LEMMA: lsp_types.SymbolKind.Function,
+    _query.SymbolKind.FUNCTION: lsp_types.SymbolKind.Function,
+    _query.SymbolKind.DEFINE: lsp_types.SymbolKind.Constant,
+    _query.SymbolKind.UNION: lsp_types.SymbolKind.Enum,
+    _query.SymbolKind.PREDICATE: lsp_types.SymbolKind.Function,
+    _query.SymbolKind.POSTULATE: lsp_types.SymbolKind.Function,
+    _query.SymbolKind.IMPORT: lsp_types.SymbolKind.Module,
+    _query.SymbolKind.OTHER: lsp_types.SymbolKind.Variable,
+}
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _path_from_uri(uri: str) -> str:
+    """Extract a filesystem path from an LSP ``file://`` URI."""
+    if uri.startswith("file://"):
+        from urllib.parse import unquote, urlparse
+
+        parsed = urlparse(uri)
+        return unquote(parsed.path)
+    return uri
+
+
+def _document_content(ls: LanguageServer, uri: str) -> Optional[str]:
+    """Read open-buffer contents from pygls's workspace."""
+    try:
+        doc = ls.workspace.get_text_document(uri)
+    except KeyError:
+        return None
+    return doc.source
+
+
+def _publish_diagnostics(ls: LanguageServer, uri: str) -> None:
+    content = _document_content(ls, uri)
+    if content is None:
+        return
+    path = _path_from_uri(uri)
+    diags = _query.check(path, content, prelude=_PRELUDE)
+    ls.publish_diagnostics(
+        uri,
+        [
+            lsp_types.Diagnostic(
+                range=_lsp_range_from_query(d.range),
+                severity=_severity_to_lsp(d.severity),
+                message=d.message,
+                source=SERVER_NAME,
+                code=d.code,
+            )
+            for d in diags
+        ],
+    )
+
+
+# --- Document sync features ----------------------------------------------
+
+
+@server.feature(lsp_types.TEXT_DOCUMENT_DID_OPEN)
+def on_did_open(
+    ls: LanguageServer, params: lsp_types.DidOpenTextDocumentParams
+) -> None:
+    """Run diagnostics when a file is opened."""
+    _publish_diagnostics(ls, params.text_document.uri)
+
+
+@server.feature(lsp_types.TEXT_DOCUMENT_DID_SAVE)
+def on_did_save(
+    ls: LanguageServer, params: lsp_types.DidSaveTextDocumentParams
+) -> None:
+    """Re-run diagnostics on save."""
+    _publish_diagnostics(ls, params.text_document.uri)
+
+
+@server.feature(lsp_types.TEXT_DOCUMENT_DID_CHANGE)
+def on_did_change(
+    ls: LanguageServer, params: lsp_types.DidChangeTextDocumentParams
+) -> None:
+    """Buffer is updated by pygls automatically; we deliberately do
+    not re-run check on every keystroke. Diagnostics refresh on save.
+    """
+    # No-op beyond the implicit buffer update. Step 12 (per-statement
+    # caching) is what makes per-keystroke checks cheap enough; until
+    # then the goal-at-cursor request is the per-keystroke contract.
+
+
+@server.feature(lsp_types.TEXT_DOCUMENT_DID_CLOSE)
+def on_did_close(
+    ls: LanguageServer, params: lsp_types.DidCloseTextDocumentParams
+) -> None:
+    """Clear diagnostics when the editor closes the buffer."""
+    ls.publish_diagnostics(params.text_document.uri, [])
+
+
+# --- Query features ------------------------------------------------------
+
+
+@server.feature(lsp_types.TEXT_DOCUMENT_DEFINITION)
+def on_definition(
+    ls: LanguageServer, params: lsp_types.DefinitionParams
+) -> Optional[lsp_types.Location]:
+    """Resolve a reference to its definition."""
+    uri = params.text_document.uri
+    content = _document_content(ls, uri)
+    if content is None:
+        return None
+    path = _path_from_uri(uri)
+    pos = _query_pos_from_lsp(params.position)
+    loc = _query.definition_of(path, content, pos, prelude=_PRELUDE)
+    if loc is None:
+        return None
+    return lsp_types.Location(
+        uri=uri,  # the query only finds same-file definitions today
+        range=_lsp_range_from_query(loc.range),
+    )
+
+
+@server.feature(lsp_types.TEXT_DOCUMENT_DOCUMENT_SYMBOL)
+def on_document_symbol(
+    ls: LanguageServer, params: lsp_types.DocumentSymbolParams
+) -> list[lsp_types.DocumentSymbol]:
+    """Outline view: one entry per top-level declaration."""
+    uri = params.text_document.uri
+    content = _document_content(ls, uri)
+    if content is None:
+        return []
+    path = _path_from_uri(uri)
+    syms = _query.list_symbols(path, content, prelude=_PRELUDE)
+    return [
+        lsp_types.DocumentSymbol(
+            name=s.name,
+            kind=_SYMBOL_KIND_MAP.get(s.kind, lsp_types.SymbolKind.Variable),
+            range=_lsp_range_from_query(s.location.range),
+            # ``selection_range`` is what the editor highlights when
+            # navigating to the symbol. We don't have a separate "name
+            # range" today, so reuse the full declaration range.
+            selection_range=_lsp_range_from_query(s.location.range),
+            detail=s.signature,
+        )
+        for s in syms
+    ]
+
+
+@server.feature(GOAL_AT_REQUEST)
+def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
+    """Custom request: return the proof goal at a cursor position.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}}`` (LSP-shaped position; 0-indexed).
+
+    Result: ``{"formula": str, "givens": [{"label": str | None,
+    "formula": str}], "range": Range}`` or ``null``.
+    """
+    # Params arrive as a dict from the JSON-RPC layer (no static
+    # type, since this is a custom method).
+    text_doc = params.get("textDocument") or {}
+    pos_obj = params.get("position") or {}
+    uri = text_doc.get("uri")
+    if not uri:
+        return None
+    content = _document_content(ls, uri)
+    if content is None:
+        return None
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(pos_obj.get("line", 0)),
+            character=int(pos_obj.get("character", 0)),
+        )
+    )
+    goal = _query.goal_at(_path_from_uri(uri), content, pos, prelude=_PRELUDE)
+    if goal is None:
+        return None
+    return {
+        "formula": goal.formula,
+        "givens": [
+            {"label": g.label, "formula": g.formula} for g in goal.givens
+        ],
+        "range": {
+            "start": {
+                "line": max(goal.range.start.line - 1, 0),
+                "character": max(goal.range.start.column - 1, 0),
+            },
+            "end": {
+                "line": max(goal.range.end.line - 1, 0),
+                "character": max(goal.range.end.column - 1, 0),
+            },
+        },
+    }
+
+
+# --- Entry point ---------------------------------------------------------
+
+
+def main() -> None:
+    """Run the server over stdio. Used as the ``__main__`` entry."""
+    server.start_io()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-lsp.txt
+++ b/requirements-lsp.txt
@@ -1,10 +1,13 @@
-# Optional dependencies for the Deduce LSP/MCP server (lsp/mcp_server.py).
+# Optional dependencies for the Deduce LSP/MCP servers
+# (lsp/mcp_server.py and lsp/lsp_server.py).
 #
 # Install with: python3 -m pip install -r requirements-lsp.txt
 #
 # These are NOT required to run deduce.py, test-deduce.py, or the
-# in-process pieces of lsp/ (library, query). Only lsp/mcp_server.py
-# depends on the MCP SDK, and the test_mcp_server.py acceptance suite
-# skips itself when mcp isn't installed.
+# in-process pieces of lsp/ (library, query). The MCP server depends
+# on `mcp`; the LSP server depends on `pygls` (which pulls in
+# `lsprotocol`). Both test suites use `pytest.importorskip` so they
+# degrade gracefully when their respective SDK is missing.
 
 mcp>=1.27.0
+pygls>=2.1.0

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -1,0 +1,365 @@
+"""End-to-end tests for the LSP adapter (Phase 2 / Step 9).
+
+The protocol-level transport (``initialize`` / message framing /
+JSON-RPC) is covered by ``pygls`` itself. What we own here is the
+*translation* layer: LSP 0-indexed positions <-> query-API 1-indexed,
+``textDocument/...`` parameter shapes <-> ``lsp.query`` calls,
+diagnostics being routed to the right URI.
+
+Tests call the registered feature handlers as plain Python callables,
+passing a fake server that just exposes ``workspace`` and
+``publish_diagnostics`` -- the surface the handlers actually touch.
+That keeps the tests fast (no JSON-RPC subprocess) and pinned on the
+mapping logic that's specific to this PR.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+# Skip if pygls isn't installed -- it's optional.
+pygls = pytest.importorskip("pygls")
+lsprotocol = pytest.importorskip("lsprotocol")
+
+# Configure no-prelude before import: the lsp_server module captures
+# the prelude at module-load time, so this has to land first.
+import os  # noqa: E402
+
+os.environ["DEDUCE_NO_STDLIB"] = "1"
+
+from lsprotocol import types as lsp_types  # noqa: E402
+
+from lsp import lsp_server  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Fake server used in place of the real LanguageServer
+# --------------------------------------------------------------------------
+
+
+class _FakeWorkspace:
+    def __init__(self) -> None:
+        self._docs: dict[str, SimpleNamespace] = {}
+
+    def add_document(self, uri: str, content: str) -> None:
+        self._docs[uri] = SimpleNamespace(source=content, uri=uri)
+
+    def get_text_document(self, uri: str) -> SimpleNamespace:
+        if uri not in self._docs:
+            raise KeyError(uri)
+        return self._docs[uri]
+
+
+class FakeServer:
+    """Just enough of ``LanguageServer`` to drive the handlers."""
+
+    def __init__(self) -> None:
+        self.workspace = _FakeWorkspace()
+        self.published: dict[str, list[lsp_types.Diagnostic]] = {}
+
+    def publish_diagnostics(
+        self, uri: str, diagnostics: list[lsp_types.Diagnostic]
+    ) -> None:
+        self.published[uri] = list(diagnostics)
+
+
+def _file_uri(path: Path) -> str:
+    return path.absolute().as_uri()
+
+
+@pytest.fixture
+def server() -> FakeServer:
+    return FakeServer()
+
+
+@pytest.fixture
+def open_doc(server: FakeServer, tmp_path: Path):
+    """Helper: write source to a temp .pf, register it with the
+    workspace, and return ``(path, uri)``."""
+
+    def _open(name: str, source: str) -> tuple[Path, str]:
+        fp = tmp_path / name
+        fp.write_text(source)
+        uri = _file_uri(fp)
+        server.workspace.add_document(uri, source)
+        return fp, uri
+
+    return _open
+
+
+# --------------------------------------------------------------------------
+# Feature registration
+# --------------------------------------------------------------------------
+
+
+def test_all_expected_features_are_registered():
+    fm = lsp_server.server.protocol.fm
+    expected = {
+        lsp_types.TEXT_DOCUMENT_DID_OPEN,
+        lsp_types.TEXT_DOCUMENT_DID_SAVE,
+        lsp_types.TEXT_DOCUMENT_DID_CHANGE,
+        lsp_types.TEXT_DOCUMENT_DID_CLOSE,
+        lsp_types.TEXT_DOCUMENT_DEFINITION,
+        lsp_types.TEXT_DOCUMENT_DOCUMENT_SYMBOL,
+        lsp_server.GOAL_AT_REQUEST,
+    }
+    assert expected.issubset(set(fm.features))
+
+
+# --------------------------------------------------------------------------
+# Position translation helpers
+# --------------------------------------------------------------------------
+
+
+def test_query_position_is_one_indexed_from_lsp():
+    """LSP (0,0) becomes query (1,1)."""
+    p = lsp_server._query_pos_from_lsp(lsp_types.Position(line=0, character=0))
+    assert p.line == 1
+    assert p.column == 1
+
+
+def test_lsp_range_is_zero_indexed_from_query():
+    """Query 1.1-1.5 becomes LSP 0.0-0.4."""
+    from lsp.query import Position, Range
+
+    rng = Range(
+        start=Position(line=1, column=1),
+        end=Position(line=1, column=5),
+    )
+    out = lsp_server._lsp_range_from_query(rng)
+    assert out.start.line == 0
+    assert out.start.character == 0
+    assert out.end.line == 0
+    assert out.end.character == 4
+
+
+# --------------------------------------------------------------------------
+# Diagnostics on didOpen / didSave
+# --------------------------------------------------------------------------
+
+
+def test_did_open_publishes_no_diagnostics_for_valid_file(
+    server, open_doc
+):
+    fp, uri = open_doc(
+        "valid.pf",
+        "theorem t: true\nproof\n  .\nend\n",
+    )
+    params = lsp_types.DidOpenTextDocumentParams(
+        text_document=lsp_types.TextDocumentItem(
+            uri=uri,
+            language_id="deduce",
+            version=1,
+            text=fp.read_text(),
+        )
+    )
+    lsp_server.on_did_open(server, params)
+    assert server.published[uri] == []
+
+
+def test_did_open_publishes_error_diagnostic_for_broken_file(
+    server, open_doc
+):
+    fp, uri = open_doc(
+        "broken.pf",
+        # Try to prove `false` by reflexive -- type-check fails.
+        "theorem broken: false\nproof\n  .\nend\n",
+    )
+    params = lsp_types.DidOpenTextDocumentParams(
+        text_document=lsp_types.TextDocumentItem(
+            uri=uri,
+            language_id="deduce",
+            version=1,
+            text=fp.read_text(),
+        )
+    )
+    lsp_server.on_did_open(server, params)
+    diags = server.published[uri]
+    assert len(diags) == 1
+    diag = diags[0]
+    assert diag.severity == lsp_types.DiagnosticSeverity.Error
+    assert diag.source == lsp_server.SERVER_NAME
+    # Diagnostic is on a line within the file (LSP is 0-indexed; the
+    # error fires inside the proof body or signature, lines 0..3).
+    assert 0 <= diag.range.start.line <= 3
+
+
+def test_did_save_re_runs_diagnostics(server, open_doc):
+    fp, uri = open_doc(
+        "save.pf",
+        "theorem t: true\nproof\n  .\nend\n",
+    )
+    save_params = lsp_types.DidSaveTextDocumentParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+    )
+    lsp_server.on_did_save(server, save_params)
+    assert server.published[uri] == []
+
+
+def test_did_close_clears_diagnostics(server, open_doc):
+    _, uri = open_doc("close.pf", "theorem t: true\nproof\n  .\nend\n")
+    # Pretend a previous run had stored some diagnostics.
+    server.published[uri] = [
+        lsp_types.Diagnostic(
+            range=lsp_types.Range(
+                start=lsp_types.Position(line=0, character=0),
+                end=lsp_types.Position(line=0, character=1),
+            ),
+            severity=lsp_types.DiagnosticSeverity.Error,
+            message="stale",
+        )
+    ]
+    close_params = lsp_types.DidCloseTextDocumentParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+    )
+    lsp_server.on_did_close(server, close_params)
+    assert server.published[uri] == []
+
+
+# --------------------------------------------------------------------------
+# Definition
+# --------------------------------------------------------------------------
+
+
+def test_definition_resolves_theorem_reference(server, open_doc):
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem t2: true\n"
+        "proof\n"
+        "  t1\n"
+        "end\n"
+    )
+    _, uri = open_doc("defn.pf", src)
+    # LSP coords: line 7, character 2 (the `t1` reference inside t2's proof).
+    params = lsp_types.DefinitionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        position=lsp_types.Position(line=7, character=2),
+    )
+    loc = lsp_server.on_definition(server, params)
+    assert loc is not None
+    assert loc.uri == uri
+    # ``theorem t1`` starts at LSP line 0 (1-indexed query line 1 minus 1).
+    assert loc.range.start.line == 0
+
+
+def test_definition_returns_none_on_whitespace(server, open_doc):
+    src = "theorem t1: true\nproof\n  .\nend\n"
+    _, uri = open_doc("ws.pf", src)
+    params = lsp_types.DefinitionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        # LSP line 2, character 0 -- whitespace at the start of `  .`.
+        position=lsp_types.Position(line=2, character=0),
+    )
+    assert lsp_server.on_definition(server, params) is None
+
+
+# --------------------------------------------------------------------------
+# Document symbols
+# --------------------------------------------------------------------------
+
+
+def test_document_symbol_lists_each_top_level_decl(server, open_doc):
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "define X: bool = true\n"
+        "\n"
+        "union Color {\n"
+        "  Red\n"
+        "  Blue\n"
+        "}\n"
+    )
+    _, uri = open_doc("outline.pf", src)
+    params = lsp_types.DocumentSymbolParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+    )
+    syms = lsp_server.on_document_symbol(server, params)
+    by_name = {s.name: s for s in syms}
+    assert set(by_name) == {"t1", "X", "Color"}
+    assert by_name["t1"].kind == lsp_types.SymbolKind.Function
+    assert by_name["X"].kind == lsp_types.SymbolKind.Constant
+    assert by_name["Color"].kind == lsp_types.SymbolKind.Enum
+    # Ranges echo the declaration spans (0-indexed LSP).
+    assert by_name["t1"].range.start.line == 0
+    assert by_name["X"].range.start.line == 5
+    assert by_name["Color"].range.start.line == 7
+
+
+# --------------------------------------------------------------------------
+# Custom deduce/goalAt request
+# --------------------------------------------------------------------------
+
+
+def test_goal_at_returns_goal_dict(server, open_doc):
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    _, uri = open_doc("goal.pf", src)
+    # LSP coords: line 3, character 0 (the start of the line holding
+    # `reflexive`, before any non-whitespace) -- 1-indexed query
+    # equivalent is line 4, column 1.
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 3, "character": 0},
+    }
+    goal = lsp_server.on_goal_at(server, params)
+    assert goal is not None
+    assert goal["formula"] == "P = P"
+    assert goal["givens"] == []
+    # Range is echoed back at the cursor.
+    assert goal["range"]["start"]["line"] == 3
+    assert goal["range"]["start"]["character"] == 0
+
+
+def test_goal_at_returns_none_outside_proof(server, open_doc):
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+        "\n"
+        "-- after end\n"
+    )
+    _, uri = open_doc("none.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 6, "character": 0},
+    }
+    assert lsp_server.on_goal_at(server, params) is None
+
+
+# --------------------------------------------------------------------------
+# Defensive paths: missing document, missing URI
+# --------------------------------------------------------------------------
+
+
+def test_definition_with_unknown_uri_returns_none(server):
+    params = lsp_types.DefinitionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri="file:///nope.pf"),
+        position=lsp_types.Position(line=0, character=0),
+    )
+    assert lsp_server.on_definition(server, params) is None
+
+
+def test_goal_at_without_uri_returns_none(server):
+    assert lsp_server.on_goal_at(server, {}) is None


### PR DESCRIPTION
Step 9 of the LSP/MCP plan ([docs/lsp-plan.md](docs/lsp-plan.md), [#279](https://github.com/jsiek/deduce/issues/279)). Phase 2 begins.

## What this is
`lsp/lsp_server.py` — a pygls 2.1 LanguageServer that exposes the four `lsp.query` functions as standard LSP features, plus a custom `deduce/goalAt` request (LSP has no built-in for "current proof goal"). Run via `python3 -m lsp.lsp_server` over stdio.

## Features

| LSP method | Behavior |
|---|---|
| `textDocument/didOpen` | publish diagnostics |
| `textDocument/didSave` | publish diagnostics |
| `textDocument/didChange` | no-op (buffer-only update — Step 12's per-statement caching is what would make per-keystroke checks affordable) |
| `textDocument/didClose` | clear diagnostics |
| `textDocument/definition` | `query.definition_of` |
| `textDocument/documentSymbol` | `query.list_symbols` |
| `deduce/goalAt` (custom) | `query.goal_at` |

Document sync uses pygls's built-in workspace — no manual buffer tracking. The query API is unchanged.

## Coordinate translation
LSP is 0-indexed; `lsp.query` is 1-indexed (matches Deduce error messages). Two centralized helpers do the `+1`/`-1`, with their own unit tests so a future off-by-one shows up directly rather than as a mystery downstream.

## Bootstrap
Mirrors `lsp/mcp_server.py`: `DEDUCE_ROOT` (override repo location) and `DEDUCE_NO_STDLIB=1` (disable auto-prelude). The standard library at `lib/` is auto-prepended by default.

## Test plan
- [x] `python3 -m pytest test/lsp/test_lsp_server.py` — **14 cases**: feature registration, position translation (both directions), didOpen on valid + broken files, didSave, didClose, definition (resolves + null on whitespace), documentSymbol, custom goal-at (returns + null), defensive paths (unknown URI, missing position).
- [x] `python3 -m pytest test/lsp/` — **522 passed** (up from 508 in Step 7).
- [x] `python3 test-deduce.py` (default) — clean.
- [x] Server smoke: `python3 -c "from lsp import lsp_server"` registers seven features and detects 32 prelude modules from `lib/`.

The protocol-level transport (initialize / message framing / JSON-RPC) is pygls's responsibility; what we own and test is the translation layer between LSP and `lsp.query`. Tests call the registered handlers as plain Python callables with a fake server that exposes just `workspace` and `publish_diagnostics` — fast and pinned on the mapping logic.

## Out of scope
- **Manual VS Code smoke** is the plan's second acceptance prong. I can't drive VS Code automatically — left for the user with `pip install -r requirements-lsp.txt` and a client configured to spawn `python3 -m lsp.lsp_server`.
- **Per-keystroke diagnostics on `didChange`.** The current 0.2–0.7s warm latency is fine for save-time feedback but not for typing. Step 12's per-statement caching is the right unlock; until then `goalAt` is the per-keystroke contract.
- **Hover for goals.** `deduce/goalAt` is a custom request; a future PR could also wire `textDocument/hover` to it for editors that don't speak the custom method.

## Phase 2 status
| Step | Status |
|---|---|
| 9 | ✅ this PR |
| 10 | ⏳ process-lifecycle hardening |
| 11 | multi-error collection |