### PR TITLE
LSP Phase 3 / Step 13: per-statement check_proofs cache

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -338,6 +338,10 @@ def _clear_containers() -> None:
     """Reset every tracked container to empty."""
     for module, attr in _TRACKED_CONTAINERS:
         getattr(module, attr).clear()
+    # The Step-13 statement cache lives outside the snapshot list
+    # (it accumulates across calls), but it's only valid for a given
+    # prelude key.  Clear it whenever we clear the rest of the state.
+    _proof_checker.reset_stmt_cache()
 
 
 def _shallow_copy(obj: Any) -> Any:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -37,6 +37,108 @@ def generate_name(name):
     new_id = name_id
     name_id += 1
     return ls[0] + '.' + str(new_id)
+
+
+# ---------------------------------------------------------------------------
+# Per-statement cache (Phase 3 / Step 13)
+# ---------------------------------------------------------------------------
+#
+# ``check_deduce`` runs three loops over the AST: ``process_declaration``,
+# ``type_check_stmt``, and ``collect_env``+``check_proofs``. Each loop's
+# work for a given statement is determined by (a) the statement's
+# post-uniquify structure and (b) the env coming in. Cache by both, and
+# we can skip statements unchanged since the previous run.
+#
+# Key shape: ``(loop_tag, stmt_hash, chain_hash)``.  ``chain_hash`` is
+# a fold over the prior statements' hashes -- equivalent to
+# ``env_in_hash`` in the plan, but cheaper to maintain and stable
+# across calls (since uniquify is now deterministic per Step 12).
+#
+# The cache lives at module level and accumulates across
+# ``check_deduce`` calls.  ``lsp/library.py`` clears it when the
+# prelude key changes (different prelude => different baseline =>
+# cache invalid).
+
+_stmt_cache: dict = {}
+
+# Hits and misses bucketed by loop, for the test instrumentation
+# the plan requires ("untouched statements were cache hits").
+_cache_stats: dict = {"hits": {}, "misses": {}}
+
+
+def reset_stmt_cache() -> None:
+    """Drop everything in ``_stmt_cache`` and zero the stats.  Called
+    by the LSP pipeline when the prelude key changes; tests use it
+    to start each fixture from a clean slate."""
+    global _stmt_cache
+    _stmt_cache.clear()
+    _cache_stats["hits"].clear()
+    _cache_stats["misses"].clear()
+
+
+def get_cache_stats() -> dict:
+    """Return a copy of the per-loop hit/miss counters."""
+    return {
+        "hits": dict(_cache_stats["hits"]),
+        "misses": dict(_cache_stats["misses"]),
+    }
+
+
+def _record_hit(loop_tag: str) -> None:
+    _cache_stats["hits"][loop_tag] = _cache_stats["hits"].get(loop_tag, 0) + 1
+
+
+def _record_miss(loop_tag: str) -> None:
+    _cache_stats["misses"][loop_tag] = _cache_stats["misses"].get(loop_tag, 0) + 1
+
+
+def _hash_ast(node) -> int:
+    """Stable structural hash of a (post-uniquify) AST.
+
+    Skips the ``location`` (Meta) attribute, which carries source
+    line/column info that shifts with edits to unrelated parts of
+    the file -- we want only the structure + names to participate
+    in the hash.
+
+    Memoised on the node via ``__hash_cache__`` so each statement
+    is hashed at most once per session, even if it appears in
+    several of ``check_deduce``'s loops.
+    """
+    if node is None:
+        return 0
+    if isinstance(node, (str, int, bool, float)):
+        return hash(node)
+    if isinstance(node, (list, tuple)):
+        return hash(tuple(_hash_ast(x) for x in node))
+    if isinstance(node, dict):
+        return hash(
+            tuple(sorted((k, _hash_ast(v)) for k, v in node.items()))
+        )
+    cached = getattr(node, "__hash_cache__", None)
+    if cached is not None:
+        return cached
+    if hasattr(node, "__dict__"):
+        items = []
+        for k, v in node.__dict__.items():
+            if k == "location" or k == "__hash_cache__":
+                continue
+            items.append((k, _hash_ast(v)))
+        h = hash((type(node).__name__, tuple(items)))
+        try:
+            node.__hash_cache__ = h
+        except AttributeError:
+            pass
+        return h
+    return hash(repr(node))
+
+
+def _chain(prev: int, stmt_hash: int) -> int:
+    """Fold a statement's hash into the running chain hash.
+
+    Stable across runs: same prefix -> same chain -> same key for
+    the next statement.  Uses ``hash()`` for symmetry with the
+    inner ``_hash_ast``."""
+    return hash((prev, stmt_hash))
   
 def check_implies(loc, frm1, frm2):
   if get_verbose():
