### PR TITLE
Emacs mode Step 3: indentation

### DIFF
--- a/editor/emacs/deduce-mode.el
+++ b/editor/emacs/deduce-mode.el
@@ -53,6 +53,157 @@
 ;; word-motion purposes.
 
 ;; ---------------------------------------------------------------------
+;; Indentation (Step 3)
+;; ---------------------------------------------------------------------
+;;
+;; A simple custom `indent-line-function' rather than SMIE.  Deduce's
+;; structure has two flavors of opener/closer:
+;;
+;;   * Bracket pairs: `{' / `}', `(' / `)', `[' / `]'.
+;;   * Keyword pair:  `proof' / `end'.
+;;
+;; Rules at TAB / RET on a line:
+;;
+;;   1. If the line starts with `end', find the matching `proof' by
+;;      depth-counting backward and align with `proof''s column.
+;;   2. If the line starts with `}', `)', or `]', use Emacs's syntax
+;;      engine (`backward-up-list') to find the opener's line and
+;;      align with that line's first non-whitespace column.
+;;   3. Otherwise, look at the previous non-blank, non-comment-only
+;;      line.  If it ends with an opener (`proof', `{', `(', `['),
+;;      indent one `deduce-mode-indent-offset' deeper than that
+;;      line; otherwise match its indent.
+;;
+;; The rules cover the common Deduce shapes:
+;;
+;;   theorem t: ...   ; col 0
+;;   proof            ; col 0
+;;     arbitrary ...  ; col 2 (proof opens)
+;;     induction Nat  ; col 2 (no opener, same as prev)
+;;     case zero {    ; col 2 (no opener, same as prev)
+;;       body         ; col 4 (`{' opens)
+;;     }              ; col 2 (matches `case zero {' line)
+;;     case suc(n) {  ; col 2
+;;       ...
+;;     }
+;;   end              ; col 0 (matches `proof')
+;;
+;; Refinements (e.g. SMIE-grade alignment for multi-line type
+;; signatures, smarter handling of `case' placement) can replace
+;; this function later without changing the mode's interface.
+
+(defcustom deduce-mode-indent-offset 2
+  "Indentation step for `deduce-mode', in spaces."
+  :type 'integer
+  :group 'deduce
+  :safe #'integerp)
+
+
+(defun deduce-mode--line-starter ()
+  "Return a symbol describing how the current line starts.
+
+Possible values: `end' for the `end' keyword, `rbra' / `rpar' /
+`rbrk' for `}', `)', `]', or nil for anything else."
+  (save-excursion
+    (back-to-indentation)
+    (cond
+     ((looking-at-p "\\_<end\\_>") 'end)
+     ((eq (char-after) ?})        'rbra)
+     ((eq (char-after) ?\))       'rpar)
+     ((eq (char-after) ?\])       'rbrk))))
+
+
+(defun deduce-mode--match-proof-for-end ()
+  "Find the column of the `proof' keyword that matches the `end'
+on the current line.  Returns the column, or nil if no match."
+  (save-excursion
+    (back-to-indentation)
+    (let ((depth 1)
+          (col nil))
+      (while (and (> depth 0) (not (bobp)))
+        (forward-line -1)
+        (back-to-indentation)
+        (cond
+         ((looking-at-p "\\_<end\\_>")
+          (setq depth (1+ depth)))
+         ((looking-at-p "\\_<proof\\_>")
+          (setq depth (1- depth))
+          (when (zerop depth)
+            (setq col (current-column))))))
+      col)))
+
+
+(defun deduce-mode--match-bracket-line-indent ()
+  "Find the column of the line containing the opener for the
+closing bracket on the current line.  Returns the column or nil."
+  (save-excursion
+    (back-to-indentation)
+    (when (memq (char-after) '(?} ?\) ?\]))
+      (forward-char 1)
+      (condition-case nil
+          (progn
+            (backward-list)
+            (back-to-indentation)
+            (current-column))
+        (scan-error nil)))))
+
+
+(defun deduce-mode--prev-line-info ()
+  "Move to the previous non-blank, non-comment-only line.
+Return cons (INDENT . OPENS) where INDENT is its indent column
+and OPENS is t if it ends with an opener (`proof', `{', `(', `[').
+Returns nil if no such line exists above point."
+  (save-excursion
+    (let ((found nil))
+      ;; `forward-line -1' returns 0 on success, nonzero (-N) when it
+      ;; couldn't move that many lines (e.g. already at bobp).  Loop
+      ;; until we either find a content line or run out of buffer.
+      (while (and (not found) (zerop (forward-line -1)))
+        (back-to-indentation)
+        (unless (or (eolp)
+                    (looking-at-p "\\(?://\\|/\\*\\)"))
+          (setq found t)))
+      (when found
+        (let ((indent (current-column))
+              (opens nil))
+          (end-of-line)
+          (skip-chars-backward " \t")
+          (cond
+           ((memq (char-before) '(?{ ?\( ?\[))
+            (setq opens t))
+           ((looking-back "\\_<proof\\_>"
+                          (max (point-min) (- (point) 6)))
+            (setq opens t)))
+          (cons indent opens))))))
+
+
+(defun deduce-mode-indent-line ()
+  "Indent the current line for `deduce-mode'.
+
+See the comment block above for the rules.  Bound to TAB and used
+by `electric-indent-mode' on RET."
+  (interactive)
+  (let* ((closer (deduce-mode--line-starter))
+         (target
+          (cond
+           ((eq closer 'end)
+            (or (deduce-mode--match-proof-for-end) 0))
+           ((memq closer '(rbra rpar rbrk))
+            (or (deduce-mode--match-bracket-line-indent) 0))
+           (t
+            (let ((info (deduce-mode--prev-line-info)))
+              (if info
+                  (+ (car info)
+                     (if (cdr info) deduce-mode-indent-offset 0))
+                0)))))
+         (point-was-at-or-before-indent
+          (<= (current-column) (current-indentation))))
+    (indent-line-to (max 0 target))
+    (when point-was-at-or-before-indent
+      (back-to-indentation))))
+
+
+;; ---------------------------------------------------------------------
 ;; Font-lock (Step 2)
 ;; ---------------------------------------------------------------------
 ;;
@@ -213,7 +364,10 @@ steps; LSP integration lives in `deduce-lsp.el'.
   ;; Font-lock: keyword highlighting (Step 2).  No multi-line
   ;; constructs need special treatment yet, so the default
   ;; defaults tuple is sufficient.
-  (setq-local font-lock-defaults '(deduce-mode-font-lock-keywords)))
+  (setq-local font-lock-defaults '(deduce-mode-font-lock-keywords))
+  ;; Indentation (Step 3).  TAB and (via electric-indent-mode) RET
+  ;; both call this.
+  (setq-local indent-line-function #'deduce-mode-indent-line))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pf\\'" . deduce-mode))

--- a/editor/emacs/test/deduce-mode-test.el
+++ b/editor/emacs/test/deduce-mode-test.el
@@ -236,6 +236,159 @@ trailing characters: symbol boundaries protect against that."
                 'font-lock-comment-face))))
 
 
+;; ---------------------------------------------------------------------
+;; Step 3: indentation
+;; ---------------------------------------------------------------------
+
+(defun deduce-mode-test--reindent (input)
+  "Indent INPUT in a fresh `deduce-mode' buffer and return the
+result as a string.  Uses `indent-region' to walk every line
+top-to-bottom through `indent-line-function'."
+  (with-temp-buffer
+    (insert input)
+    (deduce-mode)
+    (let ((indent-tabs-mode nil))
+      (indent-region (point-min) (point-max)))
+    (buffer-string)))
+
+
+(ert-deftest deduce-mode/indent-simple-proof ()
+  "`proof' opens a block; `end' aligns with its `proof'."
+  (should (equal
+           (deduce-mode-test--reindent
+            "theorem t: true\nproof\n.\nend\n")
+           "theorem t: true\nproof\n  .\nend\n")))
+
+
+(ert-deftest deduce-mode/indent-proof-with-multiple-tactics ()
+  "Tactic lines inside `proof ... end' all sit at +offset."
+  (should (equal
+           (deduce-mode-test--reindent
+            (concat
+             "theorem t: all P:bool. P = P\n"
+             "proof\n"
+             "arbitrary P:bool\n"
+             "reflexive\n"
+             "end\n"))
+           (concat
+            "theorem t: all P:bool. P = P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  reflexive\n"
+            "end\n"))))
+
+
+(ert-deftest deduce-mode/indent-union-body ()
+  "`union ... { ... }' indents body by `deduce-mode-indent-offset'."
+  (should (equal
+           (deduce-mode-test--reindent
+            "union Color {\nRed\nBlue\n}\n")
+           "union Color {\n  Red\n  Blue\n}\n")))
+
+
+(ert-deftest deduce-mode/indent-recursive-body ()
+  (should (equal
+           (deduce-mode-test--reindent
+            "recursive add(Nat, Nat) -> Nat {\nadd(0, n) = n\n}\n")
+           "recursive add(Nat, Nat) -> Nat {\n  add(0, n) = n\n}\n")))
+
+
+(ert-deftest deduce-mode/indent-induction-cases ()
+  "Cases of `induction' / `switch' sit at the same indent as the
+keyword, and case bodies (after `case ... {') are nested one
+level deeper.  Closing `}' aligns with its `case ... {' line."
+  (should (equal
+           (deduce-mode-test--reindent
+            (concat
+             "theorem t: all n:Nat. n = n\n"
+             "proof\n"
+             "arbitrary n:Nat\n"
+             "induction Nat\n"
+             "case zero {\n"
+             ".\n"
+             "}\n"
+             "case suc(n') suppose IH {\n"
+             "?\n"
+             "}\n"
+             "end\n"))
+           (concat
+            "theorem t: all n:Nat. n = n\n"
+            "proof\n"
+            "  arbitrary n:Nat\n"
+            "  induction Nat\n"
+            "  case zero {\n"
+            "    .\n"
+            "  }\n"
+            "  case suc(n') suppose IH {\n"
+            "    ?\n"
+            "  }\n"
+            "end\n"))))
+
+
+(ert-deftest deduce-mode/indent-switch-inside-proof ()
+  "`switch x { ... }' inside a `proof' nests one extra level."
+  (should (equal
+           (deduce-mode-test--reindent
+            (concat
+             "theorem t: all b:bool. b or not b\n"
+             "proof\n"
+             "arbitrary b:bool\n"
+             "switch b {\n"
+             "case true { . }\n"
+             "case false { . }\n"
+             "}\n"
+             "end\n"))
+           (concat
+            "theorem t: all b:bool. b or not b\n"
+            "proof\n"
+            "  arbitrary b:bool\n"
+            "  switch b {\n"
+            "    case true { . }\n"
+            "    case false { . }\n"
+            "  }\n"
+            "end\n"))))
+
+
+(ert-deftest deduce-mode/indent-respects-blank-lines ()
+  "Blank lines between content shouldn't break the previous-line
+indent logic -- the helper skips them."
+  (should (equal
+           (deduce-mode-test--reindent
+            (concat
+             "theorem t: true\n"
+             "proof\n"
+             ".\n"
+             "\n"
+             "  // comment-only line\n"
+             ".\n"
+             "end\n"))
+           (concat
+            "theorem t: true\n"
+            "proof\n"
+            "  .\n"
+            "\n"
+            "  // comment-only line\n"
+            "  .\n"
+            "end\n"))))
+
+
+(ert-deftest deduce-mode/indent-leaves-already-correct-buffer-stable ()
+  "Re-indenting a correctly-indented buffer is idempotent."
+  (let ((correct
+         (concat
+          "theorem t: all P:bool. P = P\n"
+          "proof\n"
+          "  arbitrary P:bool\n"
+          "  reflexive\n"
+          "end\n"
+          "\n"
+          "union Color {\n"
+          "  Red\n"
+          "  Blue\n"
+          "}\n")))
+    (should (equal (deduce-mode-test--reindent correct) correct))))
+
+
 (provide 'deduce-mode-test)
 
 ;;; deduce-mode-test.el ends here


### PR DESCRIPTION
Step 3 of the Emacs mode plan ([docs/emacs-plan.md](docs/emacs-plan.md)).

## What this is
A custom `indent-line-function` for `deduce-mode` covering Deduce's two flavors of opener/closer:
- **Bracket pairs:** `{` / `}`, `(` / `)`, `[` / `]`.
- **Keyword pair:** `proof` / `end`.

## Rules at TAB / RET on a line
1. Line starts with `end` → depth-counting backward scan finds the matching `proof`, align with that column.
2. Line starts with `}`, `)`, `]` → Emacs's syntax engine (`backward-up-list`) finds the opener line; align with its first non-whitespace column.
3. Otherwise → look at the previous non-blank, non-comment-only line. If it ends with an opener (`proof`, `{`, `(`, `[`), indent +`deduce-mode-indent-offset` from it; otherwise match its indent.

## Convention covered

```
theorem t: ...     col 0
proof              col 0   (no opener; same as prev)
  arbitrary ...    col 2   (`proof` opens)
  induction Nat    col 2
  case zero {      col 2
    body           col 4   (`{` opens)
  }                col 2   (matches `case zero {` line)
end                col 0   (matches `proof`)
```

Verified on real proofs from `lib/Nat.pf` and `lib/Base.pf` (induction-with-cases, switch-with-cases, comma-conjunction).

`deduce-mode-indent-offset` is a customize variable (default 2) so users can switch convention by editing one value.

## Tests
8 new ert cases (28 total now): simple `proof ... end`, multi-tactic body, `union` body, `recursive` body, induction with `case ... { body }` nesting, switch inside proof, blank/comment-only lines between content, idempotent re-indent.

## Verified
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-mode.el` — clean.
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-mode-test -f ert-run-tests-batch-and-exit` — 28/28 passed.

## Manual smoke (your turn)
After PR merges (or if testing the worktree directly, restart Emacs to pick up the new file):

1. **TAB on a misaligned line** — typing inside a proof, hit TAB; cursor jumps to the right indent.
2. **`M-x indent-region` on a whole proof** — the proof should come out matching the convention above.
3. **RET inside a `proof ... end` block** — the new line lands at +2 from `proof`.
4. **Type `}` on its own line** — auto-aligns to its matching `{` line.
5. **Type `end` on its own line** — auto-aligns to its matching `proof` line.

Cases known not to be perfect:
- Long type-signature wrap-arounds: `theorem foo: all x:Nat,\n   y:Nat. ...` — the continuation `y:Nat.` will sit at +0 from `theorem`, not aligned with `all`. SMIE-grade alignment is a Step 7 polish if anyone misses it.
- Multi-line comment continuations don't get a `*` prefix injected — out of scope here, would be `comment-line-break-function` work later.

Refinements can replace this function later without touching the mode's interface — `indent-line-function` is the only seam.

## Out of scope
- Eglot integration — Step 4.
- `C-c C-g` goal at point — Step 5.
- Phase-4 keybindings — Step 6.