### PR TITLE
LSP Phase 4 / Step 18: eliminate / use-fact via WorkspaceEdit

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -110,6 +110,16 @@ auto-start hook:
   IH<N>: ... { ? }\n...` -- one case per constructor in declaration
   order; recursive parameters get `IH<N>` bindings whose formula is
   the body with the inducted variable substituted.
+- `C-c C-e` -- eliminate / use-fact. Cursor on a `?`. Issues
+  `deduce/eliminableVarsAt` to fetch the in-scope hypothesis labels
+  whose formula has a supported template, prompts via
+  `completing-read` (TAB completion) for which label to use, then
+  issues `deduce/eliminateAt` with the chosen label. The template
+  depends on the hypothesis's shape: destructure for `and`, `cases`
+  for `or`, `apply ... to ?` for `if then`, `H[?]` for `all`,
+  `obtain ... from H` for `some`, `replace H` for equality, the
+  bare label for `false`. Dual to `C-c C-r` (refine): refine picks
+  by goal shape, eliminate picks by named-hypothesis shape.
 
 ## Keybindings
 
@@ -123,6 +133,7 @@ auto-start hook:
 | `C-c C-r` | `deduce-lsp-refine-hole`         | `deduce-lsp`   | Apply LSP-suggested template at hole      |
 | `C-c C-c` | `deduce-lsp-case-split`          | `deduce-lsp`   | Prompt for variable, replace `?` with case skeleton |
 | `C-c C-i` | `deduce-lsp-induction`           | `deduce-lsp`   | Replace `?` with `induction T` skeleton at a forall goal |
+| `C-c C-e` | `deduce-lsp-eliminate`           | `deduce-lsp`   | Prompt for hypothesis, replace `?` with use-fact tactic |
 
 ## Customization
 
@@ -265,6 +276,24 @@ Then verify the LSP integration:
     replaced with `induction N\n  case z { ? }\n  case s(n1) assume
     IH1: n1 = n1 { ? }`. The recursive constructor `s` gets an `IH1`
     binding for the predecessor `n1`.
+11. In a scratch `.pf` buffer with a hypothesis to eliminate:
+
+    ```
+    theorem t: all P:bool, Q:bool. if P or Q then Q or P
+    proof
+      arbitrary P:bool, Q:bool
+      assume H: P or Q
+      ?
+    end
+    ```
+
+    Place point on the `?` and press `C-c C-e`. Emacs prompts
+    `Eliminate on:` with TAB completion against the eliminable
+    hypotheses in scope (`H` for this fixture). Type `H RET`. The
+    `?` is replaced with `cases H\n  case h1: P { ? }\n  case h2: Q
+    { ? }`. Try the same with an `assume H: P and Q` hypothesis to
+    see the destructuring template, or `assume H: P = Q` to see
+    `replace H`.
 
 ## Development
 

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -35,9 +35,10 @@
 ;;   M-x imenu                  outline of top-level decls (documentSymbol)
 ;;
 ;; Step 5 adds `C-c C-g' for the custom `deduce/goalAt' request.
-;; Step 6 adds Phase-4 keybindings: `C-c C-r' (refine, LSP Step 15),
-;; `C-c C-c' (case split, LSP Step 16), and `C-c C-i' (induction
-;; skeleton, LSP Step 17) are all live.
+;; Step 6 adds the four Phase-4 keybindings: `C-c C-r' (refine, LSP
+;; Step 15), `C-c C-c' (case split, LSP Step 16), `C-c C-i'
+;; (induction, LSP Step 17), and `C-c C-e' (eliminate / use-fact,
+;; LSP Step 18) -- all live.
 ;;
 ;; Server command
 ;; --------------
@@ -309,7 +310,7 @@ is running in the current buffer."
 ;; Phase-4 structured edits (Step 6)
 ;; ---------------------------------------------------------------------
 ;;
-;; Live bindings (LSP Steps 15-17):
+;; Live bindings (LSP Steps 15-18):
 ;;
 ;;   `C-c C-r'  deduce-lsp-refine-hole  (Step 15)
 ;;     Cursor on a `?'.  Issues `textDocument/codeAction' filtered to
@@ -331,10 +332,17 @@ is running in the current buffer."
 ;;     "Induction".  Same one-keystroke shape as refine -- the goal
 ;;     itself is the only input the operation needs.
 ;;
