### PR TITLE
Fix goal_at hole insertion for nested case blocks

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -280,15 +280,21 @@ def goal_at(
 def _insert_hole(content: str, pos: Position) -> Optional[str]:
     """Modify ``content`` so that the proof at ``pos`` halts on a ``?``.
 
-    Strategy: find the byte offset for ``pos``, replace everything from
-    there up to (but not including) the next ``end`` keyword with
-    ``\\n?\\n``. The intervening tactics are dropped so the parser sees
-    a complete proof terminating at the hole.
+    Strategy: find the byte offset for ``pos``, then scan forward
+    tracking ``{``/``}`` depth. Truncate at whichever comes first:
+    the closer of the enclosing case block (a ``}`` that would make
+    the depth negative) or the proof body's ``end`` keyword (matched
+    only at depth 0). Replace the dropped span with ``\\n?\\n`` so
+    the parser sees a complete proof terminating at the hole.
 
-    Returns ``None`` when ``pos`` is out of range. If no ``end`` keyword
-    follows the cursor we fall back to "append ``?`` at the cursor and
-    leave the rest" -- the parser may still error, in which case
-    ``goal_at`` returns ``None``.
+    The depth tracker is what makes this work inside nested ``case``
+    blocks: a naive "next ``end``" search would consume the case's
+    own closing ``}`` and leave the parser with an unbalanced brace.
+
+    Returns ``None`` when ``pos`` is out of range. If no closer is
+    found we append ``?`` at the cursor and leave the rest -- the
+    parser may still error, in which case ``goal_at`` returns
+    ``None``.
     """
     offset = _line_col_to_offset(content, pos)
     if offset is None:
@@ -296,10 +302,44 @@ def _insert_hole(content: str, pos: Position) -> Optional[str]:
 
     before = content[:offset]
     after = content[offset:]
-    m = _END_RE.search(after)
-    if m is None:
+    cut = _find_block_end(after)
+    if cut is None:
         return before + "\n?\n" + after
-    return before + "\n?\n" + after[m.start():]
+    return before + "\n?\n" + after[cut:]
+
+
+def _find_block_end(s: str) -> Optional[int]:
+    """Return the offset in ``s`` where the enclosing proof block closes.
+
+    Tracks ``{``/``}`` depth from the start of ``s``. Stops at:
+    - The first ``}`` that would make depth go negative (the closer
+      of the block that encloses the cursor).
+    - The first ``\\bend\\b`` keyword at depth 0 (the proof body
+      terminator).
+
+    Returns ``None`` if neither is found before EOF.
+    """
+    depth = 0
+    i = 0
+    n = len(s)
+    while i < n:
+        c = s[i]
+        if c == "{":
+            depth += 1
+            i += 1
+        elif c == "}":
+            if depth == 0:
+                return i
+            depth -= 1
+            i += 1
+        elif depth == 0:
+            m = _END_RE.match(s, i)
+            if m:
+                return m.start()
+            i += 1
+        else:
+            i += 1
+    return None
 
 
 def _line_col_to_offset(content: str, pos: Position) -> Optional[int]:

--- a/test/lsp/test_goal_at.py
+++ b/test/lsp/test_goal_at.py
@@ -142,3 +142,50 @@ def test_goal_at_returns_none_when_position_is_invalid() -> None:
     source = "theorem t: bool = true\n"
     assert goal_at("test.pf", source, Position(line=0, column=1)) is None
     assert goal_at("test.pf", source, Position(line=1, column=0)) is None
+
+
+def test_goal_at_works_inside_nested_case_block() -> None:
+    """Regression: cursor inside a ``case ... { ... }`` block.
+
+    The hole-insertion algorithm has to stop at the case body's own
+    ``}`` rather than the proof body's ``end`` -- otherwise the ``}``
+    gets consumed and the parser sees an unbalanced brace, which
+    makes ``goal_at`` silently return ``None``.
+
+    Mirrors the proof shape that surfaced this bug in ``lib/Nat.pf``::
+
+        proof
+          induction Nat
+          case zero { ... }
+          case suc(n') suppose IH {
+            <cursor here>
+            IH
+          }
+        end
+
+    The exact reduced formula isn't asserted -- Deduce's reduction
+    is implementation-detail-y for ``switch`` on bool. What matters
+    is that ``goal_at`` doesn't trip over the nested ``}``.
+    """
+    source = (
+        "theorem t: all x:bool. x = true or x = false\n"
+        "proof\n"
+        "  arbitrary x:bool\n"
+        "  switch x {\n"
+        "    case true {\n"
+        "      .\n"
+        "    }\n"
+        "    case false {\n"
+        "      .\n"
+        "    }\n"
+        "  }\n"
+        "end\n"
+    )
+    # Line 6, column 1 -- the body of `case true { ... }`.
+    g = goal_at("test.pf", source, Position(line=6, column=1))
+    assert g is not None, (
+        "goal_at returned None inside a case body -- the nested "
+        "`}` likely confused the hole-insertion truncation."
+    )
+    assert isinstance(g, Goal)
+    assert g.range.start == Position(line=6, column=1)


### PR DESCRIPTION
## Summary

- `lsp.query._insert_hole` truncated the proof body by searching for the next `end` keyword. Inside a `case ... { ... }` block (the standard shape in `lib/Nat.pf` and most stdlib proofs), the truncation consumed the case's own closing `}`, the parser saw an unbalanced brace, and `goal_at` silently returned `None`.
- Replace the regex search with a depth-tracking scanner: stop at whichever comes first — a `}` that would close the enclosing block, or `\bend\b` at depth 0.
- Add a regression test using a `switch x { case true { ... } case false { ... } }` shape on `bool`, so it stays inside the prelude-free fixture territory the rest of `test_goal_at.py` uses.

## Background

Surfaced via end-to-end testing of the eglot integration (`C-c C-g`) on `lib/Nat.pf`: every goal request returned `null` for cursors inside the `case suc(n') suppose IH { ... }` body. The unit tests in `test_goal_at.py` didn't catch it because none of them exercised nested `{ ... }` blocks.

## Test plan

- [x] `python3 -m pytest test/lsp/` — all 526 tests pass
- [x] Verified the new regression test fails when only `lsp/query.py` is reverted (i.e., it actually catches the bug)
- [x] Manually confirmed `goal_at` now returns `Goal(formula="equal(n', n')", givens=(...IH...))` for cursor at `lib/Nat.pf:26:5` (the original failing case)
- [ ] Re-test `C-c C-g` in Emacs against `lib/Nat.pf` after merge