### PR TITLE
LSP Phase 4 / Step 17: induction skeleton via WorkspaceEdit

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -102,6 +102,14 @@ auto-start hook:
   ...` (for proof variables of `P or Q` shape). The `?` under the
   cursor is unambiguously the replacement target -- no surprise
   inserts at the wrong hole.
+- `C-c C-i` -- induction skeleton. Cursor on a `?` whose goal is
+  `all x:T. P(x)` (T a `Union` with at least two constructors).
+  Issues `textDocument/codeAction` and applies the action titled
+  `Induction` directly (no picker). Replaces the `?` with
+  `induction T\n  case Cons1(...) { ? }\n  case Cons2(...) assume
+  IH<N>: ... { ? }\n...` -- one case per constructor in declaration
+  order; recursive parameters get `IH<N>` bindings whose formula is
+  the body with the inducted variable substituted.
 
 ## Keybindings
 
@@ -114,9 +122,7 @@ auto-start hook:
 | `C-c C-g` | `deduce-show-goal-at-point`      | `deduce-lsp`   | Goal + givens at cursor                   |
 | `C-c C-r` | `deduce-lsp-refine-hole`         | `deduce-lsp`   | Apply LSP-suggested template at hole      |
 | `C-c C-c` | `deduce-lsp-case-split`          | `deduce-lsp`   | Prompt for variable, replace `?` with case skeleton |
-
-The remaining Phase-4 keybinding (`C-c C-i` induction) will land
-when the server's Step 17 operation does.
+| `C-c C-i` | `deduce-lsp-induction`           | `deduce-lsp`   | Replace `?` with `induction T` skeleton at a forall goal |
 
 ## Customization
 
@@ -240,6 +246,25 @@ Then verify the LSP integration:
    replaced with `switch x { case z { ? } case s(n1) { ? } }`. Each
    branch is now its own hole that `C-c C-r` / `C-c C-c` can refine
    further.
+10. In a scratch `.pf` buffer with the same `N` union, but with the
+    `?` *before* `arbitrary`:
+
+    ```
+    union N {
+      z
+      s(N)
+    }
+
+    theorem t: all x:N. x = x
+    proof
+      ?
+    end
+    ```
+
+    Place point on the `?` and press `C-c C-i`. The `?` should be
+    replaced with `induction N\n  case z { ? }\n  case s(n1) assume
+    IH1: n1 = n1 { ? }`. The recursive constructor `s` gets an `IH1`
+    binding for the predecessor `n1`.
 
 ## Development
 

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -35,9 +35,9 @@
 ;;   M-x imenu                  outline of top-level decls (documentSymbol)
 ;;
 ;; Step 5 adds `C-c C-g' for the custom `deduce/goalAt' request.
-;; Step 6 adds Phase-4 keybindings: `C-c C-r' (refine, LSP Step 15)
-;; and `C-c C-c' (case split, LSP Step 16) are live; `C-c C-i'
-;; (induction, Step 17) follows when that server operation lands.
+;; Step 6 adds Phase-4 keybindings: `C-c C-r' (refine, LSP Step 15),
+;; `C-c C-c' (case split, LSP Step 16), and `C-c C-i' (induction
+;; skeleton, LSP Step 17) are all live.
 ;;
 ;; Server command
 ;; --------------
@@ -306,10 +306,10 @@ is running in the current buffer."
 
 
 ;; ---------------------------------------------------------------------
-;; Phase-4 structured edits (Step 6 -- partial)
+;; Phase-4 structured edits (Step 6)
 ;; ---------------------------------------------------------------------
 ;;
-;; Live bindings (LSP Steps 15-16):
+;; Live bindings (LSP Steps 15-17):
 ;;
 ;;   `C-c C-r'  deduce-lsp-refine-hole  (Step 15)
 ;;     Cursor on a `?'.  Issues `textDocument/codeAction' filtered to
@@ -324,17 +324,17 @@ is running in the current buffer."
 ;;     which `?' the skeleton replaces -- it's the one under the
 ;;     cursor.
 ;;
-;; The two operations use different transports because their UX
-;; requirements differ: refine takes no extra input (the cursor is
-;; the only signal), so it fits cleanly in `textDocument/codeAction';
-;; case-split takes a user-supplied variable name, which codeAction
-;; can't carry, so it gets a custom server method.
+;;   `C-c C-i'  deduce-lsp-induction    (Step 17)
+;;     Cursor on a `?' whose goal is `all x:T. P(x)' (T a Union with
+;;     >=2 alternatives).  Issues `textDocument/codeAction' filtered
+;;     to `refactor.rewrite' and applies the action titled
+;;     "Induction".  Same one-keystroke shape as refine -- the goal
+;;     itself is the only input the operation needs.
 ;;