+;;   `C-c C-e'  deduce-lsp-eliminate    (Step 18)
+;;     Cursor on a `?'.  Issues `deduce/eliminableVarsAt' to fetch
+;;     candidate hypothesis labels, prompts via `completing-read'
+;;     (TAB completion), then issues `deduce/eliminateAt' with the
+;;     chosen label.  Same wire-shape as case split (custom request,
+;;     extra user-supplied label argument) -- their UX is symmetric.
+;;
 ;; Refine and induction use `textDocument/codeAction' because they
-;; take no extra user input.  Case-split takes a user-supplied
-;; variable name, which codeAction can't carry, so it gets a custom
-;; server method.
+;; take no extra user input.  Case-split and eliminate take a
+;; user-supplied identifier, which codeAction can't carry, so they
+;; get custom server methods.
 
 (defun deduce-lsp--lsp-pos-to-point (line character)
   "Convert LSP 0-indexed (LINE, CHARACTER) to a point in the current buffer.
@@ -533,12 +541,67 @@ When no eglot connection is active, prompts the user to run
     (deduce-lsp--apply-code-action action)))
 
 
-;; Bind `C-c C-r' (refine), `C-c C-c' (case split), and `C-c C-i'
-;; (induction) in `deduce-mode-map'.  Same rationale as `C-c C-g':
-;; only meaningful when LSP is loaded.
+(defun deduce-lsp-eliminate (label)
+  "Use the in-scope hypothesis LABEL at the hole at point.
+
+The cursor must sit on (or immediately adjacent to) a `?' token;
+that `?' is the replacement target.  LABEL names an in-scope
+proof binding -- typically a hypothesis introduced by `assume'.
+The template is chosen from the binding's formula shape:
+
+  H: P and Q     -> destructure with `have ... by conjunct N of H'
+  H: P or Q      -> `cases H ...'
+  H: if P then Q -> `have h: Q by apply H to ?'
+  H: all x:T. P  -> `H[?]'
+  H: some x:T. P -> `obtain ... where ... from H'
+  H: e1 = e2     -> `replace H'
+  H: false       -> `H' (discharges any goal)
+
+Interactively, queries the server for the eliminable hypothesis
+labels in scope at the hole (custom request
+`deduce/eliminableVarsAt') and prompts via `completing-read' with
+TAB completion against that list.  When the candidate list is
+empty -- e.g. the cursor isn't on a `?' or no eliminable binding
+is in scope -- errors with `No elimination available at point.'
+
+The chosen label is then sent in a `deduce/eliminateAt' request;
+the returned WorkspaceEdit is applied directly.  Errors out
+without applying when the server returns null."
+  (interactive
+   (let ((server (eglot-current-server)))
+     (unless server
+       (user-error
+        "No eglot server active in this buffer; M-x eglot first"))
+     (let* ((params (deduce-lsp--text-document-position))
+            (candidates (deduce-lsp--request server :deduce/eliminableVarsAt
+                                              params))
+            (candidate-list (if (vectorp candidates)
+                                (append candidates nil)
+                              candidates)))
+       (unless candidate-list
+         (user-error "No elimination available at point"))
+       (list (completing-read "Eliminate on: " candidate-list
+                              nil t)))))
+  (let ((server (eglot-current-server)))
+    (unless server
+      (user-error
+       "No eglot server active in this buffer; M-x eglot first"))
+    (let* ((params (append (deduce-lsp--text-document-position)
+                           (list :label label)))
+           (edit (deduce-lsp--request server :deduce/eliminateAt params)))
+      (unless edit
+        (user-error
+         "Server returned no edit for elimination on %s" label))
+      (deduce-lsp--apply-workspace-edit edit))))
+
+
+;; Bind `C-c C-r' (refine), `C-c C-c' (case split), `C-c C-i'
+;; (induction), and `C-c C-e' (eliminate) in `deduce-mode-map'.
+;; Same rationale as `C-c C-g': only meaningful when LSP is loaded.
 (define-key deduce-mode-map (kbd "C-c C-r") #'deduce-lsp-refine-hole)
 (define-key deduce-mode-map (kbd "C-c C-c") #'deduce-lsp-case-split)
 (define-key deduce-mode-map (kbd "C-c C-i") #'deduce-lsp-induction)
+(define-key deduce-mode-map (kbd "C-c C-e") #'deduce-lsp-eliminate)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -767,6 +767,151 @@ should user-error."
       (delete-file tmp))))
 
 
+;; ---------------------------------------------------------------------
+;; deduce-lsp-eliminate (LSP Step 18, fronted by `C-c C-e')
+;; ---------------------------------------------------------------------
+;;
+;; Same wire shape as case split (Step 16): cursor on `?', the
+;; interactive form fetches candidate labels via
+;; `deduce/eliminableVarsAt' and uses completing-read; the chosen
+;; label drives a `deduce/eliminateAt' request.
+
+(ert-deftest deduce-lsp/eliminate-bound-to-c-c-c-e ()
+  "`C-c C-e' in deduce-mode-map runs `deduce-lsp-eliminate'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-e"))
+              #'deduce-lsp-eliminate)))
+
+
+(ert-deftest deduce-lsp/eliminate-issues-eliminateAt-request ()
+  "Calling `deduce-lsp-eliminate' with a label arg sends
+`deduce/eliminateAt' with `{textDocument, position, label}'."
+  (let ((tmp (make-temp-file "deduce-lsp-elim" nil ".pf"))
+        calls)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool, Q:bool. if P or Q then Q or P\nproof\n  arbitrary P:bool, Q:bool\n  assume H: P or Q\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; `?` at line 5 col 3 -> LSP line 4, char 2.
+          (goto-char (point-min))
+          (forward-line 4)
+          (forward-char 2)
+          (setq calls
+                (deduce-lsp-test--with-method-mock
+                 '((:deduce/eliminateAt . nil))
+                 (lambda ()
+                   (ignore-errors (deduce-lsp-eliminate "H")))))
+          (let* ((call (assq :deduce/eliminateAt calls))
+                 (params (cdr call))
+                 (text-doc (plist-get params :textDocument))
+                 (pos (plist-get params :position)))
+            (should call)
+            (should (string-prefix-p "file://"
+                                      (plist-get text-doc :uri)))
+            (should (= (plist-get pos :line) 4))
+            (should (= (plist-get pos :character) 2))
+            (should (equal (plist-get params :label) "H"))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/eliminate-applies-workspace-edit ()
+  "Given a server response with a `:changes' WorkspaceEdit, the
+buffer ends up with the new text replacing the `?'."
+  (let ((tmp (make-temp-file "deduce-lsp-elim" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool, Q:bool. if P or Q then Q or P\nproof\n  arbitrary P:bool, Q:bool\n  assume H: P or Q\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (goto-char (point-min))
+          (forward-line 4)
+          (forward-char 2)
+          (let* ((uri (deduce-lsp--current-uri))
+                 (skeleton "cases H\n    case h1: P { ? }\n    case h2: Q { ? }")
+                 (edit `(:changes
+                         (,(intern (concat ":" uri))
+                          [(:range (:start (:line 4 :character 2)
+                                    :end (:line 4 :character 3))
+                                   :newText ,skeleton)]))))
+            (deduce-lsp-test--with-method-mock
+             `((:deduce/eliminateAt . ,edit))
+             (lambda () (deduce-lsp-eliminate "H"))))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "cases H" text))
+            (should (string-match-p "case h1: P" text))
+            (should (string-match-p "case h2: Q" text))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/eliminate-null-server-response-errors ()
+  "If the server returns null for eliminateAt, the command
+user-errors instead of silently no-op-ing."
+  (let ((tmp (make-temp-file "deduce-lsp-elim" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (deduce-lsp-test--with-method-mock
+           '((:deduce/eliminateAt . nil))
+           (lambda ()
+             (should-error (deduce-lsp-eliminate "H") :type 'user-error))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/eliminate-interactive-uses-completing-read ()
+  "Interactive entry hits `deduce/eliminableVarsAt' for candidates
+and feeds them to `completing-read'."
+  (let ((tmp (make-temp-file "deduce-lsp-elim" nil ".pf"))
+        captured-prompt
+        captured-collection)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method _params)
+                       (cond
+                        ((eq method :deduce/eliminableVarsAt) ["H1" "H2"])
+                        ((eq method :deduce/eliminateAt) nil))))
+                    ((symbol-function 'completing-read)
+                     (lambda (prompt collection &rest _rest)
+                       (setq captured-prompt prompt)
+                       (setq captured-collection collection)
+                       "H1")))
+            (ignore-errors
+              (call-interactively #'deduce-lsp-eliminate)))
+          (should (string-match-p "Eliminate on:" captured-prompt))
+          (should (member "H1" captured-collection))
+          (should (member "H2" captured-collection)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/eliminate-interactive-empty-candidates-errors ()
+  "If `deduce/eliminableVarsAt' returns no candidates, the
+interactive entry user-errors with `No elimination available'."
+  (let ((tmp (make-temp-file "deduce-lsp-elim" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server _method _params) [])))
+            (should-error (call-interactively #'deduce-lsp-eliminate)
+                          :type 'user-error)))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -138,6 +138,13 @@ GOAL_AT_REQUEST = "deduce/goalAt"
 CASE_SPLIT_REQUEST = "deduce/caseSplitAt"
 SPLITTABLE_VARS_REQUEST = "deduce/splittableVarsAt"
 
+# Custom requests for Step 18 (eliminate / use-fact).  Same shape as
+# the case-split pair: the editor fetches candidate labels via
+# ``deduce/eliminableVarsAt`` for completion, then issues
+# ``deduce/eliminateAt`` with the user's chosen label.
+ELIMINATE_REQUEST = "deduce/eliminateAt"
+ELIMINABLE_VARS_REQUEST = "deduce/eliminableVarsAt"
+
 server = LanguageServer(
     SERVER_NAME,
     SERVER_VERSION,
@@ -545,6 +552,96 @@ def on_case_split_at(ls: LanguageServer, params) -> Optional[dict]:
     # Shape-shift to the LSP wire format: an LSP WorkspaceEdit with
     # `changes: {uri: [TextEdit]}`. Mirrors what the codeAction
     # handler emits for refine.
+    return {
+        "changes": {
+            uri: [
+                {
+                    "range": {
+                        "start": {
+                            "line": max(edit.range.start.line - 1, 0),
+                            "character": max(edit.range.start.column - 1, 0),
+                        },
+                        "end": {
+                            "line": max(edit.range.end.line - 1, 0),
+                            "character": max(edit.range.end.column - 1, 0),
+                        },
+                    },
+                    "newText": edit.new_text,
+                }
+            ]
+        }
+    }
+
+
+@server.feature(ELIMINABLE_VARS_REQUEST)
+def on_eliminable_vars_at(ls: LanguageServer, params) -> list[str]:
+    """Custom request: return labels of in-scope hypotheses that
+    ``eliminate`` can target.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}}``.  Editor clients call this to populate
+    completion candidates when prompting for the hypothesis label.
+
+    Result: a list of base names (sorted, deduplicated).  Empty when
+    the cursor isn't on a ``?`` or no eliminable hypothesis is in
+    scope.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
+    if not uri:
+        return []
+    content = _document_content(ls, uri)
+    if content is None:
+        return []
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
+        )
+    )
+    path = _path_from_uri(uri)
+    return list(
+        _query.eliminable_vars_at(path, content, pos, prelude=_prelude_for(path))
+    )
+
+
+@server.feature(ELIMINATE_REQUEST)
+def on_eliminate_at(ls: LanguageServer, params) -> Optional[dict]:
+    """Custom request: return a WorkspaceEdit that uses the named
+    hypothesis at the cursor's hole.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}, "label": str}``.  The cursor must sit on
+    a ``?``; the ``label`` arg names which in-scope hypothesis to
+    use.
+
+    Result: ``{"changes": {<uri>: [{"range": Range, "newText":
+    str}]}}`` (an LSP-shaped WorkspaceEdit) or ``null`` when the
+    cursor isn't on a hole, the label isn't bound, or its formula's
+    shape isn't in the supported template table (e.g. ``true``).
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
+    label = _get_field(params, "label")
+    if not uri or not label:
+        return None
+    content = _document_content(ls, uri)
+    if content is None:
+        return None
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
+        )
+    )
+    path = _path_from_uri(uri)
+    edit = _query.eliminate_at(
+        path, content, pos, str(label), prelude=_prelude_for(path)
+    )
+    if edit is None:
+        return None
     return {
         "changes": {
             uri: [

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -310,6 +310,63 @@ def induction_skeleton_at(
 
 
 @mcp.tool()
+def eliminate_at(
+    path: str, line: int, column: int, label: str
+) -> Optional[dict]:
+    """Generate a tactic that uses ``label`` to derive a fact (or
+    discharge the goal) at the hole at ``line``:``column``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token;
+    that ``?`` is the replacement target.  ``label`` names an in-scope
+    proof binding -- typically a hypothesis introduced by ``assume``.
+    The template is chosen from the binding's formula shape:
+
+    - ``H: P and Q`` -> destructure with ``have h1: P by conjunct 1
+      of H``, etc.
+    - ``H: P or Q`` -> ``cases H ...``
+    - ``H: if P then Q`` -> ``have h: Q by apply H to ?``
+    - ``H: all x:T. P`` -> ``H[?, ...]``
+    - ``H: some x:T. P`` -> ``obtain ... where ... from H``
+    - ``H: e1 = e2`` -> ``replace H``
+    - ``H: false`` -> ``H`` (discharges any goal)
+    - ``H: true`` -> ``None`` (no useful template)
+
+    Returns ``None`` when the cursor isn't on a ``?``, ``label`` isn't
+    bound at the hole, or the binding's shape isn't supported.
+    Otherwise returns ``{path, range, new_text}``.
+
+    For a list of valid ``label`` choices, see ``eliminable_vars_at``.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    edit = query.eliminate_at(
+        path, content, pos, label, prelude=_prelude_for(path)
+    )
+    return _to_serializable(edit)
+
+
+@mcp.tool()
+def eliminable_vars_at(
+    path: str, line: int, column: int
+) -> list[str]:
+    """Return labels of in-scope hypotheses that ``eliminate_at`` can
+    target at ``line``:``column``.
+
+    The cursor must sit on a ``?`` token.  Includes labels for local
+    proof bindings (introduced by ``assume`` / ``suppose`` / ``have``)
+    whose formula has a supported template shape.  ``true``-shaped
+    facts are filtered out.  Names are sorted and deduplicated.
+    Returns ``[]`` when the cursor isn't on a ``?`` or no eliminable
+    binding is in scope.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    return list(
+        query.eliminable_vars_at(path, content, pos, prelude=_prelude_for(path))
+    )
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -67,6 +67,8 @@ __all__ = [
     "case_split_at",
     "splittable_vars_at",
     "induction_skeleton_at",
+    "eliminate_at",
+    "eliminable_vars_at",
 ]
 
 
@@ -1472,3 +1474,346 @@ def _render_induction(var_x, var_ty, body, union_def, env) -> str:
         case_lines.append(line)
 
     return f"induction {var_ty}\n" + "\n".join(case_lines)
+
+
+# ---------------------------------------------------------------------------
+# eliminate_at -- Phase 4 / Step 18: use-fact / hypothesis elimination
+# ---------------------------------------------------------------------------
+#
+# Dual to Step 15 (refine).  Step 15 picks a template based on the
+# *goal* shape (introduction); Step 18 picks based on a named
+# *hypothesis* shape (elimination).
+#
+# UX shape: cursor on a `?', plus an explicit ``label'' argument
+# naming the in-scope proof binding to use.  Same wire/transport
+# pattern as Step 16 (case split): the editor binding fetches
+# candidate labels via ``eliminable_vars_at'' and prompts via
+# ``completing-read'' before issuing ``deduce/eliminateAt''.
+#
+# Templates by hypothesis shape (mirrors ``proof_use_advice'' in
+# proof_checker.py):
+#
+# - ``H: true''         -> None ("the `true' fact is useless")
+# - ``H: false''        -> ``H'' (discharges any goal)
+# - ``H: P and Q''      -> ``have h1: P by conjunct 1 of H\nhave
+#                            h2: Q by conjunct 2 of H\n?''
+# - ``H: P or Q''       -> ``cases H\n  case h1: P { ? }\n
+#                            case h2: Q { ? }''
+# - ``H: if P then Q''  -> ``have h: Q by apply H to ?\n?''
+# - ``H: all x:T. P''   -> ``H[?, ?, ...]'' (or ``H<?, ?, ...>''
+#                            for type-arg quantifiers)
+# - ``H: some x:T. P''  -> ``obtain x1, ... where h: <body[subst]>
+#                            from H\n?''
+# - ``H: e1 = e2''      -> ``replace H\n?''
+
+
+def eliminate_at(
+    path: str, content: str, pos: Position,
+    label: str,
+    prelude: Sequence[str] = (),
+) -> Optional[WorkspaceEdit]:
+    """Generate a tactic that uses ``label'' to derive a new fact
+    or to discharge the goal at the hole at ``pos``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token;
+    that ``?`` is the replacement target. ``label`` names an in-scope
+    proof binding (a hypothesis introduced by ``assume`` or a
+    theorem/lemma reference). The template is chosen from the
+    binding's formula shape -- see the table at the top of this
+    section.
+
+    Returns ``None`` when:
+
+    - the cursor isn't on a ``?``,
+    - the file has no incomplete proof at the cursor,
+    - ``label`` isn't bound at the hole, or
+    - the binding's shape isn't in the supported template table
+      (e.g. ``H: true`` -- usability nil).
+
+    For client-side completion of valid ``label`` choices, see
+    :func:`eliminable_vars_at`.
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return None
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    if env is None:
+        return None
+
+    template = _eliminate_template(label, env)
+    if template is None:
+        return None
+
+    template = _indent_continuation(
+        template, _line_indent_at(content, hole_range.start)
+    )
+    return WorkspaceEdit(path=path, range=hole_range, new_text=template)
+
+
+def eliminable_vars_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> tuple:
+    """Return base names of in-scope proof bindings that
+    ``eliminate_at'' can target.
+
+    Used by editor clients to populate completion candidates for the
+    ``Eliminate on:'' prompt.  Includes labels for local hypotheses
+    (introduced by ``assume''/``suppose''/``have'') whose formula
+    matches one of the supported template shapes.  ``true''-shaped
+    facts are filtered out (no useful template) but everything else
+    is included; the client gets a wider candidate list at the cost
+    of the rare "Eliminate produced no edit" round-trip.
+
+    Empty when the cursor isn't on a ``?`` or no eliminable binding
+    is in scope.  Names are sorted and deduplicated.
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return ()
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return ()
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    if env is None:
+        return ()
+
+    return _eliminable_vars(env)
+
+
+def _eliminable_vars(env) -> tuple:
+    """Names of local proof bindings whose ``eliminate'' would
+    produce a meaningful edit."""
+    from abstract_syntax import (
+        Bool, ProofBinding, base_name,
+    )
+
+    seen = set()
+    for unique, binding in env.dict.items():
+        bname = base_name(unique)
+        if bname in seen:
+            continue
+        if not isinstance(binding, ProofBinding):
+            continue
+        if not binding.local:
+            # Skip theorem references: they're not what users mean
+            # when they say "eliminate <label>".  Theorems are
+            # invoked by name without completion in any case.
+            continue
+        formula = binding.formula
+        # `true' is the one shape we filter out -- there's no
+        # useful template for "use the `true' fact".
+        if isinstance(formula, Bool) and formula.value is True:
+            continue
+        if _eliminate_template_for_formula(formula, binding_name=bname,
+                                           env=env, dry_run=True) is None:
+            continue
+        seen.add(bname)
+    return tuple(sorted(seen))
+
+
+def _eliminate_template(label: str, env) -> Optional[str]:
+    """Look up ``label'' in ``env'' and dispatch to the appropriate
+    template.
+
+    Returns ``None'' when the label isn't bound, isn't a proof
+    binding, or its formula's shape isn't in the supported table.
+    """
+    from abstract_syntax import ProofBinding, base_name
+
+    matches = [k for k in env.dict if base_name(k) == label]
+    if not matches:
+        return None
+    binding = env.dict[matches[0]]
+    if not isinstance(binding, ProofBinding):
+        return None
+    return _eliminate_template_for_formula(
+        binding.formula, binding_name=label, env=env, dry_run=False,
+    )
+
+
+def _eliminate_template_for_formula(
+    formula, binding_name: str, env, dry_run: bool
+) -> Optional[str]:
+    """Pick a template for ``formula''.
+
+    ``binding_name'' is the user-facing name of the hypothesis (e.g.
+    ``H1''); it appears in the rendered template.  ``dry_run'' is
+    set by ``_eliminable_vars'' to detect "is there a template?"
+    without paying the rendering cost; in that mode we just return
+    a non-None sentinel string when the shape is supported.
+    """
+    from abstract_syntax import (
+        All, And, Bool, Call, IfThen, Or, ResolvedVar, Some, TypeType,
+        VarRef, base_name,
+    )
+
+    if isinstance(formula, Bool):
+        if formula.value is True:
+            return None
+        # `false' discharges any goal: replace ? with the label.
+        return binding_name
+
+    if isinstance(formula, And):
+        if dry_run:
+            return "and"
+        return _eliminate_and(binding_name, formula, env)
+
+    if isinstance(formula, Or):
+        if dry_run:
+            return "or"
+        return _eliminate_or(binding_name, formula, env)
+
+    if isinstance(formula, IfThen):
+        if dry_run:
+            return "if"
+        return _eliminate_ifthen(binding_name, formula, env)
+
+    if isinstance(formula, All):
+        if dry_run:
+            return "all"
+        return _eliminate_all(binding_name, formula, env)
+
+    if isinstance(formula, Some):
+        if dry_run:
+            return "some"
+        return _eliminate_some(binding_name, formula, env)
+
+    if (
+        isinstance(formula, Call)
+        and isinstance(formula.rator, VarRef)
+        and formula.rator.get_name() == "="
+        and len(formula.args) == 2
+    ):
+        if dry_run:
+            return "eq"
+        return f"replace {binding_name}\n?"
+
+    return None
+
+
+def _fresh_h_labels(env, count: int) -> list:
+    """Generate ``count`` fresh ``H<N>``-style labels not in env."""
+    from abstract_syntax import base_name
+    used = {base_name(k) for k in env.dict.keys()}
+    out = []
+    n = 1
+    for _ in range(count):
+        while f"H{n}" in used:
+            n += 1
+        out.append(f"H{n}")
+        used.add(f"H{n}")
+        n += 1
+    return out
+
+
+def _eliminate_and(label: str, formula, env) -> str:
+    """``have h1: P by conjunct 1 of H\\nhave h2: Q by conjunct 2
+    of H\\n?''"""
+    labels = _fresh_h_labels(env, len(formula.args))
+    lines = [
+        f"have {h}: {arg} by conjunct {i + 1} of {label}"
+        for i, (h, arg) in enumerate(zip(labels, formula.args))
+    ]
+    lines.append("?")
+    return "\n".join(lines)
+
+
+def _eliminate_or(label: str, formula, env) -> str:
+    """``cases H\\n  case h1: P { ? }\\n  case h2: Q { ? } ...''"""
+    from abstract_syntax import base_name
+
+    used = {base_name(k) for k in env.dict.keys()}
+
+    def fresh_lower() -> str:
+        n = 1
+        while f"h{n}" in used:
+            n += 1
+        used.add(f"h{n}")
+        return f"h{n}"
+
+    case_lines = [
+        f"  case {fresh_lower()}: {arg} {{ ? }}" for arg in formula.args
+    ]
+    return f"cases {label}\n" + "\n".join(case_lines)
+
+
+def _eliminate_ifthen(label: str, formula, env) -> str:
+    """``have h: Q by apply H to ?\\n?''"""
+    h = _fresh_h_labels(env, 1)[0]
+    return f"have {h}: {formula.conclusion} by apply {label} to ?\n?"
+
+
+def _eliminate_all(label: str, formula, env) -> str:
+    """``H[?, ?, ...]'' (term args) or ``H<?, ?, ...>'' (type args).
+
+    Handles a single all-block: ``all x:T1, y:T2. P'' yields
+    ``H[?, ?]''.  Separate blocks (``all x:T1. all y:T2. P'')
+    instantiate one at a time -- the user can chain.
+    """
+    from abstract_syntax import All, TypeType
+
+    vars_in_block = []
+    cur = formula
+    while isinstance(cur, All):
+        x, ty = cur.var
+        vars_in_block.append((x, ty))
+        s, e = cur.pos
+        if s == 0:
+            # Last var in this block; following body is no longer an
+            # All-of-the-same-block.
+            break
+        cur = cur.body
+
+    if not vars_in_block:
+        return f"{label}[?]"
+
+    has_type_param = any(isinstance(ty, TypeType) for _, ty in vars_in_block)
+    open_b, close_b = ("<", ">") if has_type_param else ("[", "]")
+    placeholders = ", ".join(["?"] * len(vars_in_block))
+    return f"{label}{open_b}{placeholders}{close_b}"
+
+
+def _eliminate_some(label: str, formula, env) -> str:
+    """``obtain x1, ... where h: <body[subst]> from H\\n?''"""
+    from abstract_syntax import ResolvedVar, base_name
+
+    used = {base_name(k) for k in env.dict.keys()}
+    fresh_witnesses = []
+    sub = {}
+    for (x, ty) in formula.vars:
+        stem = _type_first_letter(ty)
+        n = 1
+        while f"{stem}{n}" in used:
+            n += 1
+        candidate = f"{stem}{n}"
+        used.add(candidate)
+        fresh_witnesses.append(candidate)
+        sub[x] = ResolvedVar(ty.location, ty, candidate)
+
+    new_body = formula.body.substitute(sub)
+
+    h = None
+    n = 1
+    while f"H{n}" in used:
+        n += 1
+    h = f"H{n}"
+    used.add(h)
+
+    return (
+        f"obtain {', '.join(fresh_witnesses)} where "
+        f"{h}: {new_body} from {label}\n?"
+    )
+

--- a/test/lsp/test_eliminate.py
+++ b/test/lsp/test_eliminate.py
@@ -1,0 +1,360 @@
+"""Acceptance tests for ``lsp.query.eliminate_at`` and
+``lsp.query.eliminable_vars_at`` (Phase 4 / Step 18).
+
+UX shape: cursor on a ``?`` plus an explicit ``label`` argument
+naming the in-scope hypothesis to use.  Same shape as Step 16
+(case split) -- editor clients fetch candidate labels via
+``eliminable_vars_at`` and prompt with ``completing-read`` before
+issuing ``eliminate_at``.
+
+Coverage:
+
+(a) ``H: P and Q`` -> destructure with ``have ... by conjunct N of H``
+(b) ``H: P or Q``  -> ``cases H ...``
+(c) ``H: if P then Q`` -> ``have h: Q by apply H to ?\\n?``
+(d) ``H: all x:T. P`` -> ``H[?]`` (term arg) or ``H<?>`` (type arg)
+(e) ``H: some x:T. P`` -> ``obtain ... where ... from H``
+(f) ``H: e1 = e2`` -> ``replace H\\n?``
+(g) ``H: false`` -> ``H``  (discharges any goal)
+(h) ``H: true`` -> None    ("useless")
+
+Plus boundary cases:
+- cursor not on ``?``,
+- label not in scope,
+- hypothesis shape unsupported.
+
+All fixtures stay inside ``bool``-only territory so the tests run
+without the standard library prelude.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    Range,
+    WorkspaceEdit,
+    eliminable_vars_at,
+    eliminate_at,
+)
+
+
+@dataclass(frozen=True)
+class EliminateCase:
+    name: str
+    source: str
+    cursor: Position
+    label: str
+    expected_text: str
+    expected_range: Range
+
+
+CASES = [
+    EliminateCase(
+        name="and",
+        # `H: P and Q' destructures into two `have' lines plus a `?'
+        # for the original goal.
+        source=(
+            "theorem t: all P:bool, Q:bool. if P and Q then Q and P\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  assume H: P and Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=5, column=3),
+        label="H",
+        expected_text=(
+            "have H1: P by conjunct 1 of H\n"
+            "  have H2: Q by conjunct 2 of H\n"
+            "  ?"
+        ),
+        expected_range=Range(
+            start=Position(line=5, column=3),
+            end=Position(line=5, column=4),
+        ),
+    ),
+    EliminateCase(
+        name="or",
+        source=(
+            "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  assume H: P or Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=5, column=3),
+        label="H",
+        expected_text=(
+            "cases H\n"
+            "    case h1: P { ? }\n"
+            "    case h2: Q { ? }"
+        ),
+        expected_range=Range(
+            start=Position(line=5, column=3),
+            end=Position(line=5, column=4),
+        ),
+    ),
+    EliminateCase(
+        name="ifthen",
+        source=(
+            "theorem t: all P:bool, Q:bool.\n"
+            "  if (if P then Q) then if P then Q\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  assume H: if P then Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=6, column=3),
+        label="H",
+        expected_text=(
+            "have H1: Q by apply H to ?\n"
+            "  ?"
+        ),
+        expected_range=Range(
+            start=Position(line=6, column=3),
+            end=Position(line=6, column=4),
+        ),
+    ),
+    EliminateCase(
+        name="all_term_arg",
+        # `H: all Q:bool. ...' instantiates as `H[?]'.
+        source=(
+            "theorem t: all P:bool.\n"
+            "  if (all Q:bool. if Q then Q) then if P then P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  assume H: all Q:bool. if Q then Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=6, column=3),
+        label="H",
+        expected_text="H[?]",
+        expected_range=Range(
+            start=Position(line=6, column=3),
+            end=Position(line=6, column=4),
+        ),
+    ),
+    EliminateCase(
+        name="some",
+        source=(
+            "theorem t: all P:bool, Q:bool.\n"
+            "  if (some y:bool. P or Q) then true\n"
+            "proof\n"
+            "  arbitrary P:bool, Q:bool\n"
+            "  assume H: some y:bool. P or Q\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=6, column=3),
+        label="H",
+        expected_text=(
+            "obtain b1 where H1: (P or Q) from H\n"
+            "  ?"
+        ),
+        expected_range=Range(
+            start=Position(line=6, column=3),
+            end=Position(line=6, column=4),
+        ),
+    ),
+    EliminateCase(
+        name="equality",
+        source=(
+            "theorem t: all P:bool. if P = true then true = P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  assume H: P = true\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=5, column=3),
+        label="H",
+        expected_text=(
+            "replace H\n"
+            "  ?"
+        ),
+        expected_range=Range(
+            start=Position(line=5, column=3),
+            end=Position(line=5, column=4),
+        ),
+    ),
+    EliminateCase(
+        name="false",
+        # `H: false' discharges any goal: replace `?` with `H`.
+        source=(
+            "theorem t: all P:bool. if false then P\n"
+            "proof\n"
+            "  arbitrary P:bool\n"
+            "  assume H: false\n"
+            "  ?\n"
+            "end\n"
+        ),
+        cursor=Position(line=5, column=3),
+        label="H",
+        expected_text="H",
+        expected_range=Range(
+            start=Position(line=5, column=3),
+            end=Position(line=5, column=4),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_eliminate_at_template(case: EliminateCase) -> None:
+    edit = eliminate_at("test.pf", case.source, case.cursor, case.label)
+    assert edit is not None, f"{case.name}: eliminate_at returned None"
+    assert isinstance(edit, WorkspaceEdit)
+    assert edit.path == "test.pf"
+    assert edit.range == case.expected_range, (
+        f"{case.name}: range mismatch\n"
+        f"  expected: {case.expected_range}\n"
+        f"  got:      {edit.range}"
+    )
+    assert edit.new_text == case.expected_text, (
+        f"{case.name}: new_text mismatch\n"
+        f"  expected: {case.expected_text!r}\n"
+        f"  got:      {edit.new_text!r}"
+    )
+
+
+def test_eliminate_at_returns_none_for_true_fact() -> None:
+    """`H: true' has no useful template."""
+    source = (
+        "theorem t: all P:bool. if true then P or not P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: true\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = eliminate_at("test.pf", source, Position(line=5, column=3), "H")
+    assert edit is None
+
+
+def test_eliminate_at_returns_none_when_cursor_not_on_hole() -> None:
+    """Cursor not on a ``?`` -> no replacement target."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on `assume' keyword, line 4 col 3.
+    edit = eliminate_at("test.pf", source, Position(line=4, column=3), "H")
+    assert edit is None
+
+
+def test_eliminate_at_returns_none_for_unknown_label() -> None:
+    """Label doesn't match any in-scope binding."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = eliminate_at(
+        "test.pf", source, Position(line=5, column=3), "nope"
+    )
+    assert edit is None
+
+
+def test_eliminate_at_returns_none_for_term_variable() -> None:
+    """Label refers to a term variable (`P:bool'), not a proof
+    binding -> no template."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = eliminate_at("test.pf", source, Position(line=4, column=3), "P")
+    assert edit is None
+
+
+# --------------------------------------------------------------------------
+# eliminable_vars_at
+# --------------------------------------------------------------------------
+
+
+def test_eliminable_vars_includes_local_proof_bindings() -> None:
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = eliminable_vars_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert "H" in candidates
+
+
+def test_eliminable_vars_excludes_term_variables() -> None:
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = eliminable_vars_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    # `P' is a bool term variable, not a proof binding -- excluded.
+    assert "P" not in candidates
+    # `pP' is a local proof binding (atom `P' though, no template
+    # in v1 -- so it shouldn't show up either).
+    assert "pP" not in candidates
+
+
+def test_eliminable_vars_excludes_true_fact() -> None:
+    """A `true'-shaped hypothesis has no useful template -> filtered
+    out of the candidate list."""
+    source = (
+        "theorem t: all P:bool. if true then P or not P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: true\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = eliminable_vars_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert "H" not in candidates
+
+
+def test_eliminable_vars_returns_empty_off_hole() -> None:
+    """Cursor not on a `?` -> empty list."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = eliminable_vars_at(
+        "test.pf", source, Position(line=4, column=3)
+    )
+    assert candidates == ()

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -125,6 +125,8 @@ def test_all_expected_features_are_registered():
         lsp_server.GOAL_AT_REQUEST,
         lsp_server.CASE_SPLIT_REQUEST,
         lsp_server.SPLITTABLE_VARS_REQUEST,
+        lsp_server.ELIMINATE_REQUEST,
+        lsp_server.ELIMINABLE_VARS_REQUEST,
     }
     assert expected.issubset(set(fm.features))
 
@@ -814,3 +816,88 @@ def test_case_split_at_returns_null_when_variable_omitted(server, open_doc):
         "position": {"line": 0, "character": 0},
     }
     assert lsp_server.on_case_split_at(server, params) is None
+
+
+# --------------------------------------------------------------------------
+# Custom requests: deduce/eliminableVarsAt and deduce/eliminateAt
+# (Phase 4 / Step 18)
+# --------------------------------------------------------------------------
+
+
+def test_eliminable_vars_at_returns_in_scope_labels(server, open_doc):
+    """Cursor on a `?`; the response lists the eliminable hypothesis
+    labels in scope at that hole."""
+    src = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("eliminable.pf", src)
+    # `?` at line 5 col 3 (1-indexed) -> LSP line 4, char 2.
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 4, "character": 2},
+    }
+    result = lsp_server.on_eliminable_vars_at(server, params)
+    assert "H" in result
+
+
+def test_eliminate_at_returns_workspace_edit_for_or(server, open_doc):
+    """Cursor on `?`, label='H' (Or-shaped) -> WorkspaceEdit with
+    `cases H ...` skeleton."""
+    src = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("eliminate.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 4, "character": 2},
+        "label": "H",
+    }
+    result = lsp_server.on_eliminate_at(server, params)
+    assert result is not None
+    assert "changes" in result
+    edits = result["changes"][uri]
+    assert len(edits) == 1
+    assert "cases H" in edits[0]["newText"]
+    assert "case h1: P" in edits[0]["newText"]
+    assert "case h2: Q" in edits[0]["newText"]
+    assert edits[0]["range"]["start"] == {"line": 4, "character": 2}
+    assert edits[0]["range"]["end"] == {"line": 4, "character": 3}
+
+
+def test_eliminate_at_returns_null_for_unknown_label(server, open_doc):
+    src = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("eliminate_bad.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 4, "character": 2},
+        "label": "no_such_label",
+    }
+    assert lsp_server.on_eliminate_at(server, params) is None
+
+
+def test_eliminate_at_returns_null_when_label_omitted(server, open_doc):
+    """Missing `label` field -> null (defensive)."""
+    src = "x"
+    _, uri = open_doc("noop2.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 0, "character": 0},
+    }
+    assert lsp_server.on_eliminate_at(server, params) is None

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -101,6 +101,8 @@ async def test_all_tools_are_registered(server):
             "case_split_at",
             "splittable_vars_at",
             "induction_skeleton_at",
+            "eliminate_at",
+            "eliminable_vars_at",
         }
 
 
@@ -478,6 +480,56 @@ async def test_induction_skeleton_at_returns_null_for_non_forall(
         {"path": str(fp), "line": 4, "column": 3},
     )
     assert payload is None
+
+
+# --------------------------------------------------------------------------
+# eliminate_at and eliminable_vars_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_eliminate_at_returns_workspace_edit(server, tmp_path):
+    """Cursor on `?` + label='H' (Or-shaped) -> cases skeleton edit."""
+    src = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "eliminate.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "eliminate_at",
+        {"path": str(fp), "line": 5, "column": 3, "label": "H"},
+    )
+    assert payload is not None
+    assert payload["path"] == str(fp)
+    assert "cases H" in payload["new_text"]
+    assert payload["range"]["start"] == {"line": 5, "column": 3}
+    assert payload["range"]["end"] == {"line": 5, "column": 4}
+
+
+@pytest.mark.anyio
+async def test_eliminable_vars_at_returns_candidates(server, tmp_path):
+    src = (
+        "theorem t: all P:bool, Q:bool. if P or Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "candidates.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "eliminable_vars_at",
+        {"path": str(fp), "line": 5, "column": 3},
+    )
+    assert "H" in payload
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -41,6 +41,8 @@ from lsp.query import (  # noqa: E402
     case_split_at,
     check,
     definition_of,
+    eliminable_vars_at,
+    eliminate_at,
     goal_at,
     induction_skeleton_at,
     list_symbols,
@@ -73,6 +75,8 @@ EXPECTED_PUBLIC = {
     "case_split_at",
     "splittable_vars_at",
     "induction_skeleton_at",
+    "eliminate_at",
+    "eliminable_vars_at",
 }
 
 
@@ -220,6 +224,22 @@ def test_induction_skeleton_at_signature():
     )
 
 
+def test_eliminate_at_signature():
+    _check_sig(
+        eliminate_at,
+        ["path", "content", "pos", "label", "prelude"],
+        Optional[WorkspaceEdit],
+    )
+
+
+def test_eliminable_vars_at_signature():
+    _check_sig(
+        eliminable_vars_at,
+        ["path", "content", "pos", "prelude"],
+        tuple,
+    )
+
+
 def test_prelude_param_has_default():
     """``prelude`` is optional on every query function so existing
     Step 3-5 callers (which pass ``path`` and ``content`` only)
@@ -227,6 +247,7 @@ def test_prelude_param_has_default():
     for func in (
         check, goal_at, definition_of, list_symbols, refine_at,
         case_split_at, splittable_vars_at, induction_skeleton_at,
+        eliminate_at, eliminable_vars_at,
     ):
         prelude_param = inspect.signature(func).parameters["prelude"]
         assert prelude_param.default == (), (


### PR DESCRIPTION
**Phase 4 complete.** Dual to Step 15 (refine):

- **Step 15** picks a template by *goal* shape (introduction).
- **Step 18** picks a template by *named hypothesis* shape (elimination).

## Templates

Mirrors `proof_use_advice` in `proof_checker.py` — the existing dispatch the CLI's `help` statement walks.

| Hypothesis shape | Template |
|---|---|
| `H: P and Q` | `have h1: P by conjunct 1 of H\nhave h2: Q by conjunct 2 of H\n?` |
| `H: P or Q` | `cases H\n  case h1: P { ? }\n  case h2: Q { ? }` |
| `H: if P then Q` | `have h: Q by apply H to ?\n?` |
| `H: all x:T. P` | `H[?, ?, ...]` (or `H<?, ?, ...>` for type quantifiers) |
| `H: some x:T. P` | `obtain x1, ... where h: <body[subst]> from H\n?` |
| `H: e1 = e2` | `replace H\n?` |
| `H: false` | `H` (discharges any goal) |
| `H: true` | `None` (no useful template) |

## UX

Same shape as Step 16 (case split): cursor on `?` + completing-read for the hypothesis label.

```
C-c C-e
Eliminate on: H<TAB>   → completes against eliminable hypotheses in scope
```

Candidate list comes from `eliminable_vars_at` — local proof bindings whose formula has a supported template. Term variables, theorem references, and `true`-shaped facts are filtered out.

## Plan upgrade

The plan listed `H: P and Q` as "no-op-with-message in v1, revisit." Shipped the destructuring template instead (`have h1: P by conjunct 1 of H` …) — most useful output for that shape and was a one-liner to render.

## Phase 4 status after this merges

| Step | Operation | Binding | Status |
|---|---|---|---|
| 15 | refine | `C-c C-r` | merged |
| 16 | case split | `C-c C-c` | merged |
| 17 | induction skeleton | `C-c C-i` | merged |
| 18 | eliminate / use-fact | `C-c C-e` | this PR |

## Test plan

- [x] `python3 -m pytest test/lsp/` — 620 pass (was 597; +15 eliminate, +4 LSP wiring, +2 MCP, +2 sig lock)
- [x] `emacs --batch ... -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 44 pass (was 38; +6 eliminate)
- [x] `emacs --batch -f batch-byte-compile editor/emacs/deduce-lsp.el` — clean
- [x] `python3 test-deduce.py --errors` — 153 should-error fixtures unchanged
- [x] **Manual smoke** confirmed: `assume H: P or Q` then `?`; `C-c C-e` on `?` and `H RET` → cases skeleton.

## New surface

`lsp/query.py`:
- `eliminate_at(path, content, pos, label, prelude=()) -> Optional[WorkspaceEdit]`
- `eliminable_vars_at(path, content, pos, prelude=()) -> tuple[str]`

LSP custom methods: `deduce/eliminateAt`, `deduce/eliminableVarsAt`.
MCP tools: `eliminate_at`, `eliminable_vars_at`.
Emacs `C-c C-e` bound to `deduce-lsp-eliminate`.

## Files changed

- `lsp/query.py` (+345): `eliminate_at`, `eliminable_vars_at`, plus dispatch + per-shape rendering helpers
- `lsp/lsp_server.py` (+97): `on_eliminate_at` + `on_eliminable_vars_at` custom-method handlers
- `lsp/mcp_server.py` (+57): two new MCP tools
- `test/lsp/test_eliminate.py` (new, 15 tests): one fixture per template + boundary cases
- `test/lsp/test_lsp_server.py` (+87): 4 LSP wiring tests
- `test/lsp/test_mcp_server.py` (+52): 2 MCP tool tests + tool-list update
- `test/lsp/test_query.py` (+21): import + `__all__` + signature locks
- `editor/emacs/deduce-lsp.el` (+~80): `deduce-lsp-eliminate` defun + `C-c C-e` binding + commentary update
- `editor/emacs/test/deduce-lsp-test.el` (+145): 6 ert tests for `C-c C-e`
- `editor/emacs/README.md` (+~30): keybinding table + smoke test step