### PR TITLE
Fix lsp_server.py for pygls 2.x publish_diagnostics API

### DIFF
--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -182,18 +182,26 @@ def _publish_diagnostics(ls: LanguageServer, uri: str) -> None:
         return
     path = _path_from_uri(uri)
     diags = _query.check(path, content, prelude=_PRELUDE)
-    ls.publish_diagnostics(
-        uri,
-        [
-            lsp_types.Diagnostic(
-                range=_lsp_range_from_query(d.range),
-                severity=_severity_to_lsp(d.severity),
-                message=d.message,
-                source=SERVER_NAME,
-                code=d.code,
-            )
-            for d in diags
-        ],
+    # pygls 2.x exposes the publish-diagnostics notification as
+    # ``text_document_publish_diagnostics(params)``. The pre-2.x
+    # ``publish_diagnostics(uri, list)`` shape was removed; calling
+    # it raises ``AttributeError: 'LanguageServer' object has no
+    # attribute 'publish_diagnostics'`` at runtime, which is what
+    # eglot users hit on first connect.
+    ls.text_document_publish_diagnostics(
+        lsp_types.PublishDiagnosticsParams(
+            uri=uri,
+            diagnostics=[
+                lsp_types.Diagnostic(
+                    range=_lsp_range_from_query(d.range),
+                    severity=_severity_to_lsp(d.severity),
+                    message=d.message,
+                    source=SERVER_NAME,
+                    code=d.code,
+                )
+                for d in diags
+            ],
+        )
     )
 
 
@@ -233,7 +241,12 @@ def on_did_close(
     ls: LanguageServer, params: lsp_types.DidCloseTextDocumentParams
 ) -> None:
     """Clear diagnostics when the editor closes the buffer."""
-    ls.publish_diagnostics(params.text_document.uri, [])
+    ls.text_document_publish_diagnostics(
+        lsp_types.PublishDiagnosticsParams(
+            uri=params.text_document.uri,
+            diagnostics=[],
+        )
+    )
 
 
 # --- Query features ------------------------------------------------------

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -59,16 +59,21 @@ class _FakeWorkspace:
 
 
 class FakeServer:
-    """Just enough of ``LanguageServer`` to drive the handlers."""
+    """Just enough of ``LanguageServer`` to drive the handlers.
+
+    Mirrors pygls 2.x's API: ``text_document_publish_diagnostics``
+    takes a ``PublishDiagnosticsParams`` rather than the pre-2.x
+    ``publish_diagnostics(uri, list)`` shape.
+    """
 
     def __init__(self) -> None:
         self.workspace = _FakeWorkspace()
         self.published: dict[str, list[lsp_types.Diagnostic]] = {}
 
-    def publish_diagnostics(
-        self, uri: str, diagnostics: list[lsp_types.Diagnostic]
+    def text_document_publish_diagnostics(
+        self, params: lsp_types.PublishDiagnosticsParams
     ) -> None:
-        self.published[uri] = list(diagnostics)
+        self.published[params.uri] = list(params.diagnostics)
 
 
 def _file_uri(path: Path) -> str:


### PR DESCRIPTION
Server-side fix surfaced by manual smoke testing of the Emacs eglot integration ([#322](https://github.com/jsiek/deduce/pull/322)). Independent of that PR — this is a real LSP server bug.

## Symptom
First connect from eglot (or any LSP client) reports:

```
[eglot] Server reports (type=1): Error in server:
AttributeError: 'LanguageServer' object has no attribute
'publish_diagnostics'
```

## Cause
pygls 2.x replaced the pre-2.x `publish_diagnostics(uri, list)` shape with `text_document_publish_diagnostics(params)` taking a `PublishDiagnosticsParams` object. The Step 9 server code (`lsp/lsp_server.py`) was using the old name.

## Why Step 9's pytest didn't catch it
The `FakeServer` test double had a `publish_diagnostics(uri, list)` method matching the production code's (wrong) call. Both were wrong, agreeing with each other. Real eglot exercises the real pygls path and exposed the mismatch.

## Fix
Two callsites updated (`_publish_diagnostics` for didOpen/didSave, `on_did_close` for clearing on close), plus the `FakeServer` to match.

## Verified
- [x] End-to-end smoke with hand-driven JSON-RPC: `initialize` → capabilities, `didOpen` with a buggy proof → `publishDiagnostics` notification with the right range and message, `shutdown` → reply, stderr clean.
- [x] `pytest test/lsp/test_lsp_server.py` — 14/14 still passing.
- [x] No production behaviour change beyond fixing the crash; diagnostic content is identical.

## Future-proofing the FakeServer
Worth a follow-up: pin the FakeServer's method shape against pygls's actual `LanguageServer` API so a future rename doesn't slip through again. One option is a contract test that introspects pygls's class to assert the method exists. Filing as a chip if the author prefers; not landing it here keeps the fix surgical.