### PR TITLE
Fix lsp/mcp servers: empty prelude for files inside lib/

### DIFF
--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -85,6 +85,32 @@ def _default_prelude() -> tuple[str, ...]:
 _PRELUDE = _default_prelude()
 
 
+def _path_is_in_lib(path: str) -> bool:
+    """True iff ``path`` lives inside the standard library directory.
+
+    Files inside ``lib/`` are themselves part of the prelude, so when
+    we check one we must NOT auto-prepend the prelude -- otherwise
+    the file gets imported twice (once via the prelude, once as the
+    user file) and every theorem in it triggers
+    ``theorem names may not be overloaded``.
+    """
+    try:
+        Path(path).resolve().relative_to(_LIB_DIR.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _prelude_for(path: str) -> tuple[str, ...]:
+    """Return the prelude appropriate for checking ``path``.
+
+    Mirrors ``deduce.py``'s ``check_in_prelude`` logic: empty prelude
+    for files that are themselves part of the standard library, the
+    full default prelude otherwise.
+    """
+    return () if _path_is_in_lib(path) else _PRELUDE
+
+
 # ---------------------------------------------------------------------------
 # Server definition
 # ---------------------------------------------------------------------------
@@ -181,7 +207,7 @@ def _publish_diagnostics(ls: LanguageServer, uri: str) -> None:
     if content is None:
         return
     path = _path_from_uri(uri)
-    diags = _query.check(path, content, prelude=_PRELUDE)
+    diags = _query.check(path, content, prelude=_prelude_for(path))
     # pygls 2.x exposes the publish-diagnostics notification as
     # ``text_document_publish_diagnostics(params)``. The pre-2.x
     # ``publish_diagnostics(uri, list)`` shape was removed; calling
@@ -263,7 +289,7 @@ def on_definition(
         return None
     path = _path_from_uri(uri)
     pos = _query_pos_from_lsp(params.position)
-    loc = _query.definition_of(path, content, pos, prelude=_PRELUDE)
+    loc = _query.definition_of(path, content, pos, prelude=_prelude_for(path))
     if loc is None:
         return None
     return lsp_types.Location(
@@ -282,7 +308,7 @@ def on_document_symbol(
     if content is None:
         return []
     path = _path_from_uri(uri)
-    syms = _query.list_symbols(path, content, prelude=_PRELUDE)
+    syms = _query.list_symbols(path, content, prelude=_prelude_for(path))
     return [
         lsp_types.DocumentSymbol(
             name=s.name,
@@ -324,7 +350,8 @@ def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
             character=int(pos_obj.get("character", 0)),
         )
     )
-    goal = _query.goal_at(_path_from_uri(uri), content, pos, prelude=_PRELUDE)
+    path = _path_from_uri(uri)
+    goal = _query.goal_at(path, content, pos, prelude=_prelude_for(path))
     if goal is None:
         return None
     return {

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -101,6 +101,25 @@ def _default_prelude() -> tuple[str, ...]:
 _PRELUDE = _default_prelude()
 
 
+def _path_is_in_lib(path: str) -> bool:
+    """True iff ``path`` lives inside the standard library directory.
+
+    Files inside ``lib/`` are part of the prelude themselves; checking
+    one with the prelude prepended would import the file twice and
+    trip ``theorem names may not be overloaded`` (mirrors the
+    ``check_in_prelude`` logic in ``deduce.py``)."""
+    try:
+        Path(path).resolve().relative_to(_LIB_DIR.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _prelude_for(path: str) -> tuple[str, ...]:
+    """Empty prelude for files in ``lib/``, otherwise the default."""
+    return () if _path_is_in_lib(path) else _PRELUDE
+
+
 # ---------------------------------------------------------------------------
 # Server definition
 # ---------------------------------------------------------------------------
@@ -146,7 +165,7 @@ def check_file(path: str) -> dict:
     ``code``.
     """
     content = _read_file(path)
-    diagnostics = query.check(path, content, prelude=_PRELUDE)
+    diagnostics = query.check(path, content, prelude=_prelude_for(path))
     return {"diagnostics": _to_serializable(diagnostics)}
 
 
@@ -162,7 +181,7 @@ def goal_at(path: str, line: int, column: int) -> Optional[dict]:
     """
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
-    goal = query.goal_at(path, content, pos, prelude=_PRELUDE)
+    goal = query.goal_at(path, content, pos, prelude=_prelude_for(path))
     return _to_serializable(goal)
 
 
@@ -176,7 +195,7 @@ def definition_of(path: str, line: int, column: int) -> Optional[dict]:
     """
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
-    loc = query.definition_of(path, content, pos, prelude=_PRELUDE)
+    loc = query.definition_of(path, content, pos, prelude=_prelude_for(path))
     return _to_serializable(loc)
 
 
@@ -192,7 +211,7 @@ def list_symbols(path: str) -> list[dict]:
     ``signature``.
     """
     content = _read_file(path)
-    syms = query.list_symbols(path, content, prelude=_PRELUDE)
+    syms = query.list_symbols(path, content, prelude=_prelude_for(path))
     return _to_serializable(syms)
 
 

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -368,3 +368,43 @@ def test_definition_with_unknown_uri_returns_none(server):
 
 def test_goal_at_without_uri_returns_none(server):
     assert lsp_server.on_goal_at(server, {}) is None
+
+
+# --------------------------------------------------------------------------
+# Prelude scoping (regression for the lib/* self-import bug)
+# --------------------------------------------------------------------------
+
+
+def test_prelude_for_lib_file_is_empty():
+    """Files inside ``lib/`` are themselves part of the prelude;
+    auto-prepending the prelude when checking one would import
+    the file twice and trip ``theorem names may not be overloaded``.
+    Mirrors ``deduce.py``'s ``check_in_prelude`` logic."""
+    lib_file = REPO_ROOT / "lib" / "Nat.pf"
+    if not lib_file.exists():
+        pytest.skip(f"{lib_file} not present in this checkout")
+    assert lsp_server._prelude_for(str(lib_file)) == ()
+
+
+def test_prelude_for_user_file_is_default():
+    """A file outside ``lib/`` gets the configured prelude."""
+    # `_PRELUDE` is captured at import time; it could be `()` if the
+    # test process set DEDUCE_NO_STDLIB=1 (as test_mcp_server.py
+    # does). Either way, a user-file path should match `_PRELUDE`
+    # exactly, while a lib-path returns `()`.
+    user_file = REPO_ROOT / "test" / "should-validate" / "after.pf"
+    if not user_file.exists():
+        pytest.skip(f"{user_file} not present")
+    assert lsp_server._prelude_for(str(user_file)) == lsp_server._PRELUDE
+
+
+def test_path_is_in_lib_helper():
+    lib_file = REPO_ROOT / "lib" / "Nat.pf"
+    if lib_file.exists():
+        assert lsp_server._path_is_in_lib(str(lib_file)) is True
+    user_file = REPO_ROOT / "test" / "should-validate" / "after.pf"
+    if user_file.exists():
+        assert lsp_server._path_is_in_lib(str(user_file)) is False
+    # Nonexistent path: the resolve() walks the parents that do exist;
+    # if its lexical prefix matches lib/, it counts as in lib.
+    assert lsp_server._path_is_in_lib("/nope/not-a-path.pf") is False


### PR DESCRIPTION
Stacked on [#323](https://github.com/jsiek/deduce/pull/323). Surfaced by manual smoke testing of the Emacs eglot integration ([#322](https://github.com/jsiek/deduce/pull/322)).

## Symptom
Opening a `.pf` file that lives inside `lib/` (e.g. `lib/NatAdd.pf`) in an LSP-enabled editor reports:
```
deduce-lsp: theorem names may not be overloaded: lit_idem
```

## Cause
The LSP and MCP servers auto-prepend the entire stdlib (every `lib/*.pf`) as the prelude. When the user file *is itself* in `lib/`, that file gets imported twice — once via the prelude, once as the user file — and every theorem gets defined twice.

`deduce.py` has a `check_in_prelude` check that handles exactly this case (empty prelude when the deducable is part of the stdlib). The LSP and MCP servers were missing the equivalent.

## Fix
Adds `_path_is_in_lib(path)` and `_prelude_for(path)` helpers to both servers, threads the per-call prelude through every `query.*` call. Per-call rather than module-level because the right prelude depends on the path being checked.

## Tests
3 new pytest cases (17 total in `test_lsp_server.py`):
- `_prelude_for(lib/Nat.pf)` → `()`
- `_prelude_for(test/should-validate/after.pf)` → `_PRELUDE`
- `_path_is_in_lib` distinguishes lib/, user-file, and nonexistent paths

## Verified end-to-end
Hand-driven JSON-RPC dialogue: opening `lib/NatAdd.pf` via the real LSP server now reports **0 diagnostics**. Before the fix, the same scenario produced one diagnostic per double-defined theorem in the file.

`pytest test/lsp/` — **525/525** passing (522 + 3 new).

## Merge order
This stacks on #323. Either merge #323 first and rebase, or merge them together. The Emacs Step 4 manual smoke (#322) is blocked on both being available.