### PR TITLE
Separate compilation Step 25: module-prefixed symbol mangling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ tests: tests-should-validate tests-should-error
 tests-compile:
 	$(PYTHON) ./test/compile/run_lower.py
 	$(PYTHON) ./test/compile/run_e2e.py
+	$(PYTHON) ./test/compile/run_determinism.py
 
 package:
 	$(PYTHON) ./deduce.py ./lib

--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -98,7 +98,7 @@ def closure_convert(p: ir.Program) -> ir.Program:
         match d:
             case ir.UnionDecl():
                 new_decls.append(d)
-            case ir.Function(name, params, body, captures, loc):
+            case ir.Function(name, params, body, captures, loc, module):
                 if captures:
                     raise AssertionError(
                         "closure_convert: input already has lifted functions; "
@@ -107,9 +107,11 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 new_decls.append(ir.Function(
                     name=name, params=list(params),
                     body=go(body), captures=[], loc=loc,
+                    module=module,
                 ))
-            case ir.Global(name, body):
-                new_decls.append(ir.Global(name=name, body=go(body)))
+            case ir.Global(name, body, module):
+                new_decls.append(ir.Global(name=name, body=go(body),
+                                           module=module))
             case ir.Print(t):
                 new_decls.append(ir.Print(go(t)))
             case ir.AssertEq(l, r):
@@ -121,4 +123,5 @@ def closure_convert(p: ir.Program) -> ir.Program:
                     f"closure_convert: unknown top-level {type(d).__name__}"
                 )
 
-    return ir.Program(decls=new_decls + lifted)
+    return ir.Program(decls=new_decls + lifted,
+                      name_to_module=p.name_to_module)

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -49,26 +49,8 @@ def _mangle(name: str) -> str:
     return s
 
 
-def _func_id(name: str) -> str:
-    return "F_" + _mangle(name)
-
-
-def _global_id(name: str) -> str:
-    return "G_" + _mangle(name)
-
-
 def _local_id(name: str) -> str:
     return "v_" + _mangle(name)
-
-
-def _ctor_id_macro(name: str) -> str:
-    return "CTOR_" + _mangle(name)
-
-
-def _ctor_singleton(name: str) -> str:
-    """Per-ctor static value for nullary constructors. Allocated once
-    at program startup and reused at every `Con(c, [])` site."""
-    return "C_" + _mangle(name)
 
 
 def _base_name(name: str) -> str:
@@ -100,6 +82,11 @@ class EmitCtx:
     top_globals: Set[str] = field(default_factory=set)
     ctor_ids: Dict[str, int] = field(default_factory=dict)
     ctor_arities: Dict[str, int] = field(default_factory=dict)
+    # Per-name source module for `<Module>__<base_name>` symbol
+    # mangling (Step 25 of separate-compile-plan.md). Names absent
+    # from this map (closure-conversion `$lam<N>` lifts, etc.)
+    # mangle without a module prefix.
+    name_to_module: Dict[str, str] = field(default_factory=dict)
     tmp_counter: int = 0
 
     def fresh_tmp(self) -> str:
@@ -107,9 +94,32 @@ class EmitCtx:
         self.tmp_counter += 1
         return f"t{n}"
 
+    def _mangle_top(self, name: str) -> str:
+        """Mangle a top-level name. If we know its source module,
+        prefix with `<Module>__`; otherwise mangle the uniquified name
+        directly."""
+        module = self.name_to_module.get(name)
+        if module:
+            return _mangle(module) + "__" + _mangle(name)
+        return _mangle(name)
+
+    def func_id(self, name: str) -> str:
+        return "F_" + self._mangle_top(name)
+
+    def global_id(self, name: str) -> str:
+        return "G_" + self._mangle_top(name)
+
+    def ctor_id_macro(self, name: str) -> str:
+        return "CTOR_" + self._mangle_top(name)
+
+    def ctor_singleton(self, name: str) -> str:
+        """Per-ctor static value for nullary constructors. Allocated
+        once at program startup and reused at every `Con(c, [])` site."""
+        return "C_" + self._mangle_top(name)
+
 
 def emit_program(p: ir.Program) -> str:
-    ctx = EmitCtx()
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
     next_ctor_id = 0
     for d in p.decls:
         if isinstance(d, ir.UnionDecl):
@@ -138,25 +148,25 @@ def emit_program(p: ir.Program) -> str:
 
     # Constructor id macros
     for name, cid in ctx.ctor_ids.items():
-        out.append(f"#define {_ctor_id_macro(name)} {cid}")
+        out.append(f"#define {ctx.ctor_id_macro(name)} {cid}")
     out.append("")
 
     # Forward declarations
     for d in p.decls:
         if isinstance(d, ir.Function):
-            out.append(_emit_fn_decl(d) + ";")
+            out.append(_emit_fn_decl(d, ctx) + ";")
     out.append("")
 
     # Singleton storage for nullary ctors.
     for name in nullary_ctors:
-        out.append(f"deduce_value {_ctor_singleton(name)};")
+        out.append(f"deduce_value {ctx.ctor_singleton(name)};")
     out.append("")
 
     # Global variables. Same reasoning as the function declarations:
     # not `static`, so unused globals don't trip -Wunused-variable.
     for d in p.decls:
         if isinstance(d, ir.Global):
-            out.append(f"deduce_value {_global_id(d.name)};")
+            out.append(f"deduce_value {ctx.global_id(d.name)};")
     out.append("")
 
     # Function bodies
