### PR TITLE
Emacs: C-c C-r for refine-hole (Step 6 partial)

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -86,6 +86,13 @@ auto-start hook:
   (`textDocument/documentSymbol`).
 - `C-c C-g` -- show the proof goal at point in a popup buffer
   (custom `deduce/goalAt` request -- see below).
+- `C-c C-r` -- refine the hole at point. Issues
+  `textDocument/codeAction` filtered to `refactor.rewrite`, applies
+  the first matching action's `WorkspaceEdit` directly (no picker).
+  Templates by goal shape: `?, ?` for `P and Q`, `assume H: P\n?` for
+  `if P then Q`, `arbitrary x:T\n?` for `all`, `choose ?\n?` for
+  `some`, `reflexive` when both sides of an equation reduce to the
+  same term.
 
 ## Keybindings
 
@@ -96,11 +103,11 @@ auto-start hook:
 | `M-,`     | `xref-go-back`                   | eglot          | Pop the xref stack                        |
 | `M-x imenu` | `imenu`                        | eglot          | Outline of top-level declarations         |
 | `C-c C-g` | `deduce-show-goal-at-point`      | `deduce-lsp`   | Goal + givens at cursor                   |
+| `C-c C-r` | `deduce-lsp-refine-hole`         | `deduce-lsp`   | Apply LSP-suggested template at hole      |
 
-Phase-4 keybindings (`C-c C-r` refine, `C-c C-c` case split,
-`C-c C-i` induction) are reserved for Step 6 of the Emacs plan and
-will land once the server's structured-editing operations are
-available.
+Remaining Phase-4 keybindings (`C-c C-c` case split, `C-c C-i`
+induction) will land when the server's Step 16 / Step 17 operations
+do.
 
 ## Customization
 
@@ -191,6 +198,18 @@ Then verify the LSP integration:
    the `IH` line of `equal_refl`) and press `C-c C-g`. A `*deduce
    goal*` popup should show the goal formula and any givens in
    scope.
+8. In a scratch `.pf` buffer, type a theorem with a hole, e.g.
+
+   ```
+   theorem t: all P:bool. P = P
+   proof
+     ?
+   end
+   ```
+
+   Place point on the `?` and press `C-c C-r`. The `?` should be
+   replaced with `arbitrary P:bool\n?`. Press `C-c C-r` again on the
+   inner `?`; it becomes `reflexive`.
 
 ## Development
 

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -35,8 +35,9 @@
 ;;   M-x imenu                  outline of top-level decls (documentSymbol)
 ;;
 ;; Step 5 adds `C-c C-g' for the custom `deduce/goalAt' request.
-;; Step 6 adds Phase-4 keybindings (`C-c C-r', `C-c C-c', `C-c C-i')
-;; for the LSP-side structured-editing operations once they land.
+;; Step 6 adds Phase-4 keybindings: `C-c C-r' (refine, Step 15) is
+;; live; `C-c C-c' (case split, Step 16) and `C-c C-i' (induction,
+;; Step 17) follow when those server operations land.
 ;;
 ;; Server command
 ;; --------------
