### PR TITLE
Fix #353: fill hole with a given

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -163,6 +163,10 @@ Steps 15 and 18 are duals: Step 15 is **introduction** (template chosen by the *
 
   - *Acceptance:* fixtures for each shape (and/or/if-then/all/some/equality), keyed by a hypothesis label that the env binds at the cursor. Each asserts: the produced tactic parses; running `check` on the post-edit content surfaces a fresh hole at the inserted `?` (or, for the no-`?` cases like `false`, no hole). Plus boundary cases: a label that isn't in scope at the cursor returns `None`; a label whose formula is `true` returns `None` (or a stub edit with a comment-only template — pick one and pin it); the cursor outside any proof context returns `None`.
 
+- [x] **Step 19: Fill hole with a given (issue #353).** A narrower sibling of Step 18: where eliminate picks a template by the *shape* of the chosen hypothesis, fill-from-given picks by formula *equality* — the chosen given's formula must equal the goal, and the replacement is just `conclude <goal> by <label>`. The proof checker already does this matching internally (`proof_advice` in `proof_checker.py` walks `env.dict` for `ProofBinding`s whose formula equals the goal); the LSP just surfaces it as an editor command.
+
+  New query API: `fill_from_given_at(path, content, pos, label, prelude=()) -> Optional[WorkspaceEdit]` plus `matching_givens_at(path, content, pos, prelude=()) -> tuple[str, ...]`. Same wire shape as the eliminate pair — custom server methods `deduce/fillFromGivenAt` and `deduce/matchingGivensAt`, matching MCP tools, and an emacs `C-c C-f` binding that auto-applies on a single match (the prompt would just be a confirmation) and prompts via `completing-read` on multiple. Filters to local proof bindings only — theorems are referred to by name directly.
+
 ## Cross-cutting notes
 
 - Add `lsp/` to the `make tests` target as a separate phase, otherwise it'll bitrot.

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -339,6 +339,15 @@ is running in the current buffer."
 ;;     chosen label.  Same wire-shape as case split (custom request,
 ;;     extra user-supplied label argument) -- their UX is symmetric.
 ;;
+;;   `C-c C-f'  deduce-lsp-fill-from-given  (issue #353)
+;;     Cursor on a `?'.  Issues `deduce/matchingGivensAt' to fetch
+;;     labels of in-scope givens whose formula equals the goal.
+;;     With a single match, applies it directly (no prompt -- the
+;;     prompt would just be a confirmation since there's only one
+;;     answer).  With multiple matches, prompts via `completing-
+;;     read'.  Issues `deduce/fillFromGivenAt' with the chosen
+;;     label and replaces the `?' with `conclude <goal> by <label>'.
+;;
 ;; Refine and induction use `textDocument/codeAction' because they
 ;; take no extra user input.  Case-split and eliminate take a
 ;; user-supplied identifier, which codeAction can't carry, so they
@@ -595,13 +604,65 @@ without applying when the server returns null."
       (deduce-lsp--apply-workspace-edit edit))))
 
 
+(defun deduce-lsp-fill-from-given (label)
+  "Fill the hole at point with `conclude <goal> by LABEL'.
+
+The cursor must sit on (or immediately adjacent to) a `?' token;
+that `?' is the replacement target.  LABEL names an in-scope local
+proof binding whose formula equals the goal at the hole.
+
+Interactively, queries the server for the matching given labels in
+scope at the hole (custom request `deduce/matchingGivensAt') and:
+
+  - errors with `No matching given at point.' when the candidate
+    list is empty;
+  - applies the single match directly when exactly one given
+    matches (the prompt would just be a confirmation);
+  - prompts via `completing-read' with TAB completion when multiple
+    givens match.
+
+The chosen label is then sent in a `deduce/fillFromGivenAt'
+request; the returned WorkspaceEdit is applied directly.  Errors
+out without applying when the server returns null."
+  (interactive
+   (let ((server (eglot-current-server)))
+     (unless server
+       (user-error
+        "No eglot server active in this buffer; M-x eglot first"))
+     (let* ((params (deduce-lsp--text-document-position))
+            (candidates (deduce-lsp--request server :deduce/matchingGivensAt
+                                              params))
+            (candidate-list (if (vectorp candidates)
+                                (append candidates nil)
+                              candidates)))
+       (unless candidate-list
+         (user-error "No matching given at point"))
+       (list (if (= (length candidate-list) 1)
+                 (car candidate-list)
+               (completing-read "Fill from given: " candidate-list
+                                nil t))))))
+  (let ((server (eglot-current-server)))
+    (unless server
+      (user-error
+       "No eglot server active in this buffer; M-x eglot first"))
+    (let* ((params (append (deduce-lsp--text-document-position)
+                           (list :label label)))
+           (edit (deduce-lsp--request server :deduce/fillFromGivenAt params)))
+      (unless edit
+        (user-error
+         "Server returned no edit for fill-from-given on %s" label))
+      (deduce-lsp--apply-workspace-edit edit))))
+
+
 ;; Bind `C-c C-r' (refine), `C-c C-c' (case split), `C-c C-i'
-;; (induction), and `C-c C-e' (eliminate) in `deduce-mode-map'.
-;; Same rationale as `C-c C-g': only meaningful when LSP is loaded.
+;; (induction), `C-c C-e' (eliminate), and `C-c C-f' (fill from
+;; given) in `deduce-mode-map'.  Same rationale as `C-c C-g': only
+;; meaningful when LSP is loaded.
 (define-key deduce-mode-map (kbd "C-c C-r") #'deduce-lsp-refine-hole)
 (define-key deduce-mode-map (kbd "C-c C-c") #'deduce-lsp-case-split)
 (define-key deduce-mode-map (kbd "C-c C-i") #'deduce-lsp-induction)
 (define-key deduce-mode-map (kbd "C-c C-e") #'deduce-lsp-eliminate)
+(define-key deduce-mode-map (kbd "C-c C-f") #'deduce-lsp-fill-from-given)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -912,6 +912,179 @@ interactive entry user-errors with `No elimination available'."
       (delete-file tmp))))
 
 
+;; ---------------------------------------------------------------------
+;; deduce-lsp-fill-from-given (issue #353, fronted by `C-c C-f')
+;; ---------------------------------------------------------------------
+;;
+;; Same wire shape as eliminate (Step 18): cursor on `?', the
+;; interactive form fetches candidate labels via
+;; `deduce/matchingGivensAt'; on a single match it skips
+;; completing-read and applies directly; on multiple it prompts.
+;; The chosen label drives a `deduce/fillFromGivenAt' request.
+
+(ert-deftest deduce-lsp/fill-from-given-bound-to-c-c-c-f ()
+  "`C-c C-f' in deduce-mode-map runs `deduce-lsp-fill-from-given'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-f"))
+              #'deduce-lsp-fill-from-given)))
+
+
+(ert-deftest deduce-lsp/fill-from-given-issues-fillFromGivenAt-request ()
+  "Calling `deduce-lsp-fill-from-given' with a label arg sends
+`deduce/fillFromGivenAt' with `{textDocument, position, label}'."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf"))
+        calls)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool. if P then P\nproof\n  arbitrary P:bool\n  assume H: P\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; `?` at line 5 col 3 -> LSP line 4, char 2.
+          (goto-char (point-min))
+          (forward-line 4)
+          (forward-char 2)
+          (setq calls
+                (deduce-lsp-test--with-method-mock
+                 '((:deduce/fillFromGivenAt . nil))
+                 (lambda ()
+                   (ignore-errors (deduce-lsp-fill-from-given "H")))))
+          (let* ((call (assq :deduce/fillFromGivenAt calls))
+                 (params (cdr call))
+                 (text-doc (plist-get params :textDocument))
+                 (pos (plist-get params :position)))
+            (should call)
+            (should (string-prefix-p "file://"
+                                      (plist-get text-doc :uri)))
+            (should (= (plist-get pos :line) 4))
+            (should (= (plist-get pos :character) 2))
+            (should (equal (plist-get params :label) "H"))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/fill-from-given-applies-workspace-edit ()
+  "Given a server response with a `:changes' WorkspaceEdit, the
+buffer ends up with the new text replacing the `?'."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool. if P then P\nproof\n  arbitrary P:bool\n  assume H: P\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (goto-char (point-min))
+          (forward-line 4)
+          (forward-char 2)
+          (let* ((uri (deduce-lsp--current-uri))
+                 (skeleton "conclude P by H")
+                 (edit `(:changes
+                         (,(intern (concat ":" uri))
+                          [(:range (:start (:line 4 :character 2)
+                                    :end (:line 4 :character 3))
+                                   :newText ,skeleton)]))))
+            (deduce-lsp-test--with-method-mock
+             `((:deduce/fillFromGivenAt . ,edit))
+             (lambda () (deduce-lsp-fill-from-given "H"))))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "conclude P by H" text))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/fill-from-given-null-server-response-errors ()
+  "If the server returns null for fillFromGivenAt, the command
+user-errors instead of silently no-op-ing."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (deduce-lsp-test--with-method-mock
+           '((:deduce/fillFromGivenAt . nil))
+           (lambda ()
+             (should-error (deduce-lsp-fill-from-given "H") :type 'user-error))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/fill-from-given-interactive-single-match-autoselects ()
+  "With exactly one matching given, the interactive entry skips
+`completing-read' and uses the single candidate directly."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf"))
+        completing-read-called)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method _params)
+                       (cond
+                        ((eq method :deduce/matchingGivensAt) ["H"])
+                        ((eq method :deduce/fillFromGivenAt) nil))))
+                    ((symbol-function 'completing-read)
+                     (lambda (&rest _args)
+                       (setq completing-read-called t)
+                       "H")))
+            (ignore-errors
+              (call-interactively #'deduce-lsp-fill-from-given)))
+          (should-not completing-read-called))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/fill-from-given-interactive-multi-uses-completing-read ()
+  "With multiple matches, the interactive entry hits
+`deduce/matchingGivensAt' and feeds them to `completing-read'."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf"))
+        captured-prompt
+        captured-collection)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method _params)
+                       (cond
+                        ((eq method :deduce/matchingGivensAt) ["H1" "H2"])
+                        ((eq method :deduce/fillFromGivenAt) nil))))
+                    ((symbol-function 'completing-read)
+                     (lambda (prompt collection &rest _rest)
+                       (setq captured-prompt prompt)
+                       (setq captured-collection collection)
+                       "H1")))
+            (ignore-errors
+              (call-interactively #'deduce-lsp-fill-from-given)))
+          (should (string-match-p "Fill from given:" captured-prompt))
+          (should (member "H1" captured-collection))
+          (should (member "H2" captured-collection)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/fill-from-given-interactive-empty-candidates-errors ()
+  "If `deduce/matchingGivensAt' returns no candidates, the
+interactive entry user-errors with `No matching given'."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server _method _params) [])))
+            (should-error (call-interactively #'deduce-lsp-fill-from-given)
+                          :type 'user-error)))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -145,6 +145,13 @@ SPLITTABLE_VARS_REQUEST = "deduce/splittableVarsAt"
 ELIMINATE_REQUEST = "deduce/eliminateAt"
 ELIMINABLE_VARS_REQUEST = "deduce/eliminableVarsAt"
 
+# Custom requests for issue #353 (fill hole with a given).  Same shape
+# as the eliminate pair: the editor fetches matching-given labels via
+# ``deduce/matchingGivensAt`` for completion, then issues
+# ``deduce/fillFromGivenAt`` with the user's chosen label.
+FILL_FROM_GIVEN_REQUEST = "deduce/fillFromGivenAt"
+MATCHING_GIVENS_REQUEST = "deduce/matchingGivensAt"
+
 server = LanguageServer(
     SERVER_NAME,
     SERVER_VERSION,
@@ -638,6 +645,95 @@ def on_eliminate_at(ls: LanguageServer, params) -> Optional[dict]:
     )
     path = _path_from_uri(uri)
     edit = _query.eliminate_at(
+        path, content, pos, str(label), prelude=_prelude_for(path)
+    )
+    if edit is None:
+        return None
+    return {
+        "changes": {
+            uri: [
+                {
+                    "range": {
+                        "start": {
+                            "line": max(edit.range.start.line - 1, 0),
+                            "character": max(edit.range.start.column - 1, 0),
+                        },
+                        "end": {
+                            "line": max(edit.range.end.line - 1, 0),
+                            "character": max(edit.range.end.column - 1, 0),
+                        },
+                    },
+                    "newText": edit.new_text,
+                }
+            ]
+        }
+    }
+
+
+@server.feature(MATCHING_GIVENS_REQUEST)
+def on_matching_givens_at(ls: LanguageServer, params) -> list[str]:
+    """Custom request: return labels of in-scope local proof
+    bindings whose formula equals the goal at the cursor's hole.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}}``.  Editor clients call this to populate
+    completion candidates when prompting for the hypothesis label.
+
+    Result: a list of base names (sorted, deduplicated).  Empty when
+    the cursor isn't on a ``?`` or no local binding matches the goal.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
+    if not uri:
+        return []
+    content = _document_content(ls, uri)
+    if content is None:
+        return []
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
+        )
+    )
+    path = _path_from_uri(uri)
+    return list(
+        _query.matching_givens_at(path, content, pos, prelude=_prelude_for(path))
+    )
+
+
+@server.feature(FILL_FROM_GIVEN_REQUEST)
+def on_fill_from_given_at(ls: LanguageServer, params) -> Optional[dict]:
+    """Custom request: return a WorkspaceEdit that fills the cursor's
+    hole with ``conclude <goal> by <label>``.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}, "label": str}``.  The cursor must sit on
+    a ``?``; the ``label`` arg names which in-scope local hypothesis
+    to use.
+
+    Result: ``{"changes": {<uri>: [{"range": Range, "newText":
+    str}]}}`` (an LSP-shaped WorkspaceEdit) or ``null`` when the
+    cursor isn't on a hole, the label isn't bound, or the bound
+    formula doesn't match the goal.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _get_field(text_doc, "uri")
+    label = _get_field(params, "label")
+    if not uri or not label:
+        return None
+    content = _document_content(ls, uri)
+    if content is None:
+        return None
+    pos = _query_pos_from_lsp(
+        lsp_types.Position(
+            line=int(_get_field(pos_obj, "line") or 0),
+            character=int(_get_field(pos_obj, "character") or 0),
+        )
+    )
+    path = _path_from_uri(uri)
+    edit = _query.fill_from_given_at(
         path, content, pos, str(label), prelude=_prelude_for(path)
     )
     if edit is None:

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -367,6 +367,51 @@ def eliminable_vars_at(
 
 
 @mcp.tool()
+def fill_from_given_at(
+    path: str, line: int, column: int, label: str
+) -> Optional[dict]:
+    """Fill the hole at ``line``:``column`` with ``conclude <goal> by
+    <label>``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token;
+    that ``?`` is the replacement target.  ``label`` names an in-scope
+    *local* proof binding (typically a hypothesis introduced by
+    ``assume`` / ``suppose`` / ``have``) whose formula equals the goal
+    at the hole.
+
+    Returns ``None`` when the cursor isn't on a ``?``, ``label`` isn't
+    bound, the bound formula doesn't match the goal, or the binding
+    isn't local.  Otherwise returns ``{path, range, new_text}``.
+
+    For a list of valid ``label`` choices, see ``matching_givens_at``.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    edit = query.fill_from_given_at(
+        path, content, pos, label, prelude=_prelude_for(path)
+    )
+    return _to_serializable(edit)
+
+
+@mcp.tool()
+def matching_givens_at(
+    path: str, line: int, column: int
+) -> list[str]:
+    """Return labels of in-scope local proof bindings whose formula
+    equals the goal at ``line``:``column``.
+
+    The cursor must sit on a ``?`` token.  Names are sorted and
+    deduplicated.  Returns ``[]`` when the cursor isn't on a ``?``,
+    the goal AST isn't available, or no local binding matches.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    return list(
+        query.matching_givens_at(path, content, pos, prelude=_prelude_for(path))
+    )
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -70,6 +70,8 @@ __all__ = [
     "induction_skeleton_at",
     "eliminate_at",
     "eliminable_vars_at",
+    "fill_from_given_at",
+    "matching_givens_at",
 ]
 
 
@@ -1857,4 +1859,143 @@ def _eliminate_some(label: str, formula, env) -> str:
         f"obtain {', '.join(fresh_witnesses)} where "
         f"{h}: {new_body} from {label}\n?"
     )
+
+
+# ---------------------------------------------------------------------------
+# fill_from_given_at -- issue #353: fill a hole with a matching given
+# ---------------------------------------------------------------------------
+#
+# Sibling of ``eliminate_at''.  Where ``eliminate_at'' picks a template
+# from the *shape* of a named hypothesis, ``fill_from_given_at'' picks
+# by formula *equality*: the chosen given's formula must equal the goal,
+# and the replacement is just ``conclude <goal> by <label>'' -- the same
+# advice ``proof_advice'' in proof_checker.py emits when an exact match
+# is in scope.
+#
+# The proof checker already does this matching internally (see
+# proof_checker.py around line 893: it walks env.dict for ProofBindings
+# whose formula equals the goal and offers a `conclude ... by ...'
+# completion).  The LSP just surfaces it as an editor command.
+#
+# UX shape mirrors ``eliminate_at'': the editor binding fetches
+# candidate labels via ``matching_givens_at'' and prompts via
+# ``completing-read'' before issuing ``deduce/fillFromGivenAt''.
+
+
+def fill_from_given_at(
+    path: str, content: str, pos: Position,
+    label: str,
+    prelude: Sequence[str] = (),
+) -> Optional[WorkspaceEdit]:
+    """Fill the hole at ``pos`` with ``conclude <goal> by <label>``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token;
+    that ``?`` is the replacement target.  ``label`` names an in-scope
+    local proof binding whose formula equals the goal at the hole.
+
+    Returns ``None`` when:
+
+    - the cursor isn't on a ``?``,
+    - the file has no incomplete proof at the cursor,
+    - ``label`` isn't bound at the hole,
+    - the bound formula doesn't equal the goal, or
+    - the bound formula isn't local (theorems are referred to by name
+      directly, not via this command).
+
+    For client-side completion of valid ``label`` choices, see
+    :func:`matching_givens_at`.
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return None
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    goal = getattr(exc, "formula", None)
+    if env is None or goal is None:
+        return None
+
+    template = _fill_from_given_template(label, goal, env)
+    if template is None:
+        return None
+
+    template = _indent_continuation(
+        template, _line_indent_at(content, hole_range.start)
+    )
+    return WorkspaceEdit(path=path, range=hole_range, new_text=template)
+
+
+def matching_givens_at(
+    path: str, content: str, pos: Position, prelude: Sequence[str] = ()
+) -> tuple:
+    """Return base names of in-scope local proof bindings whose
+    formula equals the goal at the hole at ``pos``.
+
+    Used by editor clients to populate completion candidates for the
+    ``Fill from given:'' prompt.  Empty when the cursor isn't on a
+    ``?``, the goal AST isn't available, or no local binding matches.
+    Names are sorted and deduplicated.
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return ()
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return ()
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    goal = getattr(exc, "formula", None)
+    if env is None or goal is None:
+        return ()
+
+    return _matching_given_names(goal, env)
+
+
+def _matching_given_names(goal, env) -> tuple:
+    """Names of local proof bindings whose formula equals ``goal``."""
+    from abstract_syntax import ProofBinding, base_name
+
+    seen = set()
+    for unique, binding in env.dict.items():
+        if not isinstance(binding, ProofBinding):
+            continue
+        if not binding.local:
+            continue
+        if binding.formula != goal:
+            continue
+        seen.add(base_name(unique))
+    return tuple(sorted(seen))
+
+
+def _fill_from_given_template(label: str, goal, env) -> Optional[str]:
+    """Return ``conclude <goal> by <label>`` when ``label`` names a
+    local proof binding in ``env`` whose formula equals ``goal``.
+
+    Returns ``None`` when the label isn't bound, isn't a local proof
+    binding, or its formula doesn't match the goal.  The base-name
+    match (rather than unique-name) mirrors :func:`_eliminate_template`.
+    """
+    from abstract_syntax import ProofBinding, base_name
+
+    matches = [k for k in env.dict if base_name(k) == label]
+    if not matches:
+        return None
+    binding = env.dict[matches[0]]
+    if not isinstance(binding, ProofBinding):
+        return None
+    if not binding.local:
+        return None
+    if binding.formula != goal:
+        return None
+    return f"conclude {goal} by {label}"
 

--- a/test/lsp/test_fill_from_given.py
+++ b/test/lsp/test_fill_from_given.py
@@ -1,0 +1,297 @@
+"""Acceptance tests for ``lsp.query.fill_from_given_at`` and
+``lsp.query.matching_givens_at`` (issue #353).
+
+UX shape: cursor on a ``?`` plus an explicit ``label`` argument
+naming the in-scope local hypothesis whose formula equals the goal.
+Same shape as Step 18 (eliminate) -- editor clients fetch candidate
+labels via ``matching_givens_at`` and prompt with ``completing-read``
+before issuing ``fill_from_given_at``.
+
+Coverage:
+
+(a) goal matches a unique given -> ``conclude <goal> by <label>``;
+(b) goal matches multiple givens -> all labels listed; either works;
+(c) goal matches no given -> empty list, ``None`` edit;
+(d) cursor not on ``?`` -> empty list, ``None`` edit;
+(e) label not in scope -> ``None``;
+(f) label is a term variable (not a proof binding) -> ``None``;
+(g) label is a theorem (not a local binding) -> ``None``.
+
+All fixtures stay inside ``bool``-only territory so the tests run
+without the standard library prelude.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    Range,
+    WorkspaceEdit,
+    fill_from_given_at,
+    matching_givens_at,
+)
+
+
+# --------------------------------------------------------------------------
+# fill_from_given_at
+# --------------------------------------------------------------------------
+
+
+def test_fill_from_given_at_single_match() -> None:
+    """Goal ``P or Q`` with given ``H: P or Q`` -> conclude by H."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert edit is not None
+    assert isinstance(edit, WorkspaceEdit)
+    assert edit.path == "test.pf"
+    assert edit.range == Range(
+        start=Position(line=5, column=3),
+        end=Position(line=5, column=4),
+    )
+    assert edit.new_text == "conclude (P or Q) by H"
+
+
+def test_fill_from_given_at_atomic_goal() -> None:
+    """Atomic-formula match: goal ``P`` with given ``pP: P``."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=5, column=3), "pP"
+    )
+    assert edit is not None
+    assert edit.new_text == "conclude P by pP"
+
+
+def test_fill_from_given_at_picks_either_match() -> None:
+    """Two matching givens: caller-chosen label both work."""
+    source = (
+        "theorem t: all P:bool. if P then if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H1: P\n"
+        "  assume H2: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    for label in ("H1", "H2"):
+        edit = fill_from_given_at(
+            "test.pf", source, Position(line=6, column=3), label
+        )
+        assert edit is not None, f"label {label} produced no edit"
+        assert edit.new_text == f"conclude P by {label}"
+
+
+def test_fill_from_given_at_returns_none_when_no_match() -> None:
+    """Goal ``P or Q`` with given ``H: P`` (different formula)."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert edit is None
+
+
+def test_fill_from_given_at_returns_none_off_hole() -> None:
+    """Cursor not on a ``?`` -> no replacement target."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on `assume` keyword, line 4 col 3.
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=4, column=3), "H"
+    )
+    assert edit is None
+
+
+def test_fill_from_given_at_returns_none_for_unknown_label() -> None:
+    """Label doesn't match any in-scope binding."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=5, column=3), "nope"
+    )
+    assert edit is None
+
+
+def test_fill_from_given_at_returns_none_for_term_variable() -> None:
+    """Label refers to a term variable (`P:bool'), not a proof
+    binding -- defensively returns None even though the formula
+    doesn't make sense to compare."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=5, column=3), "P"
+    )
+    assert edit is None
+
+
+def test_fill_from_given_at_returns_none_for_non_local_binding() -> None:
+    """A theorem in scope is a non-local proof binding -- excluded
+    from the matching givens.  Users invoke theorems by name, not
+    via this command."""
+    source = (
+        "theorem h: true\n"
+        "proof . end\n"
+        "theorem t: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    # `h' has formula `true', which equals the goal `true', but `h'
+    # is a theorem reference (non-local), so fill-from-given skips it.
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=5, column=3), "h"
+    )
+    assert edit is None
+
+
+# --------------------------------------------------------------------------
+# matching_givens_at
+# --------------------------------------------------------------------------
+
+
+def test_matching_givens_includes_unique_match() -> None:
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert candidates == ("H",)
+
+
+def test_matching_givens_lists_all_matches() -> None:
+    source = (
+        "theorem t: all P:bool. if P then if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H1: P\n"
+        "  assume H2: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=6, column=3)
+    )
+    assert candidates == ("H1", "H2")
+
+
+def test_matching_givens_excludes_non_matching() -> None:
+    """Givens whose formulas differ from the goal aren't listed."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P then if Q then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H1: P\n"
+        "  assume H2: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Goal here is `P or Q`; neither H1 nor H2 matches it.
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=6, column=3)
+    )
+    assert candidates == ()
+
+
+def test_matching_givens_excludes_term_variables() -> None:
+    """Term variables aren't proof bindings -- excluded."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    # `pP` matches the goal `P` and is local -> in.
+    # `P` is a term variable -> out.
+    assert "pP" in candidates
+    assert "P" not in candidates
+
+
+def test_matching_givens_excludes_non_local() -> None:
+    """A theorem with the same formula as the goal isn't listed
+    -- only local proof bindings count."""
+    source = (
+        "theorem h: true\n"
+        "proof . end\n"
+        "theorem t: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert "h" not in candidates
+
+
+def test_matching_givens_returns_empty_off_hole() -> None:
+    """Cursor not on a `?` -> empty list."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=4, column=3)
+    )
+    assert candidates == ()

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -103,6 +103,8 @@ async def test_all_tools_are_registered(server):
             "induction_skeleton_at",
             "eliminate_at",
             "eliminable_vars_at",