@@ -173,8 +183,8 @@ def emit_program(p: ir.Program) -> str:
     # `define two = suc(suc(zero))` reference these.
     for name in nullary_ctors:
         out.append(
-            f"    {_ctor_singleton(name)} = deduce_make_ctor("
-            f"{_ctor_id_macro(name)}, {_c_string(_base_name(name))}, 0, NULL);"
+            f"    {ctx.ctor_singleton(name)} = deduce_make_ctor("
+            f"{ctx.ctor_id_macro(name)}, {_c_string(_base_name(name))}, 0, NULL);"
         )
     for d in p.decls:
         if isinstance(d, ir.Global):
@@ -182,7 +192,7 @@ def emit_program(p: ir.Program) -> str:
             stmts, expr = _emit_term(d.body, ctx, locals_in_scope=set())
             for s in stmts:
                 out.append("    " + s)
-            out.append(f"    {_global_id(d.name)} = {expr};")
+            out.append(f"    {ctx.global_id(d.name)} = {expr};")
         elif isinstance(d, ir.Print):
             stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
             for s in stmts:
@@ -204,13 +214,13 @@ def emit_program(p: ir.Program) -> str:
     return "\n".join(out) + "\n"
 
 
-def _emit_fn_decl(f: ir.Function) -> str:
+def _emit_fn_decl(f: ir.Function, ctx: EmitCtx) -> str:
     # Not `static`: a function may be unused at runtime if it's only
     # referenced by an erased proof (e.g. used inside a `terminates`
     # block that compiled to nothing). `static` would trip
     # -Wunneeded-internal-declaration; an extern function is silently
     # dropped by the linker if nothing references it.
-    return f"deduce_value {_func_id(f.name)}(deduce_value* env, deduce_value* args)"
+    return f"deduce_value {ctx.func_id(f.name)}(deduce_value* env, deduce_value* args)"
 
 
 def _emit_function(f: ir.Function, ctx: EmitCtx) -> str:
@@ -220,7 +230,7 @@ def _emit_function(f: ir.Function, ctx: EmitCtx) -> str:
     body_stmts: List[str] = []
     if f.loc:
         body_stmts.append(f"// from {f.loc}")
-    body_stmts.append(_emit_fn_decl(f) + " {")
+    body_stmts.append(_emit_fn_decl(f, ctx) + " {")
     if not f.params:
         body_stmts.append("    (void)args;")
     if not f.captures:
@@ -256,7 +266,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
             if name in locals_in_scope:
                 return [], _local_id(name)
             if name in ctx.top_globals:
-                return [], _global_id(name)
+                return [], ctx.global_id(name)
             if name in ctx.top_funcs:
                 # First-class top-level function reference: build a
                 # closure with empty env. Phase 1 doesn't exercise this,
@@ -266,7 +276,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                 tmp = ctx.fresh_tmp()
                 stmts.append(
                     f"deduce_value {tmp} = deduce_make_closure("
-                    f"{_func_id(name)}, {_c_string(_base_name(name))}, "
+                    f"{ctx.func_id(name)}, {_c_string(_base_name(name))}, "
                     f"{arity}, 0, NULL);"
                 )
                 return stmts, tmp
@@ -328,7 +338,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                 raise EmitError(f"unknown constructor: {ctor}")
             # Nullary ctors are pre-allocated singletons.
             if not args:
-                return [], _ctor_singleton(ctor)
+                return [], ctx.ctor_singleton(ctor)
             arg_stmts: List[str] = []
             arg_exprs: List[str] = []
             for a in args:
@@ -343,7 +353,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
             tmp = ctx.fresh_tmp()
             stmts.append(
                 f"deduce_value {tmp} = deduce_make_ctor("
-                f"{_ctor_id_macro(ctor)}, {_c_string(_base_name(ctor))}, "
+                f"{ctx.ctor_id_macro(ctor)}, {_c_string(_base_name(ctor))}, "
                 f"{len(args)}, {arr});"
             )
             return stmts, tmp
@@ -370,7 +380,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
             tmp = ctx.fresh_tmp()
             stmts.append(
                 f"deduce_value {tmp} = deduce_make_closure("
-                f"{_func_id(fn)}, {_c_string(_base_name(fn))}, {arity}, "
+                f"{ctx.func_id(fn)}, {_c_string(_base_name(fn))}, {arity}, "
                 f"{len(caps)}, {arr_arg});"
             )
             return stmts, tmp
@@ -403,7 +413,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                     arr_arg = "NULL"
                 tmp = ctx.fresh_tmp()
                 stmts.append(
-                    f"deduce_value {tmp} = {_func_id(rator.name)}(NULL, {arr_arg});"
+                    f"deduce_value {tmp} = {ctx.func_id(rator.name)}(NULL, {arr_arg});"
                 )
                 return stmts, tmp
 