-;; Step 17 (induction skeleton) will land as `C-c C-i' once the
-;; server's induction_skeleton_at operation is available.  Like
-;; refine, it takes no extra input -- the cursor is on a `?' whose
-;; goal is `all x:T. ...' -- so it'll surface as another
-;; `refactor.rewrite' code action.
+;; Refine and induction use `textDocument/codeAction' because they
+;; take no extra user input.  Case-split takes a user-supplied
+;; variable name, which codeAction can't carry, so it gets a custom
+;; server method.
 
 (defun deduce-lsp--lsp-pos-to-point (line character)
   "Convert LSP 0-indexed (LINE, CHARACTER) to a point in the current buffer.
@@ -512,11 +512,33 @@ out without applying when the server returns null."
     (mapc #'deduce-lsp--apply-text-edit (reverse (append edits nil)))))
 
 
-;; Bind `C-c C-r' (refine) and `C-c C-c' (case split) in
-;; `deduce-mode-map'.  Same rationale as `C-c C-g': only meaningful
-;; when LSP is loaded.
+(defun deduce-lsp-induction ()
+  "Apply the LSP-suggested induction skeleton for the goal at point.
+
+Issues a `textDocument/codeAction' request and picks the action
+titled \"Induction\" -- the LSP server's Step-17 output.  The
+matching action's WorkspaceEdit replaces the `?' under point
+with an `induction T\\n  case Cons1(...) [assume IH<N>: ...] { ? }
+  ...' skeleton, one case per constructor.
+
+When the cursor isn't on a hole, when the goal isn't `all x:T.
+P(x)' over a Union, or when the union has fewer than two
+constructors, errors with `No induction available at point.'
+When no eglot connection is active, prompts the user to run
+`M-x eglot' first."
+  (interactive)
+  (let ((action (deduce-lsp--find-action-by-title "Induction")))
+    (unless action
+      (user-error "No induction available at point"))
+    (deduce-lsp--apply-code-action action)))
+
+
+;; Bind `C-c C-r' (refine), `C-c C-c' (case split), and `C-c C-i'
+;; (induction) in `deduce-mode-map'.  Same rationale as `C-c C-g':
+;; only meaningful when LSP is loaded.
 (define-key deduce-mode-map (kbd "C-c C-r") #'deduce-lsp-refine-hole)
 (define-key deduce-mode-map (kbd "C-c C-c") #'deduce-lsp-case-split)
+(define-key deduce-mode-map (kbd "C-c C-i") #'deduce-lsp-induction)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -681,6 +681,92 @@ request."
       (delete-directory tmpdir t))))
 
 
