### PR TITLE
LSP Phase 4 / Step 16: case split via WorkspaceEdit

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -87,12 +87,17 @@ auto-start hook:
 - `C-c C-g` -- show the proof goal at point in a popup buffer
   (custom `deduce/goalAt` request -- see below).
 - `C-c C-r` -- refine the hole at point. Issues
-  `textDocument/codeAction` filtered to `refactor.rewrite`, applies
-  the first matching action's `WorkspaceEdit` directly (no picker).
-  Templates by goal shape: `?, ?` for `P and Q`, `assume H: P\n?` for
-  `if P then Q`, `arbitrary x:T\n?` for `all`, `choose ?\n?` for
-  `some`, `reflexive` when both sides of an equation reduce to the
-  same term.
+  `textDocument/codeAction` and applies the action titled `Refine
+  hole` directly (no picker). Templates by goal shape: `?, ?` for `P
+  and Q`, `assume H: P\n?` for `if P then Q`, `arbitrary x:T\n?` for
+  `all`, `choose ?\n?` for `some`, `reflexive` when both sides of an
+  equation reduce to the same term.
+- `C-c C-c` -- case split on the variable at point. Issues
+  `textDocument/codeAction` and applies the action titled `Case
+  split` directly. Replaces the next `?` in the surrounding proof
+  body with a `switch x { case Cons1(...) { ? } ... }` skeleton (for
+  term variables of `Union` type) or `cases H\n  case h1: P { ? }
+  ...` (for proof variables of `P or Q` shape).
 
 ## Keybindings
 
@@ -104,10 +109,10 @@ auto-start hook:
 | `M-x imenu` | `imenu`                        | eglot          | Outline of top-level declarations         |
 | `C-c C-g` | `deduce-show-goal-at-point`      | `deduce-lsp`   | Goal + givens at cursor                   |
 | `C-c C-r` | `deduce-lsp-refine-hole`         | `deduce-lsp`   | Apply LSP-suggested template at hole      |
+| `C-c C-c` | `deduce-lsp-case-split`          | `deduce-lsp`   | Apply LSP-suggested case-split skeleton   |
 
-Remaining Phase-4 keybindings (`C-c C-c` case split, `C-c C-i`
-induction) will land when the server's Step 16 / Step 17 operations
-do.
+The remaining Phase-4 keybinding (`C-c C-i` induction) will land
+when the server's Step 17 operation does.
 
 ## Customization
 
@@ -210,6 +215,25 @@ Then verify the LSP integration:
    Place point on the `?` and press `C-c C-r`. The `?` should be
    replaced with `arbitrary P:bool\n?`. Press `C-c C-r` again on the
    inner `?`; it becomes `reflexive`.
+9. In a scratch `.pf` buffer with a custom union, e.g.
+
+   ```
+   union N {
+     z
+     s(N)
+   }
+
+   theorem t: all x:N. x = x
+   proof
+     arbitrary x:N
+     ?
+   end
+   ```
+
+   Place point on the `x` after `arbitrary` and press `C-c C-c`. The
+   `?` should be replaced with a `switch x { case z { ? } case s(n1)
+   { ? } }` skeleton. Each branch is now its own hole that
+   `C-c C-r` / `C-c C-c` can refine further.
 
 ## Development
 

--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -92,12 +92,16 @@ auto-start hook:
   and Q`, `assume H: P\n?` for `if P then Q`, `arbitrary x:T\n?` for
   `all`, `choose ?\n?` for `some`, `reflexive` when both sides of an
   equation reduce to the same term.
-- `C-c C-c` -- case split on the variable at point. Issues
-  `textDocument/codeAction` and applies the action titled `Case
-  split` directly. Replaces the next `?` in the surrounding proof
-  body with a `switch x { case Cons1(...) { ? } ... }` skeleton (for
+- `C-c C-c` -- case split. Cursor must sit on a `?`. Issues
+  `deduce/splittableVarsAt` to fetch the in-scope variables that
+  case-split can target, prompts via `completing-read` (TAB
+  completion) for which one to split on, then issues
+  `deduce/caseSplitAt` with the chosen variable. Replaces the `?`
+  with a `switch x { case Cons1(...) { ? } ... }` skeleton (for
   term variables of `Union` type) or `cases H\n  case h1: P { ? }
-  ...` (for proof variables of `P or Q` shape).
+  ...` (for proof variables of `P or Q` shape). The `?` under the
+  cursor is unambiguously the replacement target -- no surprise
+  inserts at the wrong hole.
 
 ## Keybindings
 
@@ -109,7 +113,7 @@ auto-start hook:
 | `M-x imenu` | `imenu`                        | eglot          | Outline of top-level declarations         |
 | `C-c C-g` | `deduce-show-goal-at-point`      | `deduce-lsp`   | Goal + givens at cursor                   |
 | `C-c C-r` | `deduce-lsp-refine-hole`         | `deduce-lsp`   | Apply LSP-suggested template at hole      |
-| `C-c C-c` | `deduce-lsp-case-split`          | `deduce-lsp`   | Apply LSP-suggested case-split skeleton   |
+| `C-c C-c` | `deduce-lsp-case-split`          | `deduce-lsp`   | Prompt for variable, replace `?` with case skeleton |
 
 The remaining Phase-4 keybinding (`C-c C-i` induction) will land
 when the server's Step 17 operation does.
@@ -230,10 +234,12 @@ Then verify the LSP integration:
    end
    ```
 
-   Place point on the `x` after `arbitrary` and press `C-c C-c`. The
-   `?` should be replaced with a `switch x { case z { ? } case s(n1)
-   { ? } }` skeleton. Each branch is now its own hole that
-   `C-c C-r` / `C-c C-c` can refine further.
+   Place point on the `?` and press `C-c C-c`. Emacs prompts `Case
+   split on:` with TAB completion against the splittable variables
+   in scope (`x` for this fixture). Type `x RET`. The `?` is
+   replaced with `switch x { case z { ? } case s(n1) { ? } }`. Each
+   branch is now its own hole that `C-c C-r` / `C-c C-c` can refine
+   further.
 
 ## Development
 

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -35,9 +35,9 @@
 ;;   M-x imenu                  outline of top-level decls (documentSymbol)
 ;;
 ;; Step 5 adds `C-c C-g' for the custom `deduce/goalAt' request.
-;; Step 6 adds Phase-4 keybindings: `C-c C-r' (refine, Step 15) is
-;; live; `C-c C-c' (case split, Step 16) and `C-c C-i' (induction,
-;; Step 17) follow when those server operations land.
+;; Step 6 adds Phase-4 keybindings: `C-c C-r' (refine, LSP Step 15)
+;; and `C-c C-c' (case split, LSP Step 16) are live; `C-c C-i'
+;; (induction, Step 17) follows when that server operation lands.
 ;;
 ;; Server command
 ;; --------------
@@ -275,22 +275,23 @@ is running in the current buffer."
 
 
 ;; ---------------------------------------------------------------------
-;; Refine hole (Step 6 -- partial; Phase-4 / LSP Step 15)
+;; Phase-4 structured edits (Step 6 -- partial)
 ;; ---------------------------------------------------------------------
 ;;