@@ -459,7 +469,7 @@ def _emit_term(t: ir.Term, ctx: EmitCtx, locals_in_scope: Set[str]) -> Tuple[Lis
                     if not isinstance(arm.pattern, ir.PatCon):
                         raise EmitError("expected constructor pattern in ctor match")
                     pc: ir.PatCon = arm.pattern
-                    stmts.append(f"case {_ctor_id_macro(pc.ctor)}: {{")
+                    stmts.append(f"case {ctx.ctor_id_macro(pc.ctor)}: {{")
                     inner_scope = locals_in_scope | set(pc.binds)
                     for i, b in enumerate(pc.binds):
                         # Cast to (void) to silence -Wunused on bindings

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -21,7 +21,7 @@ against; keep it stable.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 
 # ---------- terms ----------
@@ -176,6 +176,11 @@ class Constructor:
 class UnionDecl:
     name: str
     ctors: List[Constructor]
+    # Source module the union was declared in. Used by emit_c to mangle
+    # constructor symbols as `<Module>__<base_name>`. None means
+    # "synthetic / no specific home" — emit_c falls back to a generic
+    # mangle of the uniquified name in that case.
+    module: "str | None" = None
 
 
 @dataclass
@@ -194,12 +199,17 @@ class Function:
 
     `loc` is the original `.pf` file:line where the function was
     declared. Emitted as a `// from foo.pf:42` comment so a debugger
-    or human reader can navigate from the generated C back to source."""
+    or human reader can navigate from the generated C back to source.
+
+    `module` is the source module the function came from (or None for
+    synthesised functions like closure-conversion `$lam<N>`). Used by
+    emit_c for `<Module>__<base_name>` symbol mangling."""
     name: str
     params: List[str]
     body: Term
     captures: List[str] = field(default_factory=list)
     loc: "str | None" = None
+    module: "str | None" = None
 
 
 @dataclass
@@ -207,6 +217,7 @@ class Global:
     """A top-level non-function binding. Initialised at program start."""
     name: str
     body: Term
+    module: "str | None" = None
 
 
 @dataclass
@@ -234,8 +245,16 @@ TopLevel = Union[UnionDecl, Function, Global, Print, AssertEq, AssertBool]
 class Program:
     """A complete IR program. `decls` is in source order; backends
     typically emit unions and functions first, then `main`-like glue
-    that runs the globals/prints/asserts in order."""
+    that runs the globals/prints/asserts in order.
+
+    `name_to_module` is a flat lookup from each top-level decl's
+    uniquified name (function/global/union/constructor) to its source
+    module. emit_c consults it to mangle reference sites — calls,
+    constructor applications, pattern matches — without needing to
+    chase parents. Synthesised names (closure-conversion `$lam<N>`)
+    are intentionally absent; emit_c handles them as module-less."""
     decls: List[TopLevel] = field(default_factory=list)
+    name_to_module: Dict[str, str] = field(default_factory=dict)
 
 
 # ---------- pretty printer ----------
@@ -250,16 +269,16 @@ def pp_program(p: Program) -> str:
 
 def pp_top(d: TopLevel) -> str:
     match d:
-        case UnionDecl(name, ctors):
+        case UnionDecl(name, ctors, _):
             body = ", ".join(f"{c.name}/{c.arity}" for c in ctors)
             return f"union {name} {{{body}}}"
-        case Function(name, params, body, captures, _):
+        case Function(name, params, body, captures, _, _):
             head = f"fn {name}"
             if captures:
                 head += "[" + ", ".join(captures) + "]"
             head += "(" + ", ".join(params) + ")"
             return head + " = " + pp_term(body, 2)
-        case Global(name, body):
+        case Global(name, body, _):
             return f"global {name} = " + pp_term(body, 2)
         case Print(t):
             return "print " + pp_term(t, 2)
@@ -397,13 +416,13 @@ def verify(p: Program) -> None:
                 f"verify: non-IR top-level {type(d).__name__}"
             )
         match d:
-            case UnionDecl(_, ctors):
+            case UnionDecl(_, ctors, _):
                 for c in ctors:
                     if not isinstance(c, Constructor):
                         raise AssertionError("verify: non-IR ctor")
-            case Function(name, _, body, _, _):
+            case Function(name, _, body, _, _, _):
                 check_term(body, f"function {name}")
-            case Global(name, body):
+            case Global(name, body, _):
                 check_term(body, f"global {name}")
             case Print(t):
                 check_term(t, "print")

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -63,7 +63,8 @@ def _ast_loc(loc) -> "str | None":
 # Top-level lowering
 # --------------------------------------------------------------------------
 
-def lower_program(stmts: List[ast.Statement]) -> ir.Program:
+def lower_program(stmts: List[ast.Statement],
+                  main_module: str = "main") -> ir.Program:
     """Entry point. Walks the top-level statement list, recursing into
     each `Import.ast` so the imported module's declarations end up in
     the same flat list. Each module is recursed into at most once
@@ -71,15 +72,21 @@ def lower_program(stmts: List[ast.Statement]) -> ir.Program:
     Then collects constructor names (so `Call(Var(ctor), ...)` can
     become `Con` rather than `App`) and lowers each statement.
 
+    `main_module` is the module name attached to user-file statements
+    (those not inside any `Import.ast`). Used for symbol mangling in
+    the C emitter — `<Module>__<base_name>` keeps two compilation
+    units' names from colliding at link time. Defaults to `"main"`
+    so callers that don't care (e.g. test harnesses) can ignore it.
+
     Pruning (compiler/prune.py) downstream removes everything that
     isn't transitively reached from the user's `print` statements;
     this lets us inline the entire prelude without paying for the
     parts the user doesn't touch."""
-    flat = _flatten_imports(stmts)
+    flat, name_to_module = _flatten_imports(stmts, main_module)
 
     ctors: Set[str] = set()
     arities: Dict[str, int] = {}
-    for s in flat:
+    for s, _mod in flat:
         if isinstance(s, ast.Union):
             for c in s.alternatives:
                 ctors.add(c.name)
@@ -87,39 +94,58 @@ def lower_program(stmts: List[ast.Statement]) -> ir.Program:
 
     lc = LoweringCtx(ctors=ctors, ctor_arities=arities)
     out: List[ir.TopLevel] = []
-    for s in flat:
-        d = lc.lower_stmt(s)
+    for s, mod in flat:
+        d = lc.lower_stmt(s, mod)
         if d is not None:
             if isinstance(d, list):
                 out.extend(d)
             else:
                 out.append(d)
-    return ir.Program(decls=out)
+    return ir.Program(decls=out, name_to_module=name_to_module)
 
 
-def _flatten_imports(stmts: List[ast.Statement]) -> List[ast.Statement]:
+def _flatten_imports(
+    stmts: List[ast.Statement],
+    main_module: str,
+) -> "tuple[list[tuple[ast.Statement, str]], Dict[str, str]]":
     """Walk `stmts`, splicing each `Import.ast` (the imported module's
     post-typecheck statement list — see `process_declaration` in
-    proof_checker.py) in place of the import itself. Imports are
-    deduplicated by module name; only the first occurrence's nested
-    statements are emitted, matching `imported_modules` semantics in
-    the interpreter."""
-    seen: Set[str] = set()
-    out: List[ast.Statement] = []
+    proof_checker.py) in place of the import itself, while tracking
+    each statement's source module. Imports are deduplicated by
+    module name; only the first occurrence's nested statements are
+    emitted, matching `imported_modules` semantics in the interpreter.
 
