### PR TITLE
Fix #344: remove stray debug print in lalr pattern_term branch

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -716,8 +716,7 @@ def parse_tree_to_ast(e, parent):
     elif e.data == 'pattern_term':
         params = parse_tree_to_list(e.children[0], e)
         term = parse_tree_to_ast(e.children[1], e)
-        print(params, term)
-        return PatternTerm(e.meta, term, list(params)) 
+        return PatternTerm(e.meta, term, list(params))
     
     # case of a recursive function
     elif e.data == 'fun_case':


### PR DESCRIPTION
## Summary
- Removes a leftover `print(params, term)` in `parser.py` that fired whenever a `with <names>. <term>` pattern was parsed under `--lalr`.

Fixes #344.

## Test plan
- [x] Reproduce per the issue: `python3 deduce.py --no-stdlib --dir ./test/test-imports --dir ./lib --lalr ./test/should-validate/custom_induction.pf` — no stray output, file still reports valid.
- [ ] CI runs both parsers across the test/lib tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)