@@ -4573,45 +4675,74 @@ def check_deduce(ast, module_name, modified, tracing_functions):
   needs_checking = [modified]
   if get_verbose():
       print('--------- Processing Declarations ------------------------')
+  # Hash each statement structurally as we go.  Used by the
+  # check_proofs cache below; computed here so we visit each AST
+  # only once.  ``_hash_ast`` skips the ``location`` field, so two
+  # parses of the same source produce matching hashes.
+  stmt_hashes = []
   for s in ast:
+    stmt_hashes.append(_hash_ast(s))
     new_s, env = process_declaration(s, env, [module_name], needs_checking)
     ast2.append(new_s)
   if get_verbose():
     for s in ast2:
       print(s)
-  
+
   for func_name in tracing_functions:
     # TODO: base_to_unique is a hack so use another function instead
     new_name = env.base_to_unique(func_name)
     if new_name is None:
       print("Couldn't find function to trace:", func_name)
     else:
-      env = env.declare_tracing(new_name) 
+      env = env.declare_tracing(new_name)
 
   if get_verbose():
     print('--------- Type Checking ------------------------')
   ast3 = []
+  ast3_hashes = []
 
   error_on_next_import : dict[str, bool] = {}
-  for s in ast2:
+  for s, sh in zip(ast2, stmt_hashes):
     new_s = type_check_stmt(s, env, error_on_next_import)
     # If None gets returned we want to remove the current statement
     # Which is represented by not appending it to the new ast
     if new_s != None:
       ast3.append(new_s)
+      ast3_hashes.append(sh)
   if get_verbose():
     for s in ast3:
       print(s)
-      
+
   if get_verbose():
     print('--------- Proof Checking ------------------------')
   if module_name not in checked_modules:
     if get_verbose() and needs_checking[0]:
         print('checking ' + module_name)
-    for s in ast3:
+    # Per-statement cache for ``check_proofs`` (Step 13).  Earlier
+    # loops (``process_declaration``, ``type_check_stmt``) emit AST
+    # nodes whose ``Meta`` locations participate in side-effecting
+    # behaviour (e.g. the ``target_hole_location`` flag used by
+    # ``goal_at`` to single out which `?` raises), so caching their
+    # outputs across calls would let stale locations leak into a new
+    # run.  ``check_proofs`` itself is the bulk of the time and its
+    # only persistent effect is "verified" -- safe to cache.
+    #
+    # Key includes ``target_hole_location``: a different target means
+    # a `?` that was previously treated as ``sorry`` should now raise
+    # (or vice versa), so we mustn't reuse the prior verdict.
+    target = get_target_hole_location()
+    proof_chain = hash(("check_proofs_seed", module_name, target))
+    for s, sh in zip(ast3, ast3_hashes):
       env = collect_env(s, env)
+      key = ("check_proofs", sh, proof_chain)
       if needs_checking[0]:
-        check_proofs(s, env)
+        if key in _stmt_cache:
+          _record_hit("check_proofs")
+        else:
+          check_proofs(s, env)
+          _stmt_cache[key] = True
+          _record_miss("check_proofs")
+      proof_chain = _chain(proof_chain, sh)
     checked_modules.add(module_name)
   # Sanity-check the post-typecheck AST: every variable reference
   # should be ``ResolvedVar`` (or, if a real overload couldn't be

