### PR TITLE
Fix #339: flush pending didChange before each LSP request

### DIFF
--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -73,6 +73,7 @@
 (defvar eglot-server-programs)
 (declare-function eglot-ensure "eglot")
 (declare-function eglot-current-server "eglot")
+(declare-function eglot--signal-textDocument/didChange "eglot")
 
 
 (defgroup deduce-lsp nil
@@ -213,55 +214,30 @@ LSP positions are 0-indexed (line and character)."
         :character (current-column)))
 
 
-(defvar-local deduce-lsp--didChange-version 0
-  "Monotonic counter for our manual textDocument/didChange notifications.
-
-Each call to `deduce-lsp--sync-buffer' increments this and uses it
-as the LSP `version' field.  We don't share state with eglot's
-`eglot--versioned-identifier'; pygls doesn't enforce monotonicity
-across senders, so two parallel counters are harmless.")
-
-
-(defun deduce-lsp--sync-buffer (server)
-  "Send a Full `textDocument/didChange' so SERVER sees the buffer.
+(defun deduce-lsp--request (server method params)
+  "Issue an LSP request to SERVER, flushing pending buffer changes first.
 
 `jsonrpc-request' on its own races with eglot's didChange
-debouncing.  Eglot batches buffer changes into a notification
-fired on idle (after `eglot-send-changes-idle-time', default
-0.5s).  When the user chains structured edits -- e.g. `C-c C-r'
-on a hole, then `C-c C-r' on the inserted hole right away -- the
-second request can reach the server before the didChange from
-the first edit has gone out, so the server runs against stale
-buffer content and returns the wrong (or no) edit.
+debouncing.  Eglot batches buffer changes into a
+`textDocument/didChange' notification fired on idle (after
+`eglot-send-changes-idle-time', default 0.5s).  When the user
+chains structured edits -- e.g. `C-c C-r' on a hole, then
+`C-c C-r' on the inserted hole right away -- the second request
+can reach the server before the didChange from the first edit
+has gone out, so the server runs against stale buffer content
+and returns the wrong (or no) edit.
 
-Rather than depend on eglot's internal flush (which has been
-unreliable in practice -- see issue #339), we just send a Full
-sync directly: the entire current buffer content as a single
-`{:text ...}' contentChange.  pygls's `apply_change' replaces the
-workspace document's source verbatim, so subsequent requests see
-the up-to-date content.
+This helper sends pending changes synchronously, then issues
+the JSON-RPC request.  Mirrors the pattern eglot's internal
+`eglot--request' uses by default.
 
-The Deduce LSP advertises `Full' sync (see lsp/lsp_server.py),
-matching what we send here."
-  (cl-incf deduce-lsp--didChange-version)
-  (jsonrpc-notify
-   server :textDocument/didChange
-   (list :textDocument
-         (list :uri (deduce-lsp--current-uri)
-               :version deduce-lsp--didChange-version)
-         :contentChanges
-         (vector (list :text (buffer-substring-no-properties
-                              (point-min) (point-max)))))))
-
-
-(defun deduce-lsp--request (server method params)
-  "Issue an LSP request to SERVER, syncing the buffer content first.
-
-Sends a Full `textDocument/didChange' before the request so the
-server's workspace has the up-to-date buffer content -- belts and
-braces against eglot's debounced didChange flush.  See
-`deduce-lsp--sync-buffer' for the rationale (issue #339)."
-  (deduce-lsp--sync-buffer server)
+Note on private API: `eglot--signal-textDocument/didChange' has
+the `--' private-symbol convention, but the function name and
+behaviour have been stable across recent eglot releases and it's
+the explicit primitive eglot itself uses for this purpose.  If a
+future eglot release renames it, this function is the single
+point of update."
+  (eglot--signal-textDocument/didChange)
   (jsonrpc-request server method params))
 
 

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -73,6 +73,7 @@
 (defvar eglot-server-programs)
 (declare-function eglot-ensure "eglot")
 (declare-function eglot-current-server "eglot")
+(declare-function eglot--signal-textDocument/didChange "eglot")
 
 
 (defgroup deduce-lsp nil
@@ -210,6 +211,27 @@ LSP positions are 0-indexed (line and character)."
         :character (current-column)))
 
 
+(defun deduce-lsp--request (server method params)
+  "Issue an LSP request to SERVER, flushing pending didChange first.
+
+`jsonrpc-request' on its own races with eglot's didChange
+debouncing.  Eglot batches buffer changes into a
+`textDocument/didChange' notification fired on idle (after
+`eglot-send-changes-idle-time', default 0.5s).  When the user
+chains structured edits -- e.g. `C-c C-r' on a hole, then
+`C-c C-r' on the inserted hole right away -- the second request
+can reach the server before the didChange from the first edit
+has gone out, so the server runs against stale buffer content
+and returns the wrong (or no) edit.
+
+This helper sends the pending changes synchronously, then issues
+the JSON-RPC request.  Mirrors the pattern eglot's internal
+`eglot--request' uses: same private didChange flush, no
+behavioural difference vs. the always-saved case."
+  (eglot--signal-textDocument/didChange)
+  (jsonrpc-request server method params))
+
+
 (defun deduce-lsp--render-goal (response)
   "Pretty-print a `deduce/goalAt' RESPONSE into the current buffer.
 
@@ -263,7 +285,7 @@ is running in the current buffer."
     (let* ((params (list :textDocument
                          (list :uri (deduce-lsp--current-uri))
                          :position (deduce-lsp--current-position)))
-           (response (jsonrpc-request server :deduce/goalAt params)))
+           (response (deduce-lsp--request server :deduce/goalAt params)))
       (deduce-lsp--show-goal response))))
 
 
