### PR TITLE
LSP Phase 4 / Step 15: hole refine via WorkspaceEdit

### DIFF
--- a/error.py
+++ b/error.py
@@ -72,11 +72,16 @@ def error(location, msg):
 class IncompleteProof(Exception):
   pass
 
-def incomplete_error(location, msg):
+def incomplete_error(location, msg, *, formula=None, env=None):
   exc = IncompleteProof(error_header(location) + msg)
   exc.depth = 0
   exc.location = location
   exc.message_body = msg
+  # Optional structured fields for the LSP/MCP refine pipeline:
+  # the goal AST and the type-checking env at the hole. The CLI
+  # ignores these; print(str(exc)) output is unchanged.
+  exc.formula = formula
+  exc.env = env
   raise exc
 
 def warning(location, msg):

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -339,6 +339,53 @@ def _get_field(obj, name):
     return getattr(obj, name, None)
 
 
+@server.feature(
+    lsp_types.TEXT_DOCUMENT_CODE_ACTION,
+    lsp_types.CodeActionOptions(
+        code_action_kinds=[lsp_types.CodeActionKind.RefactorRewrite],
+    ),
+)
+def on_code_action(
+    ls: LanguageServer, params: lsp_types.CodeActionParams
+) -> list[lsp_types.CodeAction]:
+    """Surface Phase-4 structured edits as refactor.rewrite actions.
+
+    Today: just the hole-refine action (Step 15). When the cursor sits
+    on a ``?`` and the goal has a recognised shape, the action's
+    ``edit`` field carries a single-file ``WorkspaceEdit`` that the
+    client applies on selection.
+
+    The action is silently absent when ``refine_at`` returns ``None``
+    -- the client (eglot, VS Code) will then offer no rewrite, which
+    matches the LSP convention of "no action available."
+    """
+    uri = params.text_document.uri
+    content = _document_content(ls, uri)
+    if content is None:
+        return []
+    path = _path_from_uri(uri)
+    pos = _query_pos_from_lsp(params.range.start)
+
+    edit = _query.refine_at(path, content, pos, prelude=_prelude_for(path))
+    if edit is None:
+        return []
+
+    text_edit = lsp_types.TextEdit(
+        range=_lsp_range_from_query(edit.range),
+        new_text=edit.new_text,
+    )
+    workspace_edit = lsp_types.WorkspaceEdit(
+        changes={uri: [text_edit]},
+    )
+    return [
+        lsp_types.CodeAction(
+            title="Refine hole",
+            kind=lsp_types.CodeActionKind.RefactorRewrite,
+            edit=workspace_edit,
+        )
+    ]
+
+
 @server.feature(GOAL_AT_REQUEST)
 def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
     """Custom request: return the proof goal at a cursor position.

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -200,6 +200,30 @@ def definition_of(path: str, line: int, column: int) -> Optional[dict]:
 
 
 @mcp.tool()
+def refine_at(path: str, line: int, column: int) -> Optional[dict]:
+    """Propose a refinement template for the hole at ``line``:``column``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token.
+    Returns ``None`` when the cursor isn't on a hole, the file has no
+    incomplete proof at that hole, or the goal shape isn't supported.
+    Otherwise returns a ``{path, range, new_text}`` dict describing
+    the edit to apply.
+
+    Templates by goal shape:
+    - ``true`` -> ``.``
+    - ``P and Q [and R...]`` -> ``?, ?[, ?...]``
+    - ``if P then Q`` -> ``assume H: P\\n?``
+    - ``all x:T. body`` -> ``arbitrary x:T\\n?``
+    - ``some x:T. body`` -> ``choose ?\\n?``
+    - reducible ``e1 = e2`` -> ``reflexive``
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    edit = query.refine_at(path, content, pos, prelude=_prelude_for(path))
+    return _to_serializable(edit)
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -57,11 +57,13 @@ __all__ = [
     "Given",
     "Goal",
     "SymbolInfo",
+    "WorkspaceEdit",
     # Query functions
     "check",
     "goal_at",
     "definition_of",
     "list_symbols",
+    "refine_at",
 ]
 
 
@@ -160,6 +162,28 @@ class Goal:
     formula: str
     givens: tuple
     range: Range
