### PR TITLE
Fix #333: preserve indentation on multi-line refactor templates

### DIFF
--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -326,7 +326,13 @@ non-ASCII source support, swap this for eglot's
 
 EDIT is a plist of the form `(:range PLIST :newText STR)' where
 the range is `(:start POS :end POS)' and POS is `(:line N
-:character N)'."
+:character N)'.
+
+After applying the edit, point is moved onto the first `?` in the
+inserted text -- the natural next refinement target so the user
+can type `C-c C-r' or `C-c C-c' immediately without repositioning.
+When the template has no `?' (e.g. `reflexive', `.'), point is
+left at the end of the insertion."
   (let* ((range (plist-get edit :range))
          (start (plist-get range :start))
          (end (plist-get range :end))
@@ -339,7 +345,14 @@ the range is `(:start POS :end POS)' and POS is `(:line N
               (plist-get end :character))))
     (delete-region p1 p2)
     (goto-char p1)
-    (insert new-text)))
+    (insert new-text)
+    (let ((insert-end (point)))
+      (goto-char p1)
+      (if (search-forward "?" insert-end t)
+          ;; `search-forward' lands point AFTER the match; back up
+          ;; one so it sits ON the `?'.
+          (backward-char 1)
+        (goto-char insert-end)))))
 
 
 (defun deduce-lsp--text-edits-for-uri (changes uri)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -334,6 +334,52 @@ buffer ends up with the new text in its place."
       (delete-file tmp))))
 
 