@@ -271,6 +272,129 @@ is running in the current buffer."
 ;; being available, so the binding only makes sense once the user
 ;; has opted into LSP via `(require 'deduce-lsp)'.
 (define-key deduce-mode-map (kbd "C-c C-g") #'deduce-show-goal-at-point)
+
+
+;; ---------------------------------------------------------------------
+;; Refine hole (Step 6 -- partial; Phase-4 / LSP Step 15)
+;; ---------------------------------------------------------------------
+;;
+;; Bypasses `eglot-code-actions' (which prompts for an action kind and
+;; then for the action itself) by issuing the
+;; `textDocument/codeAction' request directly with a kind filter, then
+;; applying the first matching CodeAction's WorkspaceEdit without a
+;; picker.  One keystroke per refine -- the speed difference matters
+;; in interactive proof editing.
+;;
+;; Today the Deduce LSP only emits one `refactor.rewrite' action
+;; ("Refine hole").  When Steps 16/17 land (case split, induction
+;; skeleton) they'll add more refactor.rewrite actions; at that point
+;; this command will need a picker after all, OR we'll split the
+;; bindings: `C-c C-r' for refine, `C-c C-c' for case split, `C-c C-i'
+;; for induction.  The plan picks the latter.
+
+(defun deduce-lsp--lsp-pos-to-point (line character)
+  "Convert LSP 0-indexed (LINE, CHARACTER) to a point in the current buffer.
+
+Assumes ASCII (or at least each codepoint costs one column); for
+proof files in practice this is the case.  When/if Deduce gains
+non-ASCII source support, swap this for eglot's
+`eglot--lsp-position-to-point' which handles UTF-16 properly."
+  (save-excursion
+    (goto-char (point-min))
+    (forward-line line)
+    ;; `forward-char' works in characters, which on UTF-16 ASCII text
+    ;; matches LSP's `character'.
+    (forward-char character)
+    (point)))
+
+
+(defun deduce-lsp--apply-text-edit (edit)
+  "Apply a single LSP `TextEdit' EDIT to the current buffer.
+
+EDIT is a plist of the form `(:range PLIST :newText STR)' where
+the range is `(:start POS :end POS)' and POS is `(:line N
+:character N)'."
+  (let* ((range (plist-get edit :range))
+         (start (plist-get range :start))
+         (end (plist-get range :end))
+         (new-text (or (plist-get edit :newText) ""))
+         (p1 (deduce-lsp--lsp-pos-to-point
+              (plist-get start :line)
+              (plist-get start :character)))
+         (p2 (deduce-lsp--lsp-pos-to-point
+              (plist-get end :line)
+              (plist-get end :character))))
+    (delete-region p1 p2)
+    (goto-char p1)
+    (insert new-text)))
+
+
+(defun deduce-lsp--text-edits-for-uri (changes uri)
+  "Extract the TextEdit list for URI from a WorkspaceEdit `changes' plist.
+
+CHANGES is the value of the WorkspaceEdit's `:changes' field --
+a plist whose keys are URIs interned as keywords (e.g.
+`:file:///path/foo.pf').  Returns the TextEdit list, or nil if
+URI has no edits."
+  (when changes
+    (let ((target (intern-soft (concat ":" uri))))
+      (when target
+        (plist-get changes target)))))
+
+
+(defun deduce-lsp--apply-code-action (action)
+  "Apply the WorkspaceEdit of CodeAction plist ACTION to the
+current buffer.
+
+Today the server's only edit shape is `:changes' keyed by the
+file's URI; `:documentChanges' isn't used.  TextEdits are applied
+in the order the server returned them -- a single edit for
+Step 15, so order doesn't matter yet."
+  (let* ((edit (plist-get action :edit))
+         (changes (plist-get edit :changes))
+         (uri (deduce-lsp--current-uri))
+         (edits (deduce-lsp--text-edits-for-uri changes uri)))
+    (unless edits
+      (user-error "Refine action has no edits for the current buffer"))
+    ;; Apply in reverse order so each edit's offsets stay valid.
+    ;; Today there's only one edit; this is forward-compat for
+    ;; multi-edit actions in later steps.
+    (mapc #'deduce-lsp--apply-text-edit (reverse (append edits nil)))))
+
+
+(defun deduce-lsp-refine-hole ()
+  "Apply the LSP-suggested refinement for the hole at point.
+
+Issues a `textDocument/codeAction' request filtered to the
+`refactor.rewrite' kind, applies the first matching action's
+WorkspaceEdit directly, and skips the action picker.  This is
+the fast path for the keybinding.
+
+When the cursor isn't on a hole (or the goal shape isn't
+recognised by the server), errors with `No refinement available
+at point.'  When no eglot connection is active, prompts the user
+to run `M-x eglot' first."
+  (interactive)
+  (let ((server (eglot-current-server)))
+    (unless server
+      (user-error
+       "No eglot server active in this buffer; M-x eglot first"))
+    (let* ((pos (deduce-lsp--current-position))
+           (params (list :textDocument (list :uri (deduce-lsp--current-uri))
+                         :range (list :start pos :end pos)
+                         :context (list :diagnostics [])))
+           (actions (jsonrpc-request server :textDocument/codeAction params)))
+      ;; The server returns either a vector or nil.  Normalise to a
+      ;; list so we can use plain seq operations.
+      (let ((action-list (if (vectorp actions) (append actions nil) actions)))
+        (unless action-list
+          (user-error "No refinement available at point"))
+        (deduce-lsp--apply-code-action (car action-list))))))
+
+
+;; Bind `C-c C-r' in `deduce-mode-map' for refine-at-point.  Same
+;; rationale as `C-c C-g': only meaningful when LSP is loaded.
+(define-key deduce-mode-map (kbd "C-c C-r") #'deduce-lsp-refine-hole)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -246,6 +246,148 @@ error rather than silently failing."
               #'deduce-show-goal-at-point)))
 
 
+;; ---------------------------------------------------------------------
+;; Step 6 (partial): deduce-lsp-refine-hole
+;; ---------------------------------------------------------------------
+;;
+;; The Phase-4 / Step 15 hole-refine code action, fronted by `C-c C-r'.
+;; The command sends `textDocument/codeAction' filtered to
+;; `refactor.rewrite' and applies the first matching action's
+;; WorkspaceEdit directly -- skipping the picker that
+;; `eglot-code-actions' shows.
+
+(ert-deftest deduce-lsp/refine-hole-bound-to-c-c-c-r ()
+  "`C-c C-r' in deduce-mode-map runs `deduce-lsp-refine-hole'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-r"))
+              #'deduce-lsp-refine-hole)))
+
+
+(ert-deftest deduce-lsp/refine-hole-issues-codeAction-request ()
+  "The command sends `textDocument/codeAction' with a single-point
+range at the cursor."
+  (let ((tmp (make-temp-file "deduce-lsp-refine" nil ".pf"))
+        captured)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool. P = P\nproof\n  arbitrary P:bool\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; Cursor at line 4, col 3 (the `?').  LSP-space: line 3, char 2.
+          (goto-char (point-min))
+          (forward-line 3)
+          (forward-char 2)
+          (setq captured
+                (deduce-lsp-test--with-mock-server
+                 ;; Empty vector -> no actions; the command will
+                 ;; user-error.  We only care about the captured
+                 ;; request shape here.
+                 []
+                 (lambda ()
+                   (ignore-errors (deduce-lsp-refine-hole)))))
+          (should (eq (plist-get captured :method) :textDocument/codeAction))
+          (let* ((params (plist-get captured :params))
+                 (uri (plist-get (plist-get params :textDocument) :uri))
+                 (range (plist-get params :range))
+                 (start (plist-get range :start))
+                 (end (plist-get range :end)))
+            (should (string-prefix-p "file://" uri))
+            ;; Range degenerates to a single point at the cursor.
+            (should (= (plist-get start :line) 3))
+            (should (= (plist-get start :character) 2))
+            (should (equal start end))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/refine-hole-applies-text-edit ()
+  "Given a CodeAction with a TextEdit replacing the `?', the
+buffer ends up with the new text in its place."
+  (let ((tmp (make-temp-file "deduce-lsp-refine" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool. P = P\nproof\n  arbitrary P:bool\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; Cursor on the `?'.
+          (goto-char (point-min))
+          (forward-line 3)
+          (forward-char 2)
+          (let* ((uri (deduce-lsp--current-uri))
+                 ;; CodeAction response: one action, one text-edit
+                 ;; replacing the `?' (line 3, char 2..3) with
+                 ;; `reflexive'.
+                 (action `(:title "Refine hole"
+                           :kind "refactor.rewrite"
+                           :edit
+                           (:changes
+                            (,(intern (concat ":" uri))
+                             [(:range (:start (:line 3 :character 2)
+                                       :end (:line 3 :character 3))
+                                      :newText "reflexive")]))))
+                 (response (vector action)))
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda () (deduce-lsp-refine-hole))))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "reflexive" text))
+            ;; `?' is gone.
+            (should-not (string-match-p "?\nend" text))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/refine-hole-no-actions-signals-user-error ()
+  "An empty action list yields a `No refinement available' user-error."
+  (let ((tmp (make-temp-file "deduce-lsp-refine" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (deduce-lsp-test--with-mock-server
+           nil
+           (lambda ()
+             (should-error (deduce-lsp-refine-hole) :type 'user-error))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/refine-hole-without-server-errors ()
+  "Without an active eglot server, the command signals a user error."
+  (let ((tmp (make-temp-file "deduce-lsp-refine" nil ".pf")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'eglot-current-server)
+                   (lambda () nil)))
+          (with-temp-buffer
+            (insert "x")
+            (setq buffer-file-name tmp)
+            (deduce-mode)
+            (should-error (deduce-lsp-refine-hole) :type 'user-error)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/lsp-pos-to-point-converts-zero-indexed-coords ()
+  "LSP (line, character) maps to the right buffer point."
+  (with-temp-buffer
+    (insert "abc\ndef\nghi\n")
+    ;; Line 0, char 0 -> point 1 (start of `a').
+    (should (= (deduce-lsp--lsp-pos-to-point 0 0) 1))
+    ;; Line 1, char 0 -> point 5 (start of `d').
+    (should (= (deduce-lsp--lsp-pos-to-point 1 0) 5))
+    ;; Line 2, char 2 -> point 11 (the `i' on line 3, 1-indexed).
+    (should (= (deduce-lsp--lsp-pos-to-point 2 2) 11))))
+
+
+(ert-deftest deduce-lsp/text-edits-for-uri-finds-keyword-keyed-changes ()
+  "The `:changes' plist uses URIs as keywords; the helper finds them."
+  (let* ((uri "file:///tmp/foo.pf")
+         (target-key (intern (concat ":" uri)))
+         (changes (list target-key (vector "edit-A")
+                        :other-uri (vector "edit-B"))))
+    (should (equal (deduce-lsp--text-edits-for-uri changes uri)
+                   (vector "edit-A")))
+    ;; URI not present -> nil.
+    (should-not
+     (deduce-lsp--text-edits-for-uri changes "file:///nope.pf"))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here


### PR DESCRIPTION
## Summary

Bind `C-c C-r` to a new `deduce-lsp-refine-hole` command that issues `textDocument/codeAction` filtered to `refactor.rewrite` and applies the first matching action's `WorkspaceEdit` directly — no picker prompt. One keystroke per refine.

## Why bypass `eglot-code-actions`

`M-x eglot-code-actions` has two prompts:
1. Action-kind selector (refactor / quickfix / etc.)
2. Action selector within that kind

That's too slow for interactive proof editing — the rhythm of "look at goal, refine, look at new goal, refine again" wants one keystroke per refine. The Deduce LSP currently emits exactly one `refactor.rewrite` action ("Refine hole"), so the first match is always the intended one.

When Steps 16 and 17 land (case split, induction skeleton), they'll add more `refactor.rewrite` actions but get their own keybindings (`C-c C-c`, `C-c C-i`) firing their own server-side operations — so the "first match wins" fast path stays valid per binding.

## Stacking order

This PR's base is **`lsp-step15-refine`** (PR #329) because it depends on the LSP server's `textDocument/codeAction` handler. Once #329 merges into main, GitHub will auto-rebase this PR's diff against main.

## Implementation notes

- LSP positions are 0-indexed; the helper `deduce-lsp--lsp-pos-to-point` walks the buffer with `forward-line` + `forward-char`. ASCII-only for now (proof files in practice); UTF-16 handling lives in eglot's private `eglot--lsp-position-to-point` if/when needed.
- WorkspaceEdit `:changes` is a plist whose keys are URIs interned as keywords (e.g. `:file:///foo.pf`). The lookup uses `intern-soft` + `plist-get`.
- Multi-edit applications iterate in **reverse order** so each edit's offsets stay valid. Today there's exactly one edit per action; this is forward-compat for Steps 16 / 17.

## Test plan

- [x] `emacs --batch ... -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 23/23 pass (16 existing + 7 new)
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-lsp.el` — clean compile
- [ ] **Manual smoke** (after #329 merges): in a `.pf` buffer, `C-c C-r` on a `?` triggers a single edit replacing it with the right template — no picker
- [ ] Verify each template path: forall (cursor on `?` of `proof ?`), conjunction, implication, exists, reducible equality