### PR TITLE
Emacs mode Step 1: bare-bones major mode + plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ actual_error.tmp
 
 # Generated deduce profile image
 profile.png
+
+# Emacs byte-compiled files
+*.elc

--- a/docs/emacs-plan.md
+++ b/docs/emacs-plan.md
@@ -1,0 +1,84 @@
+# Emacs mode implementation plan
+
+A self-contained Emacs major mode for Deduce proof files (`.pf`) with eglot-based LSP integration. Lives in `editor/emacs/`. Pairs with the LSP server from [docs/lsp-plan.md](lsp-plan.md).
+
+**Status:** Step 1 in progress.
+
+## Goals
+
+1. Replace the third-party `deduce-mode` (mateidragony/deduce-mode) with an in-repo, maintained alternative.
+2. Provide a keybinding-driven Agda-shape UX:
+   - `M-.` go-to-definition (eglot's standard binding)
+   - `C-c C-g` show the proof goal at point
+   - `C-c C-r` refine the hole at point (Phase 4 / LSP Step 15)
+   - `C-c C-c` case-split the variable at point (Phase 4 / LSP Step 16)
+   - `C-c C-i` generate the induction skeleton (Phase 4 / LSP Step 17)
+3. Stay minimal: targets Emacs 29+ (eglot is built-in), no third-party Elisp dependencies.
+
+## Non-goals
+
+- VS Code support — separate effort, comes later.
+- `lsp-mode` (the alternative LSP client) — easy to add as a sibling file when wanted; eglot is the default.
+- Inline code-lens UI for refactor actions — keybindings are the contract.
+
+## Architecture
+
+```
+editor/emacs/
+  deduce-mode.el        ; major mode + font-lock + indentation
+  deduce-lsp.el         ; eglot registration + custom commands
+  README.md             ; install + keybinding reference
+```
+
+`deduce-mode.el` is usable on its own (no LSP). `deduce-lsp.el` builds on it and adds the eglot wiring. Two files so a user can adopt syntax highlighting without committing to running the language server.
+
+## Phase A — Mode without LSP
+
+- [ ] **Step 1: Bare-bones major mode.** `define-derived-mode deduce-mode prog-mode`, syntax table for comments (`//` line, `/* */` block), file association `\.pf\'` → `deduce-mode`, package metadata. No font-lock, no indentation logic — just enough that opening a `.pf` file shows "Deduce" in the mode line and `M-;` toggles a `//` comment.
+  - *Acceptance:* byte-compile clean (`emacs --batch -f batch-byte-compile`), open a `.pf` fixture, mode line shows "Deduce", `M-;` on a non-comment line inserts `// `, `M-;` on `// foo` removes it.
+
+- [ ] **Step 2: Font-lock.** All Deduce keywords highlighted.
+  - Statement-level: `theorem`, `lemma`, `define`, `function`, `union`, `predicate`, `relation`, `import`, `postulate`, `auto`, `assert`, `module`, `private`, `public`, `opaque`.
+  - Proof tactics: `proof`, `end`, `arbitrary`, `assume`, `suppose`, `cases`, `case`, `switch`, `induction`, `replace`, `expand`, `obtain`, `recall`, `equations`, `equation`, `suffices`, `have`, `enough`, `with`, `where`, `from`, `by`, `for`, `definition`, `evaluate`, `transitive`, `symmetric`, `injective`, `extensionality`, `choose`, `apply`, `to`, `show`, `simplify`, `stop`.
+  - Logical: `if`, `then`, `else`, `all`, `some`, `let`, `in`, `fn`, `λ`, `not`, `and`, `or`, `iff`, `true`, `false`, `array`.
+  - Special faces: `?` and `sorry` rendered as `font-lock-warning-face`; constructor names (capitalized identifiers in declaration / pattern position) as `font-lock-type-face`; numeric literals as `font-lock-constant-face`.
+  - *Acceptance:* a representative fixture renders the right colors for each face; an Elisp regression test that ert-asserts `(face-at-point)` at marked positions.
+
+- [ ] **Step 3: Indentation.** Either an SMIE grammar (proper structural indent) or a small `indent-line-function` that handles the common cases: `proof` opens a block (indent +2), `end` closes it (indent -2 to match), `{` and `case` similarly. Electric pairs for `()`, `{}`, `[]`. Newline-and-indent on RET.
+  - *Acceptance:* hand-crafted fixture with known correct indentation; an ert test that re-indents the buffer and diffs against the expected text.
+
+## Phase B — LSP integration
+
+- [ ] **Step 4: Eglot registration.** `deduce-lsp.el` registers `deduce-mode` with eglot pointing at `python3 -m lsp.lsp_server`. Optional `deduce-lsp-mode` minor mode that calls `eglot-ensure` for users who want auto-start. Customization variable `deduce-lsp-server-command` so users can override the python interpreter / path.
+  - *Acceptance:* manual smoke (per the README): `M-x eglot` in a `.pf` buffer connects, diagnostics appear after save, `M-.` jumps to definitions, `M-x imenu` lists top-level symbols.
+
+- [ ] **Step 5: Goal-at-point command.** `deduce-show-goal-at-point` (`C-c C-g`). Issues `deduce/goalAt` via `jsonrpc-request`, formats the response (formula + givens), pops up a `*Deduce Goal*` buffer in `view-mode`. Subsequent calls reuse the buffer.
+  - *Acceptance:* fixture with a known cursor position (e.g. between `arbitrary` and `reflexive` in a simple equality proof), command opens the buffer with the expected formula text. Tested manually; no automation past byte-compile.
+
+- [ ] **Step 6: Phase-4 keybindings (LSP-driven structured editing).** When the LSP server's Phase 4 lands (Steps 15–17), bind:
+  - `C-c C-r` → `eglot-code-actions` filtered by kind `refactor.rewrite.deduce.refine`
+  - `C-c C-c` → ditto for `refactor.rewrite.deduce.caseSplit`
+  - `C-c C-i` → ditto for `refactor.rewrite.deduce.induction`
+  Each wrapper passes `t` for the "apply if exactly one match" parameter so the user gets Agda's "no menu, just do it" feel.
+  - *Acceptance:* keybindings exist and call the right eglot function; a small ert test stubs out `eglot-code-actions` and asserts the right kind argument is passed. End-to-end is a manual smoke once the server features land.
+
+## Phase C — Polish
+
+- [ ] **Step 7: README + customization.** `editor/emacs/README.md` with:
+  - Install snippet for `init.el` (with and without `use-package`).
+  - Prerequisites: Emacs 29+, `pip install -r requirements-lsp.txt`.
+  - Keybinding reference table.
+  - Troubleshooting (server not starting, eglot not finding the command, prelude bootstrap timing).
+
+  Customization variables:
+  - `deduce-mode-indent-offset` (default 2).
+  - `deduce-lsp-server-command` (default `("python3" "-m" "lsp.lsp_server")`).
+  - `deduce-lsp-prelude-disabled` (sets `DEDUCE_NO_STDLIB=1` in the spawned env).
+
+  - *Acceptance:* the install snippet works on a fresh Emacs config (manually verified by the user — I can byte-compile but can't drive the Emacs UI).
+
+## Cross-cutting notes
+
+- I (the agent) can byte-compile the `.el` files and lint them. I cannot drive the Emacs UI. Manual smoke tests for Steps 4–7 are the user's job; the README documents them step-by-step.
+- The mode targets Emacs 29+ specifically because eglot is built-in there and the `jsonrpc` library has a stable API. Older Emacs would need `package-install eglot` and possibly `compat`; not worth supporting.
+- Phase 4 keybindings are stubs until the server's Phase 4 lands; they'll be no-ops (eglot will report "no code actions") in the meantime. That's a known and acceptable interim state.

--- a/editor/emacs/deduce-mode.el
+++ b/editor/emacs/deduce-mode.el
@@ -1,0 +1,121 @@
+;;; deduce-mode.el --- Major mode for Deduce proof files -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Jeremy G. Siek and Deduce contributors
+;; SPDX-License-Identifier: MIT
+
+;; Author: Deduce contributors
+;; Maintainer: Jeremy G. Siek
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "29.1"))
+;; Keywords: languages
+;; URL: https://github.com/jsiek/deduce
+
+;;; Commentary:
+
+;; deduce-mode is a major mode for editing Deduce proof files (.pf).
+;;
+;; This is Step 1 of the Emacs mode plan (see docs/emacs-plan.md).
+;; It establishes the major mode, comment syntax, and file
+;; association.  Font-lock, indentation, and LSP integration are
+;; layered on by later steps.
+;;
+;; Installation (Step 1 -- syntax highlighting and LSP land in
+;; later commits):
+;;
+;;     (add-to-list 'load-path "/path/to/deduce/editor/emacs")
+;;     (require 'deduce-mode)
+;;
+;; Files matching `\\.pf\\'' open in deduce-mode automatically.
+;; `M-;' toggles a `//' line comment; `/* */' block comments are
+;; recognized by the syntax engine.
+
+;;; Code:
+
+(defgroup deduce nil
+  "Major mode for editing Deduce proof files."
+  :prefix "deduce-"
+  :group 'languages)
+
+
+;; ---------------------------------------------------------------------
+;; Syntax table
+;; ---------------------------------------------------------------------
+;;
+;; Deduce comment syntax (verified against `Deduce.lark`):
+;;
+;;   //  ... \n      -- line comment
+;;   /*  ...  */     -- block comment, non-nested
+;;
+;; Identifier characters include the usual letters/digits/underscore
+;; plus subscript digits (₀-₉) and `!', `?', `'' as continuation
+;; characters.  We mark only the ASCII identifier characters here;
+;; the unicode subscripts default to symbol class which is fine for
+;; word-motion purposes.
+
+(defvar deduce-mode-syntax-table
+  (let ((st (make-syntax-table)))
+    ;; Comment markers.  `/' is the first character of `/*' (start
+    ;; of style A), the fourth of `*/' (end of style A), and the
+    ;; first of `//' (start of style B).  `*' is the second of
+    ;; `/*' and the third of `*/'.  `\n' ends a style-B comment.
+    (modify-syntax-entry ?/ ". 124b" st)
+    (modify-syntax-entry ?* ". 23"   st)
+    (modify-syntax-entry ?\n "> b"   st)
+
+    ;; Underscore is part of identifiers.
+    (modify-syntax-entry ?_ "w" st)
+    ;; `?' and `'' appear inside identifiers in Deduce (e.g. `n'',
+    ;; `done?').  Mark them as symbol so they don't break sexp
+    ;; motion across an identifier.
+    (modify-syntax-entry ?? "_" st)
+    (modify-syntax-entry ?' "_" st)
+    (modify-syntax-entry ?! "_" st)
+
+    ;; Brackets pair up.  Deduce uses `(' / `)', `[' / `]', `{' / `}',
+    ;; and `<' / `>' (for type-argument lists).  Pairing `<>' is
+    ;; convenient for sexp navigation but interferes with `<', `>'
+    ;; as comparison operators -- skip it for now and revisit if
+    ;; users complain.
+    (modify-syntax-entry ?\( "()" st)
+    (modify-syntax-entry ?\) ")(" st)
+    (modify-syntax-entry ?\[ "(]" st)
+    (modify-syntax-entry ?\] ")[" st)
+    (modify-syntax-entry ?\{ "(}" st)
+    (modify-syntax-entry ?\} "){" st)
+
+    st)
+  "Syntax table for `deduce-mode'.")
+
+
+;; ---------------------------------------------------------------------
+;; Mode definition
+;; ---------------------------------------------------------------------
+
+;;;###autoload
+(define-derived-mode deduce-mode prog-mode "Deduce"
+  "Major mode for editing Deduce proof files.
+
+Step 1 of the Emacs mode plan: comment syntax and file
+association.  Font-lock and indentation are added in later
+steps; LSP integration lives in `deduce-lsp.el'.
+
+\\{deduce-mode-map}"
+  :syntax-table deduce-mode-syntax-table
+  ;; Comments: prefer `//' for `comment-dwim' since it round-trips
+  ;; without picking an end delimiter.  Block comments still parse
+  ;; correctly via the syntax table.
+  (setq-local comment-start "// ")
+  (setq-local comment-end "")
+  (setq-local comment-start-skip "\\(?://+\\|/\\*+\\)\\s-*")
+  (setq-local comment-end-skip "[ \t]*\\(?:\n\\|\\*+/\\)")
+  ;; Use the syntax table's comment markers for `comment-region'
+  ;; instead of `comment-padright'-derived ones.  Avoids the dwim
+  ;; helper inserting `/*' '*/' around a single-line comment.
+  (setq-local comment-use-syntax t))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.pf\\'" . deduce-mode))
+
+(provide 'deduce-mode)
+
+;;; deduce-mode.el ends here

--- a/editor/emacs/test/deduce-mode-test.el
+++ b/editor/emacs/test/deduce-mode-test.el
@@ -1,0 +1,79 @@
+;;; deduce-mode-test.el --- ert tests for deduce-mode -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Run with:
+;;
+;;     emacs --batch -L editor/emacs -L editor/emacs/test \
+;;           -l deduce-mode-test -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'deduce-mode)
+
+
+(ert-deftest deduce-mode/auto-mode-alist-includes-pf ()
+  "`.pf' files should open in deduce-mode."
+  (should (eq (assoc-default "foo.pf" auto-mode-alist #'string-match)
+              'deduce-mode)))
+
+
+(ert-deftest deduce-mode/mode-name-is-deduce ()
+  (with-temp-buffer
+    (deduce-mode)
+    (should (equal mode-name "Deduce"))))
+
+
+(ert-deftest deduce-mode/line-comment-toggles-with-double-slash ()
+  "`comment-region' / `uncomment-region' use `// '."
+  (with-temp-buffer
+    (deduce-mode)
+    (insert "theorem t: true")
+    (comment-region (point-min) (point-max))
+    (should (string-prefix-p "// " (buffer-string)))
+    (uncomment-region (point-min) (point-max))
+    (should (equal (string-trim-right (buffer-string)) "theorem t: true"))))
+
+
+(ert-deftest deduce-mode/block-comments-recognized-by-syntax ()
+  "`/*' ... `*/' should put the inside but not the outside into a
+syntactic comment region (so font-lock and movement can rely on it)."
+  (with-temp-buffer
+    (deduce-mode)
+    (insert "/* hello */ rest")
+    (goto-char 5)               ; inside the comment
+    (should (nth 4 (syntax-ppss)))
+    (goto-char (point-max))     ; past `*/'
+    (should-not (nth 4 (syntax-ppss)))))
+
+
+(ert-deftest deduce-mode/block-comments-do-not-nest ()
+  "Deduce.lark uses non-nested block comments; the syntax table
+should match (so a `/*' inside a comment doesn't keep the outer
+open)."
+  (with-temp-buffer
+    (deduce-mode)
+    (insert "/* outer /* inner */ after")
+    (goto-char (point-max))
+    (should-not (nth 4 (syntax-ppss)))))
+
+
+(ert-deftest deduce-mode/identifier-trailing-marks-are-symbol-class ()
+  "Identifiers like `n''` and `done?` shouldn't have their trailing
+character break sexp motion."
+  (with-temp-buffer
+    (deduce-mode)
+    (insert "n' done?")
+    (goto-char (point-min))
+    (forward-sexp)
+    (should (= (point) 3))      ; after `n''
+    (forward-sexp)
+    (should (= (point) (point-max)))))
+
+
+(provide 'deduce-mode-test)
+
+;;; deduce-mode-test.el ends here


### PR DESCRIPTION
A self-contained Emacs major mode for Deduce, with eglot LSP integration arriving in later steps. Replaces (and supersedes the eventual maintenance gap of) the third-party `mateidragony/deduce-mode` once Phase B lands.

## Plan

[`docs/emacs-plan.md`](docs/emacs-plan.md) lays out a 7-step plan in three phases:

| Phase | Steps | What |
|---|---|---|
| A — mode without LSP | 1, 2, 3 | bare mode, font-lock, indentation |
| B — LSP integration | 4, 5, 6 | eglot, `C-c C-g` goal-at-point, Phase-4 keybindings (`C-c C-r`, `C-c C-c`, `C-c C-i`) |
| C — polish | 7 | README + customization variables |

## Step 1 — what's in this PR

Just enough mode definition that opening a `.pf` file puts Emacs in `deduce-mode` with working comment syntax. **No font-lock, no indentation, no LSP** — those land in subsequent steps.

`editor/emacs/deduce-mode.el` (~70 lines):
- syntax table covering `//` line comments and `/* */` block comments (matched against `Deduce.lark`, non-nested)
- identifier-trailing chars (`'`, `?`, `!`) marked symbol class so sexp motion doesn't break across `n'` / `done?`
- balanced-pair entries for `()`, `[]`, `{}`
- `auto-mode-alist` wired so `\.pf\'` opens in `deduce-mode`
- `comment-start` = `"// "` so `M-;` toggles a line comment

`editor/emacs/test/deduce-mode-test.el` — 6 ert tests covering registration, mode name, line-comment round-trip, `/* */` syntax recognition, non-nesting of block comments, and sexp motion across identifier-trailing chars.

## Verified
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-mode.el` — clean, no warnings.
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-mode-test -f ert-run-tests-batch-and-exit` — 6/6 passed.

## Manual smoke (your turn)
I can byte-compile and run ert tests, but I can't drive the Emacs UI. Try:

1. Add to your `init.el`:
   ```elisp
   (add-to-list 'load-path "/path/to/deduce/editor/emacs")
   (require 'deduce-mode)
   ```
2. Open any `test/should-validate/*.pf` in Emacs.
3. Mode line should read `Deduce`.
4. `M-;` on a non-comment line should insert `// ` at the start; `M-;` again removes it.
5. Position the cursor inside a `/* */` block (use `test/should-error/block_comment.pf` for a real example) — paragraph and sexp commands should treat it as comment region.

If any of those break the way you'd expect, that's a bug in this Step 1.

## Out of scope
- Font-lock — Step 2.
- Indentation — Step 3.
- Eglot integration and `C-c C-g` — Steps 4 and 5.
- Phase-4 (refine / case split / induction) keybindings — Step 6.