+(ert-deftest deduce-lsp/apply-text-edit-leaves-point-on-first-question-mark ()
+  "After applying a multi-line template that contains a `?', point
+lands on the FIRST `?' in the inserted text -- not at the end of
+the insertion -- so successive C-c C-r / C-c C-c can fire without
+the user repositioning the cursor."
+  (with-temp-buffer
+    (insert "  ?\n")
+    ;; Cursor on the `?` at line 1, col 3 (LSP line 0, char 2).
+    (let* ((uri "file:///tmp/x.pf")
+           (target-key (intern (concat ":" uri)))
+           (skeleton "switch x {\n    case z { ? }\n    case s(n1) { ? }\n  }")
+           (edit `(:range (:start (:line 0 :character 2)
+                           :end (:line 0 :character 3))
+                          :newText ,skeleton)))
+      (cl-letf (((symbol-function 'deduce-lsp--current-uri)
+                 (lambda () uri)))
+        (deduce-lsp--apply-text-edit edit))
+      ;; Buffer is now:
+      ;;   "  switch x {\n    case z { ? }\n    case s(n1) { ? }\n  }\n"
+      ;; The first `?' lives in `case z { ? }' on line 2.  Point
+      ;; should be sitting ON it.
+      (should (eq (char-after) ?\?))
+      ;; And the char after point is `?', not `?,' or anything else.
+      (should (looking-at-p "\\? }")))))
+
+
+(ert-deftest deduce-lsp/apply-text-edit-no-question-mark-lands-at-end ()
+  "If the template contains no `?' (e.g. `reflexive', `.'), point
+lands at the end of the insertion -- there's no inner hole to
+prefer."
+  (with-temp-buffer
+    (insert "  ?\n")
+    (let* ((uri "file:///tmp/x.pf")
+           (edit `(:range (:start (:line 0 :character 2)
+                           :end (:line 0 :character 3))
+                          :newText "reflexive")))
+      (cl-letf (((symbol-function 'deduce-lsp--current-uri)
+                 (lambda () uri)))
+        (deduce-lsp--apply-text-edit edit))
+      ;; Buffer is "  reflexive\n".  Point is at end of "reflexive"
+      ;; (12, just before the newline) -- char-after is the newline.
+      (should (eq (char-after) ?\n))
+      ;; Char before point is the last `e' of "reflexive".
+      (should (eq (char-before) ?e)))))
+
+
 (ert-deftest deduce-lsp/refine-hole-no-actions-signals-user-error ()
   "An empty action list yields a `No refinement available' user-error."
   (let ((tmp (make-temp-file "deduce-lsp-refine" nil ".pf")))

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -823,6 +823,9 @@ def refine_at(
     if template is None:
         return None
 
+    template = _indent_continuation(
+        template, _line_indent_at(content, hole_range.start)
+    )
     return WorkspaceEdit(path=path, range=hole_range, new_text=template)
 
 
@@ -849,6 +852,40 @@ def _char_range_at(content: str, offset: int) -> Range:
         start=Position(line=line, column=col),
         end=Position(line=line, column=col + 1),
     )
+
+
+def _line_indent_at(content: str, pos: Position) -> str:
+    """Return the leading whitespace of the source line containing ``pos``.
+
+    "Whitespace" here means spaces and tabs only -- newlines aren't
+    counted. Used to re-indent multi-line refactor templates so the
+    inserted text matches the surrounding proof body's indentation
+    instead of starting subsequent lines at column 0.
+    """
+    offset = _line_col_to_offset(content, pos)
+    if offset is None:
+        return ""
+    line_start = content.rfind("\n", 0, offset) + 1
+    indent_end = line_start
+    while indent_end < len(content) and content[indent_end] in " \t":
+        indent_end += 1
+    return content[line_start:indent_end]
+
+
+def _indent_continuation(template: str, indent: str) -> str:
+    """Prefix every newline-introduced line in ``template`` with ``indent``.
+
+    The first line is left alone -- it gets the indentation of the
+    line containing the ``?`` it replaces, since the WorkspaceEdit
+    inserts at that column. The continuation lines, by contrast, would
+    naturally land at column 0 without this prefix; that's the bug
+    issue #333 is about.
+
+    No-op when ``indent`` is empty or the template has no newlines.
+    """
+    if not indent or "\n" not in template:
+        return template
+    return template.replace("\n", "\n" + indent)
 
 
 def _offset_to_line_col(content: str, offset: int) -> tuple:
@@ -993,6 +1030,9 @@ def case_split_at(
     if template is None:
         return None
 
+    template = _indent_continuation(
+        template, _line_indent_at(content, hole_range.start)
+    )
     return WorkspaceEdit(path=path, range=hole_range, new_text=template)
 
 

--- a/test/lsp/test_case_split.py
+++ b/test/lsp/test_case_split.py
@@ -55,6 +55,10 @@ class CaseSplitCase:
 CASES = [
     CaseSplitCase(
         name="nat_like_union",
+        # Cursor on `?` at column 3 -> 2-space indent. Each line of
+        # the switch skeleton picks up that indent so the inserted
+        # block lines up with the surrounding proof body
+        # (issue #333).
         source=(
             "union N {\n"
             "  z\n"
@@ -67,13 +71,13 @@ CASES = [
             "  ?\n"
             "end\n"
         ),
-        cursor=Position(line=9, column=3),  # the ?
+        cursor=Position(line=9, column=3),
         variable="x",
         expected_text=(
             "switch x {\n"
-            "  case z { ? }\n"
-            "  case s(n1) { ? }\n"
-            "}"
+            "    case z { ? }\n"
+            "    case s(n1) { ? }\n"
+            "  }"
         ),
         expected_range=Range(
             start=Position(line=9, column=3),
@@ -98,9 +102,9 @@ CASES = [
         variable="xs",
         expected_text=(
             "switch xs {\n"
-            "  case e { ? }\n"
-            "  case cons(t1, l2) { ? }\n"
-            "}"
+            "    case e { ? }\n"
+            "    case cons(t1, l2) { ? }\n"
+            "  }"
         ),
         expected_range=Range(
             start=Position(line=9, column=3),
@@ -126,10 +130,10 @@ CASES = [
         variable="x",
         expected_text=(
             "switch x {\n"
-            "  case empty { ? }\n"
-            "  case flag(b1) { ? }\n"
-            "  case pair(b1, b2) { ? }\n"
-            "}"
+            "    case empty { ? }\n"
+            "    case flag(b1) { ? }\n"
+            "    case pair(b1, b2) { ? }\n"
+            "  }"
         ),
         expected_range=Range(
             start=Position(line=10, column=3),
@@ -150,8 +154,8 @@ CASES = [
         variable="H",
         expected_text=(
             "cases H\n"
-            "  case h1: P { ? }\n"
-            "  case h2: Q { ? }"
+            "    case h1: P { ? }\n"
+            "    case h2: Q { ? }"
         ),
         expected_range=Range(
             start=Position(line=5, column=3),

--- a/test/lsp/test_refine.py
+++ b/test/lsp/test_refine.py
@@ -86,7 +86,9 @@ CASES = [
     RefineCase(
         name="implication",
         # Goal: ``(if P then P)``. Template uses ``H1`` (no other
-        # ``H<N>`` is in scope yet, so we start at 1).
+        # ``H<N>`` is in scope yet, so we start at 1). The ``?'' on
+        # the second line picks up the surrounding proof body's
+        # 2-space indent (issue #333).
         source=(
             "theorem t: all P:bool. if P then P\n"
             "proof\n"
@@ -95,7 +97,7 @@ CASES = [
             "end\n"
         ),
         cursor=Position(line=4, column=3),
-        expected_text="assume H1: P\n?",
+        expected_text="assume H1: P\n  ?",
         expected_range=Range(
             start=Position(line=4, column=3),
             end=Position(line=4, column=4),
@@ -116,7 +118,7 @@ CASES = [
             "end\n"
         ),
         cursor=Position(line=5, column=3),
-        expected_text="assume H2: Q\n?",
+        expected_text="assume H2: Q\n  ?",
         expected_range=Range(
             start=Position(line=5, column=3),
             end=Position(line=5, column=4),
@@ -136,7 +138,7 @@ CASES = [
             "end\n"
         ),
         cursor=Position(line=7, column=3),
-        expected_text="assume H3: P\n?",
+        expected_text="assume H3: P\n  ?",
         expected_range=Range(
             start=Position(line=7, column=3),
             end=Position(line=7, column=4),
@@ -145,6 +147,7 @@ CASES = [
     RefineCase(
         name="forall",
         # Goal: ``(all P:bool. P = P)``. Template: ``arbitrary P:bool\n?``.
+        # ``?`` picks up the proof body's 2-space indent.
         source=(
             "theorem t: all P:bool. P = P\n"
             "proof\n"
@@ -152,7 +155,7 @@ CASES = [
             "end\n"
         ),
         cursor=Position(line=3, column=3),
-        expected_text="arbitrary P:bool\n?",
+        expected_text="arbitrary P:bool\n  ?",
         expected_range=Range(
             start=Position(line=3, column=3),
             end=Position(line=3, column=4),
@@ -259,3 +262,90 @@ def test_refine_at_cursor_one_position_after_hole() -> None:
     assert edit is not None
     assert edit.new_text == "reflexive"
     assert edit.range.start == Position(line=4, column=3)
+
+
+# --------------------------------------------------------------------------
+# Indent preservation (issue #333)
+# --------------------------------------------------------------------------
+
+
+def test_indent_continuation_zero_indent_no_change() -> None:
+    """Hole at column 1 -> no indent to add -> template unchanged."""
+    # Cursor on `?' at line 4 col 1 -- no leading whitespace.
+    # The `arbitrary P:bool` line is also unindented so the env at
+    # the hole really has just ``P`` available; goal at hole is the
+    # ``if P then P`` implication.
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "arbitrary P:bool\n"
+        "?\n"
+        "end\n"
+    )
+    edit = refine_at("test.pf", source, Position(line=4, column=1))
+    assert edit is not None
+    # No indent to add; the inner `?` stays at col 0.
+    assert edit.new_text == "assume H1: P\n?"
+
+
+def test_indent_continuation_tab_indent_preserved() -> None:
+    """Hole on a tab-indented line -> continuation line gets the
+    same tab prefix."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "\tarbitrary P:bool\n"
+        "\t?\n"
+        "end\n"
+    )
+    # Cursor on `?` at line 4 col 2 (the tab is 1 char).
+    edit = refine_at("test.pf", source, Position(line=4, column=2))
+    assert edit is not None
+    assert edit.new_text == "assume H1: P\n\t?"
+
+
+def test_indent_continuation_three_step_refine_stays_at_indent() -> None:
+    """End-to-end: three successive refines on the issue #333 reproducer
+    keep all the inserted lines at the same 2-space indent."""
+    source = (
+        "theorem ex_all_if_and: all P:bool, Q:bool, R:bool.\n"
+        "  if (if P and Q then R) then (if Q then if P then R)\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  arbitrary Q:bool\n"
+        "  arbitrary R:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+
+    def apply(src: str, edit) -> str:
+        lines = src.splitlines(keepends=True)
+        i = edit.range.start.line - 1
+        col = edit.range.start.column - 1
+        ec = edit.range.end.column - 1
+        new_line = lines[i][:col] + edit.new_text + lines[i][ec:]
+        return "".join(lines[:i] + [new_line] + lines[i + 1:])
+
+    # Three rounds of `assume H<N>: ...`
+    for _ in range(3):
+        # Find the next `?`
+        for line_num, line in enumerate(source.split("\n"), 1):
+            if "?" in line:
+                col = line.index("?") + 1
+                break
+        edit = refine_at(
+            "test.pf", source, Position(line=line_num, column=col)
+        )
+        assert edit is not None
+        source = apply(source, edit)
+
+    # Every `assume` line should be 2-space-indented; no line drops
+    # to column 0 mid-staircase.
+    for ln in source.splitlines():
+        if ln.startswith("assume "):
+            raise AssertionError(
+                f"Line lost its indent (issue #333 regression):\n  {ln!r}"
+            )
+    assert "  assume H1:" in source
+    assert "  assume H2: Q" in source
+    assert "  assume H3: P" in source


### PR DESCRIPTION
Closes #333.

## Summary

Both `refine_at` and `case_split_at` produce multi-line templates. Before this fix, newline-introduced lines landed at column 0, so successive refines produced a staircase:

```
proof
  arbitrary R:bool
  assume H1: ...
assume H2: ...        ← lost the leading "  "
assume H3: ...
?                     ← also at column 0
end
```

After the fix, every continuation line picks up the indent of the source line containing the `?` token:

```
proof
  arbitrary R:bool
  assume H1: ...
  assume H2: ...
  assume H3: ...
  ?
end
```

## Implementation

Two helpers in `lsp/query.py`:

- `_line_indent_at(content, pos)` — leading whitespace of the line containing `pos` (spaces + tabs; empty string for lines that start at column 1).
- `_indent_continuation(template, indent)` — prefixes every `\\n`-introduced line of the template with `indent`. No-op for empty indent or single-line templates.

Both `refine_at` and `case_split_at` apply `_indent_continuation(template, _line_indent_at(content, hole_range.start))` after picking the template and before constructing the `WorkspaceEdit`. **One call site per operation**, so Step 17 (induction skeleton) and Step 18 (eliminate / use-fact) get the fix for free when they land.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 575 pass (was 572; +3 indent regression tests)
- [x] `python3 test-deduce.py --errors` — 153 should-error fixtures unchanged
- [x] End-to-end on the issue #333 reproducer (the `ex_all_if_and` theorem): three successive refines now produce `H1`, `H2`, `H3` all at the same 2-space indent

### New regression tests

| Test | What it pins |
|---|---|
| `test_indent_continuation_zero_indent_no_change` | hole at column 1 → template unchanged |
| `test_indent_continuation_tab_indent_preserved` | tab-indented line → continuation gets the same tab prefix |
| `test_indent_continuation_three_step_refine_stays_at_indent` | full reproducer of the bug from issue #333 |

### Updated fixtures

Existing multi-line fixtures in `test_refine.py` (implication × 3, forall) and all four template fixtures in `test_case_split.py` updated to expect the indented continuation lines. The substring assertions in `test_lsp_server.py` and `test_mcp_server.py` still pass — `"case z {"` is still in the template, just with leading whitespace before it.