-    def walk(items: List[ast.Statement]) -> None:
+    Returns (statements paired with their module names,
+    name → module map covering every uniquified top-level name a
+    decl exposes — function/global/union/constructor names).
+    """
+    seen: Set[str] = set()
+    out: List[tuple[ast.Statement, str]] = []
+    name_to_module: Dict[str, str] = {}
+
+    def walk(items: List[ast.Statement], current_module: str) -> None:
         for s in items:
             if isinstance(s, ast.Import):
                 if s.name in seen:
                     continue
                 seen.add(s.name)
                 if s.ast is not None:
-                    walk(s.ast)
+                    walk(s.ast, s.name)
             else:
-                out.append(s)
+                out.append((s, current_module))
+                if isinstance(s, ast.Define):
+                    name_to_module[s.name] = current_module
+                elif isinstance(s, ast.RecFun):
+                    name_to_module[s.name] = current_module
+                elif isinstance(s, ast.GenRecFun):
+                    name_to_module[s.name] = current_module
+                elif isinstance(s, ast.Union):
+                    name_to_module[s.name] = current_module
+                    for c in s.alternatives:
+                        name_to_module[c.name] = current_module
 
-    walk(stmts)
-    return out
+    walk(stmts, main_module)
+    return out, name_to_module
 
 
 class LoweringCtx:
@@ -137,7 +163,7 @@ class LoweringCtx:
 
     # ---- statements --------------------------------------------------
 
-    def lower_stmt(self, s: ast.Statement):
+    def lower_stmt(self, s: ast.Statement, module: str):
         if isinstance(s, ast.Theorem) or isinstance(s, ast.Postulate) \
            or isinstance(s, ast.Predicate) or isinstance(s, ast.Auto) \
            or isinstance(s, ast.Inductive) or isinstance(s, ast.Module) \
@@ -159,13 +185,14 @@ class LoweringCtx:
                 name=s.name,
                 ctors=[ir.Constructor(c.name, len(c.parameters))
                        for c in s.alternatives],
+                module=module,
             )
         if isinstance(s, ast.Define):
-            return self.lower_define(s)
+            return self.lower_define(s, module)
         if isinstance(s, ast.RecFun):
-            return self.lower_recfun(s)
+            return self.lower_recfun(s, module)
         if isinstance(s, ast.GenRecFun):
-            return self.lower_genrecfun(s)
+            return self.lower_genrecfun(s, module)
         if isinstance(s, ast.Print):
             return ir.Print(self.lower_term(s.term))
         if isinstance(s, ast.Assert):
@@ -180,7 +207,7 @@ class LoweringCtx:
             f"compiler does not yet support top-level: {type(s).__name__}",
         )
 
-    def lower_define(self, d: ast.Define):
+    def lower_define(self, d: ast.Define, module: str):
         body = d.body
         # `define f = generic <T> { fun x { ... } }` and
         # `define f = fun x { ... }` should both become a top-level
@@ -196,10 +223,12 @@ class LoweringCtx:
                 params=params,
                 body=self.lower_term(unwrapped.body),
                 loc=_ast_loc(d.location),
+                module=module,
             )
-        return ir.Global(name=d.name, body=self.lower_term(body))
+        return ir.Global(name=d.name, body=self.lower_term(body),
+                         module=module)
 
-    def lower_recfun(self, r: ast.RecFun):
+    def lower_recfun(self, r: ast.RecFun, module: str):
         if len(r.cases) == 0:
             raise CompileError(r.location, "RecFun with no cases")
 
@@ -239,9 +268,10 @@ class LoweringCtx:
             params=[scrutinee] + other_params,
             body=match,
             loc=_ast_loc(r.location),
+            module=module,
         )
 
-    def lower_genrecfun(self, r: ast.GenRecFun):
+    def lower_genrecfun(self, r: ast.GenRecFun, module: str):
         """Recfun-with-measure: a single-body recursive function. The
         measure expression and the `terminates` proof are erased — the
         compiler does no termination checking, just like the Deduce
@@ -254,6 +284,7 @@ class LoweringCtx:
             params=params,
             body=self.lower_term(r.body),
             loc=_ast_loc(r.location),
+            module=module,
         )
 
     # ---- terms -------------------------------------------------------

--- a/compiler/prune.py
+++ b/compiler/prune.py
@@ -82,7 +82,7 @@ def prune(p: ir.Program) -> ir.Program:
             # the roots themselves (and asserts are normally dropped in
             # lowering, so they shouldn't be here anyway).
             new_decls.append(d)
-    return ir.Program(decls=new_decls)
+    return ir.Program(decls=new_decls, name_to_module=p.name_to_module)
 
 
 def _referenced(t: ir.Term) -> Set[str]:

--- a/deduce.py
+++ b/deduce.py
@@ -59,7 +59,8 @@ def compile_file(filename: str, output: str, prelude: list[str],
         if traceback_flag:
             print(result.error_traceback)
         exit(1)
-    program = lower.lower_program(result.ast)
+    main_module = Path(filename).stem
+    program = lower.lower_program(result.ast, main_module=main_module)
     ir.verify(program)
     program = _closure.closure_convert(program)
     ir.verify(program)

--- a/test/compile/lower/basic.cir
+++ b/test/compile/lower/basic.cir
@@ -1,7 +1,7 @@
-union MyNat.9 {zero.10/0, suc.11/1}
-fn add.12($scr0, m.13) = match $scr0 { | zero.10 -> m.13 | suc.11(n.14) -> suc.11(add.12(n.14, m.13)) }
-global two.16 = suc.11(suc.11(zero.10))
-fn add_two.18(x.17) = add.12(two.16, x.17)
-fn pick.22(b.19, x.20, y.21) = if b.19 then x.20 else y.21
-print add_two.18(suc.11(zero.10))
-print pick.22(true, two.16, zero.10)
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+global two.7 = suc.2(suc.2(zero.1))
+fn add_two.9(x.8) = add.3(two.7, x.8)
+fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
+print add_two.9(suc.2(zero.1))
+print pick.13(true, two.7, zero.1)

--- a/test/compile/lower/basic.ir
+++ b/test/compile/lower/basic.ir
@@ -1,7 +1,7 @@
-union MyNat.9 {zero.10/0, suc.11/1}
-fn add.12($scr0, m.13) = match $scr0 { | zero.10 -> m.13 | suc.11(n.14) -> suc.11(add.12(n.14, m.13)) }
-global two.16 = suc.11(suc.11(zero.10))
-fn add_two.18(x.17) = add.12(two.16, x.17)
-fn pick.22(b.19, x.20, y.21) = if b.19 then x.20 else y.21
-print add_two.18(suc.11(zero.10))
-print pick.22(true, two.16, zero.10)
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+global two.7 = suc.2(suc.2(zero.1))
+fn add_two.9(x.8) = add.3(two.7, x.8)
+fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
+print add_two.9(suc.2(zero.1))
+print pick.13(true, two.7, zero.1)

--- a/test/compile/lower/basic.pir
+++ b/test/compile/lower/basic.pir
@@ -1,7 +1,7 @@
-union MyNat.9 {zero.10/0, suc.11/1}
-fn add.12($scr0, m.13) = match $scr0 { | zero.10 -> m.13 | suc.11(n.14) -> suc.11(add.12(n.14, m.13)) }
-global two.16 = suc.11(suc.11(zero.10))
-fn add_two.18(x.17) = add.12(two.16, x.17)
-fn pick.22(b.19, x.20, y.21) = if b.19 then x.20 else y.21
-print add_two.18(suc.11(zero.10))
-print pick.22(true, two.16, zero.10)
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+global two.7 = suc.2(suc.2(zero.1))
+fn add_two.9(x.8) = add.3(two.7, x.8)
+fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
+print add_two.9(suc.2(zero.1))
+print pick.13(true, two.7, zero.1)

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,5 +1,5 @@
-union MyNat.23 {zero.24/0, suc.25/1}
-fn add.26($scr0, m.27) = match $scr0 { | zero.24 -> m.27 | suc.25(n.28) -> suc.25(add.26(n.28, m.27)) }
-fn adder.32(x.30) = closure[$lam1](x.30)
-print adder.32(suc.25(zero.24))(suc.25(suc.25(zero.24)))
-fn $lam1[x.30](y.31) = add.26(x.30, y.31)
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+fn adder.9(x.7) = closure[$lam1](x.7)
+print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
+fn $lam1[x.7](y.8) = add.3(x.7, y.8)

--- a/test/compile/lower/closure.ir
+++ b/test/compile/lower/closure.ir
@@ -1,4 +1,4 @@
-union MyNat.23 {zero.24/0, suc.25/1}
-fn add.26($scr0, m.27) = match $scr0 { | zero.24 -> m.27 | suc.25(n.28) -> suc.25(add.26(n.28, m.27)) }
-fn adder.32(x.30) = λ(y.31). add.26(x.30, y.31)
-print adder.32(suc.25(zero.24))(suc.25(suc.25(zero.24)))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+fn adder.9(x.7) = λ(y.8). add.3(x.7, y.8)
+print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))

--- a/test/compile/lower/closure.pir
+++ b/test/compile/lower/closure.pir
@@ -1,5 +1,5 @@
-union MyNat.23 {zero.24/0, suc.25/1}
-fn add.26($scr0, m.27) = match $scr0 { | zero.24 -> m.27 | suc.25(n.28) -> suc.25(add.26(n.28, m.27)) }
-fn adder.32(x.30) = closure[$lam1](x.30)
-print adder.32(suc.25(zero.24))(suc.25(suc.25(zero.24)))
-fn $lam1[x.30](y.31) = add.26(x.30, y.31)
+union MyNat.0 {zero.1/0, suc.2/1}
+fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
+fn adder.9(x.7) = closure[$lam1](x.7)
+print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
+fn $lam1[x.7](y.8) = add.3(x.7, y.8)

--- a/test/compile/lower/generic.cir
+++ b/test/compile/lower/generic.cir
@@ -1,6 +1,6 @@
-union Box.33 {box.35/1}
-fn unbox.39(b.37) = match b.37 { | box.35(x.38) -> x.38 }
-fn id.43(x.42) = x.42
-union MyNat.44 {zero.45/0, suc.46/1}
-print id.43(suc.46(zero.45))
-print unbox.39(box.35(suc.46(suc.46(zero.45))))
+union Box.0 {box.2/1}
+fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
+fn id.10(x.9) = x.9
+union MyNat.11 {zero.12/0, suc.13/1}
+print id.10(suc.13(zero.12))
+print unbox.6(box.2(suc.13(suc.13(zero.12))))