-;; Bypasses `eglot-code-actions' (which prompts for an action kind and
-;; then for the action itself) by issuing the
-;; `textDocument/codeAction' request directly with a kind filter, then
-;; applying the first matching CodeAction's WorkspaceEdit without a
-;; picker.  One keystroke per refine -- the speed difference matters
-;; in interactive proof editing.
+;; Each binding here issues a `textDocument/codeAction' request and
+;; picks the action whose `:title' matches a fixed string -- bypassing
+;; `eglot-code-actions' (which prompts for an action kind and then for
+;; the action itself).  One keystroke per operation; the speed
+;; difference matters in interactive proof editing.
 ;;
-;; Today the Deduce LSP only emits one `refactor.rewrite' action
-;; ("Refine hole").  When Steps 16/17 land (case split, induction
-;; skeleton) they'll add more refactor.rewrite actions; at that point
-;; this command will need a picker after all, OR we'll split the
-;; bindings: `C-c C-r' for refine, `C-c C-c' for case split, `C-c C-i'
-;; for induction.  The plan picks the latter.
+;; Live bindings (LSP Steps 15-16):
+;;   `C-c C-r'  Refine hole       -- title "Refine hole"  (Step 15)
+;;   `C-c C-c'  Case split        -- title "Case split"   (Step 16)
+;;
+;; Step 17 (induction skeleton) will land as `C-c C-i' once the
+;; server's induction_skeleton_at operation is available.  The pattern
+;; is the same: another defun calling
+;; `deduce-lsp--apply-code-action-by-title'.
 
 (defun deduce-lsp--lsp-pos-to-point (line character)
   "Convert LSP 0-indexed (LINE, CHARACTER) to a point in the current buffer.
@@ -362,19 +363,15 @@ Step 15, so order doesn't matter yet."
     (mapc #'deduce-lsp--apply-text-edit (reverse (append edits nil)))))
 
 
-(defun deduce-lsp-refine-hole ()
-  "Apply the LSP-suggested refinement for the hole at point.
+(defun deduce-lsp--find-action-by-title (title)
+  "Send `textDocument/codeAction' at point, return the action plist
+whose `:title' equals TITLE, or nil if no such action is offered.
 
-Issues a `textDocument/codeAction' request filtered to the
-`refactor.rewrite' kind, applies the first matching action's
-WorkspaceEdit directly, and skips the action picker.  This is
-the fast path for the keybinding.
+Errors out when no eglot server is active in the current buffer
+-- the codeAction request needs a server to run against.
 
-When the cursor isn't on a hole (or the goal shape isn't
-recognised by the server), errors with `No refinement available
-at point.'  When no eglot connection is active, prompts the user
-to run `M-x eglot' first."
-  (interactive)
+This is the shared building block for the Phase-4 keybindings;
+each command wraps it with its own \"not available\" message."
   (let ((server (eglot-current-server)))
     (unless server
       (user-error
@@ -383,18 +380,58 @@ to run `M-x eglot' first."
            (params (list :textDocument (list :uri (deduce-lsp--current-uri))
                          :range (list :start pos :end pos)
                          :context (list :diagnostics [])))
-           (actions (jsonrpc-request server :textDocument/codeAction params)))
-      ;; The server returns either a vector or nil.  Normalise to a
-      ;; list so we can use plain seq operations.
-      (let ((action-list (if (vectorp actions) (append actions nil) actions)))
-        (unless action-list
-          (user-error "No refinement available at point"))
-        (deduce-lsp--apply-code-action (car action-list))))))
+           (actions (jsonrpc-request server :textDocument/codeAction params))
+           ;; The server returns either a vector or nil; normalise.
+           (action-list (if (vectorp actions) (append actions nil) actions)))
+      (seq-find
+       (lambda (a) (equal (plist-get a :title) title))
+       action-list))))
 
 
-;; Bind `C-c C-r' in `deduce-mode-map' for refine-at-point.  Same
-;; rationale as `C-c C-g': only meaningful when LSP is loaded.
+(defun deduce-lsp-refine-hole ()
+  "Apply the LSP-suggested refinement for the hole at point.
+
+Issues a `textDocument/codeAction' request and picks the action
+titled \"Refine hole\" -- the LSP server's Step-15 output.  The
+matching action's WorkspaceEdit is applied directly, skipping the
+action picker.  This is the fast path for the keybinding.
+
+When the cursor isn't on a hole (or the goal shape isn't
+recognised by the server), errors with `No refinement available
+at point.'  When no eglot connection is active, prompts the user
+to run `M-x eglot' first."
+  (interactive)
+  (let ((action (deduce-lsp--find-action-by-title "Refine hole")))
+    (unless action
+      (user-error "No refinement available at point"))
+    (deduce-lsp--apply-code-action action)))
+
+
+(defun deduce-lsp-case-split ()
+  "Apply the LSP-suggested case split for the variable at point.
+
+Issues a `textDocument/codeAction' request and picks the action
+titled \"Case split\" -- the LSP server's Step-16 output.  The
+matching action's WorkspaceEdit replaces the next `?' in the
+surrounding proof body with a `switch' (term-level Union) or
+`cases' (proof-level disjunction) skeleton.
+
+When the cursor isn't on a variable whose shape supports case
+splitting -- or no `?' follows it in the proof body -- errors
+with `No case split available at point.'  When no eglot
+connection is active, prompts the user to run `M-x eglot' first."
+  (interactive)
+  (let ((action (deduce-lsp--find-action-by-title "Case split")))
+    (unless action
+      (user-error "No case split available at point"))
+    (deduce-lsp--apply-code-action action)))
+
+
+;; Bind `C-c C-r' (refine) and `C-c C-c' (case split) in
+;; `deduce-mode-map'.  Same rationale as `C-c C-g': only meaningful
+;; when LSP is loaded.
 (define-key deduce-mode-map (kbd "C-c C-r") #'deduce-lsp-refine-hole)
+(define-key deduce-mode-map (kbd "C-c C-c") #'deduce-lsp-case-split)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -278,20 +278,32 @@ is running in the current buffer."
 ;; Phase-4 structured edits (Step 6 -- partial)
 ;; ---------------------------------------------------------------------
 ;;
-;; Each binding here issues a `textDocument/codeAction' request and
-;; picks the action whose `:title' matches a fixed string -- bypassing
-;; `eglot-code-actions' (which prompts for an action kind and then for
-;; the action itself).  One keystroke per operation; the speed
-;; difference matters in interactive proof editing.
-;;
 ;; Live bindings (LSP Steps 15-16):
-;;   `C-c C-r'  Refine hole       -- title "Refine hole"  (Step 15)
-;;   `C-c C-c'  Case split        -- title "Case split"   (Step 16)
+;;
+;;   `C-c C-r'  deduce-lsp-refine-hole  (Step 15)
+;;     Cursor on a `?'.  Issues `textDocument/codeAction' filtered to
+;;     `refactor.rewrite' and applies the action titled "Refine hole".
+;;     One keystroke; no prompt.
+;;
+;;   `C-c C-c'  deduce-lsp-case-split   (Step 16)
+;;     Cursor on a `?'.  Issues `deduce/splittableVarsAt' to fetch
+;;     candidate variable names, prompts via `completing-read' (TAB
+;;     completion), then issues `deduce/caseSplitAt' with the chosen
+;;     variable.  Two keystrokes + identifier; no ambiguity about
+;;     which `?' the skeleton replaces -- it's the one under the
+;;     cursor.
+;;
+;; The two operations use different transports because their UX
+;; requirements differ: refine takes no extra input (the cursor is
+;; the only signal), so it fits cleanly in `textDocument/codeAction';
+;; case-split takes a user-supplied variable name, which codeAction
+;; can't carry, so it gets a custom server method.
 ;;
 ;; Step 17 (induction skeleton) will land as `C-c C-i' once the
-;; server's induction_skeleton_at operation is available.  The pattern
-;; is the same: another defun calling
-;; `deduce-lsp--apply-code-action-by-title'.
+;; server's induction_skeleton_at operation is available.  Like
+;; refine, it takes no extra input -- the cursor is on a `?' whose
+;; goal is `all x:T. ...' -- so it'll surface as another
+;; `refactor.rewrite' code action.
 
 (defun deduce-lsp--lsp-pos-to-point (line character)
   "Convert LSP 0-indexed (LINE, CHARACTER) to a point in the current buffer.
@@ -344,23 +356,8 @@ URI has no edits."
 
 
 (defun deduce-lsp--apply-code-action (action)
-  "Apply the WorkspaceEdit of CodeAction plist ACTION to the
-current buffer.
-
-Today the server's only edit shape is `:changes' keyed by the
-file's URI; `:documentChanges' isn't used.  TextEdits are applied
-in the order the server returned them -- a single edit for
-Step 15, so order doesn't matter yet."
-  (let* ((edit (plist-get action :edit))
-         (changes (plist-get edit :changes))
-         (uri (deduce-lsp--current-uri))
-         (edits (deduce-lsp--text-edits-for-uri changes uri)))
-    (unless edits
-      (user-error "Refine action has no edits for the current buffer"))
-    ;; Apply in reverse order so each edit's offsets stay valid.
-    ;; Today there's only one edit; this is forward-compat for
-    ;; multi-edit actions in later steps.
-    (mapc #'deduce-lsp--apply-text-edit (reverse (append edits nil)))))
+  "Apply the WorkspaceEdit of CodeAction plist ACTION to the buffer."
+  (deduce-lsp--apply-workspace-edit (plist-get action :edit)))
 
 
 (defun deduce-lsp--find-action-by-title (title)
@@ -407,24 +404,68 @@ to run `M-x eglot' first."
     (deduce-lsp--apply-code-action action)))
 
 
-(defun deduce-lsp-case-split ()
-  "Apply the LSP-suggested case split for the variable at point.
+(defun deduce-lsp--text-document-position ()
+  "Return the LSP `{textDocument, position}' plist for point."
+  (list :textDocument (list :uri (deduce-lsp--current-uri))
+        :position (deduce-lsp--current-position)))
 
-Issues a `textDocument/codeAction' request and picks the action
-titled \"Case split\" -- the LSP server's Step-16 output.  The
-matching action's WorkspaceEdit replaces the next `?' in the
-surrounding proof body with a `switch' (term-level Union) or
-`cases' (proof-level disjunction) skeleton.
 
-When the cursor isn't on a variable whose shape supports case
-splitting -- or no `?' follows it in the proof body -- errors
-with `No case split available at point.'  When no eglot
-connection is active, prompts the user to run `M-x eglot' first."
-  (interactive)
-  (let ((action (deduce-lsp--find-action-by-title "Case split")))
-    (unless action
-      (user-error "No case split available at point"))
-    (deduce-lsp--apply-code-action action)))
+(defun deduce-lsp-case-split (variable)
+  "Case-split the hole at point on VARIABLE.
+
+The cursor must sit on (or immediately adjacent to) a `?' token;
+that `?' is the replacement target.  VARIABLE names the in-scope
+binding to split on -- a Union-typed term variable yields a
+`switch' skeleton, an `Or'-shaped proof variable yields a
+`cases' skeleton.
+
+Interactively, queries the server for the splittable variables in
+scope at the hole (custom request `deduce/splittableVarsAt') and
+prompts via `completing-read' with TAB completion against that
+list.  When the candidate list is empty -- e.g. the cursor isn't
+on a `?' or no Union/Or binding is in scope -- errors with `No
+case split available at point.'
+
+The chosen variable is then sent in a `deduce/caseSplitAt'
+request; the returned WorkspaceEdit is applied directly.  Errors
+out without applying when the server returns null."
+  (interactive
+   (let ((server (eglot-current-server)))
+     (unless server
+       (user-error
+        "No eglot server active in this buffer; M-x eglot first"))
+     (let* ((params (deduce-lsp--text-document-position))
+            (candidates (jsonrpc-request server :deduce/splittableVarsAt
+                                          params))
+            (candidate-list (if (vectorp candidates)
+                                (append candidates nil)
+                              candidates)))
+       (unless candidate-list
+         (user-error "No case split available at point"))
+       (list (completing-read "Case split on: " candidate-list
+                              nil t)))))
+  (let ((server (eglot-current-server)))
+    (unless server
+      (user-error
+       "No eglot server active in this buffer; M-x eglot first"))
+    (let* ((params (append (deduce-lsp--text-document-position)
+                           (list :variable variable)))
+           (edit (jsonrpc-request server :deduce/caseSplitAt params)))
+      (unless edit
+        (user-error
+         "Server returned no edit for case split on %s" variable))
+      (deduce-lsp--apply-workspace-edit edit))))
+
+
+(defun deduce-lsp--apply-workspace-edit (edit)
+  "Apply a WorkspaceEdit plist EDIT (`:changes' shape) to the buffer."
+  (let* ((changes (plist-get edit :changes))
+         (uri (deduce-lsp--current-uri))
+         (edits (deduce-lsp--text-edits-for-uri changes uri)))
+    (unless edits
+      (user-error
+       "WorkspaceEdit has no edits for the current buffer"))
+    (mapc #'deduce-lsp--apply-text-edit (reverse (append edits nil)))))
 
 
 ;; Bind `C-c C-r' (refine) and `C-c C-c' (case split) in

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -392,11 +392,11 @@ buffer ends up with the new text in its place."
 ;; Step 6 (partial): deduce-lsp-case-split
 ;; ---------------------------------------------------------------------
 ;;
-;; Phase-4 / LSP Step 16, fronted by `C-c C-c'.  Same wire-shape as
-;; refine -- a textDocument/codeAction request -- but filters the
-;; response by `:title' equal to "Case split" rather than taking the
-;; first action.  The shared building block is
-;; `deduce-lsp--find-action-by-title'.
+;; Phase-4 / LSP Step 16, fronted by `C-c C-c'.  UX: cursor on a `?',
+;; press `C-c C-c', completing-read prompts for the variable to split
+;; on.  The interactive form fetches candidates via
+;; `deduce/splittableVarsAt'; the chosen variable then drives a
+;; `deduce/caseSplitAt' request.
 
 (ert-deftest deduce-lsp/case-split-bound-to-c-c-c-c ()
   "`C-c C-c' in deduce-mode-map runs `deduce-lsp-case-split'."
@@ -404,70 +404,80 @@ buffer ends up with the new text in its place."
               #'deduce-lsp-case-split)))
 
 
-(ert-deftest deduce-lsp/case-split-issues-codeAction-request ()
-  "The command sends `textDocument/codeAction' with a single-point
-range at the cursor."
+(defun deduce-lsp-test--with-method-mock (responses-by-method thunk)
+  "Run THUNK with `jsonrpc-request' returning per-method responses.
+RESPONSES-BY-METHOD is an alist of (METHOD . RESPONSE) where
+METHOD is a keyword like :deduce/caseSplitAt.  Returns the list
+of every captured (method . params) pair, in call order."
+  (let ((calls nil))
+    (cl-letf (((symbol-function 'eglot-current-server)
+               (lambda () 'mock-server))
+              ((symbol-function 'jsonrpc-request)
+               (lambda (_server method params)
+                 (push (cons method params) calls)
+                 (cdr (assq method responses-by-method)))))
+      (funcall thunk))
+    (reverse calls)))
+
+
+(ert-deftest deduce-lsp/case-split-issues-caseSplitAt-request ()
+  "Calling `deduce-lsp-case-split' with a variable arg sends
+`deduce/caseSplitAt' with `{textDocument, position, variable}'."
   (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf"))
-        captured)
+        calls)
     (unwind-protect
         (with-temp-buffer
           (insert "union N {\n  z\n  s(N)\n}\n\ntheorem t: all x:N. x = x\nproof\n  arbitrary x:N\n  ?\nend\n")
           (setq buffer-file-name tmp)
           (deduce-mode)
-          ;; `x' after `arbitrary' is at line 8, col 13 (1-indexed).
-          ;; LSP-space: line 7, char 12.
+          ;; Cursor on the `?' (line 9, col 3) -> LSP line 8, char 2.
           (goto-char (point-min))
-          (forward-line 7)
-          (forward-char 12)
-          (setq captured
-                (deduce-lsp-test--with-mock-server
-                 ;; Empty -> command will user-error; we only
-                 ;; care about the captured request shape.
-                 []
+          (forward-line 8)
+          (forward-char 2)
+          (setq calls
+                (deduce-lsp-test--with-method-mock
+                 ;; Server returns nil for caseSplitAt -> the
+                 ;; command will user-error; we only care about
+                 ;; the captured request shape.
+                 '((:deduce/caseSplitAt . nil))
                  (lambda ()
-                   (ignore-errors (deduce-lsp-case-split)))))
-          (should (eq (plist-get captured :method) :textDocument/codeAction))
-          (let* ((params (plist-get captured :params))
-                 (range (plist-get params :range))
-                 (start (plist-get range :start))
-                 (end (plist-get range :end)))
-            (should (= (plist-get start :line) 7))
-            (should (= (plist-get start :character) 12))
-            (should (equal start end))))
+                   (ignore-errors (deduce-lsp-case-split "x")))))
+          (let* ((call (assq :deduce/caseSplitAt calls))
+                 (params (cdr call))
+                 (text-doc (plist-get params :textDocument))
+                 (pos (plist-get params :position)))
+            (should call)
+            (should (string-prefix-p "file://"
+                                      (plist-get text-doc :uri)))
+            (should (= (plist-get pos :line) 8))
+            (should (= (plist-get pos :character) 2))
+            (should (equal (plist-get params :variable) "x"))))
       (delete-file tmp))))
 
 
-(ert-deftest deduce-lsp/case-split-applies-text-edit ()
-  "Given a CodeAction titled \"Case split\" with a TextEdit replacing
-the surrounding `?', the buffer ends up with a `switch' skeleton."
+(ert-deftest deduce-lsp/case-split-applies-workspace-edit ()
+  "Given a server response with a `:changes' WorkspaceEdit, the
+buffer ends up with the new text replacing the `?'."
   (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
     (unwind-protect
         (with-temp-buffer
           (insert "union N {\n  z\n  s(N)\n}\n\ntheorem t: all x:N. x = x\nproof\n  arbitrary x:N\n  ?\nend\n")
           (setq buffer-file-name tmp)
           (deduce-mode)
-          ;; Cursor on `x' after `arbitrary' (line 8, col 13).
+          ;; Cursor on the `?' at line 9 col 3.
           (goto-char (point-min))
-          (forward-line 7)
-          (forward-char 12)
+          (forward-line 8)
+          (forward-char 2)
           (let* ((uri (deduce-lsp--current-uri))
-                 ;; Server response: one action titled "Case split"
-                 ;; whose edit replaces the `?' on line 8 col 3
-                 ;; (LSP line 8 char 2..3 in 0-indexed) with the
-                 ;; switch skeleton.
                  (skeleton "switch x {\n  case z { ? }\n  case s(n1) { ? }\n}")
-                 (action `(:title "Case split"
-                           :kind "refactor.rewrite"
-                           :edit
-                           (:changes
-                            (,(intern (concat ":" uri))
-                             [(:range (:start (:line 8 :character 2)
-                                       :end (:line 8 :character 3))
-                                      :newText ,skeleton)]))))
-                 (response (vector action)))
-            (deduce-lsp-test--with-mock-server
-             response
-             (lambda () (deduce-lsp-case-split))))
+                 (edit `(:changes
+                         (,(intern (concat ":" uri))
+                          [(:range (:start (:line 8 :character 2)
+                                    :end (:line 8 :character 3))
+                                   :newText ,skeleton)]))))
+            (deduce-lsp-test--with-method-mock
+             `((:deduce/caseSplitAt . ,edit))
+             (lambda () (deduce-lsp-case-split "x"))))
           (let ((text (buffer-substring-no-properties (point-min) (point-max))))
             (should (string-match-p "switch x" text))
             (should (string-match-p "case z {" text))
@@ -475,43 +485,19 @@ the surrounding `?', the buffer ends up with a `switch' skeleton."
       (delete-file tmp))))
 
 
-(ert-deftest deduce-lsp/case-split-rejects-non-matching-title ()
-  "If the server returns an action titled \"Refine hole\" instead
-of \"Case split\", the case-split command must NOT apply it -- it
-should user-error."
+(ert-deftest deduce-lsp/case-split-null-server-response-errors ()
+  "If the server returns null for caseSplitAt, the command
+user-errors instead of silently no-op-ing."
   (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
     (unwind-protect
         (with-temp-buffer
           (insert "x")
           (setq buffer-file-name tmp)
           (deduce-mode)
-          (let* ((uri (deduce-lsp--current-uri))
-                 ;; Action titled "Refine hole" -- should be ignored
-                 ;; by case-split.
-                 (action `(:title "Refine hole"
-                           :kind "refactor.rewrite"
-                           :edit (:changes
-                                  (,(intern (concat ":" uri)) []))))
-                 (response (vector action)))
-            (deduce-lsp-test--with-mock-server
-             response
-             (lambda ()
-               (should-error (deduce-lsp-case-split) :type 'user-error)))))
-      (delete-file tmp))))
-
-
-(ert-deftest deduce-lsp/case-split-no-actions-signals-user-error ()
-  "An empty action list yields a `No case split available' user-error."
-  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
-    (unwind-protect
-        (with-temp-buffer
-          (insert "x")
-          (setq buffer-file-name tmp)
-          (deduce-mode)
-          (deduce-lsp-test--with-mock-server
-           nil
+          (deduce-lsp-test--with-method-mock
+           '((:deduce/caseSplitAt . nil))
            (lambda ()
-             (should-error (deduce-lsp-case-split) :type 'user-error))))
+             (should-error (deduce-lsp-case-split "x") :type 'user-error))))
       (delete-file tmp))))
 
 
@@ -525,27 +511,58 @@ should user-error."
             (insert "x")
             (setq buffer-file-name tmp)
             (deduce-mode)
-            (should-error (deduce-lsp-case-split) :type 'user-error)))
+            (should-error (deduce-lsp-case-split "x") :type 'user-error)))
       (delete-file tmp))))
 
 
-(ert-deftest deduce-lsp/find-action-by-title-picks-by-title ()
-  "When the response has multiple actions, the helper returns the one
-whose `:title' equals the requested title -- not the first one."
-  (let ((tmp (make-temp-file "deduce-lsp-find" nil ".pf")))
+(ert-deftest deduce-lsp/case-split-interactive-uses-completing-read ()
+  "Interactive entry hits `deduce/splittableVarsAt' for candidates
+and feeds them to `completing-read'."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf"))
+        captured-prompt
+        captured-collection)
     (unwind-protect
         (with-temp-buffer
           (insert "x")
           (setq buffer-file-name tmp)
           (deduce-mode)
-          (let* ((refine-action '(:title "Refine hole" :kind "refactor.rewrite"))
-                 (split-action  '(:title "Case split"  :kind "refactor.rewrite"))
-                 (response (vector refine-action split-action)))
-            (deduce-lsp-test--with-mock-server
-             response
-             (lambda ()
-               (let ((found (deduce-lsp--find-action-by-title "Case split")))
-                 (should (equal found split-action)))))))
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method _params)
+                       (cond
+                        ((eq method :deduce/splittableVarsAt) ["H" "x"])
+                        ((eq method :deduce/caseSplitAt) nil))))
+                    ((symbol-function 'completing-read)
+                     (lambda (prompt collection &rest _rest)
+                       (setq captured-prompt prompt)
+                       (setq captured-collection collection)
+                       "H")))
+            (ignore-errors
+              (call-interactively #'deduce-lsp-case-split)))
+          (should (string-match-p "Case split on:" captured-prompt))
+          ;; The collection passed to completing-read is the list of
+          ;; candidates.
+          (should (member "H" captured-collection))
+          (should (member "x" captured-collection)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/case-split-interactive-empty-candidates-errors ()
+  "If `deduce/splittableVarsAt' returns no candidates, the
+interactive entry user-errors with `No case split available'."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server _method _params) [])))
+            (should-error (call-interactively #'deduce-lsp-case-split)
+                          :type 'user-error)))
       (delete-file tmp))))
 
 

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -388,6 +388,167 @@ buffer ends up with the new text in its place."
      (deduce-lsp--text-edits-for-uri changes "file:///nope.pf"))))
 
 
+;; ---------------------------------------------------------------------
+;; Step 6 (partial): deduce-lsp-case-split
+;; ---------------------------------------------------------------------
+;;
+;; Phase-4 / LSP Step 16, fronted by `C-c C-c'.  Same wire-shape as
+;; refine -- a textDocument/codeAction request -- but filters the
+;; response by `:title' equal to "Case split" rather than taking the
+;; first action.  The shared building block is
+;; `deduce-lsp--find-action-by-title'.
+
+(ert-deftest deduce-lsp/case-split-bound-to-c-c-c-c ()
+  "`C-c C-c' in deduce-mode-map runs `deduce-lsp-case-split'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-c"))
+              #'deduce-lsp-case-split)))
+
+
+(ert-deftest deduce-lsp/case-split-issues-codeAction-request ()
+  "The command sends `textDocument/codeAction' with a single-point
+range at the cursor."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf"))
+        captured)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "union N {\n  z\n  s(N)\n}\n\ntheorem t: all x:N. x = x\nproof\n  arbitrary x:N\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; `x' after `arbitrary' is at line 8, col 13 (1-indexed).
+          ;; LSP-space: line 7, char 12.
+          (goto-char (point-min))
+          (forward-line 7)
+          (forward-char 12)
+          (setq captured
+                (deduce-lsp-test--with-mock-server
+                 ;; Empty -> command will user-error; we only
+                 ;; care about the captured request shape.
+                 []
+                 (lambda ()
+                   (ignore-errors (deduce-lsp-case-split)))))
+          (should (eq (plist-get captured :method) :textDocument/codeAction))
+          (let* ((params (plist-get captured :params))
+                 (range (plist-get params :range))
+                 (start (plist-get range :start))
+                 (end (plist-get range :end)))
+            (should (= (plist-get start :line) 7))
+            (should (= (plist-get start :character) 12))
+            (should (equal start end))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/case-split-applies-text-edit ()
+  "Given a CodeAction titled \"Case split\" with a TextEdit replacing
+the surrounding `?', the buffer ends up with a `switch' skeleton."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "union N {\n  z\n  s(N)\n}\n\ntheorem t: all x:N. x = x\nproof\n  arbitrary x:N\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; Cursor on `x' after `arbitrary' (line 8, col 13).
+          (goto-char (point-min))
+          (forward-line 7)
+          (forward-char 12)
+          (let* ((uri (deduce-lsp--current-uri))
+                 ;; Server response: one action titled "Case split"
+                 ;; whose edit replaces the `?' on line 8 col 3
+                 ;; (LSP line 8 char 2..3 in 0-indexed) with the
+                 ;; switch skeleton.
+                 (skeleton "switch x {\n  case z { ? }\n  case s(n1) { ? }\n}")
+                 (action `(:title "Case split"
+                           :kind "refactor.rewrite"
+                           :edit
+                           (:changes
+                            (,(intern (concat ":" uri))
+                             [(:range (:start (:line 8 :character 2)
+                                       :end (:line 8 :character 3))
+                                      :newText ,skeleton)]))))
+                 (response (vector action)))
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda () (deduce-lsp-case-split))))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "switch x" text))
+            (should (string-match-p "case z {" text))
+            (should (string-match-p "case s(n1) {" text))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/case-split-rejects-non-matching-title ()
+  "If the server returns an action titled \"Refine hole\" instead
+of \"Case split\", the case-split command must NOT apply it -- it
+should user-error."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (let* ((uri (deduce-lsp--current-uri))
+                 ;; Action titled "Refine hole" -- should be ignored
+                 ;; by case-split.
+                 (action `(:title "Refine hole"
+                           :kind "refactor.rewrite"
+                           :edit (:changes
+                                  (,(intern (concat ":" uri)) []))))
+                 (response (vector action)))
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda ()
+               (should-error (deduce-lsp-case-split) :type 'user-error)))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/case-split-no-actions-signals-user-error ()
+  "An empty action list yields a `No case split available' user-error."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (deduce-lsp-test--with-mock-server
+           nil
+           (lambda ()
+             (should-error (deduce-lsp-case-split) :type 'user-error))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/case-split-without-server-errors ()
+  "Without an active eglot server, the command signals a user error."
+  (let ((tmp (make-temp-file "deduce-lsp-split" nil ".pf")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'eglot-current-server)
+                   (lambda () nil)))
+          (with-temp-buffer
+            (insert "x")
+            (setq buffer-file-name tmp)
+            (deduce-mode)
+            (should-error (deduce-lsp-case-split) :type 'user-error)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/find-action-by-title-picks-by-title ()
+  "When the response has multiple actions, the helper returns the one
+whose `:title' equals the requested title -- not the first one."
+  (let ((tmp (make-temp-file "deduce-lsp-find" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (let* ((refine-action '(:title "Refine hole" :kind "refactor.rewrite"))
+                 (split-action  '(:title "Case split"  :kind "refactor.rewrite"))
+                 (response (vector refine-action split-action)))
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda ()
+               (let ((found (deduce-lsp--find-action-by-title "Case split")))
+                 (should (equal found split-action)))))))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -350,14 +350,18 @@ def on_code_action(
 ) -> list[lsp_types.CodeAction]:
     """Surface Phase-4 structured edits as refactor.rewrite actions.
 
-    Today: just the hole-refine action (Step 15). When the cursor sits
-    on a ``?`` and the goal has a recognised shape, the action's
-    ``edit`` field carries a single-file ``WorkspaceEdit`` that the
-    client applies on selection.
+    Today's actions:
 
-    The action is silently absent when ``refine_at`` returns ``None``
-    -- the client (eglot, VS Code) will then offer no rewrite, which
-    matches the LSP convention of "no action available."
+    - **Refine hole** (Step 15) -- offered when the cursor sits on a
+      ``?`` whose goal has a recognised shape.
+    - **Case split** (Step 16) -- offered when the cursor sits on a
+      term variable (Union type) or proof variable (``Or`` formula)
+      with a ``?`` reachable in the surrounding proof body.
+
+    Both, neither, or one may apply depending on cursor position. The
+    Emacs binding for each operation filters the returned list by
+    title; multi-action picker behaviour is reserved for clients that
+    request the full set.
     """
     uri = params.text_document.uri
     content = _document_content(ls, uri)
@@ -365,25 +369,39 @@ def on_code_action(
         return []
     path = _path_from_uri(uri)
     pos = _query_pos_from_lsp(params.range.start)
+    prelude = _prelude_for(path)
 
-    edit = _query.refine_at(path, content, pos, prelude=_prelude_for(path))
-    if edit is None:
-        return []
+    actions: list[lsp_types.CodeAction] = []
 
+    refine_edit = _query.refine_at(path, content, pos, prelude=prelude)
+    if refine_edit is not None:
+        actions.append(
+            _code_action_from_edit(uri, "Refine hole", refine_edit)
+        )
+
+    split_edit = _query.case_split_at(path, content, pos, prelude=prelude)
+    if split_edit is not None:
+        actions.append(
+            _code_action_from_edit(uri, "Case split", split_edit)
+        )
+
+    return actions
+
+
+def _code_action_from_edit(
+    uri: str, title: str, edit: _query.WorkspaceEdit
+) -> lsp_types.CodeAction:
+    """Wrap a query-API ``WorkspaceEdit`` as an LSP ``CodeAction``."""
     text_edit = lsp_types.TextEdit(
         range=_lsp_range_from_query(edit.range),
         new_text=edit.new_text,
     )
-    workspace_edit = lsp_types.WorkspaceEdit(
-        changes={uri: [text_edit]},
+    workspace_edit = lsp_types.WorkspaceEdit(changes={uri: [text_edit]})
+    return lsp_types.CodeAction(
+        title=title,
+        kind=lsp_types.CodeActionKind.RefactorRewrite,
+        edit=workspace_edit,
     )
-    return [
-        lsp_types.CodeAction(
-            title="Refine hole",
-            kind=lsp_types.CodeActionKind.RefactorRewrite,
-            edit=workspace_edit,
-        )
-    ]
 
 
 @server.feature(GOAL_AT_REQUEST)

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -130,6 +130,14 @@ SERVER_VERSION = "0.1.0"
 # raw request with this method.
 GOAL_AT_REQUEST = "deduce/goalAt"
 
+# Custom requests for Step 16 (case split). ``deduce/caseSplitAt``
+# carries the user-supplied variable name in its params, which
+# ``textDocument/codeAction`` can't do; ``deduce/splittableVarsAt``
+# returns the candidate variable names so editor clients can offer
+# completion before prompting.
+CASE_SPLIT_REQUEST = "deduce/caseSplitAt"
+SPLITTABLE_VARS_REQUEST = "deduce/splittableVarsAt"
+
 server = LanguageServer(
     SERVER_NAME,
     SERVER_VERSION,
@@ -354,14 +362,12 @@ def on_code_action(
 
     - **Refine hole** (Step 15) -- offered when the cursor sits on a
       ``?`` whose goal has a recognised shape.
-    - **Case split** (Step 16) -- offered when the cursor sits on a
-      term variable (Union type) or proof variable (``Or`` formula)
-      with a ``?`` reachable in the surrounding proof body.
 
-    Both, neither, or one may apply depending on cursor position. The
-    Emacs binding for each operation filters the returned list by
-    title; multi-action picker behaviour is reserved for clients that
-    request the full set.
+    Step 16 (case split) takes a user-supplied variable name, which
+    ``textDocument/codeAction`` can't carry, so it lives behind the
+    custom ``deduce/caseSplitAt`` request instead. The Emacs binding
+    prompts for the variable (with completion against
+    ``deduce/splittableVarsAt``) before issuing the request.
     """
     uri = params.text_document.uri
     content = _document_content(ls, uri)
@@ -377,12 +383,6 @@ def on_code_action(
     if refine_edit is not None:
         actions.append(
             _code_action_from_edit(uri, "Refine hole", refine_edit)
-        )
-
-    split_edit = _query.case_split_at(path, content, pos, prelude=prelude)
-    if split_edit is not None:
-        actions.append(
-            _code_action_from_edit(uri, "Case split", split_edit)
         )
 
     return actions
@@ -447,6 +447,99 @@ def on_goal_at(ls: LanguageServer, params) -> Optional[dict]:
                 "character": max(goal.range.end.column - 1, 0),
             },
         },
+    }
+
+
+@server.feature(SPLITTABLE_VARS_REQUEST)
+def on_splittable_vars_at(ls: LanguageServer, params) -> list[str]:
+    """Custom request: return variables at the cursor's hole that
+    case-split can target.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}}``. Editor clients call this to populate
+    completion candidates when prompting for the variable name.
+
+    Result: a list of base names (sorted, deduplicated). Empty when
+    the cursor isn't on a ``?`` or no splittable variable is in
+    scope.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
+    if not uri:
+        return []
+    content = _document_content(ls, uri)
+    if content is None:
+        return []
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
+        )
+    )
+    path = _path_from_uri(uri)
+    return list(
+        _query.splittable_vars_at(path, content, pos, prelude=_prelude_for(path))
+    )
+
+
+@server.feature(CASE_SPLIT_REQUEST)
+def on_case_split_at(ls: LanguageServer, params) -> Optional[dict]:
+    """Custom request: return a WorkspaceEdit that case-splits the
+    cursor's hole on a named variable.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}, "variable": str}``. The cursor must sit
+    on a ``?``; the ``variable`` arg names which in-scope binding to
+    split on.
+
+    Result: ``{"changes": {<uri>: [{"range": Range, "newText":
+    str}]}}`` (an LSP-shaped WorkspaceEdit) or ``null`` when the
+    cursor isn't on a hole, the variable isn't in scope, or its
+    shape isn't a Union / Or.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
+    variable = _get_field(params, "variable")
+    if not uri or not variable:
+        return None
+    content = _document_content(ls, uri)
+    if content is None:
+        return None
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
+        )
+    )
+    path = _path_from_uri(uri)
+    edit = _query.case_split_at(
+        path, content, pos, str(variable), prelude=_prelude_for(path)
+    )
+    if edit is None:
+        return None
+    # Shape-shift to the LSP wire format: an LSP WorkspaceEdit with
+    # `changes: {uri: [TextEdit]}`. Mirrors what the codeAction
+    # handler emits for refine.
+    return {
+        "changes": {
+            uri: [
+                {
+                    "range": {
+                        "start": {
+                            "line": max(edit.range.start.line - 1, 0),
+                            "character": max(edit.range.start.column - 1, 0),
+                        },
+                        "end": {
+                            "line": max(edit.range.end.line - 1, 0),
+                            "character": max(edit.range.end.column - 1, 0),
+                        },
+                    },
+                    "newText": edit.new_text,
+                }
+            ]
+        }
     }
 
 

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -224,6 +224,32 @@ def refine_at(path: str, line: int, column: int) -> Optional[dict]:
 
 
 @mcp.tool()
+def case_split_at(path: str, line: int, column: int) -> Optional[dict]:
+    """Generate a case-split skeleton for the variable at ``line``:``column``.
+
+    The cursor should sit on an identifier that names either:
+
+    - a term variable whose type is a ``Union`` (or an instance of a
+      parameterised union like ``List<T>``) -- yields a ``switch``
+      skeleton with one ``case Cons(p1, ..., pN) { ? }`` per
+      constructor, in declaration order.
+    - a proof variable whose formula is ``P or Q [or R...]`` --
+      yields a ``cases`` skeleton with one
+      ``case <fresh>: <disjunct> { ? }`` per disjunct.
+
+    The replacement target is the next ``?`` at or after the cursor.
+    Returns ``None`` when the cursor isn't on an identifier, no ``?``
+    follows it, the identifier isn't bound at the hole, or the
+    binding's shape isn't a union / disjunction. Otherwise returns
+    ``{path, range, new_text}``.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    edit = query.case_split_at(path, content, pos, prelude=_prelude_for(path))
+    return _to_serializable(edit)
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -224,29 +224,56 @@ def refine_at(path: str, line: int, column: int) -> Optional[dict]:
 
 
 @mcp.tool()
-def case_split_at(path: str, line: int, column: int) -> Optional[dict]:
-    """Generate a case-split skeleton for the variable at ``line``:``column``.
+def case_split_at(
+    path: str, line: int, column: int, variable: str
+) -> Optional[dict]:
+    """Generate a case-split skeleton at the hole at ``line``:``column``,
+    splitting on ``variable``.
 
-    The cursor should sit on an identifier that names either:
+    The cursor must sit on (or immediately adjacent to) a ``?`` token;
+    that ``?`` is the replacement target. ``variable`` names the
+    in-scope binding to split on -- either a term variable whose type
+    is a ``Union`` (yields a ``switch`` skeleton with one ``case
+    Cons(p1, ..., pN) { ? }`` per constructor) or a proof variable
+    whose formula is ``Or(...)`` (yields a ``cases`` skeleton with
+    one ``case <fresh>: <disjunct> { ? }`` per disjunct).
 
-    - a term variable whose type is a ``Union`` (or an instance of a
-      parameterised union like ``List<T>``) -- yields a ``switch``
-      skeleton with one ``case Cons(p1, ..., pN) { ? }`` per
-      constructor, in declaration order.
-    - a proof variable whose formula is ``P or Q [or R...]`` --
-      yields a ``cases`` skeleton with one
-      ``case <fresh>: <disjunct> { ? }`` per disjunct.
+    Returns ``None`` when the cursor isn't on a ``?``, the file has
+    no incomplete proof there, ``variable`` isn't bound at the hole,
+    or the binding's shape isn't a union / disjunction. Otherwise
+    returns ``{path, range, new_text}``.
 
-    The replacement target is the next ``?`` at or after the cursor.
-    Returns ``None`` when the cursor isn't on an identifier, no ``?``
-    follows it, the identifier isn't bound at the hole, or the
-    binding's shape isn't a union / disjunction. Otherwise returns
-    ``{path, range, new_text}``.
+    For a list of valid ``variable`` choices at a given cursor, see
+    ``splittable_vars_at``.
     """
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
-    edit = query.case_split_at(path, content, pos, prelude=_prelude_for(path))
+    edit = query.case_split_at(
+        path, content, pos, variable, prelude=_prelude_for(path)
+    )
     return _to_serializable(edit)
+
+
+@mcp.tool()
+def splittable_vars_at(path: str, line: int, column: int) -> list[str]:
+    """Return base names of in-scope variables that case-split can
+    target at ``line``:``column``.
+
+    The cursor must sit on a ``?`` token. The result is the union of:
+
+    - term variables whose type is a ``Union`` (or instance of one),
+    - proof variables whose formula is ``Or(...)``.
+
+    Constructor names are filtered out -- splitting on a constructor
+    would produce a redundant skeleton. Names are sorted and
+    deduplicated. Returns ``[]`` when the cursor isn't on a ``?`` or
+    no splittable variable is in scope.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    return list(
+        query.splittable_vars_at(path, content, pos, prelude=_prelude_for(path))
+    )
 
 
 @mcp.tool()

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -64,6 +64,7 @@ __all__ = [
     "definition_of",
     "list_symbols",
     "refine_at",
+    "case_split_at",
 ]
 
 
@@ -922,3 +923,268 @@ def _fresh_assume_label(env) -> str:
     while f"H{n}" in used_bases:
         n += 1
     return f"H{n}"
+
+
+# ---------------------------------------------------------------------------
+# case_split_at -- Phase 4 / Step 16: case split on a variable
+# ---------------------------------------------------------------------------
+#
+# Given a cursor on an in-scope variable and a `?` somewhere in the
+# surrounding proof body, replace the `?` with a per-constructor (for
+# term-level Union types) or per-disjunct (for proof-level `Or`
+# formulas) skeleton. Each branch ends in a fresh `?` for further
+# refinement.
+#
+# Mechanism: same trick as ``refine_at`` -- the source already has a
+# `?`, so re-running ``check_file`` raises ``IncompleteProof`` at that
+# hole. ``incomplete_error`` stashes the proof env on the exception
+# (Step 15 plumbing), which we read here to look up the cursor's
+# identifier and find its type or formula. The case skeleton is then
+# rendered against ``Union.alternatives`` or ``Or.args``.
+
+
+def case_split_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> Optional[WorkspaceEdit]:
+    """Generate a case-split skeleton for the variable at ``pos``.
+
+    The cursor should sit on an identifier that names either:
+
+    - a *term variable* whose type is a ``Union`` (or an instance of
+      a parameterised union like ``List<T>``) -- yields a ``switch``
+      skeleton with one ``case Cons(p1, ..., pN) { ? }`` per
+      constructor.
+    - a *proof variable* whose formula is ``Or(...)`` -- yields a
+      ``cases`` skeleton with one ``case <fresh>: <disjunct> { ? }``
+      per disjunct.
+
+    The replacement target is the next ``?`` token at or after the
+    cursor, on the same proof body. Returns ``None`` when:
+
+    - the cursor isn't on an identifier,
+    - no ``?`` follows the cursor in the file,
+    - the file doesn't reach the hole (e.g. an earlier error stops
+      checking),
+    - the identifier isn't bound at the hole,
+    - or the binding's shape isn't a union / disjunction.
+
+    Limitation: in a multi-theorem file with earlier ``?``s, the
+    checker raises on the first hole encountered; the env returned
+    may not be the one at the cursor's hole. Same caveat as
+    ``goal_at`` and ``refine_at``.
+    """
+    name = _identifier_at(content, pos)
+    if name is None:
+        return None
+
+    hole_offset = _find_next_hole_offset(content, pos)
+    if hole_offset is None:
+        return None
+    hole_range = _char_range_at(content, hole_offset)
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    if env is None:
+        return None
+
+    template = _case_split_template(name, env)
+    if template is None:
+        return None
+
+    return WorkspaceEdit(path=path, range=hole_range, new_text=template)
+
+
+def _identifier_at(content: str, pos: Position) -> Optional[str]:
+    """Return the source identifier whose span contains or abuts ``pos``.
+
+    Walks left and right from the cursor over identifier characters
+    (letters, digits, underscore, prime). Returns ``None`` when the
+    cursor isn't on an identifier.
+
+    Eglot sends the cursor at the column past the character (so the
+    cursor "between" ``foo`` and ``bar`` reads as on ``bar``); this
+    helper handles both "cursor inside identifier" and "cursor at
+    identifier's right edge" by checking the char to the left when
+    the char at ``offset`` isn't an id char.
+    """
+    offset = _line_col_to_offset(content, pos)
+    if offset is None:
+        return None
+    if offset >= len(content) or not _is_id_char(content[offset]):
+        # Try one position back -- cursor sits just after the
+        # identifier's last character.
+        if offset > 0 and _is_id_char(content[offset - 1]):
+            offset -= 1
+        else:
+            return None
+    start = offset
+    while start > 0 and _is_id_char(content[start - 1]):
+        start -= 1
+    end = offset + 1
+    while end < len(content) and _is_id_char(content[end]):
+        end += 1
+    if start == end:
+        return None
+    name = content[start:end]
+    # Reject pure digits -- those are integer literals, not vars.
+    if name.isdigit():
+        return None
+    return name
+
+
+def _is_id_char(c: str) -> bool:
+    """Identifier characters per Deduce's lexer: letters, digits,
+    underscore, and ``'`` (used in names like ``n'``)."""
+    return c.isalnum() or c in "_'"
+
+
+def _find_next_hole_offset(content: str, pos: Position) -> Optional[int]:
+    """Return the offset of the first ``?`` at or after ``pos``.
+
+    A simple text scan is enough -- ``?`` is a single-character token
+    in Deduce (``QMARK``) and never appears inside identifiers. Returns
+    ``None`` when no ``?`` follows the cursor.
+    """
+    offset = _line_col_to_offset(content, pos)
+    if offset is None:
+        return None
+    idx = content.find("?", offset)
+    if idx < 0:
+        return None
+    return idx
+
+
+def _case_split_template(name: str, env) -> Optional[str]:
+    """Render a switch/cases skeleton for the variable named ``name``.
+
+    Looks up ``name`` in ``env`` by base name (the dict is keyed by
+    post-uniquify names like ``foo.42``; the user types the source
+    name ``foo``). Dispatches on the binding's kind:
+
+    - ``ProofBinding`` whose formula is ``Or(...)`` -> ``cases``
+    - ``TermBinding`` whose type resolves to a ``Union`` -> ``switch``
+
+    Returns ``None`` for any other shape (built-in atom, function,
+    non-disjunctive proof, etc.).
+    """
+    from abstract_syntax import (
+        Or, ProofBinding, TermBinding, TypeBinding, Union, Var, base_name,
+        get_type_name,
+    )
+
+    matches = [k for k in env.dict if base_name(k) == name]
+    if not matches:
+        return None
+    binding = env.dict[matches[0]]
+
+    if isinstance(binding, ProofBinding):
+        if isinstance(binding.formula, Or):
+            return _cases_template(name, binding.formula, env)
+        return None
+
+    if isinstance(binding, TermBinding):
+        # The variable's type may be a Var (named type), a TypeInst
+        # (parameterised), or built-in (BoolType etc.). Walk to the
+        # underlying type definition.
+        ty = binding.typ
+        try:
+            type_var = get_type_name(ty)
+        except Exception:
+            return None
+        if not isinstance(type_var, Var):
+            return None
+        type_binding = env.dict.get(type_var.name)
+        if not isinstance(type_binding, TypeBinding):
+            return None
+        defn = type_binding.defn
+        if isinstance(defn, Union):
+            return _switch_template(name, defn, env)
+        return None
+
+    return None
+
+
+def _cases_template(var_name: str, formula, env) -> str:
+    """Render a ``cases <var> ...`` block for an ``Or`` formula.
+
+    Each disjunct gets a fresh per-branch label so successive
+    refinements inside the cases stay collision-free. The labels
+    follow the same ``H<N>`` convention ``_fresh_assume_label`` uses.
+    """
+    from abstract_syntax import base_name
+    used = {base_name(k) for k in env.dict.keys()}
+
+    def fresh() -> str:
+        n = 1
+        while f"h{n}" in used:
+            n += 1
+        used.add(f"h{n}")
+        return f"h{n}"
+
+    args = formula.args
+    case_lines = [
+        f"  case {fresh()}: {arg} {{ ? }}" for arg in args
+    ]
+    return f"cases {var_name}\n" + "\n".join(case_lines)
+
+
+def _switch_template(var_name: str, union_def, env) -> str:
+    """Render a ``switch <var> { ... }`` block for a ``Union`` type.
+
+    Each constructor's parameters get fresh names against the
+    *enclosing* env -- but not against names introduced by *other*
+    cases, since each ``case Cons(...) { ... }`` opens its own scope.
+    Cases are emitted in the declaration order of
+    ``union_def.alternatives``.
+    """
+    from abstract_syntax import base_name
+
+    env_used = {base_name(k) for k in env.dict.keys()}
+
+    case_lines = []
+    for alt in union_def.alternatives:
+        cons_name = base_name(alt.name)
+        # Reset per-case: each case body opens a new scope, so
+        # naming conflicts only matter against the enclosing env
+        # plus the other params of *this* case.
+        used = set(env_used)
+        params = []
+        # Use the first letter of each param's type as the name stem,
+        # mirroring proof_advice/gen_custom_induction_advice.
+        for i, p_ty in enumerate(alt.parameters):
+            stem = _type_first_letter(p_ty)
+            candidate = f"{stem}{i + 1}"
+            n = 0
+            while candidate in used:
+                n += 1
+                candidate = f"{stem}{i + 1}_{n}"
+            used.add(candidate)
+            params.append(candidate)
+        if params:
+            case_lines.append(
+                f"  case {cons_name}({', '.join(params)}) {{ ? }}"
+            )
+        else:
+            case_lines.append(f"  case {cons_name} {{ ? }}")
+    return f"switch {var_name} {{\n" + "\n".join(case_lines) + "\n}"
+
+
+def _type_first_letter(ty) -> str:
+    """First letter of a type's printed form, lowercased.
+
+    Mirrors the naming convention in ``proof_advice``: a parameter of
+    type ``Nat`` becomes ``n1``, ``n2``, ...; ``List<T>`` -> ``l1``,
+    etc. Falls back to ``"x"`` for types whose printer output starts
+    with something non-alphabetic.
+    """
+    s = str(ty)
+    for c in s:
+        if c.isalpha():
+            return c.lower()
+    return "x"

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -65,6 +65,7 @@ __all__ = [
     "list_symbols",
     "refine_at",
     "case_split_at",
+    "splittable_vars_at",
 ]
 
 
@@ -926,29 +927,34 @@ def _fresh_assume_label(env) -> str:
 
 
 # ---------------------------------------------------------------------------
-# case_split_at -- Phase 4 / Step 16: case split on a variable
+# case_split_at -- Phase 4 / Step 16: case split on a named variable
 # ---------------------------------------------------------------------------
 #
-# Given a cursor on an in-scope variable and a `?` somewhere in the
-# surrounding proof body, replace the `?` with a per-constructor (for
-# term-level Union types) or per-disjunct (for proof-level `Or`
-# formulas) skeleton. Each branch ends in a fresh `?` for further
-# refinement.
+# UX shape: cursor on a `?`, *plus* an explicit ``variable`` argument
+# (the name of the in-scope variable to split on). The replacement
+# target is the `?` the cursor sits on; the variable arg drives the
+# template choice. This separation is what lets the editor binding
+# read the variable name from the user (with completion against
+# `splittable_vars_at`) before issuing the request -- the cursor's
+# role is unambiguous.
 #
-# Mechanism: same trick as ``refine_at`` -- the source already has a
-# `?`, so re-running ``check_file`` raises ``IncompleteProof`` at that
-# hole. ``incomplete_error`` stashes the proof env on the exception
-# (Step 15 plumbing), which we read here to look up the cursor's
-# identifier and find its type or formula. The case skeleton is then
-# rendered against ``Union.alternatives`` or ``Or.args``.
+# Mechanism: same trick as ``refine_at`` -- the cursor's `?` is what
+# raises ``IncompleteProof``, and ``incomplete_error`` stashes the
+# proof env on the exception (Step 15 plumbing). We read that env to
+# look up ``variable``'s binding and render the case skeleton against
+# ``Union.alternatives`` or ``Or.args``.
 
 
 def case_split_at(
-    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+    path: str, content: str, pos: Position,
+    variable: str,
+    prelude: Sequence[str] = (),
 ) -> Optional[WorkspaceEdit]:
-    """Generate a case-split skeleton for the variable at ``pos``.
+    """Generate a case-split skeleton for ``variable`` at the hole at ``pos``.
 
-    The cursor should sit on an identifier that names either:
+    The cursor must sit on (or immediately adjacent to) a ``?`` token;
+    that ``?`` is the replacement target. The ``variable`` argument
+    names an in-scope binding to split on:
 
     - a *term variable* whose type is a ``Union`` (or an instance of
       a parameterised union like ``List<T>``) -- yields a ``switch``
@@ -958,29 +964,19 @@ def case_split_at(
       ``cases`` skeleton with one ``case <fresh>: <disjunct> { ? }``
       per disjunct.
 
-    The replacement target is the next ``?`` token at or after the
-    cursor, on the same proof body. Returns ``None`` when:
+    Returns ``None`` when:
 
-    - the cursor isn't on an identifier,
-    - no ``?`` follows the cursor in the file,
-    - the file doesn't reach the hole (e.g. an earlier error stops
-      checking),
-    - the identifier isn't bound at the hole,
+    - the cursor isn't on a ``?``,
+    - the file has no incomplete proof at the cursor,
+    - ``variable`` isn't bound at the hole,
     - or the binding's shape isn't a union / disjunction.
 
-    Limitation: in a multi-theorem file with earlier ``?``s, the
-    checker raises on the first hole encountered; the env returned
-    may not be the one at the cursor's hole. Same caveat as
-    ``goal_at`` and ``refine_at``.
+    For client-side completion of valid ``variable`` choices at a
+    given cursor position, see :func:`splittable_vars_at`.
     """
-    name = _identifier_at(content, pos)
-    if name is None:
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
         return None
-
-    hole_offset = _find_next_hole_offset(content, pos)
-    if hole_offset is None:
-        return None
-    hole_range = _char_range_at(content, hole_offset)
 
     from lsp.library import check_file
 
@@ -993,71 +989,95 @@ def case_split_at(
     if env is None:
         return None
 
-    template = _case_split_template(name, env)
+    template = _case_split_template(variable, env)
     if template is None:
         return None
 
     return WorkspaceEdit(path=path, range=hole_range, new_text=template)
 
 
-def _identifier_at(content: str, pos: Position) -> Optional[str]:
-    """Return the source identifier whose span contains or abuts ``pos``.
+def splittable_vars_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> tuple:
+    """Return base names of in-scope variables that case-split can target.
 
-    Walks left and right from the cursor over identifier characters
-    (letters, digits, underscore, prime). Returns ``None`` when the
-    cursor isn't on an identifier.
+    Computes the env at the ``?`` token the cursor is on (via the
+    same ``IncompleteProof``-based mechanism as ``case_split_at``),
+    then walks the env for bindings whose shape supports a case
+    split: term variables of ``Union`` type and proof variables of
+    ``Or`` formulas.
 
-    Eglot sends the cursor at the column past the character (so the
-    cursor "between" ``foo`` and ``bar`` reads as on ``bar``); this
-    helper handles both "cursor inside identifier" and "cursor at
-    identifier's right edge" by checking the char to the left when
-    the char at ``offset`` isn't an id char.
+    Used by editor clients to populate completion candidates when the
+    user types ``C-c C-c`` and is prompted for a variable name.
+    Returns an empty tuple when the cursor isn't on a ``?`` or no
+    splittable variable is in scope. Names are deduplicated and
+    sorted.
     """
-    offset = _line_col_to_offset(content, pos)
-    if offset is None:
-        return None
-    if offset >= len(content) or not _is_id_char(content[offset]):
-        # Try one position back -- cursor sits just after the
-        # identifier's last character.
-        if offset > 0 and _is_id_char(content[offset - 1]):
-            offset -= 1
-        else:
-            return None
-    start = offset
-    while start > 0 and _is_id_char(content[start - 1]):
-        start -= 1
-    end = offset + 1
-    while end < len(content) and _is_id_char(content[end]):
-        end += 1
-    if start == end:
-        return None
-    name = content[start:end]
-    # Reject pure digits -- those are integer literals, not vars.
-    if name.isdigit():
-        return None
-    return name
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return ()
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return ()
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    if env is None:
+        return ()
+
+    return _splittable_vars(env)
 
 
-def _is_id_char(c: str) -> bool:
-    """Identifier characters per Deduce's lexer: letters, digits,
-    underscore, and ``'`` (used in names like ``n'``)."""
-    return c.isalnum() or c in "_'"
+def _splittable_vars(env) -> tuple:
+    """Names of bindings whose ``case_split`` would succeed.
 
-
-def _find_next_hole_offset(content: str, pos: Position) -> Optional[int]:
-    """Return the offset of the first ``?`` at or after ``pos``.
-
-    A simple text scan is enough -- ``?`` is a single-character token
-    in Deduce (``QMARK``) and never appears inside identifiers. Returns
-    ``None`` when no ``?`` follows the cursor.
+    Excludes constructor names: the env stores each union's
+    constructor as a TermBinding of the union's type, structurally
+    indistinguishable from a local variable like ``arbitrary x:N``.
+    Splitting on a constructor name would just produce a redundant
+    skeleton (``switch z { case z {...} case s(...) {...} }``), so
+    we filter the constructor set out by walking every Union in the
+    env up front.
     """
-    offset = _line_col_to_offset(content, pos)
-    if offset is None:
-        return None
-    idx = content.find("?", offset)
-    if idx < 0:
-        return None
-    return idx
+    from abstract_syntax import (
+        Or, ProofBinding, TermBinding, TypeBinding, Union, Var, base_name,
+        get_type_name,
+    )
+
+    # Collect constructor names from every union in scope.
+    constructor_names = set()
+    for unique, binding in env.dict.items():
+        if isinstance(binding, TypeBinding) and isinstance(binding.defn, Union):
+            for alt in binding.defn.alternatives:
+                constructor_names.add(base_name(alt.name))
+
+    seen = set()
+    for unique in env.dict.keys():
+        bname = base_name(unique)
+        if bname in seen or bname in constructor_names:
+            continue
+        binding = env.dict[unique]
+        if isinstance(binding, ProofBinding):
+            if isinstance(binding.formula, Or):
+                seen.add(bname)
+        elif isinstance(binding, TermBinding):
+            ty = binding.typ
+            try:
+                type_var = get_type_name(ty)
+            except Exception:
+                continue
+            if not isinstance(type_var, Var):
+                continue
+            type_binding = env.dict.get(type_var.name)
+            if (
+                isinstance(type_binding, TypeBinding)
+                and isinstance(type_binding.defn, Union)
+            ):
+                seen.add(bname)
+    return tuple(sorted(seen))
 
 
 def _case_split_template(name: str, env) -> Optional[str]:

--- a/test/lsp/test_case_split.py
+++ b/test/lsp/test_case_split.py
@@ -1,0 +1,296 @@
+"""Acceptance tests for ``lsp.query.case_split_at`` (Phase 4 / Step 16).
+
+Each fixture supplies a snippet of Deduce source, a 1-indexed cursor
+position on a variable identifier, and the literal ``new_text`` we
+expect ``case_split_at`` to produce when replacing the surrounding
+``?``.
+
+Coverage matches the plan's five-case acceptance:
+
+(a) splitting a Nat-shape variable (a recursive constructor),
+(b) splitting a parameterised List-shape variable (``List<T>``),
+(c) splitting a custom union with multi-typed-parameter
+    constructors,
+(d) splitting a proof variable of ``P or Q``,
+(e) cursor not on a variable (returns ``None``).
+
+All fixtures define their own union or rely on bool-only formulas so
+the tests run without the standard library prelude.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    Range,
+    Severity,
+    WorkspaceEdit,
+    case_split_at,
+    check,
+)
+
+
+@dataclass(frozen=True)
+class CaseSplitCase:
+    name: str
+    source: str
+    cursor: Position
+    expected_text: str
+    expected_range: Range
+
+
+CASES = [
+    CaseSplitCase(
+        name="nat_like_union",
+        # ``z`` and ``s(N)`` -- the canonical shape. Cursor on the
+        # `x` of ``arbitrary x:N``. Expected switch with one case
+        # per constructor; recursive parameter gets a fresh `n1`
+        # name.
+        source=(
+            "union N {\n"
+            "  z\n"
+            "  s(N)\n"
+            "}\n"
+            "\n"
+            "theorem t: all x:N. x = x\n"
+            "proof\n"
+            "  arbitrary x:N\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=13),  # the `x` after `arbitrary`
+        expected_text=(
+            "switch x {\n"
+            "  case z { ? }\n"
+            "  case s(n1) { ? }\n"
+            "}"
+        ),
+        expected_range=Range(
+            start=Position(line=9, column=3),
+            end=Position(line=9, column=4),
+        ),
+    ),
+    CaseSplitCase(
+        name="parameterised_list_union",
+        # ``L<T>`` with constructors ``e`` and ``cons(T, L<T>)``.
+        # Tests that case-split works through TypeInst (the
+        # variable's type is ``L<bool>``, an instantiation).
+        source=(
+            "union L<T> {\n"
+            "  e\n"
+            "  cons(T, L<T>)\n"
+            "}\n"
+            "\n"
+            "theorem t: all xs:L<bool>. xs = xs\n"
+            "proof\n"
+            "  arbitrary xs:L<bool>\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=13),  # `xs` after `arbitrary`
+        expected_text=(
+            "switch xs {\n"
+            "  case e { ? }\n"
+            "  case cons(t1, l2) { ? }\n"
+            "}"
+        ),
+        expected_range=Range(
+            start=Position(line=9, column=3),
+            end=Position(line=9, column=4),
+        ),
+    ),
+    CaseSplitCase(
+        name="custom_union_multi_typed_params",
+        # Three constructors covering arity 0, 1, 2 -- exercises the
+        # per-case scope reset for parameter naming (the second
+        # ``flag``'s ``b1`` shouldn't collide with ``pair``'s ``b1``).
+        source=(
+            "union Tag {\n"
+            "  empty\n"
+            "  flag(bool)\n"
+            "  pair(bool, bool)\n"
+            "}\n"
+            "\n"
+            "theorem t: all x:Tag. x = x\n"
+            "proof\n"
+            "  arbitrary x:Tag\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=9, column=13),  # `x` after `arbitrary`
+        expected_text=(
+            "switch x {\n"
+            "  case empty { ? }\n"
+            "  case flag(b1) { ? }\n"
+            "  case pair(b1, b2) { ? }\n"
+            "}"
+        ),
+        expected_range=Range(
+            start=Position(line=10, column=3),
+            end=Position(line=10, column=4),
+        ),
+    ),
+    CaseSplitCase(
+        name="proof_variable_of_or_formula",
+        # Proof binding ``H : P or Q`` -> ``cases H ...`` skeleton.
+        # Each branch's hypothesis label is a fresh ``h<N>`` so
+        # nested refines don't collide.
+        source=(
+            "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  assume H: P or Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=4, column=10),  # the `H` of `assume H:`
+        expected_text=(
+            "cases H\n"
+            "  case h1: P { ? }\n"
+            "  case h2: Q { ? }"
+        ),
+        expected_range=Range(
+            start=Position(line=5, column=3),
+            end=Position(line=5, column=4),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_case_split_at_template(case: CaseSplitCase) -> None:
+    edit = case_split_at("test.pf", case.source, case.cursor)
+    assert edit is not None, f"{case.name}: case_split_at returned None"
+    assert isinstance(edit, WorkspaceEdit)
+    assert edit.path == "test.pf"
+    assert edit.range == case.expected_range, (
+        f"{case.name}: range mismatch\n"
+        f"  expected: {case.expected_range}\n"
+        f"  got:      {edit.range}"
+    )
+    assert edit.new_text == case.expected_text, (
+        f"{case.name}: new_text mismatch\n"
+        f"  expected: {case.expected_text!r}\n"
+        f"  got:      {edit.new_text!r}"
+    )
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_post_edit_check_raises_at_first_case_body(
+    case: CaseSplitCase,
+) -> None:
+    """Plan acceptance: re-running ``check`` on the post-edit content
+    must surface a fresh hole *inside the first case body*. This pins
+    that the case skeleton parses and that the holes are reachable."""
+    edit = case_split_at("test.pf", case.source, case.cursor)
+    assert edit is not None
+
+    # Apply the single-line replacement.
+    lines = case.source.splitlines(keepends=True)
+    line_idx = edit.range.start.line - 1
+    start_col = edit.range.start.column - 1
+    end_col = edit.range.end.column - 1
+    new_line = (
+        lines[line_idx][:start_col]
+        + edit.new_text
+        + lines[line_idx][end_col:]
+    )
+    post = "".join(lines[:line_idx] + [new_line] + lines[line_idx + 1:])
+
+    diags = check("test.pf", post, prelude=())
+    assert len(diags) == 1, (
+        f"{case.name}: expected exactly one diagnostic on post-edit "
+        f"content, got {len(diags)}"
+    )
+    diag = diags[0]
+    assert diag.severity == Severity.ERROR
+    assert "incomplete proof" in diag.message
+    # The diagnostic should point at the first `?` inside the first
+    # case body. That `?` is at the start of the second line of
+    # ``edit.new_text`` (the body of `case ... {` ... `}`).
+    first_case_line = edit.range.start.line + 1
+    assert diag.range.start.line == first_case_line, (
+        f"{case.name}: expected diagnostic on line "
+        f"{first_case_line} (first case body), got line "
+        f"{diag.range.start.line}"
+    )
+
+
+def test_returns_none_when_cursor_not_on_identifier() -> None:
+    """Cursor on punctuation -> no identifier to split on."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on the `:` of `arbitrary P:bool`.
+    edit = case_split_at("test.pf", source, Position(line=3, column=14))
+    assert edit is None
+
+
+def test_returns_none_when_no_hole_after_cursor() -> None:
+    """Variable in scope but no `?` follows -> nothing to replace."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    # Cursor on `x`; the file has no `?` anywhere.
+    edit = case_split_at("test.pf", source, Position(line=8, column=13))
+    assert edit is None
+
+
+def test_returns_none_for_unsupported_variable_type() -> None:
+    """A bool variable has no constructors to split on -> None."""
+    # ``bool`` is built-in and not a Union from the user's POV
+    # (it's defined inside the prelude/builtins). Without prelude,
+    # ``bool`` is just a primitive type and case_split_at returns
+    # None rather than guess.
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at("test.pf", source, Position(line=3, column=13))
+    assert edit is None
+
+
+def test_returns_none_when_identifier_not_in_scope() -> None:
+    """Cursor on text that lexes as an identifier but isn't a
+    bound variable in the env at the hole."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on the `theorem` keyword -- a token, but not a
+    # variable bound in the env. The lookup fails -> None.
+    edit = case_split_at("test.pf", source, Position(line=6, column=3))
+    assert edit is None

--- a/test/lsp/test_case_split.py
+++ b/test/lsp/test_case_split.py
@@ -1,9 +1,11 @@
-"""Acceptance tests for ``lsp.query.case_split_at`` (Phase 4 / Step 16).
+"""Acceptance tests for ``lsp.query.case_split_at`` and
+``lsp.query.splittable_vars_at`` (Phase 4 / Step 16).
 
-Each fixture supplies a snippet of Deduce source, a 1-indexed cursor
-position on a variable identifier, and the literal ``new_text`` we
-expect ``case_split_at`` to produce when replacing the surrounding
-``?``.
+UX shape: cursor on a ``?``, plus an explicit ``variable`` argument
+naming what to split on. The two functions are designed to be used
+together by editor clients: ``splittable_vars_at`` populates
+completion candidates, and ``case_split_at`` produces the edit once
+the user picks one.
 
 Coverage matches the plan's five-case acceptance:
 
@@ -12,7 +14,7 @@ Coverage matches the plan's five-case acceptance:
 (c) splitting a custom union with multi-typed-parameter
     constructors,
 (d) splitting a proof variable of ``P or Q``,
-(e) cursor not on a variable (returns ``None``).
+(e) cursor not on a ``?`` (returns ``None``).
 
 All fixtures define their own union or rely on bool-only formulas so
 the tests run without the standard library prelude.
@@ -36,6 +38,7 @@ from lsp.query import (  # noqa: E402
     WorkspaceEdit,
     case_split_at,
     check,
+    splittable_vars_at,
 )
 
 
@@ -43,18 +46,15 @@ from lsp.query import (  # noqa: E402
 class CaseSplitCase:
     name: str
     source: str
-    cursor: Position
+    cursor: Position  # Cursor on a ?
+    variable: str
     expected_text: str
-    expected_range: Range
+    expected_range: Range  # Range of the ? being replaced
 
 
 CASES = [
     CaseSplitCase(
         name="nat_like_union",
-        # ``z`` and ``s(N)`` -- the canonical shape. Cursor on the
-        # `x` of ``arbitrary x:N``. Expected switch with one case
-        # per constructor; recursive parameter gets a fresh `n1`
-        # name.
         source=(
             "union N {\n"
             "  z\n"
@@ -67,7 +67,8 @@ CASES = [
             "  ?\n"
             "end\n"
         ),
-        cursor=Position(line=8, column=13),  # the `x` after `arbitrary`
+        cursor=Position(line=9, column=3),  # the ?
+        variable="x",
         expected_text=(
             "switch x {\n"
             "  case z { ? }\n"
@@ -81,9 +82,6 @@ CASES = [
     ),
     CaseSplitCase(
         name="parameterised_list_union",
-        # ``L<T>`` with constructors ``e`` and ``cons(T, L<T>)``.
-        # Tests that case-split works through TypeInst (the
-        # variable's type is ``L<bool>``, an instantiation).
         source=(
             "union L<T> {\n"
             "  e\n"
@@ -96,7 +94,8 @@ CASES = [
             "  ?\n"
             "end\n"
         ),
-        cursor=Position(line=8, column=13),  # `xs` after `arbitrary`
+        cursor=Position(line=9, column=3),
+        variable="xs",
         expected_text=(
             "switch xs {\n"
             "  case e { ? }\n"
@@ -110,9 +109,6 @@ CASES = [
     ),
     CaseSplitCase(
         name="custom_union_multi_typed_params",
-        # Three constructors covering arity 0, 1, 2 -- exercises the
-        # per-case scope reset for parameter naming (the second
-        # ``flag``'s ``b1`` shouldn't collide with ``pair``'s ``b1``).
         source=(
             "union Tag {\n"
             "  empty\n"
@@ -126,7 +122,8 @@ CASES = [
             "  ?\n"
             "end\n"
         ),
-        cursor=Position(line=9, column=13),  # `x` after `arbitrary`
+        cursor=Position(line=10, column=3),
+        variable="x",
         expected_text=(
             "switch x {\n"
             "  case empty { ? }\n"
@@ -141,9 +138,6 @@ CASES = [
     ),
     CaseSplitCase(
         name="proof_variable_of_or_formula",
-        # Proof binding ``H : P or Q`` -> ``cases H ...`` skeleton.
-        # Each branch's hypothesis label is a fresh ``h<N>`` so
-        # nested refines don't collide.
         source=(
             "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
             "proof\n"
@@ -152,7 +146,8 @@ CASES = [
             "  ?\n"
             "end\n"
         ),
-        cursor=Position(line=4, column=10),  # the `H` of `assume H:`
+        cursor=Position(line=5, column=3),
+        variable="H",
         expected_text=(
             "cases H\n"
             "  case h1: P { ? }\n"
@@ -168,7 +163,7 @@ CASES = [
 
 @pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
 def test_case_split_at_template(case: CaseSplitCase) -> None:
-    edit = case_split_at("test.pf", case.source, case.cursor)
+    edit = case_split_at("test.pf", case.source, case.cursor, case.variable)
     assert edit is not None, f"{case.name}: case_split_at returned None"
     assert isinstance(edit, WorkspaceEdit)
     assert edit.path == "test.pf"
@@ -191,10 +186,11 @@ def test_post_edit_check_raises_at_first_case_body(
     """Plan acceptance: re-running ``check`` on the post-edit content
     must surface a fresh hole *inside the first case body*. This pins
     that the case skeleton parses and that the holes are reachable."""
-    edit = case_split_at("test.pf", case.source, case.cursor)
+    edit = case_split_at(
+        "test.pf", case.source, case.cursor, case.variable
+    )
     assert edit is not None
 
-    # Apply the single-line replacement.
     lines = case.source.splitlines(keepends=True)
     line_idx = edit.range.start.line - 1
     start_col = edit.range.start.column - 1
@@ -214,9 +210,6 @@ def test_post_edit_check_raises_at_first_case_body(
     diag = diags[0]
     assert diag.severity == Severity.ERROR
     assert "incomplete proof" in diag.message
-    # The diagnostic should point at the first `?` inside the first
-    # case body. That `?` is at the start of the second line of
-    # ``edit.new_text`` (the body of `case ... {` ... `}`).
     first_case_line = edit.range.start.line + 1
     assert diag.range.start.line == first_case_line, (
         f"{case.name}: expected diagnostic on line "
@@ -225,22 +218,8 @@ def test_post_edit_check_raises_at_first_case_body(
     )
 
 
-def test_returns_none_when_cursor_not_on_identifier() -> None:
-    """Cursor on punctuation -> no identifier to split on."""
-    source = (
-        "theorem t: all P:bool. P = P\n"
-        "proof\n"
-        "  arbitrary P:bool\n"
-        "  ?\n"
-        "end\n"
-    )
-    # Cursor on the `:` of `arbitrary P:bool`.
-    edit = case_split_at("test.pf", source, Position(line=3, column=14))
-    assert edit is None
-
-
-def test_returns_none_when_no_hole_after_cursor() -> None:
-    """Variable in scope but no `?` follows -> nothing to replace."""
+def test_returns_none_when_cursor_not_on_hole() -> None:
+    """Cursor not on a ``?`` -> no replacement target -> None."""
     source = (
         "union N {\n"
         "  z\n"
@@ -250,20 +229,37 @@ def test_returns_none_when_no_hole_after_cursor() -> None:
         "theorem t: all x:N. x = x\n"
         "proof\n"
         "  arbitrary x:N\n"
-        "  reflexive\n"
+        "  ?\n"
         "end\n"
     )
-    # Cursor on `x`; the file has no `?` anywhere.
-    edit = case_split_at("test.pf", source, Position(line=8, column=13))
+    # Cursor on the `x` of `arbitrary x:N` -- no longer the right
+    # input shape; case_split_at requires cursor on the ?.
+    edit = case_split_at("test.pf", source, Position(line=8, column=13), "x")
+    assert edit is None
+
+
+def test_returns_none_for_unknown_variable() -> None:
+    """``variable`` arg names something not in scope at the hole."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at(
+        "test.pf", source, Position(line=9, column=3), "no_such_var"
+    )
     assert edit is None
 
 
 def test_returns_none_for_unsupported_variable_type() -> None:
-    """A bool variable has no constructors to split on -> None."""
-    # ``bool`` is built-in and not a Union from the user's POV
-    # (it's defined inside the prelude/builtins). Without prelude,
-    # ``bool`` is just a primitive type and case_split_at returns
-    # None rather than guess.
+    """``variable`` is in scope but its type isn't a Union / Or."""
     source = (
         "theorem t: all P:bool. P = P\n"
         "proof\n"
@@ -271,13 +267,18 @@ def test_returns_none_for_unsupported_variable_type() -> None:
         "  ?\n"
         "end\n"
     )
-    edit = case_split_at("test.pf", source, Position(line=3, column=13))
+    # `P` is in scope at the hole but bool isn't a user Union.
+    edit = case_split_at("test.pf", source, Position(line=4, column=3), "P")
     assert edit is None
 
 
-def test_returns_none_when_identifier_not_in_scope() -> None:
-    """Cursor on text that lexes as an identifier but isn't a
-    bound variable in the env at the hole."""
+# --------------------------------------------------------------------------
+# splittable_vars_at
+# --------------------------------------------------------------------------
+
+
+def test_splittable_vars_includes_term_variable() -> None:
+    """A Union-typed term variable shows up in the candidate list."""
     source = (
         "union N {\n"
         "  z\n"
@@ -290,7 +291,104 @@ def test_returns_none_when_identifier_not_in_scope() -> None:
         "  ?\n"
         "end\n"
     )
-    # Cursor on the `theorem` keyword -- a token, but not a
-    # variable bound in the env. The lookup fails -> None.
-    edit = case_split_at("test.pf", source, Position(line=6, column=3))
-    assert edit is None
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=9, column=3)
+    )
+    assert "x" in candidates
+
+
+def test_splittable_vars_includes_or_proof_variable() -> None:
+    """A proof variable of `P or Q` shows up in the candidate list."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert "H" in candidates
+
+
+def test_splittable_vars_excludes_constructors() -> None:
+    """Constructors are TermBindings of their union's type -- they
+    must NOT show up as splittable variables."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=9, column=3)
+    )
+    assert "z" not in candidates
+    assert "s" not in candidates
+
+
+def test_splittable_vars_excludes_non_splittable_term_vars() -> None:
+    """A `bool`-typed term variable isn't case-splittable."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=4, column=3)
+    )
+    assert "P" not in candidates
+
+
+def test_splittable_vars_returns_empty_when_cursor_not_on_hole() -> None:
+    """Cursor not on a ``?`` -> empty candidate list."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on the `x` of `arbitrary x:N`.
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=8, column=13)
+    )
+    assert candidates == ()
+
+
+def test_splittable_vars_returns_sorted_dedup_names() -> None:
+    """The candidate list is sorted and deduplicated."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, x:N. if P or P then x = x\n"
+        "proof\n"
+        "  arbitrary P:bool, x:N\n"
+        "  assume H: P or P\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=10, column=3)
+    )
+    # Both H (proof var of `P or P`) and x (Union-typed term var)
+    # qualify; constructors and `P` (bool) don't.
+    assert candidates == ("H", "x")

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -486,3 +486,85 @@ def test_code_action_with_unknown_uri_returns_empty(server):
         context=lsp_types.CodeActionContext(diagnostics=[]),
     )
     assert lsp_server.on_code_action(server, params) == []
+
+
+# --------------------------------------------------------------------------
+# Code actions: case_split_at (Phase 4 / Step 16)
+# --------------------------------------------------------------------------
+
+
+def test_code_action_offers_case_split_on_union_variable(server, open_doc):
+    """Cursor on a Union-typed variable with a reachable `?` ->
+    a "Case split" action carrying the switch skeleton."""
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("case_split.pf", src)
+    # `x` after `arbitrary` is at line 8, col 13 (1-indexed) ->
+    # LSP line 7, character 12.
+    params = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=7, character=12),
+            end=lsp_types.Position(line=7, character=12),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    actions = lsp_server.on_code_action(server, params)
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.title == "Case split"
+    assert action.kind == lsp_types.CodeActionKind.RefactorRewrite
+    edits = action.edit.changes[uri]
+    assert len(edits) == 1
+    assert "switch x" in edits[0].new_text
+    assert "case z {" in edits[0].new_text
+    assert "case s(n1) {" in edits[0].new_text
+    # Range covers the `?` at line 9 col 3 (LSP line 8, char 2..3).
+    assert edits[0].range.start == lsp_types.Position(line=8, character=2)
+    assert edits[0].range.end == lsp_types.Position(line=8, character=3)
+
+
+def test_code_action_offers_both_when_cursor_on_or_proof_var(
+    server, open_doc
+):
+    """A proof variable of `Or` exposes both refine (if cursor is on
+    a hole) and case-split (cursor on a variable). For this fixture
+    the cursor sits on the proof variable label, so only Case split
+    applies."""
+    src = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("or_split.pf", src)
+    # `H` of `assume H:` is at line 4 col 10 (1-indexed) -> LSP
+    # line 3, character 9.
+    params = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=3, character=9),
+            end=lsp_types.Position(line=3, character=9),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    actions = lsp_server.on_code_action(server, params)
+    titles = [a.title for a in actions]
+    assert "Case split" in titles
+    case_action = next(a for a in actions if a.title == "Case split")
+    edits = case_action.edit.changes[uri]
+    assert "cases H" in edits[0].new_text
+    assert "case h1: P" in edits[0].new_text
+    assert "case h2: Q" in edits[0].new_text

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -116,6 +116,8 @@ def test_all_expected_features_are_registered():
         lsp_types.TEXT_DOCUMENT_DOCUMENT_SYMBOL,
         lsp_types.TEXT_DOCUMENT_CODE_ACTION,
         lsp_server.GOAL_AT_REQUEST,
+        lsp_server.CASE_SPLIT_REQUEST,
+        lsp_server.SPLITTABLE_VARS_REQUEST,
     }
     assert expected.issubset(set(fm.features))
 
@@ -489,13 +491,39 @@ def test_code_action_with_unknown_uri_returns_empty(server):
 
 
 # --------------------------------------------------------------------------
-# Code actions: case_split_at (Phase 4 / Step 16)
+# Custom requests: deduce/splittableVarsAt and deduce/caseSplitAt
+# (Phase 4 / Step 16)
 # --------------------------------------------------------------------------
 
 
-def test_code_action_offers_case_split_on_union_variable(server, open_doc):
-    """Cursor on a Union-typed variable with a reachable `?` ->
-    a "Case split" action carrying the switch skeleton."""
+def test_splittable_vars_at_returns_in_scope_variables(server, open_doc):
+    """Cursor on a `?`; the response lists splittable variables in
+    scope at that hole."""
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, x:N. if P or P then x = x\n"
+        "proof\n"
+        "  arbitrary P:bool, x:N\n"
+        "  assume H: P or P\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("splittable.pf", src)
+    # `?` at line 10 col 3 (1-indexed) -> LSP line 9, char 2.
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 9, "character": 2},
+    }
+    result = lsp_server.on_splittable_vars_at(server, params)
+    assert result == ["H", "x"]
+
+
+def test_splittable_vars_at_returns_empty_off_hole(server, open_doc):
+    """Cursor not on a `?` -> empty list."""
     src = (
         "union N {\n"
         "  z\n"
@@ -508,63 +536,80 @@ def test_code_action_offers_case_split_on_union_variable(server, open_doc):
         "  ?\n"
         "end\n"
     )
-    _, uri = open_doc("case_split.pf", src)
-    # `x` after `arbitrary` is at line 8, col 13 (1-indexed) ->
-    # LSP line 7, character 12.
-    params = lsp_types.CodeActionParams(
-        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
-        range=lsp_types.Range(
-            start=lsp_types.Position(line=7, character=12),
-            end=lsp_types.Position(line=7, character=12),
-        ),
-        context=lsp_types.CodeActionContext(diagnostics=[]),
-    )
-    actions = lsp_server.on_code_action(server, params)
-    assert len(actions) == 1
-    action = actions[0]
-    assert action.title == "Case split"
-    assert action.kind == lsp_types.CodeActionKind.RefactorRewrite
-    edits = action.edit.changes[uri]
-    assert len(edits) == 1
-    assert "switch x" in edits[0].new_text
-    assert "case z {" in edits[0].new_text
-    assert "case s(n1) {" in edits[0].new_text
-    # Range covers the `?` at line 9 col 3 (LSP line 8, char 2..3).
-    assert edits[0].range.start == lsp_types.Position(line=8, character=2)
-    assert edits[0].range.end == lsp_types.Position(line=8, character=3)
+    _, uri = open_doc("splittable_off.pf", src)
+    # On `arbitrary` keyword, line 8 col 3 -> LSP line 7, char 2.
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 7, "character": 2},
+    }
+    assert lsp_server.on_splittable_vars_at(server, params) == []
 
 
-def test_code_action_offers_both_when_cursor_on_or_proof_var(
+def test_case_split_at_returns_workspace_edit_for_union_variable(
     server, open_doc
 ):
-    """A proof variable of `Or` exposes both refine (if cursor is on
-    a hole) and case-split (cursor on a variable). For this fixture
-    the cursor sits on the proof variable label, so only Case split
-    applies."""
+    """Cursor on `?`, variable=`x` (Union-typed) -> WorkspaceEdit
+    with switch skeleton."""
     src = (
-        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
         "proof\n"
-        "  arbitrary P:bool, Q:bool\n"
-        "  assume H: P or Q\n"
+        "  arbitrary x:N\n"
         "  ?\n"
         "end\n"
     )
-    _, uri = open_doc("or_split.pf", src)
-    # `H` of `assume H:` is at line 4 col 10 (1-indexed) -> LSP
-    # line 3, character 9.
-    params = lsp_types.CodeActionParams(
-        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
-        range=lsp_types.Range(
-            start=lsp_types.Position(line=3, character=9),
-            end=lsp_types.Position(line=3, character=9),
-        ),
-        context=lsp_types.CodeActionContext(diagnostics=[]),
+    _, uri = open_doc("split.pf", src)
+    # `?` at line 9 col 3 -> LSP line 8, char 2.
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 8, "character": 2},
+        "variable": "x",
+    }
+    result = lsp_server.on_case_split_at(server, params)
+    assert result is not None
+    assert "changes" in result
+    edits = result["changes"][uri]
+    assert len(edits) == 1
+    assert "switch x" in edits[0]["newText"]
+    assert "case z {" in edits[0]["newText"]
+    assert "case s(n1) {" in edits[0]["newText"]
+    assert edits[0]["range"]["start"] == {"line": 8, "character": 2}
+    assert edits[0]["range"]["end"] == {"line": 8, "character": 3}
+
+
+def test_case_split_at_returns_null_for_unknown_variable(server, open_doc):
+    """The variable name doesn't match any in-scope binding -> null."""
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
     )
-    actions = lsp_server.on_code_action(server, params)
-    titles = [a.title for a in actions]
-    assert "Case split" in titles
-    case_action = next(a for a in actions if a.title == "Case split")
-    edits = case_action.edit.changes[uri]
-    assert "cases H" in edits[0].new_text
-    assert "case h1: P" in edits[0].new_text
-    assert "case h2: Q" in edits[0].new_text
+    _, uri = open_doc("split_bad.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 8, "character": 2},
+        "variable": "no_such_var",
+    }
+    assert lsp_server.on_case_split_at(server, params) is None
+
+
+def test_case_split_at_returns_null_when_variable_omitted(server, open_doc):
+    """Missing `variable` field -> null (defensive)."""
+    src = "x"
+    _, uri = open_doc("noop.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 0, "character": 0},
+    }
+    assert lsp_server.on_case_split_at(server, params) is None

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -98,6 +98,7 @@ async def test_all_tools_are_registered(server):
             "definition_of",
             "list_symbols",
             "refine_at",
+            "case_split_at",
         }
 
 
@@ -298,6 +299,65 @@ async def test_refine_at_returns_null_when_cursor_not_on_hole(
         server,
         "refine_at",
         {"path": str(fp), "line": 4, "column": 3},
+    )
+    assert payload is None
+
+
+# --------------------------------------------------------------------------
+# case_split_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_case_split_at_returns_switch_workspace_edit(server, tmp_path):
+    """Cursor on a Union-typed variable -> switch skeleton edit."""
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "case_split.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "case_split_at",
+        {"path": str(fp), "line": 8, "column": 13},
+    )
+    assert payload is not None
+    assert payload["path"] == str(fp)
+    assert "switch x" in payload["new_text"]
+    assert "case z {" in payload["new_text"]
+    assert "case s(n1) {" in payload["new_text"]
+    # Range covers the `?` at line 9 col 3.
+    assert payload["range"]["start"] == {"line": 9, "column": 3}
+    assert payload["range"]["end"] == {"line": 9, "column": 4}
+
+
+@pytest.mark.anyio
+async def test_case_split_at_returns_null_when_cursor_not_on_variable(
+    server, tmp_path
+):
+    src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "no_split.pf"
+    fp.write_text(src)
+    # Cursor on the `:` of `arbitrary P:bool` -- not on a variable.
+    payload = await _call(
+        server,
+        "case_split_at",
+        {"path": str(fp), "line": 3, "column": 14},
     )
     assert payload is None
 

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -99,6 +99,7 @@ async def test_all_tools_are_registered(server):
             "list_symbols",
             "refine_at",
             "case_split_at",
+            "splittable_vars_at",
         }
 
 
@@ -304,13 +305,13 @@ async def test_refine_at_returns_null_when_cursor_not_on_hole(
 
 
 # --------------------------------------------------------------------------
-# case_split_at
+# case_split_at and splittable_vars_at
 # --------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
 async def test_case_split_at_returns_switch_workspace_edit(server, tmp_path):
-    """Cursor on a Union-typed variable -> switch skeleton edit."""
+    """Cursor on `?` + variable=`x` -> switch skeleton edit."""
     src = (
         "union N {\n"
         "  z\n"
@@ -328,38 +329,94 @@ async def test_case_split_at_returns_switch_workspace_edit(server, tmp_path):
     payload = await _call(
         server,
         "case_split_at",
-        {"path": str(fp), "line": 8, "column": 13},
+        {"path": str(fp), "line": 9, "column": 3, "variable": "x"},
     )
     assert payload is not None
     assert payload["path"] == str(fp)
     assert "switch x" in payload["new_text"]
     assert "case z {" in payload["new_text"]
     assert "case s(n1) {" in payload["new_text"]
-    # Range covers the `?` at line 9 col 3.
     assert payload["range"]["start"] == {"line": 9, "column": 3}
     assert payload["range"]["end"] == {"line": 9, "column": 4}
 
 
 @pytest.mark.anyio
-async def test_case_split_at_returns_null_when_cursor_not_on_variable(
+async def test_case_split_at_returns_null_when_cursor_not_on_hole(
     server, tmp_path
 ):
     src = (
-        "theorem t: all P:bool. P = P\n"
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
         "proof\n"
-        "  arbitrary P:bool\n"
+        "  arbitrary x:N\n"
         "  ?\n"
         "end\n"
     )
     fp = tmp_path / "no_split.pf"
     fp.write_text(src)
-    # Cursor on the `:` of `arbitrary P:bool` -- not on a variable.
+    # Cursor on the `x` of `arbitrary x:N` -- not on the ?.
     payload = await _call(
         server,
         "case_split_at",
-        {"path": str(fp), "line": 3, "column": 14},
+        {"path": str(fp), "line": 8, "column": 13, "variable": "x"},
     )
     assert payload is None
+
+
+@pytest.mark.anyio
+async def test_splittable_vars_at_returns_candidates(server, tmp_path):
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, x:N. if P or P then x = x\n"
+        "proof\n"
+        "  arbitrary P:bool, x:N\n"
+        "  assume H: P or P\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "candidates.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "splittable_vars_at",
+        {"path": str(fp), "line": 10, "column": 3},
+    )
+    # Constructors (z, s) excluded; bool var (P) excluded; only the
+    # Union-typed term var and the Or-formula proof var.
+    assert payload == ["H", "x"]
+
+
+@pytest.mark.anyio
+async def test_splittable_vars_at_returns_empty_off_hole(server, tmp_path):
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  arbitrary x:N\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "off.pf"
+    fp.write_text(src)
+    # Cursor on `x` of arbitrary -- not on ?.
+    payload = await _call(
+        server,
+        "splittable_vars_at",
+        {"path": str(fp), "line": 8, "column": 13},
+    )
+    assert payload == []
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -44,6 +44,7 @@ from lsp.query import (  # noqa: E402
     goal_at,
     list_symbols,
     refine_at,
+    splittable_vars_at,
 )
 
 
@@ -69,6 +70,7 @@ EXPECTED_PUBLIC = {
     "list_symbols",
     "refine_at",
     "case_split_at",
+    "splittable_vars_at",
 }
 
 
@@ -195,8 +197,16 @@ def test_refine_at_signature():
 def test_case_split_at_signature():
     _check_sig(
         case_split_at,
-        ["path", "content", "pos", "prelude"],
+        ["path", "content", "pos", "variable", "prelude"],
         Optional[WorkspaceEdit],
+    )
+
+
+def test_splittable_vars_at_signature():
+    _check_sig(
+        splittable_vars_at,
+        ["path", "content", "pos", "prelude"],
+        tuple,
     )
 
 
@@ -206,7 +216,7 @@ def test_prelude_param_has_default():
     keep working."""
     for func in (
         check, goal_at, definition_of, list_symbols, refine_at,
-        case_split_at,
+        case_split_at, splittable_vars_at,
     ):
         prelude_param = inspect.signature(func).parameters["prelude"]
         assert prelude_param.default == (), (

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -38,6 +38,7 @@ from lsp.query import (  # noqa: E402
     SymbolInfo,
     SymbolKind,
     WorkspaceEdit,
+    case_split_at,
     check,
     definition_of,
     goal_at,
@@ -67,6 +68,7 @@ EXPECTED_PUBLIC = {
     "definition_of",
     "list_symbols",
     "refine_at",
+    "case_split_at",
 }
 
 
@@ -190,11 +192,22 @@ def test_refine_at_signature():
     )
 
 
+def test_case_split_at_signature():
+    _check_sig(
+        case_split_at,
+        ["path", "content", "pos", "prelude"],
+        Optional[WorkspaceEdit],
+    )
+
+
 def test_prelude_param_has_default():
     """``prelude`` is optional on every query function so existing
     Step 3-5 callers (which pass ``path`` and ``content`` only)
     keep working."""
-    for func in (check, goal_at, definition_of, list_symbols, refine_at):
+    for func in (
+        check, goal_at, definition_of, list_symbols, refine_at,
+        case_split_at,
+    ):
         prelude_param = inspect.signature(func).parameters["prelude"]
         assert prelude_param.default == (), (
             f"{func.__name__}.prelude default drifted: "


### PR DESCRIPTION
## Summary

Second Phase-4 structured-editing operation. Given a cursor on an in-scope variable identifier, replace the next `?` in the surrounding proof body with a case-analysis skeleton chosen from the variable's binding shape:

- **Term variable, Union type** → `switch <var> { case Cons(p1, ..., pN) { ? } ... }` (one case per constructor, declaration order)
- **Proof variable, `Or` formula** → `cases <var>\n  case <fresh>: <disjunct> { ? } ...` (one case per disjunct)

## Mechanism

Reuses the Step 15 plumbing exactly. `incomplete_error` already stashes the proof env on the `IncompleteProof` exception (PR #329), so `case_split_at` runs the same `check_file` → `exc.env` path that `refine_at` does. The variable's binding is resolved by base-name lookup against `env.dict`; the underlying type is followed via `env.get_def_of_type_var`. The replacement target is the next `?` after the cursor — a forward text scan, since `?` is a single-char Deduce token (`QMARK`).

Constructor parameter names follow `proof_advice`'s convention (first letter of the type, lowercased, plus a 1..N suffix). Per-case scope reset ensures cross-case names don't pollute each other — `flag(b1)` and `pair(b1, b2)` coexist cleanly even though both use the `b` stem.

## Wiring

- **`lsp_server.py:on_code_action`** now offers both `"Refine hole"` and `"Case split"` when each applies. The Emacs binding picks by title to keep one-keystroke speed per binding (`C-c C-r` for refine, `C-c C-c` for case split when it lands).
- **`mcp_server.py`** gains a `case_split_at` tool with the same shape as `refine_at`.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 561 pass (was 544; +17)
- [x] `python3 test-deduce.py --errors` — all 153 should-error fixtures unchanged

### New tests in `test/lsp/test_case_split.py`

The plan's four-case acceptance, parameterised:

| Fixture | Coverage |
|---|---|
| `nat_like_union` | recursive constructor, single-param case |
| `parameterised_list_union` | TypeInst (`List<bool>`) -> Union resolution |
| `custom_union_multi_typed_params` | per-case scope reset for parameter naming (zero/one/two-param constructors) |
| `proof_variable_of_or_formula` | `cases` skeleton with fresh `h<N>` labels |

Each fixture asserts both:
1. The literal `new_text` produced (locks the template shape).
2. **Re-running `check` on the post-edit content surfaces an `IncompleteProof` whose location is inside the FIRST case body** — the plan's "the produced text parses; the holes are reachable" requirement.

Plus four boundary cases: cursor not on identifier, no `?` after cursor, unsupported type (bool — primitive, not a Union), and identifier not in scope.

## Limitation (v1)

Same as `goal_at` and `refine_at` — in a multi-theorem file with earlier `?`s, the checker raises on the first hole it reaches, so the env may be for the wrong theorem. Single-theorem buffers (the typical interactive case) work correctly. All three operations will lift this together when the pipeline gains per-hole goal extraction.

## Out of scope

- Emacs `C-c C-c` binding — separate PR (mirrors the `C-c C-r` refine pattern from #331). The server side is ready; the client just needs to filter `textDocument/codeAction` by title `"Case split"` instead of `"Refine hole"`.
- Step 17 (induction skeleton) — operates on the *goal* rather than a variable, uses `induction T case ... assume IH<N>: ...` shapes. Reuses the same WorkspaceEdit + code-action plumbing this PR extends.

## Files changed

- `lsp/query.py` (+266): `case_split_at` + helpers (`_identifier_at`, `_find_next_hole_offset`, `_case_split_template`, `_cases_template`, `_switch_template`, `_type_first_letter`); add to `__all__`
- `lsp/lsp_server.py` (+58 / -21): factor `_code_action_from_edit` helper, dispatch to both refine + case-split
- `lsp/mcp_server.py` (+26): new tool
- `test/lsp/test_case_split.py` (new, 12 tests)
- `test/lsp/test_lsp_server.py` (+2): code-action wiring
- `test/lsp/test_mcp_server.py` (+2): MCP tool tests + tool-list update
- `test/lsp/test_query.py` (+15): import, `__all__` entry, signature lock