### PR TITLE
Emacs mode Step 4: eglot integration via deduce-lsp.el

### DIFF
--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -1,0 +1,146 @@
+;;; deduce-lsp.el --- Eglot integration for deduce-mode -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Jeremy G. Siek and Deduce contributors
+;; SPDX-License-Identifier: MIT
+
+;; Author: Deduce contributors
+;; Maintainer: Jeremy G. Siek
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "29.1") (deduce-mode "0.1.0"))
+;; Keywords: languages
+;; URL: https://github.com/jsiek/deduce
+
+;;; Commentary:
+
+;; deduce-lsp.el wires `deduce-mode' buffers to the Deduce LSP server
+;; in lsp/lsp_server.py via eglot.  Phase B / Step 4 of the Emacs mode
+;; plan (see docs/emacs-plan.md).
+;;
+;; Installation
+;; ------------
+;;
+;;     (add-to-list 'load-path "/path/to/deduce/editor/emacs")
+;;     (require 'deduce-mode)
+;;     (require 'deduce-lsp)
+;;
+;; By default, opening a `.pf' file auto-starts eglot.  Set
+;; `deduce-lsp-auto-start' to nil to opt out and trigger eglot
+;; manually with `M-x eglot'.
+;;
+;; What you get
+;; ------------
+;;
+;;   Diagnostics on save        flycheck/flymake-style underlines
+;;   M-.                        go to definition (textDocument/definition)
+;;   M-x imenu                  outline of top-level decls (documentSymbol)
+;;
+;; Step 5 adds `C-c C-g' for the custom `deduce/goalAt' request.
+;; Step 6 adds Phase-4 keybindings (`C-c C-r', `C-c C-c', `C-c C-i')
+;; for the LSP-side structured-editing operations once they land.
+;;
+;; Server command
+;; --------------
+;;
+;; The default command is `python3 -m lsp.lsp_server', invoked from
+;; the project root determined by `project-current'.  When you edit
+;; `.pf' files inside the deduce repo this works out of the box --
+;; `lsp/lsp_server.py' is on Python's import path.
+;;
+;; If your proofs live OUTSIDE the deduce repo, customize
+;; `deduce-lsp-deduce-root' to point at your deduce checkout; the
+;; server command will then be invoked with PYTHONPATH including
+;; that directory so the import resolves regardless of cwd.
+
+;;; Code:
+
+(require 'deduce-mode)
+
+;; Declare eglot's variables so the byte-compiler doesn't warn when
+;; we reference them inside `with-eval-after-load'.  We don't
+;; `require' eglot at top level because it isn't strictly needed
+;; until the user opens a `.pf' file -- eglot is built into Emacs
+;; 29+ so loading it lazily keeps `(require 'deduce-lsp)' fast.
+(defvar eglot-server-programs)
+(declare-function eglot-ensure "eglot")
+
+
+(defgroup deduce-lsp nil
+  "Eglot integration for `deduce-mode'."
+  :group 'deduce
+  :prefix "deduce-lsp-")
+
+
+(defcustom deduce-lsp-python-program "python3"
+  "Python interpreter used to launch the Deduce LSP server."
+  :type 'string
+  :group 'deduce-lsp)
+
+
+(defcustom deduce-lsp-deduce-root nil
+  "Path to a Deduce repository checkout, or nil to rely on cwd.
+
+When nil, eglot launches the server from the project root
+determined by `project-current' -- this works when editing `.pf'
+files inside the deduce repo, where `lsp/lsp_server.py' is on
+Python's import path.
+
+When set to a directory path, the server command runs through
+`env' with PYTHONPATH including that directory, so `python3 -m
+lsp.lsp_server' resolves regardless of cwd.  Useful when your
+proofs live outside the deduce repo."
+  :type '(choice (const :tag "Auto (project root)" nil)
+                 (directory :tag "Deduce checkout"))
+  :group 'deduce-lsp)
+
+
+(defcustom deduce-lsp-auto-start t
+  "If non-nil, automatically start eglot when entering `deduce-mode'.
+
+Set to nil to opt out and trigger eglot manually with `M-x eglot'.
+The first call per process bootstraps the prelude (~1s with `.thm'
+cache, ~13s without) and is the slowest one; subsequent connects
+are warm."
+  :type 'boolean
+  :group 'deduce-lsp)
+
+
+(defun deduce-lsp-server-command (&optional _interactive)
+  "Return the command list eglot uses to launch the Deduce LSP server.
+
+When `deduce-lsp-deduce-root' is set, prepend it to PYTHONPATH
+via `env'.  Otherwise return the bare `python3 -m lsp.lsp_server'
+form and trust eglot's cwd to be the deduce repo root.
+
+The optional argument is unused; it's accepted because eglot
+calls server-program functions with one argument (an
+`interactive' flag) since Emacs 29."
+  (let ((py deduce-lsp-python-program)
+        (mod-args '("-m" "lsp.lsp_server")))
+    (if deduce-lsp-deduce-root
+        (let ((root (expand-file-name deduce-lsp-deduce-root)))
+          (append (list "env" (format "PYTHONPATH=%s" root) py) mod-args))
+      (cons py mod-args))))
+
+
+(defun deduce-lsp--maybe-ensure ()
+  "Hook function: call `eglot-ensure' when entering `deduce-mode'
+unless `deduce-lsp-auto-start' is nil."
+  (when deduce-lsp-auto-start
+    (eglot-ensure)))
+
+
+;; Register with eglot.  We use `with-eval-after-load' so this works
+;; whether eglot is loaded before or after deduce-lsp.
+;;;###autoload
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '(deduce-mode . deduce-lsp-server-command)))
+
+
+;;;###autoload
+(add-hook 'deduce-mode-hook #'deduce-lsp--maybe-ensure)
+
+
+(provide 'deduce-lsp)
+
+;;; deduce-lsp.el ends here

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -1,0 +1,98 @@
+;;; deduce-lsp-test.el --- ert tests for deduce-lsp -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Run with:
+;;
+;;     emacs --batch -L editor/emacs -L editor/emacs/test \
+;;           -l deduce-lsp-test -f ert-run-tests-batch-and-exit
+;;
+;; The end-to-end loop (subprocess server, JSON-RPC, real LSP traffic)
+;; is impractical to drive from a batch process.  These tests pin the
+;; pieces of `deduce-lsp.el' that live entirely in Emacs Lisp:
+;; eglot-server-programs registration, server-command shape under
+;; both `deduce-lsp-deduce-root' branches, and the auto-start hook.
+
+;;; Code:
+
+(require 'ert)
+(require 'eglot)
+(require 'deduce-mode)
+(require 'deduce-lsp)
+
+
+(ert-deftest deduce-lsp/registered-with-eglot ()
+  "Loading `deduce-lsp' should add a `(deduce-mode . ...)' entry to
+`eglot-server-programs'."
+  (should (assq 'deduce-mode eglot-server-programs)))
+
+
+(ert-deftest deduce-lsp/server-command-default-form ()
+  "With `deduce-lsp-deduce-root' nil, the command is just python3 +
+the module spec."
+  (let ((deduce-lsp-deduce-root nil)
+        (deduce-lsp-python-program "python3"))
+    (should (equal (deduce-lsp-server-command)
+                   '("python3" "-m" "lsp.lsp_server")))))
+
+
+(ert-deftest deduce-lsp/server-command-default-form-respects-python-program ()
+  "Customizing `deduce-lsp-python-program' swaps the interpreter."
+  (let ((deduce-lsp-deduce-root nil)
+        (deduce-lsp-python-program "python3.13"))
+    (should (equal (deduce-lsp-server-command)
+                   '("python3.13" "-m" "lsp.lsp_server")))))
+
+
+(ert-deftest deduce-lsp/server-command-with-deduce-root-uses-env ()
+  "Setting `deduce-lsp-deduce-root' wraps the command in `env' so
+PYTHONPATH carries the checkout location."
+  (let ((deduce-lsp-deduce-root "/tmp/deduce-checkout")
+        (deduce-lsp-python-program "python3"))
+    (let ((cmd (deduce-lsp-server-command)))
+      (should (equal (car cmd) "env"))
+      (should (equal (cadr cmd) "PYTHONPATH=/tmp/deduce-checkout"))
+      (should (equal (nthcdr 2 cmd)
+                     '("python3" "-m" "lsp.lsp_server"))))))
+
+
+(ert-deftest deduce-lsp/server-command-expands-deduce-root ()
+  "`~/...' in `deduce-lsp-deduce-root' expands to absolute path."
+  (let ((deduce-lsp-deduce-root "~/deduce")
+        (deduce-lsp-python-program "python3"))
+    (let ((cmd (deduce-lsp-server-command)))
+      (should (string-prefix-p "PYTHONPATH=/" (cadr cmd)))
+      (should-not (string-match-p "~" (cadr cmd))))))
+
+
+(ert-deftest deduce-lsp/auto-start-hook-installed ()
+  "`deduce-lsp--maybe-ensure' is on `deduce-mode-hook' after load."
+  (should (memq #'deduce-lsp--maybe-ensure deduce-mode-hook)))
+
+
+(ert-deftest deduce-lsp/maybe-ensure-respects-auto-start-flag ()
+  "When `deduce-lsp-auto-start' is nil, the hook is a no-op."
+  (let ((deduce-lsp-auto-start nil)
+        (eglot-called nil))
+    (cl-letf (((symbol-function 'eglot-ensure)
+               (lambda () (setq eglot-called t))))
+      (deduce-lsp--maybe-ensure)
+      (should-not eglot-called))))
+
+
+(ert-deftest deduce-lsp/maybe-ensure-calls-eglot-when-enabled ()
+  "When `deduce-lsp-auto-start' is non-nil, the hook calls
+`eglot-ensure'."
+  (let ((deduce-lsp-auto-start t)
+        (eglot-called nil))
+    (cl-letf (((symbol-function 'eglot-ensure)
+               (lambda () (setq eglot-called t))))
+      (deduce-lsp--maybe-ensure)
+      (should eglot-called))))
+
+
+(provide 'deduce-lsp-test)
+
+;;; deduce-lsp-test.el ends here


### PR DESCRIPTION
Step 4 of the Emacs mode plan ([docs/emacs-plan.md](docs/emacs-plan.md)). The mode crosses over to Phase B — talking to the LSP server.

## What this is
A new `editor/emacs/deduce-lsp.el` (~150 lines) that wires `deduce-mode` buffers to the existing `lsp/lsp_server.py` via eglot. After `(require 'deduce-lsp)`, opening a `.pf` file auto-starts eglot.

## What the user gets
| Action | Method | Backed by |
|---|---|---|
| Diagnostics on save | flymake gutter underlines | `textDocument/publishDiagnostics` |
| `M-.` | go-to-definition | `textDocument/definition` |
| `M-x imenu` | top-level outline | `textDocument/documentSymbol` |

## Customize variables
- `deduce-lsp-python-program` (default `"python3"`) — interpreter.
- `deduce-lsp-deduce-root` (default `nil`) — when set, prepends the path to `PYTHONPATH` via `env` so `python3 -m lsp.lsp_server` resolves regardless of cwd. For users with proofs outside the deduce repo.
- `deduce-lsp-auto-start` (default `t`) — set `nil` to require manual `M-x eglot`.

## Tests
8 new ert tests (36 total): registration with `eglot-server-programs`, both branches of the server-command function, the auto-start flag wiring (with `cl-letf` mocking `eglot-ensure`).

## Verified
- [x] `emacs --batch -f batch-byte-compile` — clean, no warnings.
- [x] `ert-run-tests-batch-and-exit` — 36/36 passed.
- [x] `python3 -m lsp.lsp_server` responds to `initialize` with the expected LSP capabilities (`definitionProvider`, `documentSymbolProvider`, `textDocumentSync` open/change/save).

## Manual smoke (your turn)

After this merges (or testing the worktree directly), add to your `.emacs`:

```elisp
(add-to-list 'load-path "/path/to/deduce/editor/emacs")
(require 'deduce-mode)
(require 'deduce-lsp)
```

Then:

1. Restart Emacs and open a `.pf` file in the deduce repo. Mode line should show `deduce-mode` and an eglot indicator (something like `[deduce-lsp:1234]` or `EGLOT(deduce-mode/...)`).
2. Wait ~1s on the first open per session — that's the prelude bootstrap. Subsequent connects in the same session are warm.
3. Introduce a deliberate error (e.g. change a proof body to `bogus`), save the file. A diagnostic should appear in the gutter / fringe at the offending line.
4. Put cursor on a theorem reference inside another proof (e.g. `pos2nat` in `lib/Pos.pf` if it exists), press `M-.`. Cursor should jump to the theorem declaration.
5. `M-x imenu` should let you pick from a list of top-level declarations in the current file.

If the eglot indicator doesn't appear, check `*Messages*` for errors. The most common cause is `python3 -m lsp.lsp_server` not finding the module — set `deduce-lsp-deduce-root` to your repo path and try again.

## Out of scope
- `C-c C-g` for goal-at-cursor — Step 5.
- Phase-4 keybindings (`C-c C-r` refine, `C-c C-c` case split, `C-c C-i` induction) — Step 6, gated on the LSP server's Phase 4 features landing.
- Polished error messages when the server fails to start — Step 7 polish.