### PR TITLE
Fix refine: pick fresh H<N> label for assume template

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -877,7 +877,8 @@ def _refine_template(formula, env) -> Optional[str]:
         case And(_, _, args):
             return ", ".join(["?"] * len(args))
         case IfThen(_, _, prem, _conc):
-            return f"assume H: {prem}\n?"
+            label = _fresh_assume_label(env)
+            return f"assume {label}: {prem}\n?"
         case All(_, _, var, _, _body):
             x, ty = var
             return f"arbitrary {base_name(x)}:{ty}\n?"
@@ -895,3 +896,29 @@ def _refine_template(formula, env) -> Optional[str]:
                 return None
             return None
     return None
+
+
+def _fresh_assume_label(env) -> str:
+    """Return the lowest ``H<N>`` (N >= 1) not already bound in ``env``.
+
+    Successive ``assume H1: ...``, ``assume H2: ...`` invocations
+    keep climbing rather than collide -- otherwise repeatedly
+    refining nested implications produces several ``assume H: ...``
+    lines in a row, which Deduce accepts (with a warning) but
+    confuses any subsequent proof step that names the hypothesis.
+
+    Checks against the *base* names in ``env.dict`` so we look at
+    pre-uniquification source-level identifiers, not the post-
+    uniquify ``foo.42`` form. Falls back to ``"H1"`` when ``env``
+    is None (the `IfThen` case is reachable today only via the
+    `IncompleteProof` exception, so ``env`` is always non-None in
+    practice; the guard is for defensive composition).
+    """
+    if env is None:
+        return "H1"
+    from abstract_syntax import base_name
+    used_bases = {base_name(k) for k in env.dict.keys()}
+    n = 1
+    while f"H{n}" in used_bases:
+        n += 1
+    return f"H{n}"

--- a/test/lsp/test_refine.py
+++ b/test/lsp/test_refine.py
@@ -85,7 +85,8 @@ CASES = [
     ),
     RefineCase(
         name="implication",
-        # Goal: ``(if P then P)``. Template: ``assume H: P\n?``.
+        # Goal: ``(if P then P)``. Template uses ``H1`` (no other
+        # ``H<N>`` is in scope yet, so we start at 1).
         source=(
             "theorem t: all P:bool. if P then P\n"
             "proof\n"
@@ -94,10 +95,51 @@ CASES = [
             "end\n"
         ),
         cursor=Position(line=4, column=3),
-        expected_text="assume H: P\n?",
+        expected_text="assume H1: P\n?",
         expected_range=Range(
             start=Position(line=4, column=3),
             end=Position(line=4, column=4),
+        ),
+    ),
+    RefineCase(
+        name="implication_picks_H2_when_H1_in_scope",
+        # Regression for the label-collision bug: the user already
+        # has ``H1`` in scope from a prior ``assume H1:``. The
+        # template must pick the next free ``H<N>``, i.e. ``H2``,
+        # rather than re-using ``H`` or ``H1``.
+        source=(
+            "theorem t: all P:bool, Q:bool. if P then if Q then P\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  assume H1: P\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=5, column=3),
+        expected_text="assume H2: Q\n?",
+        expected_range=Range(
+            start=Position(line=5, column=3),
+            end=Position(line=5, column=4),
+        ),
+    ),
+    RefineCase(
+        name="implication_picks_H3_when_H1_and_H2_in_scope",
+        # Two hypotheses already in scope -> next is H3.
+        source=(
+            "theorem t: all P:bool, Q:bool, R:bool.\n"
+            "  if (if P and Q then R) then if Q then if P then R\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool, R:bool\n"
+            "  assume H1: (if (P and Q) then R)\n"
+            "  assume H2: Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=7, column=3),
+        expected_text="assume H3: P\n?",
+        expected_range=Range(
+            start=Position(line=7, column=3),
+            end=Position(line=7, column=4),
         ),
     ),
     RefineCase(


### PR DESCRIPTION
## Summary

Reported by manual smoke on `ex_all_if_and`: three successive `C-c C-r` invocations on nested implications produced

```
assume H: (if (P and Q) then R)
assume H: Q
assume H: P
```

— same label `H` every time. Deduce accepts this with a warning but the bindings shadow each other, so any later proof step that names the hypothesis sees only the innermost one. After this fix, the same flow produces `H1`, `H2`, `H3`.

## The fix

`_refine_template` now calls `_fresh_assume_label(env)` for the IfThen case. The helper scans `env.dict` for proof-binding **base names** (source-level identifiers, before uniquify suffixes them with `.42` etc.) and returns the lowest `H<N>` not already in scope.

The base-name check is what makes this work — Deduce's uniquify pass renames every binding to a globally unique form, so a literal `"H1" in env` check would always say "free." Stripping back to the source-level name catches the user's prior `assume H1:` regardless of what suffix it grew internally.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 544 pass (was 542; +2 new tests)
- [x] Manual end-to-end simulation on the reported theorem: three successive refines produce `H1` → `H2` → `H3`, then stop at the inner atom `R` (no further template — correct)
- [x] `python3 test-deduce.py --errors` — 153/153 should-error fixtures unchanged

## Tests added

- `implication_picks_H2_when_H1_in_scope` — one prior `assume H1:` in scope
- `implication_picks_H3_when_H1_and_H2_in_scope` — the user's exact 3-implication structure
- Updated the existing `implication` test from `assume H:` to `assume H1:` (the new starting point)

## Side note (out of scope here)

The end-to-end simulation also surfaced an indentation issue: the second and third `assume H<N>:` lines lose the surrounding `  ` indent because the template `"assume HN: ...\n?"` doesn't carry the indent level. That's a separate quality-of-life fix; the label collision was the show-stopper and is what this PR addresses.