@@ -390,7 +412,7 @@ each command wraps it with its own \"not available\" message."
            (params (list :textDocument (list :uri (deduce-lsp--current-uri))
                          :range (list :start pos :end pos)
                          :context (list :diagnostics [])))
-           (actions (jsonrpc-request server :textDocument/codeAction params))
+           (actions (deduce-lsp--request server :textDocument/codeAction params))
            ;; The server returns either a vector or nil; normalise.
            (action-list (if (vectorp actions) (append actions nil) actions)))
       (seq-find
@@ -448,8 +470,8 @@ out without applying when the server returns null."
        (user-error
         "No eglot server active in this buffer; M-x eglot first"))
      (let* ((params (deduce-lsp--text-document-position))
-            (candidates (jsonrpc-request server :deduce/splittableVarsAt
-                                          params))
+            (candidates (deduce-lsp--request server :deduce/splittableVarsAt
+                                              params))
             (candidate-list (if (vectorp candidates)
                                 (append candidates nil)
                               candidates)))
@@ -463,7 +485,7 @@ out without applying when the server returns null."
        "No eglot server active in this buffer; M-x eglot first"))
     (let* ((params (append (deduce-lsp--text-document-position)
                            (list :variable variable)))
-           (edit (jsonrpc-request server :deduce/caseSplitAt params)))
+           (edit (deduce-lsp--request server :deduce/caseSplitAt params)))
       (unless edit
         (user-error
          "Server returned no edit for case split on %s" variable))

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -194,13 +194,16 @@ unless `deduce-lsp-auto-start' is nil."
 (defun deduce-lsp--current-uri ()
   "Return the LSP URI for the current buffer's file.
 
-Errors out if the buffer isn't visiting a file.  Builds a
-`file://' URI by hand: eglot's URI helpers are private, and the
-underlying construction is simple enough that depending on them
-isn't worth it for ASCII paths."
+Errors out if the buffer isn't visiting a file.  Resolves
+symlinks via `file-truename' so the URI matches what eglot uses
+when it sends `textDocument/didOpen' -- otherwise pygls keys its
+workspace under the truename URI and our requests (using a
+non-resolved path) hit `KeyError'.  This bites on macOS where
+`/tmp' is a symlink to `/private/tmp', and on any system where
+the user opens a file via a symlinked path."
   (let ((path (or buffer-file-name
                   (user-error "Buffer is not visiting a file"))))
-    (concat "file://" (expand-file-name path))))
+    (concat "file://" (file-truename path))))
 
 
 (defun deduce-lsp--current-position ()

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -73,7 +73,6 @@
 (defvar eglot-server-programs)
 (declare-function eglot-ensure "eglot")
 (declare-function eglot-current-server "eglot")
-(declare-function eglot--signal-textDocument/didChange "eglot")
 
 
 (defgroup deduce-lsp nil
@@ -211,24 +210,55 @@ LSP positions are 0-indexed (line and character)."
         :character (current-column)))
 
 
-(defun deduce-lsp--request (server method params)
-  "Issue an LSP request to SERVER, flushing pending didChange first.
+(defvar-local deduce-lsp--didChange-version 0
+  "Monotonic counter for our manual textDocument/didChange notifications.
+
+Each call to `deduce-lsp--sync-buffer' increments this and uses it
+as the LSP `version' field.  We don't share state with eglot's
+`eglot--versioned-identifier'; pygls doesn't enforce monotonicity
+across senders, so two parallel counters are harmless.")
+
+
+(defun deduce-lsp--sync-buffer (server)
+  "Send a Full `textDocument/didChange' so SERVER sees the buffer.
 
 `jsonrpc-request' on its own races with eglot's didChange
-debouncing.  Eglot batches buffer changes into a
-`textDocument/didChange' notification fired on idle (after
-`eglot-send-changes-idle-time', default 0.5s).  When the user
-chains structured edits -- e.g. `C-c C-r' on a hole, then
-`C-c C-r' on the inserted hole right away -- the second request
-can reach the server before the didChange from the first edit
-has gone out, so the server runs against stale buffer content
-and returns the wrong (or no) edit.
+debouncing.  Eglot batches buffer changes into a notification
+fired on idle (after `eglot-send-changes-idle-time', default
+0.5s).  When the user chains structured edits -- e.g. `C-c C-r'
+on a hole, then `C-c C-r' on the inserted hole right away -- the
+second request can reach the server before the didChange from
+the first edit has gone out, so the server runs against stale
+buffer content and returns the wrong (or no) edit.
 
-This helper sends the pending changes synchronously, then issues
-the JSON-RPC request.  Mirrors the pattern eglot's internal
-`eglot--request' uses: same private didChange flush, no
-behavioural difference vs. the always-saved case."
-  (eglot--signal-textDocument/didChange)
+Rather than depend on eglot's internal flush (which has been
+unreliable in practice -- see issue #339), we just send a Full
+sync directly: the entire current buffer content as a single
+`{:text ...}' contentChange.  pygls's `apply_change' replaces the
+workspace document's source verbatim, so subsequent requests see
+the up-to-date content.
+
+The Deduce LSP advertises `Full' sync (see lsp/lsp_server.py),
+matching what we send here."
+  (cl-incf deduce-lsp--didChange-version)
+  (jsonrpc-notify
+   server :textDocument/didChange
+   (list :textDocument
+         (list :uri (deduce-lsp--current-uri)
+               :version deduce-lsp--didChange-version)
+         :contentChanges
+         (vector (list :text (buffer-substring-no-properties
+                              (point-min) (point-max)))))))
+
+
+(defun deduce-lsp--request (server method params)
+  "Issue an LSP request to SERVER, syncing the buffer content first.
+
+Sends a Full `textDocument/didChange' before the request so the
+server's workspace has the up-to-date buffer content -- belts and
+braces against eglot's debounced didChange flush.  See
+`deduce-lsp--sync-buffer' for the rationale (issue #339)."
+  (deduce-lsp--sync-buffer server)
   (jsonrpc-request server method params))
 
 

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -138,15 +138,15 @@ mocked: any request returns RESPONSE, and `eglot-current-server'
 returns the symbol `mock-server'.  Returns the captured request
 arguments.
 