+
+
+@dataclass(frozen=True)
+class WorkspaceEdit:
+    """A single textual edit to apply to a file.
+
+    Adapters map this to their wire-format equivalents:
+
+    - LSP wraps it in ``WorkspaceEdit`` / ``TextDocumentEdit`` /
+      ``TextEdit`` and exposes it via ``textDocument/codeAction``.
+    - MCP returns the dict ``{path, range, new_text}`` as a tool
+      result; the agent applies it through its own edit tooling.
+
+    The semantics are "replace ``range`` with ``new_text``". Multi-
+    file edits and file creates/renames aren't represented here --
+    the Phase-4 refactoring operations in this module all return a
+    single-file, single-range edit, so a flat shape is enough.
+    """
+
+    path: str
+    range: Range
+    new_text: str
 
 
 @dataclass(frozen=True)
@@ -730,3 +754,144 @@ def _symbol_info_for(stmt, path: str) -> Optional[SymbolInfo]:
         location=location,
         signature=signature,
     )
+
+
+# ---------------------------------------------------------------------------
+# refine_at -- Phase 4 / Step 15: hole refine
+# ---------------------------------------------------------------------------
+#
+# Given a cursor on a `?` token, return a WorkspaceEdit that replaces
+# the hole with a tactic skeleton chosen from the goal's shape. The
+# adapters expose this as a code action (LSP) and as an MCP tool.
+#
+# Mechanism: the source already has a `?`, so re-running ``check_file``
+# raises ``IncompleteProof`` at that hole. ``proof_checker.py`` stashes
+# the goal AST and the type-checking env on the exception
+# (``incomplete_error(..., formula=, env=)``), which we read here to
+# select the template -- string-based shape detection isn't expressive
+# enough for the reducible-equality case (``e1.reduce(env) ==
+# e2.reduce(env)``).
+#
+# Limitation (v1): in a multi-theorem file with earlier `?`s, the
+# checker raises on the first hole encountered; the goal returned may
+# not be for the cursor's hole. The same limitation applies to
+# ``goal_at``; both will lift it together when the pipeline gains
+# per-hole goal extraction.
+
+
+def refine_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> Optional[WorkspaceEdit]:
+    """Propose a refinement template for the hole at ``pos``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token
+    in the source. The template is selected based on the goal's shape:
+
+    - ``true`` -> ``.``
+    - ``P and Q [and R...]`` -> ``?, ?[, ?...]``
+    - ``if P then Q`` -> ``assume H: P\\n?``
+    - ``all x:T. body`` -> ``arbitrary x:T\\n?`` (one quantifier per
+      invocation; nested quantifiers are refined in further steps)
+    - ``some x:T. body`` -> ``choose ?\\n?``
+    - reducible ``e1 = e2`` -> ``reflexive``
+
+    Returns ``None`` when the cursor is not on a ``?``, when the file
+    does not raise at a hole, or when the goal shape is not in the
+    list above.
+
+    ``prelude`` matches the meaning in :func:`check`.
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return None
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    formula = getattr(exc, "formula", None)
+    env = getattr(exc, "env", None)
+    if formula is None:
+        return None
+
+    template = _refine_template(formula, env)
+    if template is None:
+        return None
+
+    return WorkspaceEdit(path=path, range=hole_range, new_text=template)
+
+
+def _find_hole_at(content: str, pos: Position) -> Optional[Range]:
+    """Return the source range of a ``?`` token at or adjacent to ``pos``.
+
+    Tries the cursor offset itself, then one position to the left
+    (cursor sits just after the ``?``). Returns ``None`` when neither
+    matches.
+    """
+    offset = _line_col_to_offset(content, pos)
+    if offset is None:
+        return None
+    for try_off in (offset, offset - 1):
+        if 0 <= try_off < len(content) and content[try_off] == "?":
+            return _char_range_at(content, try_off)
+    return None
+
+
+def _char_range_at(content: str, offset: int) -> Range:
+    """Return the 1-indexed Range covering exactly the character at ``offset``."""
+    line, col = _offset_to_line_col(content, offset)
+    return Range(
+        start=Position(line=line, column=col),
+        end=Position(line=line, column=col + 1),
+    )
+
+
+def _offset_to_line_col(content: str, offset: int) -> tuple:
+    """Inverse of ``_line_col_to_offset``: 0-indexed offset to 1-indexed (line, col)."""
+    line = 1
+    line_start = 0
+    for i in range(offset):
+        if content[i] == "\n":
+            line += 1
+            line_start = i + 1
+    return (line, offset - line_start + 1)
+
+
+def _refine_template(formula, env) -> Optional[str]:
+    """Select a refinement template based on the goal AST.
+
+    Imports the AST node classes lazily so this module's import-time
+    cost stays minimal -- the same pattern the rest of ``query.py``
+    uses for pipeline-level imports.
+    """
+    from abstract_syntax import (
+        All, And, Bool, Call, IfThen, Some, Var, base_name,
+    )
+
+    match formula:
+        case Bool(_, _, True):
+            return "."
+        case And(_, _, args):
+            return ", ".join(["?"] * len(args))
+        case IfThen(_, _, prem, _conc):
+            return f"assume H: {prem}\n?"
+        case All(_, _, var, _, _body):
+            x, ty = var
+            return f"arbitrary {base_name(x)}:{ty}\n?"
+        case Some(_, _, vars, _body):
+            choices = ", ".join("?" for _ in vars)
+            return f"choose {choices}\n?"
+        case Call(_, _, Var(_, _, "=", _), [lhs, rhs]) if env is not None:
+            try:
+                if lhs.reduce(env) == rhs.reduce(env):
+                    return "reflexive"
+            except Exception:
+                # If reduction fails (e.g. a malformed env after a
+                # mid-check error), don't crash the editor request --
+                # just report "no template".
+                return None
+            return None
+    return None

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1046,7 +1046,8 @@ def check_proof_of(proof, formula, env):
       incomplete_error(loc, 'incomplete proof\n' \
                        + 'Goal:\n\t' + str(new_formula) + '\n'\
                        + proof_advice(new_formula, env) \
-                       + givens_str(env))
+                       + givens_str(env),
+                       formula=new_formula, env=env)
 
     case PSorry(loc):
       warning(loc, 'unfinished proof')

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -114,6 +114,7 @@ def test_all_expected_features_are_registered():
         lsp_types.TEXT_DOCUMENT_DID_CLOSE,
         lsp_types.TEXT_DOCUMENT_DEFINITION,
         lsp_types.TEXT_DOCUMENT_DOCUMENT_SYMBOL,
+        lsp_types.TEXT_DOCUMENT_CODE_ACTION,
         lsp_server.GOAL_AT_REQUEST,
     }
     assert expected.issubset(set(fm.features))
@@ -408,3 +409,80 @@ def test_path_is_in_lib_helper():
     # Nonexistent path: the resolve() walks the parents that do exist;
     # if its lexical prefix matches lib/, it counts as in lib.
     assert lsp_server._path_is_in_lib("/nope/not-a-path.pf") is False
+
+
+# --------------------------------------------------------------------------
+# Code actions: refine_at (Phase 4 / Step 15)
+# --------------------------------------------------------------------------
+
+
+def test_code_action_offers_refine_when_cursor_on_hole(server, open_doc):
+    """Cursor on a `?` whose goal is a recognised shape -> one
+    RefactorRewrite action carrying a single-file WorkspaceEdit."""
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp, uri = open_doc("refine.pf", src)
+    # LSP coords for the `?` at line 4 col 3 (1-indexed) -- that's
+    # line=3, character=2 in LSP-space.
+    params = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=3, character=2),
+            end=lsp_types.Position(line=3, character=2),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    actions = lsp_server.on_code_action(server, params)
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.title == "Refine hole"
+    assert action.kind == lsp_types.CodeActionKind.RefactorRewrite
+    # The edit has one TextEdit in the file's URI bucket.
+    assert action.edit is not None
+    assert list(action.edit.changes.keys()) == [uri]
+    edits = action.edit.changes[uri]
+    assert len(edits) == 1
+    text_edit = edits[0]
+    assert text_edit.new_text == "reflexive"
+    # Range covers exactly the `?` (LSP 0-indexed: line 3, col 2-3).
+    assert text_edit.range.start == lsp_types.Position(line=3, character=2)
+    assert text_edit.range.end == lsp_types.Position(line=3, character=3)
+
+
+def test_code_action_returns_empty_when_cursor_not_on_hole(server, open_doc):
+    """No `?` near the cursor -> no actions offered."""
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    _, uri = open_doc("complete.pf", src)
+    params = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=3, character=2),
+            end=lsp_types.Position(line=3, character=2),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    assert lsp_server.on_code_action(server, params) == []
+
+
+def test_code_action_with_unknown_uri_returns_empty(server):
+    """Defensive: the workspace doesn't know about this URI."""
+    params = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri="file:///nope.pf"),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=0, character=0),
+            end=lsp_types.Position(line=0, character=0),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    assert lsp_server.on_code_action(server, params) == []

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -85,7 +85,7 @@ async def _call(server, name: str, arguments: dict) -> Any:
 
 
 @pytest.mark.anyio
