### PR TITLE
Fix #346: broaden .thm gitignore to all directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,8 @@ lark/parsers/__pycache__
 personal
 
 # test theorems and generated proofs
-test/**/*.thm
+*.thm
 test/**/doc_*.pf
-lib/*.thm
 
 # vscode files
 .vscode


### PR DESCRIPTION
## Summary
- Replace `test/**/*.thm` and `lib/*.thm` with a single `*.thm` pattern so stray `.thm` artifacts no longer slip into commits.

## Why
`deduce.py` writes `.thm` files next to whatever `.pf` is being checked. That puts them at the repo root (e.g. `example.thm`), in `gh_pages/deduce-code/` when running `test-deduce.py --site`, and anywhere else a user happens to run the checker. The previous narrow patterns missed all of those, which is why several commits on PR #330 had to be amended to drop accidentally-staged artifacts. `.thm` is purely a generated artifact, so a broad `*.thm` rule is the right fix.

## Test plan
- [x] `git ls-files | grep '\.thm$'` returns nothing — no currently tracked `.thm` files would be untracked by this change.
- [ ] After merging, run `python deduce.py example.pf` from the repo root and confirm `git status` does not list `example.thm`.

Closes #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)