### PR TITLE
Narrow types during type-check (post-typecheck invariant tightening, in progress)

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -5268,68 +5268,6 @@ def check_post_uniquify_invariants(ast_list):
       'Each one is a leftover construction site that wasn\'t migrated '
       'to OverloadedVar/ResolvedVar.\n' + '\n'.join(msgs) + suffix)
 
-def normalize_post_typecheck(ast_list):
-  """Walk the post-typecheck AST and promote every single-candidate
-  ``OverloadedVar`` to ``ResolvedVar``.
-
-  After type checking, an ``OverloadedVar`` whose ``resolved_names``
-  list has exactly one element is no longer overloaded — there's no
-  candidate to choose between. The class transition is normally
-  performed inline by the type checker (``type_synth_term`` /
-  ``type_check_term`` produce a ``ResolvedVar`` once they've narrowed
-  to one option), but several positions in the AST aren't visited by
-  those code paths: type annotations, the `definitions` list of an
-  ``ApplyDefsGoal``, components of ``FunctionType`` / ``TypeInst``
-  buried inside theorems, etc. This pass enforces the invariant
-  uniformly.
-
-  The conversion is *in place*: each AST node that holds a reference
-  to an ``OverloadedVar`` field has that field rebound to a freshly
-  constructed ``ResolvedVar`` carrying the same canonical name and
-  ``typeof``. Multi-candidate ``OverloadedVar`` nodes (genuine
-  unresolved overloads) are left untouched.
-
-  Run after ``check_deduce`` and before
-  ``check_post_typecheck_invariants``."""
-  from dataclasses import fields, is_dataclass
-
-  def normalize(value):
-    """Recursively normalize ``value``, returning a (possibly
-    new) version with single-candidate OverloadedVars replaced by
-    ResolvedVars. Containers (list/tuple/dict) are rebuilt with
-    normalized children; AST nodes have their fields mutated in
-    place to point to normalized children."""
-    if isinstance(value, OverloadedVar) and len(value.resolved_names) == 1:
-      return ResolvedVar(value.location, normalize(value.typeof),
-                         value.resolved_names[0])
-    if isinstance(value, list):
-      return [normalize(v) for v in value]
-    if isinstance(value, tuple):
-      return tuple(normalize(v) for v in value)
-    if isinstance(value, dict):
-      return {k: normalize(v) for k, v in value.items()}
-    if isinstance(value, AST) and is_dataclass(value):
-      if id(value) in seen:
-        return value
-      seen.add(id(value))
-      for f in fields(value):
-        old = getattr(value, f.name, None)
-        if old is None:
-          continue
-        if isinstance(old, str) or isinstance(old, (int, bool)):
-          continue
-        new = normalize(old)
-        if new is not old:
-          # ResolvedVar enforces a non-empty name via __post_init__,
-          # but does not freeze its fields. Plain attribute set is
-          # fine for the dataclass.
-          object.__setattr__(value, f.name, new)
-      return value
-    return value
-
-  seen = set()
-  return [normalize(stmt) for stmt in ast_list]
-
 def check_post_typecheck_invariants(ast_list):
   """Strict post-typecheck invariants:
 

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -516,9 +516,9 @@ class GenericUnknownInst(Type):
     return GenericUnknownInst(self.location, self.typ.uniquify(env))
 
 def get_type_name(ty):
+  if isinstance(ty, VarRef):
+    return ty
   match ty:
-    case OverloadedVar(l1, tyof, rs):
-      return ty
     case TypeInst(l1, ty, type_args):
       return get_type_name(ty)
     case _:
@@ -5268,31 +5268,106 @@ def check_post_uniquify_invariants(ast_list):
       'Each one is a leftover construction site that wasn\'t migrated '
       'to OverloadedVar/ResolvedVar.\n' + '\n'.join(msgs) + suffix)
 
+def normalize_post_typecheck(ast_list):
+  """Walk the post-typecheck AST and promote every single-candidate
+  ``OverloadedVar`` to ``ResolvedVar``.
+
+  After type checking, an ``OverloadedVar`` whose ``resolved_names``
+  list has exactly one element is no longer overloaded — there's no
+  candidate to choose between. The class transition is normally
+  performed inline by the type checker (``type_synth_term`` /
+  ``type_check_term`` produce a ``ResolvedVar`` once they've narrowed
+  to one option), but several positions in the AST aren't visited by
+  those code paths: type annotations, the `definitions` list of an
+  ``ApplyDefsGoal``, components of ``FunctionType`` / ``TypeInst``
+  buried inside theorems, etc. This pass enforces the invariant
+  uniformly.
+
+  The conversion is *in place*: each AST node that holds a reference
+  to an ``OverloadedVar`` field has that field rebound to a freshly
+  constructed ``ResolvedVar`` carrying the same canonical name and
+  ``typeof``. Multi-candidate ``OverloadedVar`` nodes (genuine
+  unresolved overloads) are left untouched.
+
+  Run after ``check_deduce`` and before
+  ``check_post_typecheck_invariants``."""
+  from dataclasses import fields, is_dataclass
+
+  def normalize(value):
+    """Recursively normalize ``value``, returning a (possibly
+    new) version with single-candidate OverloadedVars replaced by
+    ResolvedVars. Containers (list/tuple/dict) are rebuilt with
+    normalized children; AST nodes have their fields mutated in
+    place to point to normalized children."""
+    if isinstance(value, OverloadedVar) and len(value.resolved_names) == 1:
+      return ResolvedVar(value.location, normalize(value.typeof),
+                         value.resolved_names[0])
+    if isinstance(value, list):
+      return [normalize(v) for v in value]
+    if isinstance(value, tuple):
+      return tuple(normalize(v) for v in value)
+    if isinstance(value, dict):
+      return {k: normalize(v) for k, v in value.items()}
+    if isinstance(value, AST) and is_dataclass(value):
+      if id(value) in seen:
+        return value
+      seen.add(id(value))
+      for f in fields(value):
+        old = getattr(value, f.name, None)
+        if old is None:
+          continue
+        if isinstance(old, str) or isinstance(old, (int, bool)):
+          continue
+        new = normalize(old)
+        if new is not old:
+          # ResolvedVar enforces a non-empty name via __post_init__,
+          # but does not freeze its fields. Plain attribute set is
+          # fine for the dataclass.
+          object.__setattr__(value, f.name, new)
+      return value
+    return value
+
+  seen = set()
+  return [normalize(stmt) for stmt in ast_list]
+
 def check_post_typecheck_invariants(ast_list):
-  """Check post-typecheck invariants. Hard error if any pre-uniquify
-  ``Var`` survives (that's a refactor leak). Soft warning if a
-  single-candidate ``OverloadedVar`` exists — those should have been
-  narrowed to ``ResolvedVar`` by overload resolution, but the type
-  checker doesn't visit every node yet, so we tolerate them while
-  the migration is in progress. Multi-candidate ``OverloadedVar``
-  is permitted (genuine unresolved overload)."""
+  """Strict post-typecheck invariants:
+
+  1. No pre-uniquify ``Var``.
+  2. No single-candidate ``OverloadedVar`` — these should have been
+     narrowed to ``ResolvedVar`` by overload resolution. (Multi-
+     candidate ``OverloadedVar`` is permitted; that's a genuine
+     unresolved overload the type checker punted on.)
+
+  Raises ``Exception`` listing up to 20 offending nodes on failure.
+  Each violation is a sign that some type-checker code path didn't
+  visit a node it should have, or built a fresh Var-like in a
+  helper and forgot to narrow it."""
+  def loc_prefix(loc):
+    try:
+      if loc is not None and not getattr(loc, 'empty', True):
+        return f'{loc.filename}:{loc.line}: '
+    except Exception:
+      pass
+    return ''
   bad_var = []
+  bad_singleton = []
   for node in _walk_ast_descendants(ast_list):
     if type(node) is Var:
       bad_var.append((getattr(node, 'location', None), node.name))
-  if bad_var:
-    def loc_prefix(loc):
-      try:
-        if loc is not None and not getattr(loc, 'empty', True):
-          return f'{loc.filename}:{loc.line}: '
-      except Exception:
-        pass
-      return ''
-    msgs = [f'  {loc_prefix(loc)}pre-uniquify Var({name!r})'
-            for (loc, name) in bad_var[:20]]
-    raise Exception(
-      'Post-typecheck AST sanity check failed: pre-uniquify `Var` '
-      'nodes still present.\n' + '\n'.join(msgs))
+    elif type(node) is OverloadedVar and len(node.resolved_names) == 1:
+      bad_singleton.append((getattr(node, 'location', None),
+                            node.resolved_names[0]))
+  if not bad_var and not bad_singleton:
+    return
+  msgs = []
+  for (loc, name) in bad_var[:10]:
+    msgs.append(f'  {loc_prefix(loc)}pre-uniquify Var({name!r})')
+  for (loc, name) in bad_singleton[:10]:
+    msgs.append(f'  {loc_prefix(loc)}OverloadedVar([{name!r}]) '
+                'with one candidate (should be ResolvedVar)')
+  raise Exception(
+    'Post-typecheck AST sanity check failed:\n' + '\n'.join(msgs))
 
 def uniquify_deduce(ast):
   env = {}

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -5269,18 +5269,16 @@ def check_post_uniquify_invariants(ast_list):
       'to OverloadedVar/ResolvedVar.\n' + '\n'.join(msgs) + suffix)
 
 def check_post_typecheck_invariants(ast_list):
-  """Strict post-typecheck invariants:
+  """Post-typecheck invariants. Hard error on any pre-uniquify ``Var``.
+  Single-candidate ``OverloadedVar`` is currently a soft warning:
+  the type checker doesn't visit proof bodies yet, so those leak
+  OverloadedVars even when they aren't actually overloaded. The
+  invariant will go strict once ``check_proof_of`` is refactored to
+  rebuild proof ASTs (tracked separately).
 
-  1. No pre-uniquify ``Var``.
-  2. No single-candidate ``OverloadedVar`` — these should have been
-     narrowed to ``ResolvedVar`` by overload resolution. (Multi-
-     candidate ``OverloadedVar`` is permitted; that's a genuine
-     unresolved overload the type checker punted on.)
-
-  Raises ``Exception`` listing up to 20 offending nodes on failure.
-  Each violation is a sign that some type-checker code path didn't
-  visit a node it should have, or built a fresh Var-like in a
-  helper and forgot to narrow it."""
+  Multi-candidate ``OverloadedVar`` is permitted (genuine unresolved
+  overload).
+  """
   def loc_prefix(loc):
     try:
       if loc is not None and not getattr(loc, 'empty', True):
@@ -5289,23 +5287,15 @@ def check_post_typecheck_invariants(ast_list):
       pass
     return ''
   bad_var = []
-  bad_singleton = []
   for node in _walk_ast_descendants(ast_list):
     if type(node) is Var:
       bad_var.append((getattr(node, 'location', None), node.name))
-    elif type(node) is OverloadedVar and len(node.resolved_names) == 1:
-      bad_singleton.append((getattr(node, 'location', None),
-                            node.resolved_names[0]))
-  if not bad_var and not bad_singleton:
-    return
-  msgs = []
-  for (loc, name) in bad_var[:10]:
-    msgs.append(f'  {loc_prefix(loc)}pre-uniquify Var({name!r})')
-  for (loc, name) in bad_singleton[:10]:
-    msgs.append(f'  {loc_prefix(loc)}OverloadedVar([{name!r}]) '
-                'with one candidate (should be ResolvedVar)')
-  raise Exception(
-    'Post-typecheck AST sanity check failed:\n' + '\n'.join(msgs))
+  if bad_var:
+    msgs = [f'  {loc_prefix(loc)}pre-uniquify Var({name!r})'
+            for (loc, name) in bad_var[:20]]
+    raise Exception(
+      'Post-typecheck AST sanity check failed: pre-uniquify `Var` '
+      'nodes still present.\n' + '\n'.join(msgs))
 
 def uniquify_deduce(ast):
   env = {}

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2633,15 +2633,16 @@ def _lookup_param_polarities(head, env):
   return None
 
 def check_strict_positivity(ty, union_name, env, forbidden=False):
+  if isinstance(ty, VarRef):
+    ref_name = ty.get_name()
+    if forbidden and ref_name == union_name:
+      error(ty.location,
+            f"the union '{base_name(union_name)}' must not occur in a "
+            f"negative position (to the left of '->') of its own "
+            f"constructor parameters; this would make the logic "
+            f"inconsistent (Russell's paradox)")
+    return
   match ty:
-    case OverloadedVar(loc, _, rns):
-      ref_name = rns[0]
-      if forbidden and ref_name == union_name:
-        error(loc,
-              f"the union '{base_name(union_name)}' must not occur in a "
-              f"negative position (to the left of '->') of its own "
-              f"constructor parameters; this would make the logic "
-              f"inconsistent (Russell's paradox)")
     case TypeInst(loc, head, type_args):
       check_strict_positivity(head, union_name, env, forbidden)
       head_pols = _lookup_param_polarities(head, env)
@@ -2678,13 +2679,14 @@ def infer_param_polarities(union_decl, env):
   type_param_names = set(union_decl.type_params)
 
   def walk(ty, current):
+    if isinstance(ty, VarRef):
+      ref_name = ty.get_name()
+      if ref_name in type_param_names:
+        idx = union_decl.type_params.index(ref_name)
+        if current == '-':
+          polarities[idx] = '-'
+      return
     match ty:
-      case OverloadedVar(loc, _, rns):
-        ref_name = rns[0]
-        if ref_name in type_param_names:
-          idx = union_decl.type_params.index(ref_name)
-          if current == '-':
-            polarities[idx] = '-'
       case TypeInst(loc, head, type_args):
         walk(head, current)
         head_pols = _lookup_param_polarities(head, env)

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -4591,10 +4591,17 @@ def check_deduce(ast, module_name, modified, tracing_functions):
       if needs_checking[0]:
         check_proofs(s, env)
     checked_modules.add(module_name)
+  # Promote every single-candidate ``OverloadedVar`` to
+  # ``ResolvedVar`` uniformly. The type checker handles most term
+  # references inline, but type annotations / def-list entries /
+  # buried sub-ASTs aren't always visited. This walker enforces the
+  # phase invariant in one place rather than chasing every leaky
+  # site individually.
+  ast3 = normalize_post_typecheck(ast3)
   # Sanity-check the post-typecheck AST: every variable reference
-  # should be ResolvedVar (or, if the type-checker punted, a
-  # multi-candidate OverloadedVar). Any pre-uniquify Var or
-  # single-candidate OverloadedVar is a refactor leak.
+  # should be ``ResolvedVar`` (or, if a real overload couldn't be
+  # resolved, a multi-candidate ``OverloadedVar``). Any pre-uniquify
+  # ``Var`` or single-candidate ``OverloadedVar`` is a refactor leak.
   check_post_typecheck_invariants(ast3)
   # Return the post-typecheck AST so callers (lsp.library.check_file,
   # the Deduce-to-C compiler) can read the overload-resolved form.

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -600,13 +600,13 @@ def check_proof(proof, env):
   return ret
 
 def get_type_args(ty):
+  if isinstance(ty, VarRef):
+    return []
   match ty:
-    case OverloadedVar(l1, tyof, rs):
-      return []
     case TypeInst(l1, ty, type_args):
       return type_args
     case _:
-      raise Exception('unhandled case in get_type_args')
+      raise Exception('unhandled case in get_type_args: ' + repr(ty))
 
 label_count = 0
 
@@ -3695,18 +3695,26 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
             return_type = TypeInst(loc, body_union_type, tyvars)
           else:
             return_type = body_union_type
+          # Narrow each constructor parameter's type. The check_type
+          # return goes back into the new Constructor so the union's
+          # AST has ResolvedVars in place of single-candidate
+          # OverloadedVars.
+          new_params = []
           for ty in constr.parameters:
-            check_type(ty, body_env)
-            validate_union_type(ty, [], body_env)
-            check_strict_positivity(ty, name, body_env)
+            new_ty = check_type(ty, body_env)
+            validate_union_type(new_ty, [], body_env)
+            check_strict_positivity(new_ty, name, body_env)
+            new_params.append(new_ty)
           constr_type = FunctionType(constr.location, typarams,
-                                     constr.parameters, return_type)
+                                     new_params, return_type)
+          new_constr = Constructor(constr.location, constr.name, new_params)
         elif len(typarams) > 0:
           constr_type = GenericUnknownInst(loc, union_type)
+          new_constr = constr
         else:
           constr_type = union_type
+          new_constr = constr
 
-        new_constr = constr
         env = env.declare_term_var(loc, constr.name, constr_type,
                                    visibility=decl.visibility)
         new_alts.append(new_constr)
@@ -3920,8 +3928,8 @@ def type_check_stmt(stmt, env, error_on_next_import : dict[str, bool]):
         new_body = body # already type checked in process_declaration
         new_ty = body.typeof
       else:
-        new_body = type_check_term(body, ty, env, None, [])
-        new_ty = ty
+        new_ty = check_type(ty, env)
+        new_body = type_check_term(body, new_ty, env, None, [])
       return Define(loc, name, new_ty, new_body, visibility=stmt.visibility)
         
     case Theorem(loc, name, frm, pf, isLemma):

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1922,7 +1922,13 @@ def check_recursive_call(call, recfun, subterms):
           + " or ".join([base_name(x) for x in subterms]) \
           + ", not " + str(call.args[0]))
 
-# well-formed types
+# Validate that ``typ`` is well-formed in ``env`` and return the type
+# with every single-candidate ``OverloadedVar`` narrowed to
+# ``ResolvedVar``. The returned type may share structure with ``typ``
+# when nothing changed; otherwise it's a freshly constructed copy.
+# Callers MUST use the returned value, not the original ``typ`` —
+# the strict post-typecheck invariant rejects single-candidate
+# OverloadedVars, so dropping the return on the floor leaks them.
 def check_type(typ, env):
   match typ:
     case OverloadedVar(loc, tyof, rs):
@@ -1930,28 +1936,27 @@ def check_type(typ, env):
         error(loc, 'undefined type variable ' + str(typ))
       if len(rs) > 1:
         error(loc, 'type names may not be overloaded ' + str(typ))
+      # len(rs) == 1: this is a non-overloaded type reference. Promote.
+      return ResolvedVar(loc, tyof, rs[0])
     case ResolvedVar(loc, tyof, name):
       if not env.type_var_is_defined(typ):
         error(loc, 'undefined type variable ' + str(typ))
-    case IntType(loc):
-      pass
-    case BoolType(loc):
-      pass
-    case TypeType(loc):
-      pass
+      return typ
+    case IntType(loc) | BoolType(loc) | TypeType(loc):
+      return typ
     case FunctionType(loc, typarams, param_types, return_type):
-      env = env.declare_type_vars(loc, typarams)
-      for ty in param_types:
-        check_type(ty, env)
-      check_type(return_type, env)
-    case TypeInst(loc, typ, arg_types):
-      check_type(typ, env)
-      for ty in arg_types:
-        check_type(ty, env)
-    case GenericUnknownInst(loc, typ):
-      check_type(typ, env)
+      body_env = env.declare_type_vars(loc, typarams)
+      new_param_types = [check_type(ty, body_env) for ty in param_types]
+      new_return_type = check_type(return_type, body_env)
+      return FunctionType(loc, typarams, new_param_types, new_return_type)
+    case TypeInst(loc, inner_typ, arg_types):
+      new_inner = check_type(inner_typ, env)
+      new_args = [check_type(ty, env) for ty in arg_types]
+      return TypeInst(loc, new_inner, new_args)
+    case GenericUnknownInst(loc, inner_typ):
+      return GenericUnknownInst(loc, check_type(inner_typ, env))
     case ArrayType(loc, elt_type):
-      check_type(elt_type, env)
+      return ArrayType(loc, check_type(elt_type, env))
     case _:
       error(typ.location, 'error in check_type: unhandled type ' + repr(typ) + ' ' + str(type(typ)))
 
@@ -2128,8 +2133,8 @@ def type_synth_term(term, env, recfun, subterms):
     case All(loc, _, var, pos, body):
       all_types = None
       x, ty = var
-      check_type(ty, env)
-      if isinstance(ty, TypeType):
+      new_ty = check_type(ty, env)
+      if isinstance(new_ty, TypeType):
         if all_types == None or all_types == True:
           all_types = True
         else:
@@ -2139,18 +2144,16 @@ def type_synth_term(term, env, recfun, subterms):
           all_types = False
         else:
           error(loc, 'cannot mix type and term variables in an all formula')
-      body_env = env.declare_term_vars(loc, [var])
-      new_body = check_formula(body, body_env, recfun, subterms)      
-      ty = BoolType(loc)
-      ret = All(loc, ty, var, pos, new_body)
-  
-    case Some(loc, _, vars, body):
-      for (x,ty) in vars:
-          check_type(ty, env)
-      body_env = env.declare_term_vars(loc, vars)
+      new_var = (x, new_ty)
+      body_env = env.declare_term_vars(loc, [new_var])
       new_body = check_formula(body, body_env, recfun, subterms)
-      ty = BoolType(loc)
-      ret = Some(loc, ty, vars, new_body)
+      ret = All(loc, BoolType(loc), new_var, pos, new_body)
+
+    case Some(loc, _, vars, body):
+      new_vars = [(x, check_type(ty, env)) for (x, ty) in vars]
+      body_env = env.declare_term_vars(loc, new_vars)
+      new_body = check_formula(body, body_env, recfun, subterms)
+      ret = Some(loc, BoolType(loc), new_vars, new_body)
       
     case MakeArray(loc, _, arg):
       lst = type_synth_term(arg, env, recfun, subterms)
@@ -3942,30 +3945,32 @@ def type_check_stmt(stmt, env, error_on_next_import : dict[str, bool]):
       new_params = [p.substitute(sub) for p in params]
       new_returns = returns.substitute(sub)
       fun_type = FunctionType(loc, new_typarams, new_params, new_returns)
-      
+
       env = env.define_term_var(loc, name, fun_type, stmt.reduce(env),
                                 stmt.visibility)
       cases_present = {}
       body_env = env.declare_type_vars(loc, typarams)
+      # Narrow params and returns once we have body_env (with the
+      # original typarams in scope, since `params`/`returns` reference
+      # them, not `new_typarams`).
+      checked_params = [check_type(p, body_env) for p in params]
+      checked_returns = check_type(returns, body_env)
       reset_recursive_call_count()
-      new_cases = [type_check_fun_case(c, name, params, returns, body_env,
-                                       cases_present) \
+      new_cases = [type_check_fun_case(c, name, checked_params, checked_returns,
+                                       body_env, cases_present) \
                    for c in cases]
       if get_recursive_call_count() == 0:
           error(loc, name + ' is declared recursive, but does not make any recursive calls.\n' \
                 + 'Use a "fun" statement instead.')
-      
+
       # check for completeness of cases
-      uniondef = lookup_union(params[0].location, params[0], env)
+      uniondef = lookup_union(checked_params[0].location, checked_params[0], env)
       for c in uniondef.alternatives:
         if not c.name in cases_present.keys():
           error(loc, 'missing function case for ' + base_name(c.name))
 
-      new_recfun = RecFun(loc, name, typarams, params, returns, new_cases,
-                          visibility=stmt.visibility)
-      # print('type check stmt:')
-      # print(new_recfun.pretty_print(4))
-      return new_recfun
+      return RecFun(loc, name, typarams, checked_params, checked_returns,
+                    new_cases, visibility=stmt.visibility)
 
     case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty,
                    body, terminates):
@@ -4591,13 +4596,6 @@ def check_deduce(ast, module_name, modified, tracing_functions):
       if needs_checking[0]:
         check_proofs(s, env)
     checked_modules.add(module_name)
-  # Promote every single-candidate ``OverloadedVar`` to
-  # ``ResolvedVar`` uniformly. The type checker handles most term
-  # references inline, but type annotations / def-list entries /
-  # buried sub-ASTs aren't always visited. This walker enforces the
-  # phase invariant in one place rather than chasing every leaky
-  # site individually.
-  ast3 = normalize_post_typecheck(ast3)
   # Sanity-check the post-typecheck AST: every variable reference
   # should be ``ResolvedVar`` (or, if a real overload couldn't be
   # resolved, a multi-candidate ``OverloadedVar``). Any pre-uniquify


### PR DESCRIPTION
## Summary

Follow-up to [#330](https://github.com/jsiek/deduce/pull/330) (Var split into 3 classes). Tightens the post-typecheck invariant by fixing the type-checker sites that were leaving single-candidate ``OverloadedVar`` nodes when they should have produced ``ResolvedVar``.

Per @jsiek's review, this fixes the leaks at their source rather than papering over them with a normalization pass — each violation surfaced by the strict invariant is a latent bug.

## What changed

- **``check_type`` is now return-narrowing.** It used to be a pure validator; now it returns the type with every single-candidate ``OverloadedVar`` rewritten to ``ResolvedVar``. Callers MUST use the returned value.
- **Updated callers:**
  - ``type_check_stmt`` for ``RecFun``: params and returns are narrowed and stored on the new ``RecFun`` node.
  - ``process_declaration_visibility`` for ``Union``: each constructor parameter type is narrowed; the new union AST holds the narrowed types.
  - ``type_check_stmt`` for ``Define``: the annotation type is narrowed before being used to type-check the body.
  - ``type_check_term`` ``All`` / ``Some`` cases: the bound variable's type is narrowed and threaded into the new ``All`` / ``Some`` node.
- **``get_type_args``** now handles any ``VarRef``, not just ``OverloadedVar``, so a narrowed ``ResolvedVar`` in a ``TypeInst`` head doesn't trip the catch-all.
- **Strict invariant** (``check_post_typecheck_invariants``) is currently set to "no pre-uniquify ``Var``" only. Single-candidate ``OverloadedVar`` is a known follow-up — see below.

## Status

- ✅ ``deduce.py example.pf``
- ✅ ``test-deduce.py`` (full)
- ✅ All lib files

## Remaining work — proof bodies

After this commit, the leaks the strict invariant would catch are all inside proof bodies:

- ``PLet.proved`` (the ``frm`` part of ``have <label>: <frm> by ...``)
- ``ApplyDefsGoal.definitions`` (the ``x`` in ``expand x.``)
- ``RewriteGoal.equations``, ``Suffices.claim``, etc.

The proof checker (``check_proof_of``) does call ``check_formula`` etc. on these sub-fields and uses the narrowed result for verification, but it doesn't propagate the narrowed value back into the proof AST. The fix is to rebuild proof ASTs as we descend.

Two approaches considered:

1. **Refactor ``check_proof_of`` to return a rebuilt proof tree.** Cleanest — env-extension logic already lives in one place. ~40 cases to update mechanically.
2. **Add a dedicated ``type_check_proof`` walker** that mirrors ``check_proof_of`` env-extension. I drafted this; the env mirroring duplicates a lot of code, so reverted.

Going to do (1) in a follow-up PR. Once that lands, ``check_post_typecheck_invariants`` can flip back to strict (rejecting single-candidate ``OverloadedVar``).

## Test plan

- [x] ``deduce.py example.pf``
- [x] ``test-deduce.py`` full
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)