-async def test_all_four_tools_are_registered(server):
+async def test_all_tools_are_registered(server):
     async with create_connected_server_and_client_session(
         server._mcp_server
     ) as session:
@@ -97,6 +97,7 @@ async def test_all_four_tools_are_registered(server):
             "goal_at",
             "definition_of",
             "list_symbols",
+            "refine_at",
         }
 
 
@@ -249,6 +250,56 @@ async def test_list_symbols_returns_each_top_level_decl(server, tmp_path):
     assert by_name["t1"]["kind"] == "theorem"
     assert by_name["X"]["kind"] == "define"
     assert by_name["Color"]["kind"] == "union"
+
+
+# --------------------------------------------------------------------------
+# refine_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_refine_at_returns_workspace_edit(server, tmp_path):
+    """Cursor on a `?` whose goal is `P = P` -> reflexive template."""
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "refine.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "refine_at",
+        {"path": str(fp), "line": 4, "column": 3},
+    )
+    assert payload is not None
+    assert payload["path"] == str(fp)
+    assert payload["new_text"] == "reflexive"
+    assert payload["range"]["start"] == {"line": 4, "column": 3}
+    assert payload["range"]["end"] == {"line": 4, "column": 4}
+
+
+@pytest.mark.anyio
+async def test_refine_at_returns_null_when_cursor_not_on_hole(
+    server, tmp_path
+):
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    fp = tmp_path / "complete.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "refine_at",
+        {"path": str(fp), "line": 4, "column": 3},
+    )
+    assert payload is None
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -37,10 +37,12 @@ from lsp.query import (  # noqa: E402
     Severity,
     SymbolInfo,
     SymbolKind,
+    WorkspaceEdit,
     check,
     definition_of,
     goal_at,
     list_symbols,
+    refine_at,
 )
 
 
