### PR TITLE
Emacs mode Step 2: font-lock keyword highlighting

### DIFF
--- a/editor/emacs/deduce-mode.el
+++ b/editor/emacs/deduce-mode.el
@@ -173,6 +173,14 @@ at true symbol edges."
     (modify-syntax-entry ?\{ "(}" st)
     (modify-syntax-entry ?\} "){" st)
 
+    ;; Operator chars Emacs's default syntax table marks as
+    ;; symbol-class (or, for `%', word-class).  We need them
+    ;; punctuation so they break symbol boundaries -- otherwise
+    ;; `Option<Pos>' would parse as one symbol and `\_<...\_>'
+    ;; couldn't match the inner identifiers.
+    (dolist (c '(?+ ?- ?= ?< ?> ?& ?| ?%))
+      (modify-syntax-entry c "." st))
+
     st)
   "Syntax table for `deduce-mode'.")
 

--- a/editor/emacs/deduce-mode.el
+++ b/editor/emacs/deduce-mode.el
@@ -52,6 +52,96 @@
 ;; the unicode subscripts default to symbol class which is fine for
 ;; word-motion purposes.
 
+;; ---------------------------------------------------------------------
+;; Font-lock (Step 2)
+;; ---------------------------------------------------------------------
+;;
+;; Keyword categorization is based on the actual `Deduce.lark` grammar,
+;; not a guess.  All quoted lowercase tokens in the grammar become
+;; keywords; `true' / `false' become constants; `bool' / `type' (the
+;; built-in kind) become types; `sorry' and a standalone `?' become
+;; warning-faced.  Capitalized identifiers (constructors, type names
+;; like `Nat' or `List') are heuristically rendered as type-face.
+;;
+;; If `Deduce.lark' grows a new keyword, append it to one of the lists
+;; below -- nothing else needs to change.
+
+(defconst deduce-mode--keywords
+  '(;; declaration / structure
+    "theorem" "lemma" "postulate" "define" "recursive" "recfun"
+    "union" "inductive" "predicate" "relation" "import" "export"
+    "module" "auto" "assert" "print" "operator" "associative"
+    "terminates" "measure" "trace" "generic" "fun" "λ"
+    ;; visibility
+    "public" "private" "opaque"
+    ;; proof structure
+    "proof" "end" "case" "cases" "with" "where"
+    ;; tactics
+    "arbitrary" "assume" "suppose" "have" "show" "obtain" "from" "for"
+    "induction" "rule" "inversion" "switch" "replace" "expand"
+    "evaluate" "simplify" "equations" "recall" "reflexive" "symmetric"
+    "transitive" "injective" "extensionality" "apply" "to" "conclude"
+    "conjunct" "contradict" "suffices" "choose" "stop" "help" "by" "of"
+    ;; logical / control
+    "if" "then" "else" "all" "some" "in"
+    "not" "and" "or" "iff"
+    ;; built-in operators / forms
+    "fn" "array")
+  "Deduce keywords highlighted with `font-lock-keyword-face'.")
+
+(defconst deduce-mode--constants
+  '("true" "false")
+  "Deduce literal constants highlighted with `font-lock-constant-face'.")
+
+(defconst deduce-mode--types
+  '("bool" "type")
+  "Built-in Deduce type-level identifiers highlighted with
+`font-lock-type-face'.  User-defined types (capitalized
+identifiers) are caught by a separate rule.")
+
+(defconst deduce-mode--warnings
+  '("sorry")
+  "Words highlighted with `font-lock-warning-face' to draw the eye
+to incomplete proofs.  Standalone `?' is matched separately.")
+
+(defun deduce-mode--symbol-regexp (words)
+  "Build a `\\_<...\\_>' alternation from WORDS.
+
+Symbol boundaries (rather than word boundaries) ensure that
+`theorem' inside an identifier like `theorem1?' is not
+mis-highlighted: identifier-trailing characters `'', `?', `!'
+are symbol-class in our syntax table, so the boundary fires only
+at true symbol edges."
+  (concat "\\_<" (regexp-opt words t) "\\_>"))
+
+(defvar deduce-mode-font-lock-keywords
+  ;; Order matters: the first rule that matches a span sets the face,
+  ;; and later rules don't override unless told to.  We put the most
+  ;; specific (warning-face) first.
+  `(;; Standalone `?' as a proof hole.  Symbol boundaries skip the `?'
+    ;; inside identifiers like `done?'.
+    ("\\_<\\?\\_>" 0 font-lock-warning-face)
+    ;; Other warning-face words (currently just `sorry').
+    (,(deduce-mode--symbol-regexp deduce-mode--warnings)
+     0 font-lock-warning-face)
+    ;; Built-in constants: `true', `false'.
+    (,(deduce-mode--symbol-regexp deduce-mode--constants)
+     0 font-lock-constant-face)
+    ;; Integer / Nat literals.
+    ("\\_<\\(?:ℕ\\)?[0-9]+\\_>" 0 font-lock-constant-face)
+    ;; Built-in types: `bool', `type'.
+    (,(deduce-mode--symbol-regexp deduce-mode--types)
+     0 font-lock-type-face)
+    ;; All Deduce keywords.
+    (,(deduce-mode--symbol-regexp deduce-mode--keywords)
+     0 font-lock-keyword-face)
+    ;; Capitalized identifiers (user-defined types and constructors).
+    ;; ASCII only for now; subscripted variants like `Nat₁' fall
+    ;; through to default face -- revisit if it comes up.
+    ("\\_<[A-Z][[:alnum:]_]*\\_>" 0 font-lock-type-face))
+  "Font-lock keywords for `deduce-mode'.")
+
+
 (defvar deduce-mode-syntax-table
   (let ((st (make-syntax-table)))
     ;; Comment markers.  `/' is the first character of `/*' (start
@@ -111,7 +201,11 @@ steps; LSP integration lives in `deduce-lsp.el'.
   ;; Use the syntax table's comment markers for `comment-region'
   ;; instead of `comment-padright'-derived ones.  Avoids the dwim
   ;; helper inserting `/*' '*/' around a single-line comment.
-  (setq-local comment-use-syntax t))
+  (setq-local comment-use-syntax t)
+  ;; Font-lock: keyword highlighting (Step 2).  No multi-line
+  ;; constructs need special treatment yet, so the default
+  ;; defaults tuple is sufficient.
+  (setq-local font-lock-defaults '(deduce-mode-font-lock-keywords)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pf\\'" . deduce-mode))

--- a/editor/emacs/test/deduce-mode-test.el
+++ b/editor/emacs/test/deduce-mode-test.el
@@ -153,6 +153,28 @@ should be type-faced."
               'font-lock-type-face)))
 
 
+(ert-deftest deduce-mode/type-arguments-each-get-type-face ()
+  "`Option<Pos>' parses as three tokens, not one symbol -- the type
+parameters should each be picked up by the capitalized-identifier
+rule.  Regression test for an early bug where `<' and `>' were
+symbol-class and swallowed the symbol boundary, leaving `Option'
+and `Pos' default-faced inside `Foo<Bar>'."
+  (with-temp-buffer
+    (insert "recursive nat2pos(Nat) -> Option<Pos> {\n  ?\n}\n")
+    (deduce-mode)
+    (font-lock-ensure)
+    ;; case-fold-search defaults to t, which would let `search-forward
+    ;; "Nat"' match `nat' inside `nat2pos'. Bind it nil so we land on
+    ;; the capitalized occurrence.
+    (let ((case-fold-search nil))
+      (dolist (name '("Nat" "Option" "Pos"))
+        (goto-char (point-min))
+        (should (search-forward name nil t))
+        (goto-char (match-beginning 0))
+        (should (eq (get-text-property (point) 'face)
+                    'font-lock-type-face))))))
+
+
 (ert-deftest deduce-mode/standalone-question-mark-gets-warning-face ()
   "A standalone `?' (proof hole) should be warning-faced."
   (should (eq (deduce-mode-test--face-at

--- a/editor/emacs/test/deduce-mode-test.el
+++ b/editor/emacs/test/deduce-mode-test.el
@@ -74,6 +74,146 @@ character break sexp motion."
     (should (= (point) (point-max)))))
 
 
+;; ---------------------------------------------------------------------
+;; Step 2: font-lock
+;; ---------------------------------------------------------------------
+
+(defun deduce-mode-test--face-at (target text)
+  "Return the `face' text property at the start of TARGET in TEXT,
+after `deduce-mode' font-locking.  Returns nil if TARGET isn't
+found or if the position has no face property."
+  (with-temp-buffer
+    (insert text)
+    (deduce-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (when (search-forward target nil t)
+      (get-text-property (match-beginning 0) 'face))))
+
+
+(ert-deftest deduce-mode/keyword-theorem-gets-keyword-face ()
+  (should (eq (deduce-mode-test--face-at
+               "theorem"
+               "theorem t: true\nproof\n  .\nend\n")
+              'font-lock-keyword-face)))
+
+
+(ert-deftest deduce-mode/keyword-proof-gets-keyword-face ()
+  (should (eq (deduce-mode-test--face-at
+               "proof"
+               "theorem t: true\nproof\n  .\nend\n")
+              'font-lock-keyword-face)))
+
+
+(ert-deftest deduce-mode/keyword-arbitrary-gets-keyword-face ()
+  (should (eq (deduce-mode-test--face-at
+               "arbitrary"
+               "theorem t: all P:bool. P\nproof\n  arbitrary P:bool\n  ?\nend\n")
+              'font-lock-keyword-face)))
+
+
+(ert-deftest deduce-mode/constant-true-gets-constant-face ()
+  (should (eq (deduce-mode-test--face-at
+               "true"
+               "theorem t: true\n")
+              'font-lock-constant-face)))
+
+
+(ert-deftest deduce-mode/constant-false-gets-constant-face ()
+  (should (eq (deduce-mode-test--face-at
+               "false"
+               "theorem t: false\n")
+              'font-lock-constant-face)))
+
+
+(ert-deftest deduce-mode/integer-literal-gets-constant-face ()
+  (should (eq (deduce-mode-test--face-at
+               "42"
+               "define x: bool = 42 = 42\n")
+              'font-lock-constant-face)))
+
+
+(ert-deftest deduce-mode/builtin-type-bool-gets-type-face ()
+  (should (eq (deduce-mode-test--face-at
+               "bool"
+               "define x: bool = true\n")
+              'font-lock-type-face)))
+
+
+(ert-deftest deduce-mode/capitalized-identifier-gets-type-face ()
+  "User-defined types and constructors (capitalized identifiers)
+should be type-faced."
+  (should (eq (deduce-mode-test--face-at
+               "Nat"
+               "import Nat\n")
+              'font-lock-type-face))
+  (should (eq (deduce-mode-test--face-at
+               "Color"
+               "union Color {\n  Red\n}\n")
+              'font-lock-type-face)))
+
+
+(ert-deftest deduce-mode/standalone-question-mark-gets-warning-face ()
+  "A standalone `?' (proof hole) should be warning-faced."
+  (should (eq (deduce-mode-test--face-at
+               "?"
+               "theorem t: true\nproof\n  ?\nend\n")
+              'font-lock-warning-face)))
+
+
+(ert-deftest deduce-mode/sorry-gets-warning-face ()
+  (should (eq (deduce-mode-test--face-at
+               "sorry"
+               "theorem t: true\nproof\n  sorry\nend\n")
+              'font-lock-warning-face)))
+
+
+(ert-deftest deduce-mode/question-mark-inside-identifier-not-warning ()
+  "The `?' in `done?' is part of the identifier, not a hole, and
+should not be warning-faced."
+  (with-temp-buffer
+    (insert "define done?: bool = true\n")
+    (deduce-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "done?")
+    ;; Move to the `?' character itself.
+    (backward-char)
+    (should-not (eq (get-text-property (point) 'face)
+                    'font-lock-warning-face))))
+
+
+(ert-deftest deduce-mode/keyword-not-matched-inside-identifier ()
+  "`theoremish' should NOT be highlighted as `theorem' followed by
+trailing characters: symbol boundaries protect against that."
+  (with-temp-buffer
+    (insert "define theoremish: bool = true\n")
+    (deduce-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "theoremish")
+    (goto-char (match-beginning 0))
+    (should-not (eq (get-text-property (point) 'face)
+                    'font-lock-keyword-face))))
+
+
+(ert-deftest deduce-mode/keywords-inside-comments-not-highlighted ()
+  "Keywords inside line and block comments should not be highlighted."
+  (with-temp-buffer
+    (insert "// theorem t: true\n/* theorem t: true */\n")
+    (deduce-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "theorem")
+    (goto-char (match-beginning 0))
+    (should (eq (get-text-property (point) 'face)
+                'font-lock-comment-face))
+    (search-forward "theorem")
+    (goto-char (match-beginning 0))
+    (should (eq (get-text-property (point) 'face)
+                'font-lock-comment-face))))
+
+
 (provide 'deduce-mode-test)
 
 ;;; deduce-mode-test.el ends here


### PR DESCRIPTION
Step 2 of the Emacs mode plan ([docs/emacs-plan.md](docs/emacs-plan.md)).

## What this is
Keyword highlighting for `.pf` buffers, with the keyword list verified directly against `Deduce.lark` (every quoted lowercase token in the grammar is categorized).

| Face | Tokens |
|---|---|
| `font-lock-keyword-face` | declaration / structure / tactic keywords (`theorem`, `lemma`, `define`, `union`, `proof`, `end`, `arbitrary`, `switch`, `induction`, …), visibility (`public`/`private`/`opaque`), logical operators (`if`/`then`/`else`, `all`/`some`, `and`/`or`/`not`/`iff`, `fn`/`λ`/`array`) |
| `font-lock-constant-face` | `true`, `false`, integer literals, `ℕ`-prefixed Nat literals |
| `font-lock-type-face` | `bool`, `type` (built-in), and any capitalized identifier (constructors and user types like `Nat`, `Color`) |
| `font-lock-warning-face` | `sorry` and a standalone `?` (proof hole) |

## Implementation notes
- Symbol boundaries (`\_<…\_>`) rather than word boundaries throughout, so identifier-trailing chars (`'`, `?`, `!`, set symbol-class in Step 1) don't break the regex. `theoremish` doesn't get mis-highlighted as `theorem`-with-suffix; the `?` in `done?` doesn't get mis-flagged as a hole.
- Keyword lists live in three small `defconst`s — adding a new Deduce keyword later is a one-line append, no other changes.
- `regexp-opt` builds the optimized alternation.

## Tests
13 new ert cases covering each face category, both positive (`theorem` → keyword-face) and negative (`theoremish` not keyword-face, `?` in `done?` not warning-face, keywords inside `//` and `/* */` stay comment-face).

## Verified
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-mode.el` — clean, no warnings.
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-mode-test -f ert-run-tests-batch-and-exit` — 19/19 passed (6 from Step 1 + 13 new).

## Manual smoke (your turn)
Open `test/should-validate/NatTests.pf` (or any non-trivial `.pf` file) and check:

1. Statement keywords (`theorem`, `define`, `import`) and tactic keywords (`arbitrary`, `proof`, `end`) appear in the keyword color.
2. `bool`, `Nat`, `List` appear in the type color.
3. `0`, `42` appear in the constant color.
4. Add a `?` somewhere in a proof body; it appears in the warning color.
5. `// comment` and `/* comment */` stay comment-colored — keywords inside aren't highlighted.

If a token you expect to see colored stays default-faced, tell me which one — likely a missing entry in one of the three lists.

## Out of scope
- Indentation — Step 3.
- Eglot integration and `C-c C-g` — Steps 4 and 5.