### PR TITLE
Fix #341: goal_at handles cursor on or just past existing ?

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -314,18 +314,37 @@ def goal_at(
 
     Returns ``None`` when there is no active proof at that position --
     e.g. the cursor is outside any ``proof ... end`` block, or the file
-    does not parse. Implemented by inserting a ``?`` hole at ``pos``
-    (more precisely: replacing the content from ``pos`` up to the next
-    ``end`` keyword with ``?``) and capturing the goal text the checker
-    prints when it reaches the hole.
+    does not parse.
+
+    When the cursor sits on or immediately adjacent to a ``?`` already
+    present in the source, that hole IS the goal site and we run
+    ``check`` on the original content -- the existing ``?`` raises
+    ``IncompleteProof`` and we read the goal off the exception. The
+    returned ``Goal.range`` covers exactly the ``?`` token (1-char
+    span), matching what :func:`refine_at` and :func:`case_split_at`
+    return.
+
+    Otherwise we insert a synthetic ``?`` at the cursor (truncating
+    forward to the enclosing block end) and capture the goal text the
+    checker prints when it reaches that hole. The returned
+    ``Goal.range`` is then a degenerate range at the cursor.
 
     ``prelude`` matches the meaning in :func:`check`.
     """
     from lsp.library import check_file
 
-    modified = _insert_hole(content, pos)
-    if modified is None:
-        return None
+    # Cursor on (or just past) an existing `?`?  Don't insert a
+    # second one -- `_insert_hole` would emit `?\n?` which the parser
+    # rejects (issue #341).
+    existing_hole = _find_hole_at(content, pos)
+    if existing_hole is not None:
+        modified = content
+        goal_range = existing_hole
+    else:
+        modified = _insert_hole(content, pos)
+        if modified is None:
+            return None
+        goal_range = Range(start=pos, end=pos)
 
     result = check_file(path, content=modified, prelude=prelude)
     if result.ok:
@@ -333,7 +352,7 @@ def goal_at(
         # without needing the inserted ?. Nothing to report.
         return None
 
-    return _goal_from_exception(result.exception, pos)
+    return _goal_from_exception(result.exception, goal_range)
 
 
 def _insert_hole(content: str, pos: Position) -> Optional[str]:
@@ -426,7 +445,7 @@ _END_RE = re.compile(r"\bend\b")
 
 
 def _goal_from_exception(
-    exc: Optional[BaseException], pos: Position
+    exc: Optional[BaseException], goal_range: Range
 ) -> Optional[Goal]:
     """Parse an ``IncompleteProof`` message into a ``Goal``.
 
@@ -446,6 +465,11 @@ def _goal_from_exception(
     advice that follows is intentionally discarded -- callers that want
     advice can read ``Diagnostic.message`` from ``check`` instead.
 
+    ``goal_range`` is the source range to attach to the returned
+    :class:`Goal` -- typically the 1-char span of an existing ``?``
+    token, or a degenerate range at the cursor when ``goal_at``
+    inserted a synthetic hole.
+
     Returns ``None`` when the message doesn't match (e.g. the exception
     is something other than the goal-bearing PHole, like a parse error
     triggered by the inserted ``?`` ending up in a bad spot).
@@ -461,9 +485,7 @@ def _goal_from_exception(
         return None
 
     givens = _parse_givens_section(body)
-
-    cursor_range = Range(start=pos, end=pos)
-    return Goal(formula=formula, givens=givens, range=cursor_range)
+    return Goal(formula=formula, givens=givens, range=goal_range)
 
 
 def _extract_goal_formula(body: str) -> Optional[str]:

--- a/test/lsp/test_goal_at.py
+++ b/test/lsp/test_goal_at.py
@@ -189,3 +189,81 @@ def test_goal_at_works_inside_nested_case_block() -> None:
     )
     assert isinstance(g, Goal)
     assert g.range.start == Position(line=6, column=1)
+
+
+# --------------------------------------------------------------------------
+# Cursor on or adjacent to an existing `?` (issue #341)
+# --------------------------------------------------------------------------
+#
+# When the cursor sits on -- or one column past -- a `?` already in
+# the source, the existing hole IS the goal site.  ``goal_at`` should
+# *not* synthesise a second `?` (which would put two `?`s in a row in
+# the modified source and trip the parser); it should run ``check``
+# on the unmodified content and let the existing `?` raise.
+
+
+def test_goal_at_cursor_on_existing_hole() -> None:
+    """Cursor exactly on the `?` returns the goal at that hole, with
+    a Range covering the `?` itself."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    g = goal_at("test.pf", source, Position(line=4, column=3))
+    assert g is not None
+    assert g.formula == "P = P"
+    # Range covers exactly the `?` token, matching what refine_at
+    # and case_split_at return.
+    assert g.range.start == Position(line=4, column=3)
+    assert g.range.end == Position(line=4, column=4)
+
+
+def test_goal_at_cursor_immediately_after_existing_hole() -> None:
+    """Cursor one column past the `?` (the natural cursor position
+    just after typing `?`) still resolves to the existing hole.
+    Without the fix this returned ``None`` because ``_insert_hole''
+    produced an unparseable ``?\\n?`` sequence."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    # `?` is at line 4 col 3; cursor at col 4 sits just past it.
+    g = goal_at("test.pf", source, Position(line=4, column=4))
+    assert g is not None, (
+        "goal_at returned None for cursor-just-past-`?` -- the "
+        "regression for issue #341 has reappeared."
+    )
+    assert g.formula == "P = P"
+    # Range still covers the `?`, not the cursor position.
+    assert g.range.start == Position(line=4, column=3)
+    assert g.range.end == Position(line=4, column=4)
+
+
+def test_goal_at_cursor_on_hole_matches_synthetic_hole_path() -> None:
+    """Sanity: the cursor-on-`?` path and the synthesise-a-hole path
+    return the same formula and givens for matching positions.
+    (Range differs: 1-char vs degenerate.)"""
+    source_with_hole = (
+        "theorem t: all P:bool, Q:bool. if P then if Q then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    source_without_hole = source_with_hole.replace("?", "pP")
+    # On the `?`: existing-hole path.
+    g1 = goal_at("test.pf", source_with_hole, Position(line=6, column=3))
+    # Synthesise-a-hole path: cursor on the same line, but the source
+    # has `pP` instead of `?`.
+    g2 = goal_at("test.pf", source_without_hole, Position(line=6, column=1))
+    assert g1 is not None and g2 is not None
+    assert g1.formula == g2.formula
+    assert g1.givens == g2.givens


### PR DESCRIPTION
Closes #341.

## Summary

`goal_at` previously called `_insert_hole` unconditionally, producing a `?\n?` sequence when the cursor was on (or one column past) an existing `?` in the source. The parser rejects that, so the request returned `None` instead of the goal at the existing hole.

Fix: route through `_find_hole_at` first — the helper `refine_at` and `case_split_at` already use. When the cursor is on or adjacent to a real `?`, run `check` on the unmodified content; the existing `?` raises `IncompleteProof` on its own. Otherwise fall back to the existing synthesise-a-hole path.

## UX impact

Two flows that were previously broken now work:

1. **Just typed `?`.** Emacs leaves point past the inserted character; `C-c C-g` immediately after used to say "no goal." Now it works.
2. **`C-f` past a `?` then `C-c C-g`.** Same thing — peeking past a hole and asking for the goal.

## Bonus

`Goal.range` now covers exactly the `?` token (1-char span) when an existing hole was found — matches what `refine_at` / `case_split_at` return, and gives the editor a tighter hover region. The synthesise-a-hole path keeps its degenerate `(cursor, cursor)` range; the cursor *is* the goal site there.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 583 pass (was 580; +3 new in `test_goal_at.py`)
- [x] Manual smoke at the query layer (no LSP transport):
  ```
  cursor on `?` (col 3):       Goal('P = P', range=col 3..4)
  cursor just past `?` (col 4): Goal('P = P', range=col 3..4)
  cursor on whitespace before `?` (col 1): Goal('P = P', range=col 1..1)
  ```
- [ ] Manual smoke in Emacs after merge: open a `.pf` with a `?`, place point on the `?`, hit `C-c C-g` → goal popup. Press `C-f` to advance one column, hit `C-c C-g` → same goal popup (no "no goal" message).

## Tests added

- `test_goal_at_cursor_on_existing_hole` — cursor exactly on `?` returns the goal with a 1-char range.
- `test_goal_at_cursor_immediately_after_existing_hole` — cursor at col+1 resolves to the same hole. Pins the issue-#341 regression case.
- `test_goal_at_cursor_on_hole_matches_synthetic_hole_path` — the two paths return matching formula/givens for matching cursor positions.

## Files changed

- `lsp/query.py` (+~30 / -~10): `goal_at` checks `_find_hole_at` first; `_goal_from_exception` takes a `Range` instead of a `Position`.
- `test/lsp/test_goal_at.py` (+~80): three new test cases.