@@ -59,10 +61,12 @@ EXPECTED_PUBLIC = {
     "Given",
     "Goal",
     "SymbolInfo",
+    "WorkspaceEdit",
     "check",
     "goal_at",
     "definition_of",
     "list_symbols",
+    "refine_at",
 }
 
 
@@ -92,7 +96,8 @@ def test_no_protocol_imports():
 
 @pytest.mark.parametrize(
     "cls",
-    [Position, Range, Location, Diagnostic, Given, Goal, SymbolInfo],
+    [Position, Range, Location, Diagnostic, Given, Goal, SymbolInfo,
+     WorkspaceEdit],
 )
 def test_dataclasses_are_frozen(cls):
     """All public data types must be frozen so callers can't mutate
@@ -177,11 +182,19 @@ def test_list_symbols_signature():
     )
 
 
+def test_refine_at_signature():
+    _check_sig(
+        refine_at,
+        ["path", "content", "pos", "prelude"],
+        Optional[WorkspaceEdit],
+    )
+
+
 def test_prelude_param_has_default():
     """``prelude`` is optional on every query function so existing
     Step 3-5 callers (which pass ``path`` and ``content`` only)
     keep working."""
-    for func in (check, goal_at, definition_of, list_symbols):
+    for func in (check, goal_at, definition_of, list_symbols, refine_at):
         prelude_param = inspect.signature(func).parameters["prelude"]
         assert prelude_param.default == (), (
             f"{func.__name__}.prelude default drifted: "
@@ -191,4 +204,5 @@ def test_prelude_param_has_default():
 
 # All Phase 1 query functions are now implemented; their acceptance
 # tests live in test_check.py (Step 3), test_goal_at.py (Step 4), and
-# test_symbols.py (Step 5).
+# test_symbols.py (Step 5). The Phase 4 / Step 15 ``refine_at``
+# acceptance tests live in test_refine.py.

--- a/test/lsp/test_refine.py
+++ b/test/lsp/test_refine.py
@@ -1,0 +1,219 @@
+"""Acceptance tests for ``lsp.query.refine_at`` (Phase 4 / Step 15).
+
+Hand-crafted fixtures embedded inline -- one per template shape worth
+pinning. Each case supplies a snippet of Deduce source, the 1-indexed
+cursor position of the ``?``, and the literal template text that
+``refine_at`` should produce.
+
+All fixtures stay inside ``bool``-only territory so the tests run
+without the standard library prelude. The pipeline reaches the
+cursor's ``?`` (each fixture has exactly one) and ``incomplete_error``
+stashes the goal AST on the exception for ``_refine_template`` to
+match against.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    Range,
+    WorkspaceEdit,
+    refine_at,
+)
+
+
+@dataclass(frozen=True)
+class RefineCase:
+    name: str
+    source: str
+    cursor: Position
+    expected_text: str
+    # 1-indexed range covering exactly the `?` token in ``source``.
+    expected_range: Range
+
+
+CASES = [
+    RefineCase(
+        name="conjunction_two_args",
+        # Goal at the hole: ``(P and Q)``. Template: ``?, ?``.
+        source=(
+            "theorem t: all P:bool, Q:bool. if P then if Q then P and Q\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  suppose pP: P\n"
+            "  suppose qQ: Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=6, column=3),
+        expected_text="?, ?",
+        expected_range=Range(
+            start=Position(line=6, column=3),
+            end=Position(line=6, column=4),
+        ),
+    ),
+    RefineCase(
+        name="conjunction_three_args",
+        # Goal: ``(P and Q and R)``. Template: ``?, ?, ?``.
+        source=(
+            "theorem t: all P:bool, Q:bool, R:bool.\n"
+            "  if P then if Q then if R then P and Q and R\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool, R:bool\n"
+            "  suppose pP: P\n"
+            "  suppose qQ: Q\n"
+            "  suppose rR: R\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=3),
+        expected_text="?, ?, ?",
+        expected_range=Range(
+            start=Position(line=8, column=3),
+            end=Position(line=8, column=4),
+        ),
+    ),
+    RefineCase(
+        name="implication",
+        # Goal: ``(if P then P)``. Template: ``assume H: P\n?``.
+        source=(
+            "theorem t: all P:bool. if P then P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=4, column=3),
+        expected_text="assume H: P\n?",
+        expected_range=Range(
+            start=Position(line=4, column=3),
+            end=Position(line=4, column=4),
+        ),
+    ),
+    RefineCase(
+        name="forall",
+        # Goal: ``(all P:bool. P = P)``. Template: ``arbitrary P:bool\n?``.
+        source=(
+            "theorem t: all P:bool. P = P\n"
+            "proof\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=3, column=3),
+        expected_text="arbitrary P:bool\n?",
+        expected_range=Range(
+            start=Position(line=3, column=3),
+            end=Position(line=3, column=4),
+        ),
+    ),
+    RefineCase(
+        name="reflexive_equality",
+        # Goal at hole (after `arbitrary`): ``P = P``. Both sides
+        # already reduce to the same term, so template is
+        # ``reflexive``.
+        source=(
+            "theorem t: all P:bool. P = P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=4, column=3),
+        expected_text="reflexive",
+        expected_range=Range(
+            start=Position(line=4, column=3),
+            end=Position(line=4, column=4),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_refine_at_template(case: RefineCase) -> None:
+    edit = refine_at("test.pf", case.source, case.cursor)
+    assert edit is not None, f"{case.name}: refine_at returned None"
+    assert isinstance(edit, WorkspaceEdit)
+    assert edit.path == "test.pf"
+    assert edit.range == case.expected_range, (
+        f"{case.name}: range mismatch\n"
+        f"  expected: {case.expected_range}\n"
+        f"  got:      {edit.range}"
+    )
+    assert edit.new_text == case.expected_text, (
+        f"{case.name}: new_text mismatch\n"
+        f"  expected: {case.expected_text!r}\n"
+        f"  got:      {edit.new_text!r}"
+    )
+
+
+def test_refine_at_returns_none_when_cursor_not_on_hole() -> None:
+    """No `?` at or adjacent to the cursor -> no edit."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    # Cursor on the `r` of `reflexive` -- no hole anywhere near.
+    assert refine_at("test.pf", source, Position(line=4, column=3)) is None
+
+
+def test_refine_at_returns_none_for_unsupported_goal_shape() -> None:
+    """A bare bool atom (no logical structure) has no template here."""
+    # Goal at hole: ``P`` (a bool literal-shape variable). Not in the
+    # template table, so refine_at returns None rather than guess.
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  suppose pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = refine_at("test.pf", source, Position(line=5, column=3))
+    assert edit is None
+
+
+def test_refine_at_returns_none_when_file_is_complete() -> None:
+    """File without a hole -> nothing for refine_at to do."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    # Cursor wherever; there's no ? in the source.
+    assert refine_at("test.pf", source, Position(line=3, column=3)) is None
+
+
+def test_refine_at_cursor_one_position_after_hole() -> None:
+    """Cursor immediately after the `?` should still match it.
+
+    Eglot sends the cursor at the column past the character; this
+    keeps the editor UX intuitive (`C-c C-r` while typing right after
+    a hole).
+    """
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor at col 4, one past the `?` at col 3.
+    edit = refine_at("test.pf", source, Position(line=4, column=4))
+    assert edit is not None
+    assert edit.new_text == "reflexive"
+    assert edit.range.start == Position(line=4, column=3)


### PR DESCRIPTION
## Summary

First Phase-4 structured-editing operation. Given a cursor on a `?` token, propose a refinement template chosen from the goal's shape. Lays the `WorkspaceEdit` + `textDocument/codeAction` plumbing that Steps 16 (case split) and 17 (induction skeleton) will reuse.

Templates by goal shape (matched on the goal AST, not its rendered text — reducible equality needs `lhs.reduce(env) == rhs.reduce(env)`):

| Goal shape | Template |
|---|---|
| `true` | `.` |
| `P and Q [and R...]` | `?, ?[, ?...]` |
| `if P then Q` | `assume H: P\n?` |
| `all x:T. body` | `arbitrary x:T\n?` (one quantifier per call) |
| `some x:T. body` | `choose ?\n?` |
| reducible `e1 = e2` | `reflexive` |

## Mechanism

The source already has a `?`, so re-running `check_file` raises `IncompleteProof` at that hole. `incomplete_error` gains optional `formula=` and `env=` kwargs; the `PHole` case in `proof_checker.py` passes them, so the goal AST and proof env are visible to `refine_at` without re-parsing strings. The CLI error message is byte-for-byte unchanged — the kwargs are stashed on the exception object, `str(exc)` is identical, and the 153 should-error fixtures all match unchanged.

## New surface

`lsp/query.py`:
- `WorkspaceEdit(path, range, new_text)` — frozen dataclass, single-file/single-range. Added to `__all__`.
- `refine_at(path, content, pos, prelude=()) -> Optional[WorkspaceEdit]` — returns `None` when the cursor isn't on a `?`, the file has no incomplete proof there, or the goal shape isn't recognised.

Adapter wiring:
- **`lsp_server.py`**: new `textDocument/codeAction` handler. Surfaces `refine_at`'s output as a `RefactorRewrite` `CodeAction` carrying a single-file `WorkspaceEdit`. Eglot exposes this via `M-x eglot-code-actions`.
- **`mcp_server.py`**: new `refine_at` MCP tool returning the `{path, range, new_text}` dict for Claude Code to apply.

## Limitation (v1)

In a multi-theorem file with earlier `?`s, the checker raises on the first hole encountered, so the goal returned may not be the cursor's hole. Same limitation as `goal_at`; both will lift it together when the pipeline gains per-hole goal extraction. Single-theorem files (the typical interactive editing scenario) work correctly.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 542 pass (was 526; +9 refine, +3 codeAction, +2 MCP, +2 signature lock)
- [x] `python3 test-deduce.py --errors` — all 153 should-error fixtures still match (CLI error messages unchanged)
- [x] `python3 test-deduce.py --passable` — should-validate suite passes on both `--recursive-descent` and `--lalr`
- [ ] Manual smoke: open `lib/Nat.pf`, place point inside an empty proof body, type `?`, press `M-x eglot-code-actions`, confirm "Refine hole" appears and applies the right template
- [ ] After merge: continue with Step 16 (case split) — reuses the same WorkspaceEdit plumbing

## Files changed

- `error.py` (+5 / -0): optional `formula=` / `env=` on `incomplete_error`
- `proof_checker.py` (+2 / -1): pass formula + env at the `PHole` site
- `lsp/query.py` (+165): `WorkspaceEdit` + `refine_at` + helpers
- `lsp/lsp_server.py` (+47): `on_code_action` handler
- `lsp/mcp_server.py` (+24): `refine_at` MCP tool
- `test/lsp/test_refine.py` (new, 200 lines): 9 acceptance tests
- `test/lsp/test_lsp_server.py` (+78): 3 codeAction tests
- `test/lsp/test_mcp_server.py` (+53): 2 MCP refine tests + tool-list rename
- `test/lsp/test_query.py` (+20): signature lock additions