+            "fill_from_given_at",
+            "matching_givens_at",
         }
 
 

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -77,6 +77,8 @@ EXPECTED_PUBLIC = {
     "induction_skeleton_at",
     "eliminate_at",
     "eliminable_vars_at",
+    "fill_from_given_at",
+    "matching_givens_at",
 }
 
 


### PR DESCRIPTION
## Summary

Adds an LSP/MCP/emacs command that fills a `?` with a `conclude <goal> by <label>` tactic, where `<label>` names an in-scope local hypothesis whose formula equals the goal. Closes #353.

The proof checker already does exactly this matching internally — see [`proof_advice`](https://github.com/jsiek/deduce/blob/main/proof_checker.py) (it walks `env.dict` for `ProofBinding`s whose formula equals the goal and prints "You can conclude the proof with: `conclude ... by ...`"). This PR just surfaces it as an editor command.

## Wire shape

Mirrors the existing eliminate pair (LSP Step 18) point-for-point:

- **Query API** (`lsp/query.py`): `matching_givens_at(...) -> tuple[str, ...]` and `fill_from_given_at(..., label) -> Optional[WorkspaceEdit]`.
- **LSP custom requests** (`lsp/lsp_server.py`): `deduce/matchingGivensAt` and `deduce/fillFromGivenAt`, returning the same shapes the eliminate pair returns.
- **MCP tools** (`lsp/mcp_server.py`): `matching_givens_at(path, line, column)` and `fill_from_given_at(path, line, column, label)`.
- **Emacs command** (`editor/emacs/deduce-lsp.el`): `deduce-lsp-fill-from-given` bound to `C-c C-f`. Auto-applies on a single match (the prompt would just be a confirmation) and prompts via `completing-read` on multiple. UX otherwise identical to `C-c C-e` (eliminate).

## Notes

- Only local proof bindings count — theorems are referred to by name directly, not via this command (filtered out the same way `eliminable_vars_at` filters them).
- v1 uses bare AST `==` for formula equality, matching what `proof_advice` already does. Alpha-equivalence and reduction-up-to matching are deliberately out of scope.
- Plan doc updated as Step 19 in `docs/lsp-plan.md` (and the canonical `__all__` / MCP tool registry tests).

## Test plan

- [x] `test/lsp/test_fill_from_given.py` — 14 pytest cases covering single match, multiple matches, no match, off-hole cursor, unknown label, term variable, and theorem (non-local) labels.
- [x] `editor/emacs/test/deduce-lsp-test.el` — 7 ert tests covering the keybinding, request shape, edit application, null response, single-match autoselect, multi-match prompt, and empty-candidate user-error.
- [x] All 647 existing LSP tests still pass; canonical-list tests (`test_query.test_all_matches_expected`, `test_mcp_server.test_all_tools_are_registered`) updated to include the new entries.
- [x] `byte-compile-file` on `deduce-lsp.el` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)