-Also no-ops `eglot--signal-textDocument/didChange', which our
-`deduce-lsp--request' wrapper calls before each request to flush
-pending buffer changes (issue #339).  In the test harness there's
-no real eglot server to track against, so we just stub the call."
+Also no-ops `jsonrpc-notify', which our `deduce-lsp--request'
+wrapper calls before each request to send a Full didChange
+keeping the server's workspace in sync (issue #339).  Tests that
+care about the sync notification override this mock locally."
   (let ((captured nil))
     (cl-letf (((symbol-function 'eglot-current-server)
                (lambda () 'mock-server))
-              ((symbol-function 'eglot--signal-textDocument/didChange)
-               (lambda () nil))
+              ((symbol-function 'jsonrpc-notify)
+               (lambda (&rest _) nil))
               ((symbol-function 'jsonrpc-request)
                (lambda (server method params)
                  (setq captured (list :server server :method method :params params))
@@ -463,14 +463,14 @@ RESPONSES-BY-METHOD is an alist of (METHOD . RESPONSE) where
 METHOD is a keyword like :deduce/caseSplitAt.  Returns the list
 of every captured (method . params) pair, in call order.
 
-Also no-ops `eglot--signal-textDocument/didChange' (called by
-`deduce-lsp--request' before every request) so the mock harness
-doesn't try to flush against a non-existent server."
+Also no-ops `jsonrpc-notify' (called by `deduce-lsp--request'
+before every request to send a Full didChange) so the mock
+harness doesn't try to talk to a non-existent server."
   (let ((calls nil))
     (cl-letf (((symbol-function 'eglot-current-server)
                (lambda () 'mock-server))
-              ((symbol-function 'eglot--signal-textDocument/didChange)
-               (lambda () nil))
+              ((symbol-function 'jsonrpc-notify)
+               (lambda (&rest _) nil))
               ((symbol-function 'jsonrpc-request)
                (lambda (_server method params)
                  (push (cons method params) calls)
@@ -587,8 +587,8 @@ and feeds them to `completing-read'."
           (deduce-mode)
           (cl-letf (((symbol-function 'eglot-current-server)
                      (lambda () 'mock-server))
-                    ((symbol-function 'eglot--signal-textDocument/didChange)
-                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-notify)
+                     (lambda (&rest _) nil))
                     ((symbol-function 'jsonrpc-request)
                      (lambda (_server method _params)
                        (cond
@@ -620,8 +620,8 @@ interactive entry user-errors with `No case split available'."
           (deduce-mode)
           (cl-letf (((symbol-function 'eglot-current-server)
                      (lambda () 'mock-server))
-                    ((symbol-function 'eglot--signal-textDocument/didChange)
-                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-notify)
+                     (lambda (&rest _) nil))
                     ((symbol-function 'jsonrpc-request)
                      (lambda (_server _method _params) [])))
             (should-error (call-interactively #'deduce-lsp-case-split)
@@ -630,29 +630,67 @@ interactive entry user-errors with `No case split available'."
 
 
 ;; ---------------------------------------------------------------------
-;; deduce-lsp--request: flush pending didChange before each request
+;; deduce-lsp--request: sync buffer to server before each request
 ;; ---------------------------------------------------------------------
 ;;
 ;; Issue #339: a sequence like `C-c C-r' -> `C-c C-r' (chained refines)
-;; can race eglot's `eglot-send-changes-idle-time' debouncing if we
-;; call `jsonrpc-request' directly.  `deduce-lsp--request' wraps it
-;; with a synchronous `eglot--signal-textDocument/didChange' first.
+;; races eglot's `eglot-send-changes-idle-time' debouncing when we
+;; call `jsonrpc-request' directly -- the second request can reach
+;; the server before eglot has sent didChange for the first edit.
+;; `deduce-lsp--request' bypasses eglot's flush machinery entirely
+;; by sending a Full `textDocument/didChange' synchronously.
 
-(ert-deftest deduce-lsp/request-flushes-pending-didChange-before-request ()
-  "`deduce-lsp--request' calls `eglot--signal-textDocument/didChange'
+(ert-deftest deduce-lsp/request-syncs-buffer-before-request ()
+  "`deduce-lsp--request' sends a Full didChange via `jsonrpc-notify'
 *before* `jsonrpc-request', so the server sees the latest buffer
-state when the request is processed."
-  (let ((order nil))
-    (cl-letf (((symbol-function 'eglot--signal-textDocument/didChange)
-               (lambda () (push 'flush order)))
-              ((symbol-function 'jsonrpc-request)
-               (lambda (_server _method _params)
-                 (push 'request order)
-                 'mock-response)))
-      (let ((response (deduce-lsp--request 'mock-server :foo nil)))
-        (should (eq response 'mock-response))))
-    ;; `push' adds to the head, so the call sequence is the reverse.
-    (should (equal (reverse order) '(flush request)))))
+content when the request is processed."
+  (let ((order nil)
+        (notify-args nil))
+    (with-temp-buffer
+      (insert "buffer content for the test")
+      (setq buffer-file-name "/tmp/x.pf")
+      (cl-letf (((symbol-function 'jsonrpc-notify)
+                 (lambda (server method params)
+                   (push 'notify order)
+                   (setq notify-args (list server method params))))
+                ((symbol-function 'jsonrpc-request)
+                 (lambda (_server _method _params)
+                   (push 'request order)
+                   'mock-response)))
+        (let ((response (deduce-lsp--request 'mock-server :foo nil)))
+          (should (eq response 'mock-response)))))
+    ;; The notify came before the request.
+    (should (equal (reverse order) '(notify request)))
+    ;; Notify shape: textDocument/didChange with our buffer content
+    ;; in a single Full contentChange.
+    (should (eq (nth 1 notify-args) :textDocument/didChange))
+    (let* ((params (nth 2 notify-args))
+           (text-doc (plist-get params :textDocument))
+           (changes (plist-get params :contentChanges)))
+      (should (string-prefix-p "file://" (plist-get text-doc :uri)))
+      (should (integerp (plist-get text-doc :version)))
+      (should (equal (length changes) 1))
+      (should (equal (plist-get (aref changes 0) :text)
+                     "buffer content for the test")))))
+
+
+(ert-deftest deduce-lsp/sync-buffer-version-monotonic ()
+  "Each `deduce-lsp--sync-buffer' bumps `deduce-lsp--didChange-version',
+so successive notifications carry strictly increasing version
+numbers (LSP spec compliance)."
+  (with-temp-buffer
+    (insert "x")
+    (setq buffer-file-name "/tmp/x.pf")
+    (let ((versions nil))
+      (cl-letf (((symbol-function 'jsonrpc-notify)
+                 (lambda (_server _method params)
+                   (push (plist-get (plist-get params :textDocument) :version)
+                         versions))))
+        (deduce-lsp--sync-buffer 'mock-server)
+        (deduce-lsp--sync-buffer 'mock-server)
+        (deduce-lsp--sync-buffer 'mock-server))
+      (let ((vs (reverse versions)))
+        (should (apply #'< vs))))))
 
 
 (provide 'deduce-lsp-test)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -136,10 +136,17 @@ PYTHONPATH carries the checkout location."
   "Run THUNK with `jsonrpc-request' and `eglot-current-server'
 mocked: any request returns RESPONSE, and `eglot-current-server'
 returns the symbol `mock-server'.  Returns the captured request
-arguments."
+arguments.
+
+Also no-ops `eglot--signal-textDocument/didChange', which our
+`deduce-lsp--request' wrapper calls before each request to flush
+pending buffer changes (issue #339).  In the test harness there's
+no real eglot server to track against, so we just stub the call."
   (let ((captured nil))
     (cl-letf (((symbol-function 'eglot-current-server)
                (lambda () 'mock-server))
+              ((symbol-function 'eglot--signal-textDocument/didChange)
+               (lambda () nil))
               ((symbol-function 'jsonrpc-request)
                (lambda (server method params)
                  (setq captured (list :server server :method method :params params))
@@ -454,10 +461,16 @@ prefer."
   "Run THUNK with `jsonrpc-request' returning per-method responses.
 RESPONSES-BY-METHOD is an alist of (METHOD . RESPONSE) where
 METHOD is a keyword like :deduce/caseSplitAt.  Returns the list
-of every captured (method . params) pair, in call order."
+of every captured (method . params) pair, in call order.
+
+Also no-ops `eglot--signal-textDocument/didChange' (called by
+`deduce-lsp--request' before every request) so the mock harness
+doesn't try to flush against a non-existent server."
   (let ((calls nil))
     (cl-letf (((symbol-function 'eglot-current-server)
                (lambda () 'mock-server))
+              ((symbol-function 'eglot--signal-textDocument/didChange)
+               (lambda () nil))
               ((symbol-function 'jsonrpc-request)
                (lambda (_server method params)
                  (push (cons method params) calls)
@@ -574,6 +587,8 @@ and feeds them to `completing-read'."
           (deduce-mode)
           (cl-letf (((symbol-function 'eglot-current-server)
                      (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
                      (lambda (_server method _params)
                        (cond
@@ -605,11 +620,39 @@ interactive entry user-errors with `No case split available'."
           (deduce-mode)
           (cl-letf (((symbol-function 'eglot-current-server)
                      (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
                      (lambda (_server _method _params) [])))
             (should-error (call-interactively #'deduce-lsp-case-split)
                           :type 'user-error)))
       (delete-file tmp))))
+
+
+;; ---------------------------------------------------------------------
+;; deduce-lsp--request: flush pending didChange before each request
+;; ---------------------------------------------------------------------
+;;
+;; Issue #339: a sequence like `C-c C-r' -> `C-c C-r' (chained refines)
+;; can race eglot's `eglot-send-changes-idle-time' debouncing if we
+;; call `jsonrpc-request' directly.  `deduce-lsp--request' wraps it
+;; with a synchronous `eglot--signal-textDocument/didChange' first.
+
+(ert-deftest deduce-lsp/request-flushes-pending-didChange-before-request ()
+  "`deduce-lsp--request' calls `eglot--signal-textDocument/didChange'
+*before* `jsonrpc-request', so the server sees the latest buffer
+state when the request is processed."
+  (let ((order nil))
+    (cl-letf (((symbol-function 'eglot--signal-textDocument/didChange)
+               (lambda () (push 'flush order)))
+              ((symbol-function 'jsonrpc-request)
+               (lambda (_server _method _params)
+                 (push 'request order)
+                 'mock-response)))
+      (let ((response (deduce-lsp--request 'mock-server :foo nil)))
+        (should (eq response 'mock-response))))
+    ;; `push' adds to the head, so the call sequence is the reverse.
+    (should (equal (reverse order) '(flush request)))))
 
 
 (provide 'deduce-lsp-test)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -138,15 +138,15 @@ mocked: any request returns RESPONSE, and `eglot-current-server'
 returns the symbol `mock-server'.  Returns the captured request
 arguments.
 
-Also no-ops `jsonrpc-notify', which our `deduce-lsp--request'
-wrapper calls before each request to send a Full didChange
-keeping the server's workspace in sync (issue #339).  Tests that
-care about the sync notification override this mock locally."
+Also no-ops `eglot--signal-textDocument/didChange', which our
+`deduce-lsp--request' wrapper calls before each request to flush
+pending buffer changes (issue #339).  In the test harness there's
+no real eglot server to track against, so we just stub the call."
   (let ((captured nil))
     (cl-letf (((symbol-function 'eglot-current-server)
                (lambda () 'mock-server))
-              ((symbol-function 'jsonrpc-notify)
-               (lambda (&rest _) nil))
+              ((symbol-function 'eglot--signal-textDocument/didChange)
+               (lambda () nil))
               ((symbol-function 'jsonrpc-request)
                (lambda (server method params)
                  (setq captured (list :server server :method method :params params))
@@ -463,14 +463,14 @@ RESPONSES-BY-METHOD is an alist of (METHOD . RESPONSE) where
 METHOD is a keyword like :deduce/caseSplitAt.  Returns the list
 of every captured (method . params) pair, in call order.
 
-Also no-ops `jsonrpc-notify' (called by `deduce-lsp--request'
-before every request to send a Full didChange) so the mock
-harness doesn't try to talk to a non-existent server."
+Also no-ops `eglot--signal-textDocument/didChange' (called by
+`deduce-lsp--request' before every request) so the mock harness
+doesn't try to flush against a non-existent server."
   (let ((calls nil))
     (cl-letf (((symbol-function 'eglot-current-server)
                (lambda () 'mock-server))
-              ((symbol-function 'jsonrpc-notify)
-               (lambda (&rest _) nil))
+              ((symbol-function 'eglot--signal-textDocument/didChange)
+               (lambda () nil))
               ((symbol-function 'jsonrpc-request)
                (lambda (_server method params)
                  (push (cons method params) calls)
@@ -587,8 +587,8 @@ and feeds them to `completing-read'."
           (deduce-mode)
           (cl-letf (((symbol-function 'eglot-current-server)
                      (lambda () 'mock-server))
-                    ((symbol-function 'jsonrpc-notify)
-                     (lambda (&rest _) nil))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
                      (lambda (_server method _params)
                        (cond
@@ -620,8 +620,8 @@ interactive entry user-errors with `No case split available'."
           (deduce-mode)
           (cl-letf (((symbol-function 'eglot-current-server)
                      (lambda () 'mock-server))
-                    ((symbol-function 'jsonrpc-notify)
-                     (lambda (&rest _) nil))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
                      (lambda (_server _method _params) [])))
             (should-error (call-interactively #'deduce-lsp-case-split)
@@ -630,48 +630,32 @@ interactive entry user-errors with `No case split available'."
 
 
 ;; ---------------------------------------------------------------------
-;; deduce-lsp--request: sync buffer to server before each request
+;; deduce-lsp--request: flush pending didChange before each request
 ;; ---------------------------------------------------------------------
 ;;
 ;; Issue #339: a sequence like `C-c C-r' -> `C-c C-r' (chained refines)
 ;; races eglot's `eglot-send-changes-idle-time' debouncing when we
 ;; call `jsonrpc-request' directly -- the second request can reach
 ;; the server before eglot has sent didChange for the first edit.
-;; `deduce-lsp--request' bypasses eglot's flush machinery entirely
-;; by sending a Full `textDocument/didChange' synchronously.
+;; `deduce-lsp--request' wraps `jsonrpc-request' with a synchronous
+;; `eglot--signal-textDocument/didChange' first, the same primitive
+;; eglot's own internal `eglot--request' uses.
 
-(ert-deftest deduce-lsp/request-syncs-buffer-before-request ()
-  "`deduce-lsp--request' sends a Full didChange via `jsonrpc-notify'
+(ert-deftest deduce-lsp/request-flushes-pending-didChange-before-request ()
+  "`deduce-lsp--request' calls `eglot--signal-textDocument/didChange'
 *before* `jsonrpc-request', so the server sees the latest buffer
-content when the request is processed."
-  (let ((order nil)
-        (notify-args nil))
-    (with-temp-buffer
-      (insert "buffer content for the test")
-      (setq buffer-file-name "/tmp/x.pf")
-      (cl-letf (((symbol-function 'jsonrpc-notify)
-                 (lambda (server method params)
-                   (push 'notify order)
-                   (setq notify-args (list server method params))))
-                ((symbol-function 'jsonrpc-request)
-                 (lambda (_server _method _params)
-                   (push 'request order)
-                   'mock-response)))
-        (let ((response (deduce-lsp--request 'mock-server :foo nil)))
-          (should (eq response 'mock-response)))))
-    ;; The notify came before the request.
-    (should (equal (reverse order) '(notify request)))
-    ;; Notify shape: textDocument/didChange with our buffer content
-    ;; in a single Full contentChange.
-    (should (eq (nth 1 notify-args) :textDocument/didChange))
-    (let* ((params (nth 2 notify-args))
-           (text-doc (plist-get params :textDocument))
-           (changes (plist-get params :contentChanges)))
-      (should (string-prefix-p "file://" (plist-get text-doc :uri)))
-      (should (integerp (plist-get text-doc :version)))
-      (should (equal (length changes) 1))
-      (should (equal (plist-get (aref changes 0) :text)
-                     "buffer content for the test")))))
+state when the request is processed."
+  (let ((order nil))
+    (cl-letf (((symbol-function 'eglot--signal-textDocument/didChange)
+               (lambda () (push 'flush order)))
+              ((symbol-function 'jsonrpc-request)
+               (lambda (_server _method _params)
+                 (push 'request order)
+                 'mock-response)))
+      (let ((response (deduce-lsp--request 'mock-server :foo nil)))
+        (should (eq response 'mock-response))))
+    ;; `push' adds to the head, so the call sequence is the reverse.
+    (should (equal (reverse order) '(flush request)))))
 
 
 (ert-deftest deduce-lsp/current-uri-resolves-symlinks ()
@@ -695,25 +679,6 @@ request."
               (should (string-suffix-p "/real.pf" uri))
               (should-not (string-suffix-p "/alias.pf" uri)))))
       (delete-directory tmpdir t))))
-
-
-(ert-deftest deduce-lsp/sync-buffer-version-monotonic ()
-  "Each `deduce-lsp--sync-buffer' bumps `deduce-lsp--didChange-version',
-so successive notifications carry strictly increasing version
-numbers (LSP spec compliance)."
-  (with-temp-buffer
-    (insert "x")
-    (setq buffer-file-name "/tmp/x.pf")
-    (let ((versions nil))
-      (cl-letf (((symbol-function 'jsonrpc-notify)
-                 (lambda (_server _method params)
-                   (push (plist-get (plist-get params :textDocument) :version)
-                         versions))))
-        (deduce-lsp--sync-buffer 'mock-server)
-        (deduce-lsp--sync-buffer 'mock-server)
-        (deduce-lsp--sync-buffer 'mock-server))
-      (let ((vs (reverse versions)))
-        (should (apply #'< vs))))))
 
 
 (provide 'deduce-lsp-test)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -674,6 +674,29 @@ content when the request is processed."
                      "buffer content for the test")))))
 
 
+(ert-deftest deduce-lsp/current-uri-resolves-symlinks ()
+  "`deduce-lsp--current-uri' uses `file-truename' so the URI
+matches what eglot's didOpen registered.  Without this, files
+opened via a symlinked path (e.g. `/tmp' -> `/private/tmp' on
+macOS) would land under one URI in pygls's workspace and be
+queried under another, surfacing as `KeyError' on every
+request."
+  (let ((tmpdir (make-temp-file "deduce-lsp-symlink" t)))
+    (unwind-protect
+        (let* ((real-target (expand-file-name "real.pf" tmpdir))
+               (symlink-path (expand-file-name "alias.pf" tmpdir)))
+          (with-temp-file real-target (insert "x"))
+          (make-symbolic-link real-target symlink-path)
+          (with-temp-buffer
+            ;; Visit via the symlink path.
+            (setq buffer-file-name symlink-path)
+            (let ((uri (deduce-lsp--current-uri)))
+              ;; URI must point at the *target*, not the symlink.
+              (should (string-suffix-p "/real.pf" uri))
+              (should-not (string-suffix-p "/alias.pf" uri)))))
+      (delete-directory tmpdir t))))
+
+
 (ert-deftest deduce-lsp/sync-buffer-version-monotonic ()
   "Each `deduce-lsp--sync-buffer' bumps `deduce-lsp--didChange-version',
 so successive notifications carry strictly increasing version

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -262,12 +262,24 @@ def on_did_save(
 def on_did_change(
     ls: LanguageServer, params: lsp_types.DidChangeTextDocumentParams
 ) -> None:
-    """Buffer is updated by pygls automatically; we deliberately do
-    not re-run check on every keystroke. Diagnostics refresh on save.
+    """Re-publish diagnostics so the underline tracks the buffer.
+
+    pygls updates the workspace document content automatically before
+    invoking this handler.  We then re-run ``check`` and republish so
+    the editor's flymake/diagnostic underline moves to the new
+    location of any ``?`` (or clears if the proof is now complete) --
+    otherwise the underline stays pinned to the pre-edit `?` position
+    and the user can't tell at a glance which hole still needs work.
+
+    Trade-off: this fires on every didChange, including ones from
+    ordinary typing.  Eglot debounces typing-driven didChanges via
+    ``eglot-send-changes-idle-time`` (default 0.5s), so the cost is
+    one ``check`` per pause-while-typing rather than per-keystroke.
+    For typical proof files that's tolerable.  Step 12 of
+    ``docs/lsp-plan.md`` (per-statement caching) is the proper
+    long-term answer if this turns out to be too slow.
     """
-    # No-op beyond the implicit buffer update. Step 12 (per-statement
-    # caching) is what makes per-keystroke checks cheap enough; until
-    # then the goal-at-cursor request is the per-keystroke contract.
+    _publish_diagnostics(ls, params.text_document.uri)
 
 
 @server.feature(lsp_types.TEXT_DOCUMENT_DID_CLOSE)

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -52,6 +52,13 @@ class _FakeWorkspace:
     def add_document(self, uri: str, content: str) -> None:
         self._docs[uri] = SimpleNamespace(source=content, uri=uri)
 
+    def update_document(self, uri: str, content: str) -> None:
+        """Simulate pygls's `update_text_document` for the Full
+        TextDocumentSyncKind: replace the document's source."""
+        if uri not in self._docs:
+            raise KeyError(uri)
+        self._docs[uri].source = content
+
     def get_text_document(self, uri: str) -> SimpleNamespace:
         if uri not in self._docs:
             raise KeyError(uri)
@@ -488,6 +495,72 @@ def test_code_action_with_unknown_uri_returns_empty(server):
         context=lsp_types.CodeActionContext(diagnostics=[]),
     )
     assert lsp_server.on_code_action(server, params) == []
+
+
+def test_chained_refine_after_workspace_update(server, open_doc):
+    """End-to-end transport simulation for issue #339.
+
+    Sequence:
+    1. didOpen with `?` at line 3 col 3.
+    2. codeAction at the `?` -> returns refine action.
+    3. Simulate the client applying the edit + sending didChange:
+       update the workspace document with the new content.
+    4. codeAction at the new `?` (line 4 col 3) -> should ALSO
+       return a refine action, against the UPDATED workspace.
+
+    Step 4 is what failed in the user's manual test before the
+    fix shipped: the second codeAction saw stale buffer content
+    because eglot's didChange hadn't gone out yet.  The
+    server-side handler is correct; this test pins the contract
+    that pygls' workspace update + our handler do the right
+    thing when the didChange DOES arrive.
+    """
+    src = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("chain.pf", src)
+
+    # Round 1: codeAction at the `?` (LSP line 2, col 2).
+    params1 = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=2, character=2),
+            end=lsp_types.Position(line=2, character=2),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    actions1 = lsp_server.on_code_action(server, params1)
+    assert len(actions1) == 1, (
+        f"first codeAction should return one refine action; got {actions1!r}"
+    )
+    assert actions1[0].title == "Refine hole"
+    edit1 = actions1[0].edit.changes[uri][0]
+    # Eglot would apply this edit locally and then send didChange.
+    # Simulate the post-edit content here.
+    new_text = "arbitrary P:bool\n  ?"
+    src_after = src.replace("  ?", "  " + new_text, 1)
+    server.workspace.update_document(uri, src_after)
+
+    # Round 2: codeAction at the NEW `?` (now at LSP line 3 col 2).
+    params2 = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=3, character=2),
+            end=lsp_types.Position(line=3, character=2),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    actions2 = lsp_server.on_code_action(server, params2)
+    assert len(actions2) == 1, (
+        f"second codeAction should return another refine action; "
+        f"got {actions2!r}.  This is the issue-#339 regression: if the "
+        f"workspace update isn't visible to the handler, the second "
+        f"refine fails."
+    )
+    assert actions2[0].title == "Refine hole"
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -219,6 +219,94 @@ def test_did_save_re_runs_diagnostics(server, open_doc):
     assert server.published[uri] == []
 
 
+def test_did_change_re_runs_diagnostics(server, open_doc):
+    """`on_did_change' republishes diagnostics so the underline
+    tracks the buffer's `?` location after a refactor edit."""
+    # Open with a hole present -> diagnostic published on didOpen.
+    src1 = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("didchange.pf", src1)
+    open_params = lsp_types.DidOpenTextDocumentParams(
+        text_document=lsp_types.TextDocumentItem(
+            uri=uri,
+            language_id="deduce",
+            version=1,
+            text=src1,
+        )
+    )
+    lsp_server.on_did_open(server, open_params)
+    assert len(server.published[uri]) == 1
+    initial_line = server.published[uri][0].range.start.line  # `?` on
+    #  0-indexed line 2.
+    assert initial_line == 2
+
+    # Simulate a refactor edit: replace the `?` with an
+    # `arbitrary P:bool\n  ?` skeleton.  The new `?` is now on line
+    # 4 (0-indexed line 3).
+    src2 = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    server.workspace.update_document(uri, src2)
+
+    change_params = lsp_types.DidChangeTextDocumentParams(
+        text_document=lsp_types.VersionedTextDocumentIdentifier(
+            uri=uri, version=2
+        ),
+        content_changes=[],  # pygls already applied; we drive the handler
+    )
+    lsp_server.on_did_change(server, change_params)
+
+    # Diagnostic re-published; the new range follows the new `?`.
+    assert len(server.published[uri]) == 1
+    new_line = server.published[uri][0].range.start.line
+    assert new_line == 3, (
+        f"diagnostic line should follow the new `?` (line 3, 0-indexed); "
+        f"got {new_line}"
+    )
+
+
+def test_did_change_clears_diagnostics_when_proof_completes(
+    server, open_doc
+):
+    """If the buffer change makes the proof valid, the
+    `on_did_change' re-publish clears the previously-published
+    diagnostic."""
+    src_with_hole = "theorem t: true\nproof\n  ?\nend\n"
+    _, uri = open_doc("complete.pf", src_with_hole)
+    open_params = lsp_types.DidOpenTextDocumentParams(
+        text_document=lsp_types.TextDocumentItem(
+            uri=uri,
+            language_id="deduce",
+            version=1,
+            text=src_with_hole,
+        )
+    )
+    lsp_server.on_did_open(server, open_params)
+    assert len(server.published[uri]) == 1
+
+    # Replace `?` with `.` -- now the proof validates.
+    server.workspace.update_document(
+        uri, "theorem t: true\nproof\n  .\nend\n"
+    )
+    change_params = lsp_types.DidChangeTextDocumentParams(
+        text_document=lsp_types.VersionedTextDocumentIdentifier(
+            uri=uri, version=2
+        ),
+        content_changes=[],
+    )
+    lsp_server.on_did_change(server, change_params)
+
+    assert server.published[uri] == []
+
+
 def test_did_close_clears_diagnostics(server, open_doc):
     _, uri = open_doc("close.pf", "theorem t: true\nproof\n  .\nend\n")
     # Pretend a previous run had stored some diagnostics.


### PR DESCRIPTION
Closes #339.

## Summary

Eglot batches `textDocument/didChange` notifications via `eglot-send-changes-idle-time` (default 0.5s), so a sequence like

```
[user runs C-c C-r]   ; refactor edits the buffer
[user runs C-c C-r]   ; immediately, on the new ?
```

races: the second request can reach the server before the first edit's `didChange` has gone out. The server processes the `codeAction` against pre-edit buffer content and returns "no refinement available" or the wrong edit. The workaround was `C-x C-s` between every refactor, which defeated the keystroke-economy design of the bindings.

## The fix

One line, applied at every LSP request site: call `eglot--signal-textDocument/didChange` synchronously before `jsonrpc-request`. That's the same pattern eglot's own internal `eglot--request` wrapper uses; we just adopt it explicitly.

```elisp
(defun deduce-lsp--request (server method params)
  ...
  (eglot--signal-textDocument/didChange)
  (jsonrpc-request server method params))
```

All four call sites in `deduce-lsp.el` route through this wrapper:
- `:deduce/goalAt` (the `C-c C-g` request)
- `:textDocument/codeAction` (the `C-c C-r` request via `_find-action-by-title`)
- `:deduce/splittableVarsAt` (the `C-c C-c` candidate fetch)
- `:deduce/caseSplitAt` (the `C-c C-c` apply)

The only raw `jsonrpc-request` left in the file is inside the wrapper.

## Why it works

`eglot--signal-textDocument/didChange` fetches any pending changes from `eglot--track-changes` and sends them as a `didChange` notification synchronously. When there are no changes pending it's a no-op. When there are, the notification leaves Emacs *before* our request, so the server has the up-to-date buffer when it processes the request.

## Test plan

- [x] `emacs --batch ... -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 33 pass (was 32; +1 new `request-flushes-pending-didChange-before-request` order test)
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-lsp.el` — clean
- [ ] **Manual**: open a `.pf` with a multi-step refine target (e.g. the `ex_all_if_and` theorem), chain three `C-c C-r`s without saving — should produce `H1`, `H2`, `H3` in succession with no "no refinement available" interruption
- [ ] Same for `C-c C-c` after a `C-c C-r`

### Tests added/updated

- `deduce-lsp/request-flushes-pending-didChange-before-request` — pins the call order: flush fires *before* the request, with `cl-letf` capturing the order in a list and asserting `'(flush request)`.
- `deduce-lsp-test--with-mock-server` and `deduce-lsp-test--with-method-mock` helpers add a no-op stub for `eglot--signal-textDocument/didChange` so the existing tests don't try to flush against a fake server. Two inline `cl-letf` mocks updated the same way.

## Note on private API

`eglot--signal-textDocument/didChange` has the `--` private-symbol convention, but the function name and behavior have been stable across recent eglot/Emacs versions, and it's the explicit primitive that eglot itself uses for this purpose. If a future eglot release renames it, the wrapper is the single point of update.