+;; ---------------------------------------------------------------------
+;; deduce-lsp-induction (LSP Step 17, fronted by `C-c C-i')
+;; ---------------------------------------------------------------------
+;;
+;; Same wire-shape as refine -- a `textDocument/codeAction' request,
+;; filtered by `:title' "Induction".  No user input beyond the
+;; cursor on a `?'.
+
+(ert-deftest deduce-lsp/induction-bound-to-c-c-c-i ()
+  "`C-c C-i' in deduce-mode-map runs `deduce-lsp-induction'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-i"))
+              #'deduce-lsp-induction)))
+
+
+(ert-deftest deduce-lsp/induction-applies-text-edit ()
+  "Given a CodeAction titled \"Induction\" with a TextEdit replacing
+the `?', the buffer ends up with an `induction T' skeleton."
+  (let ((tmp (make-temp-file "deduce-lsp-induction" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "union N {\n  z\n  s(N)\n}\n\ntheorem t: all x:N. x = x\nproof\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; Cursor on the `?` at line 8 col 3 -> LSP line 7, char 2.
+          (goto-char (point-min))
+          (forward-line 7)
+          (forward-char 2)
+          (let* ((uri (deduce-lsp--current-uri))
+                 (skeleton "induction N\n    case z { ? }\n    case s(n1) assume IH1: n1 = n1 { ? }")
+                 (action `(:title "Induction"
+                           :kind "refactor.rewrite"
+                           :edit
+                           (:changes
+                            (,(intern (concat ":" uri))
+                             [(:range (:start (:line 7 :character 2)
+                                       :end (:line 7 :character 3))
+                                      :newText ,skeleton)]))))
+                 (response (vector action)))
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda () (deduce-lsp-induction))))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "induction N" text))
+            (should (string-match-p "case z {" text))
+            (should (string-match-p "case s(n1) assume IH1" text))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/induction-no-action-signals-user-error ()
+  "An empty action list yields a `No induction available' user-error."
+  (let ((tmp (make-temp-file "deduce-lsp-induction" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (deduce-lsp-test--with-mock-server
+           nil
+           (lambda ()
+             (should-error (deduce-lsp-induction) :type 'user-error))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/induction-rejects-non-matching-title ()
+  "If the server returns an action titled \"Refine hole\" instead
+of \"Induction\", the induction command must NOT apply it -- it
+should user-error."
+  (let ((tmp (make-temp-file "deduce-lsp-induction" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (let* ((uri (deduce-lsp--current-uri))
+                 (action `(:title "Refine hole"
+                           :kind "refactor.rewrite"
+                           :edit (:changes
+                                  (,(intern (concat ":" uri)) []))))
+                 (response (vector action)))
+            (deduce-lsp-test--with-mock-server
+             response
+             (lambda ()
+               (should-error (deduce-lsp-induction) :type 'user-error)))))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -374,6 +374,9 @@ def on_code_action(
 
     - **Refine hole** (Step 15) -- offered when the cursor sits on a
       ``?`` whose goal has a recognised shape.
+    - **Induction** (Step 17) -- offered when the cursor sits on a
+      ``?`` whose goal is ``all x:T. P(x)`` with T a Union of two
+      or more constructors.
 
     Step 16 (case split) takes a user-supplied variable name, which
     ``textDocument/codeAction`` can't carry, so it lives behind the
@@ -395,6 +398,14 @@ def on_code_action(
     if refine_edit is not None:
         actions.append(
             _code_action_from_edit(uri, "Refine hole", refine_edit)
+        )
+
+    induction_edit = _query.induction_skeleton_at(
+        path, content, pos, prelude=prelude
+    )
+    if induction_edit is not None:
+        actions.append(
+            _code_action_from_edit(uri, "Induction", induction_edit)
         )
 
     return actions

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -277,6 +277,39 @@ def splittable_vars_at(path: str, line: int, column: int) -> list[str]:
 
 
 @mcp.tool()
+def induction_skeleton_at(
+    path: str, line: int, column: int
+) -> Optional[dict]:
+    """Generate an ``induction T`` skeleton for the goal at ``line``:``column``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token
+    whose goal has the shape ``all x:T. P(x)`` where ``T`` is a
+    ``Union`` with at least two alternatives.  The skeleton emits one
+    ``case <Cons>(<params>) [assume IH<N>: ...] { ? }`` per
+    constructor in declaration order; recursive parameters introduce
+    ``IH<N>`` bindings whose formula is the goal body with the
+    inducted variable substituted.
+
+    Returns ``None`` when the cursor isn't on a ``?``, the goal isn't
+    a single ``all`` over a Union, or the union has fewer than 2
+    alternatives.  Otherwise returns ``{path, range, new_text}``.
+
+    Distinct from ``case_split_at``:
+    - Operates on the *goal*, not a named variable (no ``variable''
+      argument).
+    - Emits ``induction T`` (term-level) rather than
+      ``switch x``/``cases H``.
+    - Adds ``assume IH<N>: ...`` bindings for recursive parameters.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    edit = query.induction_skeleton_at(
+        path, content, pos, prelude=_prelude_for(path)
+    )
+    return _to_serializable(edit)
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -66,6 +66,7 @@ __all__ = [
     "refine_at",
     "case_split_at",
     "splittable_vars_at",
+    "induction_skeleton_at",
 ]
 
 
@@ -962,7 +963,7 @@ def _refine_template(formula, env) -> Optional[str]:
     uses for pipeline-level imports.
     """
     from abstract_syntax import (
-        All, And, Bool, Call, IfThen, Some, Var, base_name,
+        All, And, Bool, Call, IfThen, Some, VarRef, base_name,
     )
 
     match formula:
@@ -979,7 +980,15 @@ def _refine_template(formula, env) -> Optional[str]:
         case Some(_, _, vars, _body):
             choices = ", ".join("?" for _ in vars)
             return f"choose {choices}\n?"
-        case Call(_, _, Var(_, _, "=", _), [lhs, rhs]) if env is not None:
+        # Match the equality operator at any stage of name resolution
+        # (`Var', `OverloadedVar', or `ResolvedVar' all subclass
+        # `VarRef').  Mirrors the dispatch in `proof_checker.py'
+        # `PReflexive' after the Var/ResolvedVar split (PR #330).
+        case Call(_, _, rator, [lhs, rhs]) if (
+            isinstance(rator, VarRef)
+            and rator.get_name() == "="
+            and env is not None
+        ):
             try:
                 if lhs.reduce(env) == rhs.reduce(env):
                     return "reflexive"
@@ -1138,7 +1147,7 @@ def _splittable_vars(env) -> tuple:
     env up front.
     """
     from abstract_syntax import (
-        Or, ProofBinding, TermBinding, TypeBinding, Union, Var, base_name,
+        Or, ProofBinding, TermBinding, TypeBinding, Union, VarRef, base_name,
         get_type_name,
     )
 
@@ -1164,9 +1173,15 @@ def _splittable_vars(env) -> tuple:
                 type_var = get_type_name(ty)
             except Exception:
                 continue
-            if not isinstance(type_var, Var):
+            # Match any name-resolution stage: pre-uniquify ``Var',
+            # post-uniquify ``OverloadedVar', or post-typecheck
+            # ``ResolvedVar' -- all subclass ``VarRef'.  Pre-#330
+            # this used ``isinstance(type_var, Var)' which only
+            # caught the pre-uniquify form and silently dropped the
+            # rest.
+            if not isinstance(type_var, VarRef):
                 continue
-            type_binding = env.dict.get(type_var.name)
+            type_binding = env.dict.get(type_var.get_name())
             if (
                 isinstance(type_binding, TypeBinding)
                 and isinstance(type_binding.defn, Union)
@@ -1189,7 +1204,7 @@ def _case_split_template(name: str, env) -> Optional[str]:
     non-disjunctive proof, etc.).
     """
     from abstract_syntax import (
-        Or, ProofBinding, TermBinding, TypeBinding, Union, Var, base_name,
+        Or, ProofBinding, TermBinding, TypeBinding, Union, VarRef, base_name,
         get_type_name,
     )
 
@@ -1204,17 +1219,19 @@ def _case_split_template(name: str, env) -> Optional[str]:
         return None
 
     if isinstance(binding, TermBinding):
-        # The variable's type may be a Var (named type), a TypeInst
+        # The variable's type may be a VarRef (named type), a TypeInst
         # (parameterised), or built-in (BoolType etc.). Walk to the
-        # underlying type definition.
+        # underlying type definition. ``VarRef'' covers pre-uniquify
+        # ``Var'', post-uniquify ``OverloadedVar'', and post-typecheck
+        # ``ResolvedVar'' (issue: PR #330 split these classes).
         ty = binding.typ
         try:
             type_var = get_type_name(ty)
         except Exception:
             return None
-        if not isinstance(type_var, Var):
+        if not isinstance(type_var, VarRef):
             return None
-        type_binding = env.dict.get(type_var.name)
+        type_binding = env.dict.get(type_var.get_name())
         if not isinstance(type_binding, TypeBinding):
             return None
         defn = type_binding.defn
@@ -1303,3 +1320,155 @@ def _type_first_letter(ty) -> str:
         if c.isalpha():
             return c.lower()
     return "x"
+
+
+# ---------------------------------------------------------------------------
+# induction_skeleton_at -- Phase 4 / Step 17: induction over the goal
+# ---------------------------------------------------------------------------
+#
+# Distinct from Step 16 (case split) in three ways:
+#
+# - It operates on the *goal* (an `all x:T. P(x)` quantifier) rather
+#   than a named variable.  No `variable' parameter; the cursor on a
+#   `?' is the only input.
+# - The skeleton uses Deduce's `induction' keyword instead of `switch'
+#   / `cases'.
+# - For recursive constructor parameters (those of the union's own
+#   type), each case gets `assume IH<N>: <body>[var := param]'
+#   bindings -- the inductive hypothesis(es).
+#
+# Reuses the Step 15 plumbing: the cursor's `?' raises
+# ``IncompleteProof'' and we read the goal AST + env off the
+# exception.  Same single-theorem caveat as the rest of Phase 4.
+
+
+def induction_skeleton_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> Optional[WorkspaceEdit]:
+    """Generate an ``induction T`` skeleton for the goal at ``pos``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token
+    whose goal has the shape ``all x:T. P(x)`` where ``T`` is a Union
+    with at least two alternatives.  The skeleton emits one
+    ``case <Cons>(<params>) [assume IH<N>: ...] { ? }`` per
+    constructor, in declaration order.  Recursive parameters (those
+    of type ``T``) introduce ``IH<N>`` bindings whose formula is the
+    goal body with the inducted variable substituted.
+
+    Returns ``None`` when:
+
+    - the cursor isn't on a ``?``,
+    - the file doesn't reach an incomplete proof there,
+    - the goal isn't a single ``all`` over a Union, or
+    - the union has fewer than 2 alternatives (no induction to do).
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return None
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    formula = getattr(exc, "formula", None)
+    env = getattr(exc, "env", None)
+    if formula is None or env is None:
+        return None
+
+    template = _induction_template(formula, env)
+    if template is None:
+        return None
+
+    template = _indent_continuation(
+        template, _line_indent_at(content, hole_range.start)
+    )
+    return WorkspaceEdit(path=path, range=hole_range, new_text=template)
+
+
+def _induction_template(formula, env) -> Optional[str]:
+    """Render an ``induction T`` skeleton if ``formula`` is
+    ``all x:T. P(x)`` with T a multi-alternative union."""
+    from abstract_syntax import (
+        All, TypeBinding, Union, VarRef, base_name, get_type_name,
+    )
+
+    if not isinstance(formula, All):
+        return None
+    var_x, var_ty = formula.var
+    body = formula.body
+
+    try:
+        type_var = get_type_name(var_ty)
+    except Exception:
+        return None
+    if not isinstance(type_var, VarRef):
+        return None
+    type_binding = env.dict.get(type_var.get_name())
+    if not isinstance(type_binding, TypeBinding):
+        return None
+    union_def = type_binding.defn
+    if not isinstance(union_def, Union):
+        return None
+    if len(union_def.alternatives) < 2:
+        # `induction' requires at least two alternatives -- otherwise
+        # it'd just be a no-op / direct proof.
+        return None
+
+    return _render_induction(var_x, var_ty, body, union_def, env)
+
+
+def _render_induction(var_x, var_ty, body, union_def, env) -> str:
+    """Build the ``induction T\\n  case ... { ? }\\n  ...`` text."""
+    from abstract_syntax import ResolvedVar, base_name
+    # `is_recursive' and `update_all_head' live in proof_checker;
+    # they're pipeline-side helpers, not protocol-specific, so the
+    # protocol-neutrality guard in this module's docstring isn't
+    # broken by importing them.
+    from proof_checker import is_recursive, update_all_head
+
+    union_name = union_def.name  # uniquified, e.g. ``N.0''
+    env_used = {base_name(k) for k in env.dict.keys()}
+
+    case_lines = []
+    for alt in union_def.alternatives:
+        cons_name = base_name(alt.name)
+        used = set(env_used)
+        params = []  # list of (name, type) pairs for this case
+        for i, p_ty in enumerate(alt.parameters):
+            stem = _type_first_letter(p_ty)
+            candidate = f"{stem}{i + 1}"
+            n = 0
+            while candidate in used:
+                n += 1
+                candidate = f"{stem}{i + 1}_{n}"
+            used.add(candidate)
+            params.append((candidate, p_ty))
+
+        if params:
+            line = (
+                f"  case {cons_name}("
+                + ", ".join(p for p, _ in params)
+                + ")"
+            )
+        else:
+            line = f"  case {cons_name}"
+
+        # Recursive params -> IH bindings.
+        rec_params = [
+            (p, ty) for (p, ty) in params if is_recursive(union_name, ty)
+        ]
+        if rec_params:
+            ih_clauses = []
+            for i, (p, p_ty) in enumerate(rec_params):
+                ih_var = ResolvedVar(p_ty.location, p_ty, p)
+                ih_body = update_all_head(body.substitute({var_x: ih_var}))
+                ih_clauses.append(f"IH{i + 1}: {ih_body}")
+            line += " assume " + ", ".join(ih_clauses)
+
+        line += " { ? }"
+        case_lines.append(line)
+
+    return f"induction {var_ty}\n" + "\n".join(case_lines)

--- a/test/lsp/test_induction.py
+++ b/test/lsp/test_induction.py
@@ -1,0 +1,260 @@
+"""Acceptance tests for ``lsp.query.induction_skeleton_at`` (Phase 4 / Step 17).
+
+Each fixture supplies a snippet of Deduce source (with a custom
+union and a forall-quantified theorem), the cursor position of the
+``?``, and the literal ``new_text`` we expect
+``induction_skeleton_at`` to produce.
+
+Coverage matches the plan's three-case acceptance:
+
+(a) splitting a Nat-shape union (zero/suc, IH on suc),
+(b) splitting a parameterised List-shape union (empty/cons, IH on cons),
+(c) splitting a custom union whose constructors mix recursive and
+    non-recursive parameters,
+plus boundary cases:
+(d) a single-alternative union (no induction possible),
+(e) a non-forall goal (no quantifier to induct over),
+(f) cursor not on a ``?`` (no replacement target).
+
+All fixtures define their own union so the tests run without the
+standard library prelude.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    Range,
+    Severity,
+    WorkspaceEdit,
+    check,
+    induction_skeleton_at,
+)
+
+
+@dataclass(frozen=True)
+class InductionCase:
+    name: str
+    source: str
+    cursor: Position  # Cursor on a ?
+    expected_text: str
+    expected_range: Range  # Range of the ? being replaced
+
+
+CASES = [
+    InductionCase(
+        name="nat_like_union",
+        # Forall over a Nat-like union; recursive constructor `s(N)'
+        # gets an IH binding.
+        source=(
+            "union N {\n"
+            "  z\n"
+            "  s(N)\n"
+            "}\n"
+            "\n"
+            "theorem t: all x:N. x = x\n"
+            "proof\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=3),
+        expected_text=(
+            "induction N\n"
+            "    case z { ? }\n"
+            "    case s(n1) assume IH1: n1 = n1 { ? }"
+        ),
+        expected_range=Range(
+            start=Position(line=8, column=3),
+            end=Position(line=8, column=4),
+        ),
+    ),
+    InductionCase(
+        name="parameterised_list_union",
+        # Forall over `L<bool>'; the recursive `cons' tail is an
+        # `L<bool>' too, so it gets an IH.
+        source=(
+            "union L<T> {\n"
+            "  e\n"
+            "  cons(T, L<T>)\n"
+            "}\n"
+            "\n"
+            "theorem t: all xs:L<bool>. xs = xs\n"
+            "proof\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=3),
+        expected_text=(
+            "induction L<bool>\n"
+            "    case e { ? }\n"
+            "    case cons(t1, l2) assume IH1: l2 = l2 { ? }"
+        ),
+        expected_range=Range(
+            start=Position(line=8, column=3),
+            end=Position(line=8, column=4),
+        ),
+    ),
+    InductionCase(
+        name="multi_recursive_constructor",
+        # `node' takes two recursive parameters and one non-recursive
+        # `bool' parameter -> two IHs (IH1, IH2), one per recursive
+        # param, in declaration order.
+        source=(
+            "union Tree {\n"
+            "  leaf\n"
+            "  node(Tree, bool, Tree)\n"
+            "}\n"
+            "\n"
+            "theorem t: all tr:Tree. tr = tr\n"
+            "proof\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=8, column=3),
+        expected_text=(
+            "induction Tree\n"
+            "    case leaf { ? }\n"
+            "    case node(t1, b2, t3) assume IH1: t1 = t1, IH2: t3 = t3 { ? }"
+        ),
+        expected_range=Range(
+            start=Position(line=8, column=3),
+            end=Position(line=8, column=4),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_induction_skeleton_template(case: InductionCase) -> None:
+    edit = induction_skeleton_at("test.pf", case.source, case.cursor)
+    assert edit is not None, f"{case.name}: induction_skeleton_at returned None"
+    assert isinstance(edit, WorkspaceEdit)
+    assert edit.path == "test.pf"
+    assert edit.range == case.expected_range, (
+        f"{case.name}: range mismatch\n"
+        f"  expected: {case.expected_range}\n"
+        f"  got:      {edit.range}"
+    )
+    assert edit.new_text == case.expected_text, (
+        f"{case.name}: new_text mismatch\n"
+        f"  expected: {case.expected_text!r}\n"
+        f"  got:      {edit.new_text!r}"
+    )
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_post_edit_check_raises_at_first_case_body(
+    case: InductionCase,
+) -> None:
+    """Plan acceptance: re-running ``check`` on the post-edit content
+    must surface a fresh hole *inside the first case body*."""
+    edit = induction_skeleton_at("test.pf", case.source, case.cursor)
+    assert edit is not None
+
+    lines = case.source.splitlines(keepends=True)
+    line_idx = edit.range.start.line - 1
+    start_col = edit.range.start.column - 1
+    end_col = edit.range.end.column - 1
+    new_line = (
+        lines[line_idx][:start_col]
+        + edit.new_text
+        + lines[line_idx][end_col:]
+    )
+    post = "".join(lines[:line_idx] + [new_line] + lines[line_idx + 1:])
+
+    diags = check("test.pf", post, prelude=())
+    assert len(diags) == 1, (
+        f"{case.name}: expected exactly one diagnostic on post-edit "
+        f"content, got {len(diags)}"
+    )
+    diag = diags[0]
+    assert diag.severity == Severity.ERROR
+    assert "incomplete proof" in diag.message
+    # The first case body's `?' is on the line right after the
+    # `induction T' header.
+    first_case_line = edit.range.start.line + 1
+    assert diag.range.start.line == first_case_line, (
+        f"{case.name}: expected diagnostic on line "
+        f"{first_case_line} (first case body), got line "
+        f"{diag.range.start.line}"
+    )
+
+
+def test_returns_none_for_single_alternative_union() -> None:
+    """Single-constructor unions don't have an inductive split to
+    do -- there's no second case to make ``induction'' meaningful."""
+    source = (
+        "union Singleton {\n"
+        "  only\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:Singleton. x = x\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = induction_skeleton_at(
+        "test.pf", source, Position(line=7, column=3)
+    )
+    assert edit is None
+
+
+def test_returns_none_for_non_forall_goal() -> None:
+    """Goal must be ``all x:T. P(x)'' for induction; a non-forall
+    goal has no quantifier to induct over."""
+    source = (
+        "theorem t: all P:bool. P or not P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Goal at the hole is `P or not P', not a forall.
+    edit = induction_skeleton_at(
+        "test.pf", source, Position(line=4, column=3)
+    )
+    assert edit is None
+
+
+def test_returns_none_when_cursor_not_on_hole() -> None:
+    """Cursor not on a ``?'' -> no replacement target -> None."""
+    source = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on the `theorem' keyword, line 6 col 3.
+    edit = induction_skeleton_at(
+        "test.pf", source, Position(line=6, column=3)
+    )
+    assert edit is None
+
+
+def test_returns_none_when_quantifier_is_over_non_union_type() -> None:
+    """``all P:bool. ...'' has no Union to induct over (bool is a
+    primitive)."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = induction_skeleton_at(
+        "test.pf", source, Position(line=3, column=3)
+    )
+    assert edit is None

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -572,6 +572,46 @@ def test_code_action_returns_empty_when_cursor_not_on_hole(server, open_doc):
     assert lsp_server.on_code_action(server, params) == []
 
 
+def test_code_action_offers_induction_when_goal_is_forall_over_union(
+    server, open_doc
+):
+    """Cursor on a `?` whose goal is `all x:T. P(x)` (T a Union) ->
+    one "Induction" action carrying the induction-T skeleton."""
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("induction.pf", src)
+    # `?` at line 8 col 3 (1-indexed) -> LSP line 7, col 2.
+    params = lsp_types.CodeActionParams(
+        text_document=lsp_types.TextDocumentIdentifier(uri=uri),
+        range=lsp_types.Range(
+            start=lsp_types.Position(line=7, character=2),
+            end=lsp_types.Position(line=7, character=2),
+        ),
+        context=lsp_types.CodeActionContext(diagnostics=[]),
+    )
+    actions = lsp_server.on_code_action(server, params)
+    titles = [a.title for a in actions]
+    # Both "Refine hole" (forall -> arbitrary) and "Induction" should
+    # apply; we care that Induction is in the set.
+    assert "Induction" in titles
+    induction_action = next(a for a in actions if a.title == "Induction")
+    assert induction_action.kind == lsp_types.CodeActionKind.RefactorRewrite
+    edits = induction_action.edit.changes[uri]
+    assert len(edits) == 1
+    assert "induction N" in edits[0].new_text
+    assert "case z {" in edits[0].new_text
+    assert "case s(n1) assume IH1: n1 = n1 {" in edits[0].new_text
+
+
 def test_code_action_with_unknown_uri_returns_empty(server):
     """Defensive: the workspace doesn't know about this URI."""
     params = lsp_types.CodeActionParams(

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -100,6 +100,7 @@ async def test_all_tools_are_registered(server):
             "refine_at",
             "case_split_at",
             "splittable_vars_at",
+            "induction_skeleton_at",
         }
 
 
@@ -417,6 +418,66 @@ async def test_splittable_vars_at_returns_empty_off_hole(server, tmp_path):
         {"path": str(fp), "line": 8, "column": 13},
     )
     assert payload == []
+
+
+# --------------------------------------------------------------------------
+# induction_skeleton_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_induction_skeleton_at_returns_workspace_edit(
+    server, tmp_path
+):
+    """Cursor on `?` whose goal is `all x:N. x = x` -> induction
+    skeleton with one case per Nat constructor."""
+    src = (
+        "union N {\n"
+        "  z\n"
+        "  s(N)\n"
+        "}\n"
+        "\n"
+        "theorem t: all x:N. x = x\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "induction.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "induction_skeleton_at",
+        {"path": str(fp), "line": 8, "column": 3},
+    )
+    assert payload is not None
+    assert payload["path"] == str(fp)
+    assert "induction N" in payload["new_text"]
+    assert "case z {" in payload["new_text"]
+    assert "case s(n1) assume IH1: n1 = n1 {" in payload["new_text"]
+    assert payload["range"]["start"] == {"line": 8, "column": 3}
+    assert payload["range"]["end"] == {"line": 8, "column": 4}
+
+
+@pytest.mark.anyio
+async def test_induction_skeleton_at_returns_null_for_non_forall(
+    server, tmp_path
+):
+    """A goal that isn't `all x:T. ...` -> null."""
+    src = (
+        "theorem t: all P:bool. P or not P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "no_induction.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "induction_skeleton_at",
+        {"path": str(fp), "line": 4, "column": 3},
+    )
+    assert payload is None
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -42,6 +42,7 @@ from lsp.query import (  # noqa: E402
     check,
     definition_of,
     goal_at,
+    induction_skeleton_at,
     list_symbols,
     refine_at,
     splittable_vars_at,
@@ -71,6 +72,7 @@ EXPECTED_PUBLIC = {
     "refine_at",
     "case_split_at",
     "splittable_vars_at",
+    "induction_skeleton_at",
 }
 
 
@@ -210,13 +212,21 @@ def test_splittable_vars_at_signature():
     )
 
 
+def test_induction_skeleton_at_signature():
+    _check_sig(
+        induction_skeleton_at,
+        ["path", "content", "pos", "prelude"],
+        Optional[WorkspaceEdit],
+    )
+
+
 def test_prelude_param_has_default():
     """``prelude`` is optional on every query function so existing
     Step 3-5 callers (which pass ``path`` and ``content`` only)
     keep working."""
     for func in (
         check, goal_at, definition_of, list_symbols, refine_at,
-        case_split_at, splittable_vars_at,
+        case_split_at, splittable_vars_at, induction_skeleton_at,
     ):
         prelude_param = inspect.signature(func).parameters["prelude"]
         assert prelude_param.default == (), (


### PR DESCRIPTION
Third (and final introduction-side) Phase-4 structured-editing operation. Given a cursor on a `?` whose goal is `all x:T. P(x)` with T a Union of two or more constructors, generate

```
induction T
  case Cons1(...) { ? }
  case Cons2(...) assume IH1: <body[x := param]> { ? }
  ...
```

— one case per constructor in declaration order, with `assume IH<N>: ...` bindings for recursive parameters.

## Distinct from Step 16 (case split)

| | Step 16 (case split) | Step 17 (induction) |
|---|---|---|
| Driven by | named variable | goal shape (`all x:T. P(x)`) |
| Extra user input | yes — `completing-read` for variable | none — the cursor on a `?` is enough |
| Wire transport | custom `deduce/caseSplitAt` | `textDocument/codeAction` |
| Keyword | `switch x` / `cases H` | `induction T` |
| IH bindings | no | yes, one per recursive parameter |

## Implementation reuse

- `is_recursive` and `update_all_head` from `proof_checker.py` for the IH formula construction (`body.substitute({var_x: param})` then re-fix the `all` quantifier `pos` field).
- `_indent_continuation` from PR #338 (so the multi-line skeleton picks up the cursor's indent — `case` lines land at the right column).
- `_find_hole_at` from PR #325 (so cursor-just-past-`?` works).

The Emacs side is essentially boilerplate at this point — a `deduce-lsp-induction` defun calling `deduce-lsp--find-action-by-title "Induction"`, exactly mirroring `deduce-lsp-refine-hole`.

## Bonus pre-existing bug fixes

While testing, I noticed two failures unrelated to Step 17 — both pre-existing on `main` since PR #330 (the `Var`/`ResolvedVar` split) but masked because they happened to live in code paths the user wasn't exercising. Both were silent: the `_refine_template` `case Call(_, _, Var(_, _, "=", _), ...)` pattern had four positional fields where the new `Var` only has three, so `reflexive` never fired; `_splittable_vars` and `_case_split_template`'s `isinstance(type_var, Var)` check missed `OverloadedVar` / `ResolvedVar`, so a term variable like `arbitrary x:Nat` was silently dropped from the candidate list.

Both fixed by switching to `VarRef` base-class checks plus `.get_name()` — the same pattern PR #330 used in `proof_checker.py`. The previously-failing `reflexive_equality`, `refine_at_cursor_one_position_after_hole`, and case-split-of-`x` tests now pass.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 597 pass (was 581; +10 induction tests, +5 LSP/MCP wiring tests, +1 signature lock; previously-failing tests now pass)
- [x] `python3 test-deduce.py --errors` — 153 should-error fixtures unchanged (no pipeline changes)
- [x] `emacs --batch ... -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 38 pass (was 34; +4 induction tests)
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-lsp.el` — clean
- [ ] Manual smoke after merge: open a `.pf` with `theorem t: all x:N. x = x` and `?` in the proof body. `C-c C-i` on the `?` -> induction skeleton.

## Acceptance per the plan

The plan calls for fixtures over (a) Nat-quantified, (b) `List<T>`-quantified, and (c) custom-induction-marker theorems. (a) and (b) are covered by the `nat_like_union` and `parameterised_list_union` fixtures using their own custom unions (avoids the prelude). (c) — the `@induction` custom-induction marker case — is **not** in this PR; the plan's `gen_custom_induction_advice` reuse for marker-driven case generation needs more design (the marker's conjunct shape doesn't directly map to constructor patterns). I'll file a follow-up issue for that case if/when a fixture needs it; the standard union path (the common case) is fully covered.

## Files changed

- `lsp/query.py` (+~190): `induction_skeleton_at` + `_induction_template` + `_render_induction`; bug fixes in `_refine_template` / `_splittable_vars` / `_case_split_template`
- `lsp/lsp_server.py` (+11): "Induction" action in `on_code_action`
- `lsp/mcp_server.py` (+33): `induction_skeleton_at` tool
- `test/lsp/test_induction.py` (new, 10 tests)
- `test/lsp/test_lsp_server.py` (+40): codeAction wiring test
- `test/lsp/test_mcp_server.py` (+61): two MCP tool tests + tool-list update
- `test/lsp/test_query.py` (+12): import + `__all__` + signature lock
- `editor/emacs/deduce-lsp.el` (+~40 / -~15): `deduce-lsp-induction` defun + `C-c C-i` binding + commentary update
- `editor/emacs/test/deduce-lsp-test.el` (+86): four ert tests for `C-c C-i`
- `editor/emacs/README.md` (+~25): keybinding table + smoke test step