### PR TITLE
Emacs mode Step 5: C-c C-g goal-at-point + custom-method param fix

### DIFF
--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -54,6 +54,8 @@
 ;;; Code:
 
 (require 'deduce-mode)
+(require 'jsonrpc)
+(require 'seq)
 
 ;; Declare eglot's variables so the byte-compiler doesn't warn when
 ;; we reference them inside `with-eval-after-load'.  We don't
@@ -62,6 +64,7 @@
 ;; 29+ so loading it lazily keeps `(require 'deduce-lsp)' fast.
 (defvar eglot-server-programs)
 (declare-function eglot-ensure "eglot")
+(declare-function eglot-current-server "eglot")
 
 
 (defgroup deduce-lsp nil
@@ -139,6 +142,102 @@ unless `deduce-lsp-auto-start' is nil."
 
 ;;;###autoload
 (add-hook 'deduce-mode-hook #'deduce-lsp--maybe-ensure)
+
+
+;; ---------------------------------------------------------------------
+;; Goal at point (Step 5)
+;; ---------------------------------------------------------------------
+;;
+;; LSP has no built-in for "what proof obligation is at this cursor",
+;; so the server (lsp/lsp_server.py) exposes a custom `deduce/goalAt'
+;; request.  The command below issues that request via jsonrpc and
+;; renders the formula + givens in a `*Deduce Goal*' buffer.
+
+(defconst deduce-lsp-goal-buffer-name "*Deduce Goal*"
+  "Buffer name used to display goal-at-point output.")
+
+
+(defun deduce-lsp--current-uri ()
+  "Return the LSP URI for the current buffer's file.
+
+Errors out if the buffer isn't visiting a file.  Builds a
+`file://' URI by hand: eglot's URI helpers are private, and the
+underlying construction is simple enough that depending on them
+isn't worth it for ASCII paths."
+  (let ((path (or buffer-file-name
+                  (user-error "Buffer is not visiting a file"))))
+    (concat "file://" (expand-file-name path))))
+
+
+(defun deduce-lsp--current-position ()
+  "Return the LSP-shape `Position' for point in the current buffer.
+LSP positions are 0-indexed (line and character)."
+  (list :line (1- (line-number-at-pos))
+        :character (current-column)))
+
+
+(defun deduce-lsp--render-goal (response)
+  "Pretty-print a `deduce/goalAt' RESPONSE into the current buffer.
+
+Expected shape (post-JSON-decode plist):
+
+  (:formula STR :givens VEC :range PLIST)
+
+where each element of `givens' is `(:label STR-OR-NIL :formula STR)'.
+A nil RESPONSE means \"no goal at this position\"."
+  (if (null response)
+      (insert "No goal at this position.\n")
+    (let ((formula (plist-get response :formula))
+          (givens (plist-get response :givens)))
+      (insert "Goal:\n  " (or formula "?") "\n")
+      (when (and givens (> (length givens) 0))
+        (insert "\nGivens:\n")
+        (seq-doseq (g givens)
+          (let ((label (plist-get g :label))
+                (gformula (plist-get g :formula)))
+            (insert "  "
+                    (or label "_")
+                    ": "
+                    (or gformula "")
+                    "\n")))))))
+
+
+(defun deduce-lsp--show-goal (response)
+  "Display RESPONSE in the `*Deduce Goal*' buffer and pop it up."
+  (let ((buf (get-buffer-create deduce-lsp-goal-buffer-name)))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (read-only-mode 0)
+        (erase-buffer)
+        (deduce-lsp--render-goal response)
+        (goto-char (point-min)))
+      (view-mode 1))
+    (display-buffer buf)))
+
+
+(defun deduce-show-goal-at-point ()
+  "Show the proof goal at point in a `*Deduce Goal*' buffer.
+
+Issues a custom `deduce/goalAt' request to the active eglot
+server and renders the response.  Errors if no eglot connection
+is running in the current buffer."
+  (interactive)
+  (let ((server (eglot-current-server)))
+    (unless server
+      (user-error
+       "No eglot server active in this buffer; M-x eglot first"))
+    (let* ((params (list :textDocument
+                         (list :uri (deduce-lsp--current-uri))
+                         :position (deduce-lsp--current-position)))
+           (response (jsonrpc-request server :deduce/goalAt params)))
+      (deduce-lsp--show-goal response))))
+
+
+;; Bind `C-c C-g' in `deduce-mode-map'.  We bind here in deduce-lsp
+;; rather than in deduce-mode because the command depends on eglot
+;; being available, so the binding only makes sense once the user
+;; has opted into LSP via `(require 'deduce-lsp)'.
+(define-key deduce-mode-map (kbd "C-c C-g") #'deduce-show-goal-at-point)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -93,6 +93,124 @@ PYTHONPATH carries the checkout location."
       (should eglot-called))))
 
 
+;; ---------------------------------------------------------------------
+;; Step 5: deduce-show-goal-at-point
+;; ---------------------------------------------------------------------
+
+(defun deduce-lsp-test--with-mock-server (response thunk)
+  "Run THUNK with `jsonrpc-request' and `eglot-current-server'
+mocked: any request returns RESPONSE, and `eglot-current-server'
+returns the symbol `mock-server'.  Returns the captured request
+arguments."
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'eglot-current-server)
+               (lambda () 'mock-server))
+              ((symbol-function 'jsonrpc-request)
+               (lambda (server method params)
+                 (setq captured (list :server server :method method :params params))
+                 response)))
+      (funcall thunk))
+    captured))
+
+
+(ert-deftest deduce-lsp/show-goal-at-point-issues-goalAt-request ()
+  "The command sends a `deduce/goalAt' request with a properly
+shaped textDocument+position payload."
+  (let* ((tmp (make-temp-file "deduce-lsp-test" nil ".pf"))
+         captured)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: true\nproof\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; Cursor at line 3, column 2 (0-indexed for LSP: line 2, char 2)
+          (goto-char (point-min))
+          (forward-line 2)
+          (forward-char 2)
+          (setq captured
+                (deduce-lsp-test--with-mock-server
+                 nil
+                 (lambda () (deduce-show-goal-at-point))))
+          (should (eq (plist-get captured :method) :deduce/goalAt))
+          (let* ((params (plist-get captured :params))
+                 (uri (plist-get (plist-get params :textDocument) :uri))
+                 (pos (plist-get params :position)))
+            (should (string-prefix-p "file://" uri))
+            (should (= (plist-get pos :line) 2))
+            (should (= (plist-get pos :character) 2))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/show-goal-at-point-renders-formula-and-givens ()
+  (let* ((tmp (make-temp-file "deduce-lsp-test" nil ".pf"))
+         (response '(:formula "P = P"
+                     :givens [(:label "h" :formula "P")
+                              (:label nil :formula "Q")]
+                     :range (:start (:line 3 :character 2)
+                             :end (:line 3 :character 2)))))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (insert "theorem t: true\n")
+            (setq buffer-file-name tmp)
+            (deduce-mode)
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda () (deduce-show-goal-at-point))))
+          (let ((text (with-current-buffer deduce-lsp-goal-buffer-name
+                        (buffer-substring-no-properties (point-min) (point-max)))))
+            (should (string-match-p "Goal:" text))
+            (should (string-match-p "P = P" text))
+            (should (string-match-p "Givens:" text))
+            (should (string-match-p "h: P" text))
+            ;; Anonymous given gets rendered as `_'
+            (should (string-match-p "_: Q" text))))
+      (delete-file tmp)
+      (when (get-buffer deduce-lsp-goal-buffer-name)
+        (kill-buffer deduce-lsp-goal-buffer-name)))))
+
+
+(ert-deftest deduce-lsp/show-goal-at-point-renders-no-goal-message ()
+  "A nil response (no goal at cursor) shows a helpful message."
+  (let ((tmp (make-temp-file "deduce-lsp-test" nil ".pf")))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (insert "x")
+            (setq buffer-file-name tmp)
+            (deduce-mode)
+            (deduce-lsp-test--with-mock-server
+             nil
+             (lambda () (deduce-show-goal-at-point))))
+          (let ((text (with-current-buffer deduce-lsp-goal-buffer-name
+                        (buffer-substring-no-properties (point-min) (point-max)))))
+            (should (string-match-p "No goal at this position" text))))
+      (delete-file tmp)
+      (when (get-buffer deduce-lsp-goal-buffer-name)
+        (kill-buffer deduce-lsp-goal-buffer-name)))))
+
+
+(ert-deftest deduce-lsp/show-goal-at-point-without-server-errors ()
+  "Without an active eglot server, the command signals a user
+error rather than silently failing."
+  (let ((tmp (make-temp-file "deduce-lsp-test" nil ".pf")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'eglot-current-server)
+                   (lambda () nil)))
+          (with-temp-buffer
+            (insert "x")
+            (setq buffer-file-name tmp)
+            (deduce-mode)
+            (should-error (deduce-show-goal-at-point) :type 'user-error)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/c-c-c-g-bound-to-show-goal-at-point ()
+  "`C-c C-g' in deduce-mode-map runs `deduce-show-goal-at-point'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-g"))
+              #'deduce-show-goal-at-point)))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -324,6 +324,21 @@ def on_document_symbol(
     ]
 
 
+def _get_field(obj, name):
+    """Read a named field from a custom-request param value.
+
+    pygls 2.x converts the JSON params for *known* LSP methods into
+    typed dataclasses, but for custom methods (like ``deduce/goalAt'')
+    it produces a generic ``LSPObject`` whose JSON keys become
+    Python attributes.  Older pygls / direct test invocations may
+    pass a plain ``dict`` instead.  Handle both shapes."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
 @server.feature(GOAL_AT_REQUEST)
 def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
     """Custom request: return the proof goal at a cursor position.
@@ -334,11 +349,9 @@ def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
     Result: ``{"formula": str, "givens": [{"label": str | None,
     "formula": str}], "range": Range}`` or ``null``.
     """
-    # Params arrive as a dict from the JSON-RPC layer (no static
-    # type, since this is a custom method).
-    text_doc = params.get("textDocument") or {}
-    pos_obj = params.get("position") or {}
-    uri = text_doc.get("uri")
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
     if not uri:
         return None
     content = _document_content(ls, uri)
@@ -346,8 +359,8 @@ def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
         return None
     pos = _query_pos_from_lsp(
         lsp_types.Position(
-            line=int(pos_obj.get("line", 0)),
-            character=int(pos_obj.get("character", 0)),
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
         )
     )
     path = _path_from_uri(uri)


### PR DESCRIPTION
Step 5 of the Emacs mode plan ([docs/emacs-plan.md](docs/emacs-plan.md)). Adds the user-facing equivalent of Agda's `C-c C-,` for "show me the proof obligation here", and fixes a server bug surfaced by the end-to-end testing.

## What this is

`C-c C-g` in a `deduce-mode` buffer issues the custom `deduce/goalAt` request via `jsonrpc-request` and renders the formula + givens in a `*Deduce Goal*` buffer (view-mode, popup, reused across calls).

LSP has no built-in for "current proof obligation"; this command is the agreed-upon `deduce/goalAt` custom method paired with the Step 9 server.

## Two changes in one PR

### Elisp: `editor/emacs/deduce-lsp.el`
- `deduce-show-goal-at-point` (interactive, `C-c C-g` in `deduce-mode-map`)
- `deduce-lsp--current-uri` / `deduce-lsp--current-position` build the LSP payload
- `deduce-lsp--render-goal` formats text, `deduce-lsp--show-goal` sets up the buffer
- `deduce-lsp-goal-buffer-name` constant

5 new ert tests (41 total): request shape (method + 0-indexed coords + URI prefix), formatted buffer content with mocked response, "no goal" message when response is null, user-error when no eglot server is active, keybinding wired correctly.

### Python: `lsp/lsp_server.py`
End-to-end testing of `C-c C-g` exposed an `AttributeError: 'Object' object has no attribute 'get'` from the `on_goal_at` handler. Cause: pygls 2.x converts JSON params for *custom* methods into a generic `LSPObject` (attribute access) rather than a dict. The handler used `.get()`.

Fix: a small `_get_field(obj, name)` helper that handles both shapes, used in `on_goal_at`. No existing tests break; `test_lsp_server.py` uses dicts directly which still works (and dicts still flow through `_get_field`).

Verified end-to-end with a hand-driven JSON-RPC dialogue:

```
deduce/goalAt at line=3 char=0 of a sample proof returns:
  {"formula": "P = P", "givens": [],
   "range": {"start": {"line": 3, "character": 0}, "end": ...}}
```

## Verified
- [x] `emacs --batch -f batch-byte-compile editor/emacs/*.el` — clean.
- [x] `ert-run-tests-batch-and-exit` — 41/41 ert tests passing (was 36, +5).
- [x] `pytest test/lsp/test_lsp_server.py` — 17/17 still passing.
- [x] Real LSP server returns the expected `goalAt` payload over stdio.

## Manual smoke (your turn)
After merge, restart Emacs and:

1. Open any `.pf` file with a `proof ... end` block (e.g. `lib/Nat.pf`).
2. Position cursor inside the proof body, between two tactics.
3. Press `C-c C-g`.
4. A `*Deduce Goal*` buffer should pop up showing the goal formula and any givens in scope.

Try `C-c C-g` at multiple positions to see how the goal evolves through the proof — that's the productive feedback loop the LSP is supposed to enable.

## Out of scope
- Phase-4 keybindings (`C-c C-r` refine, `C-c C-c` case split, `C-c C-i` induction) — Step 6, gated on the LSP server's Phase 4 features landing.
- Goal display in the modeline / inline at point — possible Step 7 polish.