--- a/test/compile/lower/generic.ir
+++ b/test/compile/lower/generic.ir
@@ -1,6 +1,6 @@
-union Box.33 {box.35/1}
-fn unbox.39(b.37) = match b.37 { | box.35(x.38) -> x.38 }
-fn id.43(x.42) = x.42
-union MyNat.44 {zero.45/0, suc.46/1}
-print id.43(suc.46(zero.45))
-print unbox.39(box.35(suc.46(suc.46(zero.45))))
+union Box.0 {box.2/1}
+fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
+fn id.10(x.9) = x.9
+union MyNat.11 {zero.12/0, suc.13/1}
+print id.10(suc.13(zero.12))
+print unbox.6(box.2(suc.13(suc.13(zero.12))))

--- a/test/compile/lower/generic.pir
+++ b/test/compile/lower/generic.pir
@@ -1,6 +1,6 @@
-union Box.33 {box.35/1}
-fn unbox.39(b.37) = match b.37 { | box.35(x.38) -> x.38 }
-fn id.43(x.42) = x.42
-union MyNat.44 {zero.45/0, suc.46/1}
-print id.43(suc.46(zero.45))
-print unbox.39(box.35(suc.46(suc.46(zero.45))))
+union Box.0 {box.2/1}
+fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
+fn id.10(x.9) = x.9
+union MyNat.11 {zero.12/0, suc.13/1}
+print id.10(suc.13(zero.12))
+print unbox.6(box.2(suc.13(suc.13(zero.12))))

