### PR TITLE
Fix #257: enforce generic union arity in all type contexts

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1922,6 +1922,21 @@ def check_recursive_call(call, recfun, subterms):
           + " or ".join([base_name(x) for x in subterms]) \
           + ", not " + str(call.args[0]))
 
+# Helper for check_type: a bare reference to a generic union (one with N>0
+# type parameters) is ill-formed. The arity check used to live in a separate
+# `validate_union_type` pass that was only run on union-constructor parameters
+# (issue #257); folding it into `check_type` makes every site that accepts a
+# user-written type — postulate/define/recursive/theorem signatures, etc. —
+# reject `Foo` when it should be `Foo<...>`.
+def _check_union_arity(head, given, env):
+  if not env.type_var_is_defined(head):
+    return
+  type_def = env.get_def_of_type_var(head)
+  if isinstance(type_def, Union) and len(type_def.type_params) != given:
+    error(head.location,
+          f"Expected union type '{head}' to have "
+          f"{len(type_def.type_params)} type arguments, not {given}")
+
 # well-formed types
 def check_type(typ, env):
   match typ:
@@ -1930,9 +1945,11 @@ def check_type(typ, env):
         error(loc, 'undefined type variable ' + str(typ))
       if len(rs) > 1:
         error(loc, 'type names may not be overloaded ' + str(typ))
+      _check_union_arity(typ, 0, env)
     case ResolvedVar(loc, tyof, name):
       if not env.type_var_is_defined(typ):
         error(loc, 'undefined type variable ' + str(typ))
+      _check_union_arity(typ, 0, env)
     case IntType(loc):
       pass
     case BoolType(loc):
@@ -1944,12 +1961,26 @@ def check_type(typ, env):
       for ty in param_types:
         check_type(ty, env)
       check_type(return_type, env)
-    case TypeInst(loc, typ, arg_types):
-      check_type(typ, env)
+    case TypeInst(loc, head, arg_types):
+      # Validate the head's arity against arg_types directly rather than
+      # recursing via check_type on the bare head (which would now fire the
+      # arity error). The head must be a VarRef referring to a generic union.
+      if isinstance(head, VarRef):
+        if not env.type_var_is_defined(head):
+          error(head.location, 'undefined type variable ' + str(head))
+        _check_union_arity(head, len(arg_types), env)
+      else:
+        check_type(head, env)
       for ty in arg_types:
         check_type(ty, env)
-    case GenericUnknownInst(loc, typ):
-      check_type(typ, env)
+    case GenericUnknownInst(loc, head):
+      # Internal node wrapping a deliberately-unapplied generic; don't trigger
+      # the arity check on its bare head.
+      if isinstance(head, VarRef):
+        if not env.type_var_is_defined(head):
+          error(head.location, 'undefined type variable ' + str(head))
+      else:
+        check_type(head, env)
     case ArrayType(loc, elt_type):
       check_type(elt_type, env)
     case _:
@@ -2566,35 +2597,6 @@ def is_modified(filename):
     else:
         return True
           
-def validate_union_type(ty, params, env):
-  if isinstance(ty, VarRef):
-    type_def = env.get_def_of_type_var(ty)
-    if isinstance(type_def, Union):
-      union_params_len = len(type_def.type_params)
-      provided_params_len = len(params)
-      if union_params_len != provided_params_len:
-        error(ty.location, f"Expected union type '{ty}' in constructor parameters " \
-             + f"to have {union_params_len} parameters, not {provided_params_len}")
-    return
-  match ty:
-    case TypeInst(loc, ty, type_args):
-      for t in type_args:
-        validate_union_type(t, [], env)
-      validate_union_type(ty, type_args, env)
-      pass
-    case FunctionType(loc, ty_params, param_types, return_type):
-      for t in param_types:
-        validate_union_type(t, [], env)
-      validate_union_type(return_type, [], env)
-    case IntType():
-      pass
-    case BoolType():
-      pass
-    case ArrayType(loc, elt_ty):
-      validate_union_type(elt_ty, [], env)
-    case _:
-      error(ty.location, f"Unhandled case '{type(ty)}' in 'validate_union_type")
-
 # Strict-positivity check for inductive (union) types.
 #
 # A constructor parameter type is strictly positive in the union being defined
@@ -3694,7 +3696,6 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
             return_type = body_union_type
           for ty in constr.parameters:
             check_type(ty, body_env)
-            validate_union_type(ty, [], body_env)
             check_strict_positivity(ty, name, body_env)
           constr_type = FunctionType(constr.location, typarams,
                                      constr.parameters, return_type)