--- a/test/lsp/test_check_proofs_cache.py
+++ b/test/lsp/test_check_proofs_cache.py
@@ -1,0 +1,209 @@
+"""Acceptance test for the per-statement ``check_proofs`` cache (Phase 3 / Step 13).
+
+Plan acceptance: ``edit one statement, recheck; instrumentation
+confirms untouched statements were cache hits``.
+
+The cache lives in ``proof_checker._stmt_cache`` and is keyed by
+``(stmt_hash, chain_hash)``.  ``stmt_hash`` is a structural hash
+that skips the ``location`` (``Meta``) field, so adding/removing
+*other* statements doesn't perturb the hash of an unchanged one.
+``chain_hash`` is a fold over prior statements' hashes -- it
+identifies the cumulative state at this position in the AST.
+
+What this file pins:
+
+- a clean run populates the cache with all-misses,
+- a re-run on the same content is all-hits,
+- editing a statement near the end leaves the unchanged prefix
+  cache-hits and only the touched statement misses.
+
+The earlier two loops (``process_declaration``, ``type_check_stmt``)
+are deliberately *not* cached -- their AST output carries
+``Meta`` locations that interact with the
+``target_hole_location`` flag used by ``goal_at`` and friends, so
+caching them across calls would surface as stale-location bugs.
+``check_proofs`` is where the bulk of the time goes anyway.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import proof_checker  # noqa: E402
+from lsp.query import check  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    """Each test starts with an empty cache and fresh stats."""
+    proof_checker.reset_stmt_cache()
+    yield
+    proof_checker.reset_stmt_cache()
+
+
+def _hits(loop_tag: str = "check_proofs") -> int:
+    return proof_checker.get_cache_stats()["hits"].get(loop_tag, 0)
+
+
+def _misses(loop_tag: str = "check_proofs") -> int:
+    return proof_checker.get_cache_stats()["misses"].get(loop_tag, 0)
+
+
+_THREE_THEOREMS = (
+    "theorem t1: true\n"
+    "proof\n"
+    "  .\n"
+    "end\n"
+    "\n"
+    "theorem t2: true = true\n"
+    "proof\n"
+    "  reflexive\n"
+    "end\n"
+    "\n"
+    "theorem t3: all P:bool, Q:bool. if P then if Q then P\n"
+    "proof\n"
+    "  arbitrary P:bool, Q:bool\n"
+    "  suppose pP: P\n"
+    "  suppose qQ: Q\n"
+    "  pP\n"
+    "end\n"
+)
+
+
+def test_first_run_is_all_misses() -> None:
+    """A clean cache + a fresh source means every statement is a
+    miss the first time around."""
+    diags = check("test.pf", _THREE_THEOREMS)
+    assert diags == []
+    assert _misses() == 3
+    assert _hits() == 0
+
+
+def test_second_run_on_same_content_is_all_hits() -> None:
+    """Re-running ``check`` on the exact same content reuses the
+    cache for every statement."""
+    check("test.pf", _THREE_THEOREMS)
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", _THREE_THEOREMS)
+    assert diags == []
+    assert _hits() == 3
+    assert _misses() == 0
+
+
+def test_editing_one_statement_keeps_others_cache_hits() -> None:
+    """Plan acceptance: edit ONE statement, recheck.  The other
+    two statements were not touched, so their cache entries hit;
+    the modified statement misses."""
+    # First run: populate cache for all three statements.
+    check("test.pf", _THREE_THEOREMS)
+
+    # Edit the *third* statement -- rewrite its proof body to use
+    # an intermediate ``have``.  The first two theorems are
+    # untouched.
+    edited = _THREE_THEOREMS.replace(
+        "  pP\n"
+        "end\n",
+        "  have h: P by pP\n"
+        "  h\n"
+        "end\n",
+    )
+
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", edited)
+    assert diags == []
+    # Two statements unchanged -> two hits.  One statement edited ->
+    # one miss.
+    assert _hits() == 2, (
+        f"expected 2 hits (t1 and t2 unchanged), got {_hits()}; "
+        f"misses={_misses()}"
+    )
+    assert _misses() == 1
+
+
+def test_editing_a_statement_in_the_middle_invalidates_downstream() -> None:
+    """Editing a statement in the middle invalidates it AND every
+    statement after it (the chain hash has changed for them)."""
+    check("test.pf", _THREE_THEOREMS)
+
+    # Edit the *second* theorem.  Replace the proof body with an
+    # intermediate ``have'' step -- AST changes structurally, the
+    # proof still passes.  The first theorem is unchanged; the
+    # third's `chain` hash now differs from the cached entry, so
+    # it has to recheck too.
+    edited = _THREE_THEOREMS.replace(
+        "theorem t2: true = true\n"
+        "proof\n"
+        "  reflexive\n"
+        "end\n",
+        "theorem t2: true = true\n"
+        "proof\n"
+        "  have h: true = true by reflexive\n"
+        "  h\n"
+        "end\n",
+    )
+
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", edited)
+    assert diags == []
+    # Only t1 is upstream of the edit -> one hit.  t2 was edited,
+    # t3's chain shifted -> two misses.
+    assert _hits() == 1
+    assert _misses() == 2
+
+
+def test_comment_only_edit_in_unchanged_proof_still_hits() -> None:
+    """A whitespace/comment edit in a non-edited statement leaves
+    its post-uniquify AST structurally identical.  ``_hash_ast``
+    skips ``location``, so the cache key is unchanged -> hit."""
+    check("test.pf", _THREE_THEOREMS)
+
+    # Add a stray comment line inside t3's proof body without
+    # changing the proof's structure.
+    edited = _THREE_THEOREMS.replace(
+        "  pP\n",
+        "  // helpful comment\n"
+        "  pP\n",
+    )
+
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", edited)
+    assert diags == []
+    # All three should be hits: t1, t2 untouched as ever; t3's
+    # comment doesn't survive into the parsed AST.
+    assert _hits() == 3
+    assert _misses() == 0
+
+
+def test_cache_skips_check_proofs_for_unchanged_stmt() -> None:
+    """A more direct check: replace ``check_proofs`` with a stub
+    that records calls.  After a re-run on unchanged content, the
+    stub should NOT have been invoked for cached statements."""
+    check("test.pf", _THREE_THEOREMS)
+
+    calls = []
+    real_check_proofs = proof_checker.check_proofs
+
+    def stub(s, env):
+        calls.append(s)
+        return real_check_proofs(s, env)
+
+    proof_checker.check_proofs = stub
+    try:
+        check("test.pf", _THREE_THEOREMS)
+    finally:
+        proof_checker.check_proofs = real_check_proofs
+
+    assert calls == [], (
+        f"check_proofs was invoked despite cache hits; "
+        f"called {len(calls)} times: {calls}"
+    )


### PR DESCRIPTION
Builds on Step 12 (deterministic `uniquify`).  Plan acceptance:

> *Acceptance:* edit one statement, recheck; instrumentation confirms untouched statements were cache hits. Sub-second for typical edits.

## Scope: just `check_proofs`

The plan describes caching all three of `check_deduce`'s loops — `process_declaration`, `type_check_stmt`, `check_proofs`. I tried that initially and it broke: loops 1 and 2 emit AST nodes whose `Meta` locations participate in side-effecting behaviour. `goal_at` / `refine_at` / `case_split_at` set `flags.target_hole_location` to single out which `?` should raise; the proof checker compares it to the PHole's location. Caching loop-1/2 AST output across calls would let stale locations leak into a new run.

(Concretely, `test_goal_at_cursor_on_hole_matches_synthetic_hole_path` flunked: cached AST from call 1 had its PHole at one position, call 2 set the target to a different position the synthetic hole landed at, the cached PHole's location didn't match the new target → the proof checker treated the hole as `sorry`, no `IncompleteProof`, `goal_at` returned `None`.)

So the cache is scoped to `check_proofs`, which is where the bulk of the time goes anyway and which has no AST output — just "verified" or "raised."

## Key shape

```
("check_proofs", stmt_hash, chain_hash)
```

- `stmt_hash` is a structural hash of the post-uniquify statement, skipping the `location` field. Memoised on the AST node via `__hash_cache__`. Step 12's deterministic `uniquify` is what makes this stable across runs.
- `chain_hash` is a fold over prior statements' hashes — equivalent to the plan's `env_in_hash` but cheaper to maintain (`hash((prev_chain, stmt_hash))`). The seed includes `module_name` and the current `target_hole_location` so changing the latter doesn't let us reuse a verdict made under a different target.

Failed lookups run `check_proofs` and store `True` on success. Failed lookups whose `check_proofs` *raises* leave the cache untouched — next call re-runs and re-raises (preserves `IncompleteProof`-driven goal extraction).

## Lifecycle

The cache lives at `proof_checker._stmt_cache` and accumulates across calls. `lsp/library.py:_clear_containers` calls `reset_stmt_cache` when the prelude key changes, so entries from a different baseline can't pollute a new session.

## Test plan

- [x] `python3 -m pytest test/lsp/` — 645 pass (was 639; +6 in `test_check_proofs_cache.py`)
- [x] `python3 test-deduce.py --errors` — 153 should-error fixtures unchanged
- [x] `python3 test-deduce.py --passable` — should-validate passes under both `--recursive-descent` and `--lalr`

### Timing on a 20-theorem bool-only fixture

| Run | Time |
|---|---|
| Cold cache, all 20 misses | 49ms |
| Hot cache, all 20 hits | 40ms |
| Hot cache, edit one stmt, recheck | 40ms |

Both well under "sub-second." The 1.2× speedup is modest because trivial proofs spend most of their time in the un-cached loops; on real proof files where `check_proofs` dominates (large recursive proofs, `induction`, etc.) the savings will be larger.

### New tests in `test/lsp/test_check_proofs_cache.py`

- `first_run_is_all_misses` — clean cache + fresh source → every stmt a miss.
- `second_run_on_same_content_is_all_hits` — re-run on identical content reuses every entry.
- `editing_one_statement_keeps_others_cache_hits` — the headline acceptance: edit one of three theorems, the other two hit, only the touched one misses.
- `editing_a_statement_in_the_middle_invalidates_downstream` — middle edit invalidates itself plus downstream (chain hash shifts).
- `comment_only_edit_in_unchanged_proof_still_hits` — `_hash_ast` skips `Meta`, so a whitespace-only change on an unrelated statement doesn't perturb its hash.
- `cache_skips_check_proofs_for_unchanged_stmt` — direct observation: stub `check_proofs` and confirm it isn't invoked on a re-run of unchanged content.

## What's next (Step 14)

Dependency-aware invalidation: walk each statement's post-uniquify AST to collect referenced names; invalidate dependents on edit. Right now if you edit the *first* theorem, every downstream theorem misses (chain hash shifts) — even when none of them reference the edited one. Step 14 fixes that.