--- a/test/compile/lower/genrecfun.cir
+++ b/test/compile/lower/genrecfun.cir
@@ -1,6 +1,6 @@
-union MyNat.47 {zero.48/0, suc.49/1}
-fn iszero.52(n.50) = match n.50 { | zero.48 -> true | suc.49(n'.51) -> false }
-fn pred.55(n.53) = match n.53 { | zero.48 -> zero.48 | suc.49(n'.54) -> n'.54 }
-fn <.56($scr0, m.57) = match $scr0 { | zero.48 -> match m.57 { | zero.48 -> false | suc.49(m'.58) -> true } | suc.49(n'.59) -> match m.57 { | zero.48 -> false | suc.49(m'.61) -> <.56(n'.59, m'.61) } }
-fn count_down.69(n.70) = if iszero.52(n.70) then zero.48 else count_down.69(pred.55(n.70))
-print count_down.69(suc.49(suc.49(suc.49(zero.48))))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
+fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
+fn <.9($scr0, m.10) = match $scr0 { | zero.1 -> match m.10 { | zero.1 -> false | suc.2(m'.11) -> true } | suc.2(n'.12) -> match m.10 { | zero.1 -> false | suc.2(m'.14) -> <.9(n'.12, m'.14) } }
+fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
+print count_down.22(suc.2(suc.2(suc.2(zero.1))))

--- a/test/compile/lower/genrecfun.ir
+++ b/test/compile/lower/genrecfun.ir
@@ -1,6 +1,6 @@
-union MyNat.47 {zero.48/0, suc.49/1}
-fn iszero.52(n.50) = match n.50 { | zero.48 -> true | suc.49(n'.51) -> false }
-fn pred.55(n.53) = match n.53 { | zero.48 -> zero.48 | suc.49(n'.54) -> n'.54 }
-fn <.56($scr0, m.57) = match $scr0 { | zero.48 -> match m.57 { | zero.48 -> false | suc.49(m'.58) -> true } | suc.49(n'.59) -> match m.57 { | zero.48 -> false | suc.49(m'.61) -> <.56(n'.59, m'.61) } }
-fn count_down.69(n.70) = if iszero.52(n.70) then zero.48 else count_down.69(pred.55(n.70))
-print count_down.69(suc.49(suc.49(suc.49(zero.48))))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
+fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
+fn <.9($scr0, m.10) = match $scr0 { | zero.1 -> match m.10 { | zero.1 -> false | suc.2(m'.11) -> true } | suc.2(n'.12) -> match m.10 { | zero.1 -> false | suc.2(m'.14) -> <.9(n'.12, m'.14) } }
+fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
+print count_down.22(suc.2(suc.2(suc.2(zero.1))))

--- a/test/compile/lower/genrecfun.pir
+++ b/test/compile/lower/genrecfun.pir
@@ -1,5 +1,5 @@
-union MyNat.47 {zero.48/0, suc.49/1}
-fn iszero.52(n.50) = match n.50 { | zero.48 -> true | suc.49(n'.51) -> false }
-fn pred.55(n.53) = match n.53 { | zero.48 -> zero.48 | suc.49(n'.54) -> n'.54 }
-fn count_down.69(n.70) = if iszero.52(n.70) then zero.48 else count_down.69(pred.55(n.70))
-print count_down.69(suc.49(suc.49(suc.49(zero.48))))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
+fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
+fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
+print count_down.22(suc.2(suc.2(suc.2(zero.1))))

--- a/test/compile/lower/pruning.cir
+++ b/test/compile/lower/pruning.cir
@@ -1,5 +1,5 @@
-union MyNat.76 {zero.77/0, suc.78/1}
-fn used.79($scr0, m.80) = match $scr0 { | zero.77 -> m.80 | suc.78(n.81) -> suc.78(used.79(n.81, m.80)) }
-fn unused.83($scr1, m.84) = match $scr1 { | zero.77 -> m.84 | suc.78(n.85) -> suc.78(unused.83(n.85, m.84)) }
-global also_unused.87 = suc.78(suc.78(suc.78(zero.77)))
-print used.79(suc.78(zero.77), suc.78(suc.78(zero.77)))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
+fn unused.7($scr1, m.8) = match $scr1 { | zero.1 -> m.8 | suc.2(n.9) -> suc.2(unused.7(n.9, m.8)) }
+global also_unused.11 = suc.2(suc.2(suc.2(zero.1)))
+print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))

--- a/test/compile/lower/pruning.ir
+++ b/test/compile/lower/pruning.ir
@@ -1,5 +1,5 @@
-union MyNat.76 {zero.77/0, suc.78/1}
-fn used.79($scr0, m.80) = match $scr0 { | zero.77 -> m.80 | suc.78(n.81) -> suc.78(used.79(n.81, m.80)) }
-fn unused.83($scr1, m.84) = match $scr1 { | zero.77 -> m.84 | suc.78(n.85) -> suc.78(unused.83(n.85, m.84)) }
-global also_unused.87 = suc.78(suc.78(suc.78(zero.77)))
-print used.79(suc.78(zero.77), suc.78(suc.78(zero.77)))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
+fn unused.7($scr1, m.8) = match $scr1 { | zero.1 -> m.8 | suc.2(n.9) -> suc.2(unused.7(n.9, m.8)) }
+global also_unused.11 = suc.2(suc.2(suc.2(zero.1)))
+print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))

--- a/test/compile/lower/pruning.pir
+++ b/test/compile/lower/pruning.pir
@@ -1,3 +1,3 @@
-union MyNat.76 {zero.77/0, suc.78/1}
-fn used.79($scr0, m.80) = match $scr0 { | zero.77 -> m.80 | suc.78(n.81) -> suc.78(used.79(n.81, m.80)) }
-print used.79(suc.78(zero.77), suc.78(suc.78(zero.77)))
+union MyNat.0 {zero.1/0, suc.2/1}
+fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
+print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))

--- a/test/compile/lower/source_map.cir
+++ b/test/compile/lower/source_map.cir
@@ -1,4 +1,4 @@
-union MyNat.88 {zero.89/0, suc.90/1}
-union List.91 {empty.93/0, node.94/2}
-global A.95 = array(node.94(zero.89, empty.93))
-print A.95[suc.90(zero.89)]
+union MyNat.0 {zero.1/0, suc.2/1}
+union List.3 {empty.5/0, node.6/2}
+global A.7 = array(node.6(zero.1, empty.5))
+print A.7[suc.2(zero.1)]

--- a/test/compile/lower/source_map.ir
+++ b/test/compile/lower/source_map.ir
@@ -1,4 +1,4 @@
-union MyNat.88 {zero.89/0, suc.90/1}
-union List.91 {empty.93/0, node.94/2}
-global A.95 = array(node.94(zero.89, empty.93))
-print A.95[suc.90(zero.89)]
+union MyNat.0 {zero.1/0, suc.2/1}
+union List.3 {empty.5/0, node.6/2}
+global A.7 = array(node.6(zero.1, empty.5))
+print A.7[suc.2(zero.1)]

--- a/test/compile/lower/source_map.pir
+++ b/test/compile/lower/source_map.pir
@@ -1,4 +1,4 @@
-union MyNat.88 {zero.89/0, suc.90/1}
-union List.91 {empty.93/0, node.94/2}
-global A.95 = array(node.94(zero.89, empty.93))
-print A.95[suc.90(zero.89)]
+union MyNat.0 {zero.1/0, suc.2/1}
+union List.3 {empty.5/0, node.6/2}
+global A.7 = array(node.6(zero.1, empty.5))
+print A.7[suc.2(zero.1)]

--- a/test/compile/lower/unbox.cir
+++ b/test/compile/lower/unbox.cir
@@ -1,6 +1,6 @@
-union MyNat.96 {zero.97/0, suc.98/1}
-print zero.97
-print zero.97
-print zero.97
-print zero.97
-print zero.97
+union MyNat.0 {zero.1/0, suc.2/1}
+print zero.1
+print zero.1
+print zero.1
+print zero.1
+print zero.1

--- a/test/compile/lower/unbox.ir
+++ b/test/compile/lower/unbox.ir
@@ -1,6 +1,6 @@
-union MyNat.96 {zero.97/0, suc.98/1}
-print zero.97
-print zero.97
-print zero.97
-print zero.97
-print zero.97
+union MyNat.0 {zero.1/0, suc.2/1}
+print zero.1
+print zero.1
+print zero.1
+print zero.1
+print zero.1

--- a/test/compile/lower/unbox.pir
+++ b/test/compile/lower/unbox.pir
@@ -1,6 +1,6 @@
-union MyNat.96 {zero.97/0, suc.98/1}
-print zero.97
-print zero.97
-print zero.97
-print zero.97
-print zero.97
+union MyNat.0 {zero.1/0, suc.2/1}
+print zero.1
+print zero.1
+print zero.1
+print zero.1
+print zero.1

--- a/test/compile/run_determinism.py
+++ b/test/compile/run_determinism.py
@@ -1,0 +1,89 @@
+"""Determinism check for the C emitter.
+
+Step 25 of `docs/separate-compile-plan.md` requires that emit_c
+output is a pure function of the input source. This script compiles
+each lowering fixture in two fresh subprocess invocations and
+byte-diffs the resulting `.c` files.
+
+Run from the repo root:
+
+    python3 test/compile/run_determinism.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+LOWER_DIR = ROOT / "test" / "compile" / "lower"
+PRELUDE_DIR = ROOT / "test" / "compile" / "prelude"
+
+
+def compile_to_c(pf: Path, c_out: Path) -> None:
+    cmd = [
+        sys.executable, str(ROOT / "deduce.py"),
+        "--suppress-theorems", "--quiet", "--compile",
+        "-o", str(c_out), str(pf),
+    ]
+    # Mirror run_e2e's heuristic for `--no-stdlib`.
+    text = pf.read_text()
+    needs_prelude = any(
+        line.strip().startswith("import ") or line.strip().startswith("public import ")
+        for line in text.splitlines()
+        if not line.strip().startswith("//")
+    )
+    if not needs_prelude:
+        cmd.insert(2, "--no-stdlib")
+    subprocess.run(cmd, cwd=str(ROOT), check=True,
+                   capture_output=True, text=True)
+
+
+def main() -> int:
+    fixtures: list[Path] = []
+    for d in (LOWER_DIR, PRELUDE_DIR):
+        if d.exists():
+            fixtures.extend(sorted(d.glob("*.pf")))
+
+    if not fixtures:
+        print("no fixtures found", file=sys.stderr)
+        return 1
+
+    tmp = Path(tempfile.mkdtemp(prefix="deduce-det-"))
+    failures: list[str] = []
+    for pf in fixtures:
+        a = tmp / f"{pf.stem}.a.c"
+        b = tmp / f"{pf.stem}.b.c"
+        try:
+            compile_to_c(pf, a)
+            compile_to_c(pf, b)
+        except subprocess.CalledProcessError as e:
+            failures.append(f"{pf.name}: compile failed: {e.stderr}")
+            continue
+        if a.read_bytes() != b.read_bytes():
+            failures.append(
+                f"{pf.name}: two compiles produced different .c "
+                f"(see {a} and {b})"
+            )
+            continue
+        print(f"ok {pf.relative_to(ROOT)}")
+
+    # Cleanup unless we have failures (in which case keep the tmp for
+    # human inspection).
+    if not failures:
+        for p in tmp.iterdir():
+            p.unlink()
+        tmp.rmdir()
+    else:
+        print(f"\nFAILURES (tmp kept at {tmp}):")
+        for msg in failures:
+            print(msg)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/compile/run_lower.py
+++ b/test/compile/run_lower.py
@@ -36,7 +36,7 @@ def lower_file(path: Path) -> tuple[str, str, str]:
     result = check_file(str(path), prelude=[])
     if not result.ok:
         raise RuntimeError(f"{path}: deduce check failed:\n{result.error_message}")
-    program = lower.lower_program(result.ast)
+    program = lower.lower_program(result.ast, main_module=path.stem)
     ir.verify(program)
     lowered_str = ir.pp_program(program)
     converted = closure.closure_convert(program)


### PR DESCRIPTION
## Summary

First step of [`docs/separate-compile-plan.md`](docs/separate-compile-plan.md). Switches `emit_c` from bare `<base_name>__<id>` mangling to `<Module>__<base_name>__<id>`. Prepares the way for Step 27 (per-`.pf` compilation), where each module emits its own `.o` and the linker resolves cross-module symbols — under the current scheme, two modules' `add` functions would collide at link time.

No behavioural change in monolithic mode: every fixture still compiles, links, and produces the expected stdout. The only thing that changes is what the emitted C symbols look like.

## What's in the diff

- **`compiler/lower._flatten_imports`** now tracks the source module per statement and returns a `name_to_module` map covering every uniquified top-level name (function/global/union/constructor). The module of a statement directly inside `Import.ast` is the import's `name`; user-file statements get the filename stem (`main_module`).
- **`ir.Function`/`Global`/`UnionDecl`** gain an optional `module` field; **`ir.Program`** gains `name_to_module: Dict[str, str]`. Closure-conversion `$lam<N>` lifts are intentionally module-less — they're synthesised, not source-mapped.
- **`emit_c.EmitCtx`** consults `name_to_module` from a new `_mangle_top` helper. Names without a known module fall back to the bare mangle (closure lifts). The mangling helpers (`_func_id`, `_global_id`, `_ctor_id_macro`, `_ctor_singleton`) became `EmitCtx` methods.
- **New `test/compile/run_determinism.py`** is the Step 25 acceptance: compile every fixture twice in fresh subprocess invocations and byte-diff the `.c` outputs. Wired into `make tests-compile`.
- **IR `.ir`/`.cir`/`.pir` fixtures regenerated** — the diff is just shifted uniquify-counter values from PR [#356](https://github.com/jsiek/deduce/pull/356)'s per-test-fresh-context change; the structural pretty-print shape didn't change.

## Sample output

Quick-start fixture (`hello.pf` with a custom `union MyNat`):

```c
#define CTOR_hello__zero_1 0
#define CTOR_hello__suc_2 1
deduce_value F_hello__add_3(deduce_value* env, deduce_value* args);
deduce_value C_hello__zero_1;
```

Prelude code:

```c
deduce_value F_NatDefs___x2b_98(deduce_value* env, deduce_value* args);
deduce_value C_NatDefs__zero_96;
```

The prefix is the file the symbol was defined in (e.g. `lib/NatDefs.pf` for the `+` on `Nat`).

## Test plan

- [x] `make tests-compile` — 68 ok lines (was 59): 24 lowering stages + 35 e2e + 9 determinism.
- [x] `make tests` — interpreter suite unchanged.
- [x] `python3 deduce.py example.pf` (interpreter mode) — unaffected.

## What's *not* in this PR

Closure-lifted lambdas (`__lam<N>`) keep their bare form for now. Making those stable across compilation contexts is part of Step 27's source-location-keyed scheme — they don't have a "source module" in the way user-written defs do, and the right answer is to derive a stable name from the lambda's source location once we actually compile modules independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