@@ -3885,7 +3886,14 @@ def process_declaration(stmt : Statement, env : Env, module_chain, downstream_ne
       return stmt, env
     
     case Inductive(loc, typ, name):
-      check_type(typ, env)
+      # `inductive Foo by ...` names a union by its bare name (the
+      # corresponding `case Inductive(...)` in check_proofs enforces this).
+      # Skip the usual `check_type` here so the generic-arity check doesn't
+      # reject `inductive Foo by ...` when Foo is a generic union.
+      if not isinstance(typ, VarRef):
+        error(loc, "Only able to declare uninstantiated union types inductive")
+      if not env.type_var_is_defined(typ):
+        error(typ.location, 'undefined type variable ' + str(typ))
       return stmt, env
   
     case _:

--- a/test/should-error/union_missing_typarams.pf.err
+++ b/test/should-error/union_missing_typarams.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/union_missing_typarams.pf:7.8-7.10: Expected union type 'No' in constructor parameters to have 2 parameters, not 1
+./test/should-error/union_missing_typarams.pf:7.8-7.10: Expected union type 'No' to have 2 type arguments, not 1

--- a/test/should-error/union_missing_typarams_define.pf
+++ b/test/should-error/union_missing_typarams_define.pf
@@ -1,0 +1,7 @@
+union TwoList<K, V> {
+  empty
+  vnode(V, TwoList<K, V>)
+  knode(K, TwoList<K, V>)
+}
+
+define x : TwoList = empty

--- a/test/should-error/union_missing_typarams_define.pf.err
+++ b/test/should-error/union_missing_typarams_define.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/union_missing_typarams_define.pf:7.12-7.19: Expected union type 'TwoList' to have 2 type arguments, not 0

--- a/test/should-error/union_missing_typarams_fun.pf.err
+++ b/test/should-error/union_missing_typarams_fun.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/union_missing_typarams_fun.pf:6.13-6.14: Expected union type 'A' in constructor parameters to have 1 parameters, not 0
+./test/should-error/union_missing_typarams_fun.pf:6.13-6.14: Expected union type 'A' to have 1 type arguments, not 0

--- a/test/should-error/union_missing_typarams_postulate.pf
+++ b/test/should-error/union_missing_typarams_postulate.pf
@@ -1,0 +1,7 @@
+union TwoList<K, V> {
+  empty
+  vnode(V, TwoList<K, V>)
+  knode(K, TwoList<K, V>)
+}
+
+postulate foo: all x: TwoList. true

--- a/test/should-error/union_missing_typarams_postulate.pf.err
+++ b/test/should-error/union_missing_typarams_postulate.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/union_missing_typarams_postulate.pf:7.23-7.30: Expected union type 'TwoList' to have 2 type arguments, not 0

--- a/test/should-error/union_missing_typarams_rec.pf.err
+++ b/test/should-error/union_missing_typarams_rec.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/union_missing_typarams_rec.pf:8.9-8.10: Expected union type 'A' in constructor parameters to have 1 parameters, not 0
+./test/should-error/union_missing_typarams_rec.pf:8.9-8.10: Expected union type 'A' to have 1 type arguments, not 0

--- a/test/should-error/union_missing_typarams_recursive.pf
+++ b/test/should-error/union_missing_typarams_recursive.pf
@@ -1,0 +1,11 @@
+union TwoList<K, V> {
+  empty
+  vnode(V, TwoList<K, V>)
+  knode(K, TwoList<K, V>)
+}
+
+recursive nonempty<K, V>(TwoList) -> bool {
+  nonempty(empty) = false
+  nonempty(vnode(v, t)) = true
+  nonempty(knode(k, t)) = true
+}

--- a/test/should-error/union_missing_typarams_recursive.pf.err
+++ b/test/should-error/union_missing_typarams_recursive.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/union_missing_typarams_recursive.pf:7.26-7.33: Expected union type 'TwoList' to have 2 type arguments, not 0


### PR DESCRIPTION
## Summary

Closes #257.

[PR #270](https://github.com/jsiek/deduce/pull/270) addressed the issue for **union-constructor parameters** by adding `validate_union_type`. This PR extends the same well-formedness check to **every** user-written type expression — postulate signatures, `define`, `recursive`/`recfun`, theorem signatures, etc. — so bare references to generic unions are rejected uniformly with a clear error.

Previously, `postulate foo: all x: TwoList. true` was silently accepted, and `define x : TwoList = empty` / `recursive length(TwoList) -> Nat` produced cryptic downstream errors. They now all error at the type expression with:

```
Expected union type 'TwoList' to have 2 type arguments, not 0
```

## What changed

- Folded the arity check into `check_type` via a small `_check_union_arity` helper. Removed the now-redundant `validate_union_type` function and its call site in the `Union` branch of `process_declaration`.
- Refactored the `TypeInst` case in `check_type` to validate its head's arity directly against `arg_types` rather than recursing via `check_type` on the bare head (which would now itself trigger the arity error).
- The `GenericUnknownInst` case (an internal node deliberately wrapping an unapplied generic) continues to accept a bare head.
- The `Inductive` declaration legitimately takes a bare union name (`inductive Foo by ProofName`); switched its `check_type` call to a name-only check so generics aren't rejected here.
- Updated wording of the existing 3 should-error fixtures (`union_missing_typarams{,_fun,_rec}`) to match the new generalized message.
- Added 3 new should-error fixtures for the previously-silent contexts: `union_missing_typarams_{postulate,define,recursive}`.

## Test plan

- [x] `python3 test-deduce.py` — full suite passes
- [x] `make tests` — both parsers (recursive-descent + lalr) pass on `should-validate` and `should-error`
- [x] `make tests-lib` — stdlib still validates with the stricter check

🤖 Generated with [Claude Code](https://claude.com/claude-code)