### PR TITLE
Separate compilation Step 26: per-module .h generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ tests-compile:
 	$(PYTHON) ./test/compile/run_lower.py
 	$(PYTHON) ./test/compile/run_e2e.py
 	$(PYTHON) ./test/compile/run_determinism.py
+	$(PYTHON) ./test/compile/run_headers.py
 
 package:
 	$(PYTHON) ./deduce.py ./lib

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -214,6 +214,107 @@ def emit_program(p: ir.Program) -> str:
     return "\n".join(out) + "\n"
 
 
+def emit_header(p: ir.Program, module_name: str) -> str:
+    """Generate the C header for a single module of an IR program.
+
+    Declares (forward-decl / extern) every top-level decl whose
+    `module == module_name`, plus the module's nullary-ctor
+    singletons and constructor-ID macros for its unions. Wrapped in
+    a standard `#ifndef`/`#define`/`#endif` include guard so a
+    consumer can `#include "Foo.h"` from multiple translation units
+    without redefinition errors.
+
+    The constructor IDs match the IDs `emit_program` assigns for the
+    same `Program`, so a `.c` and its `.h` agree. Step 27 will use
+    this to wire up per-module compilation; Step 26 exposes it for
+    fixture-based testing of the header's shape.
+    """
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
+    next_ctor_id = 0
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                ctx.ctor_ids[c.name] = next_ctor_id
+                ctx.ctor_arities[c.name] = c.arity
+                next_ctor_id += 1
+        elif isinstance(d, ir.Function):
+            ctx.top_funcs[d.name] = len(d.params)
+        elif isinstance(d, ir.Global):
+            ctx.top_globals.add(d.name)
+
+    def in_module(decl) -> bool:
+        return getattr(decl, "module", None) == module_name
+
+    guard = "DEDUCE_" + _mangle(module_name) + "_H"
+    out: List[str] = [
+        f"#ifndef {guard}",
+        f"#define {guard}",
+        '#include "deduce.h"',
+        "",
+    ]
+
+    # Constructor ID macros — one per ctor of any union in this module.
+    macros: List[str] = []
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl) and in_module(d):
+            for c in d.ctors:
+                macros.append(
+                    f"#define {ctx.ctor_id_macro(c.name)} {ctx.ctor_ids[c.name]}"
+                )
+    if macros:
+        out.extend(macros)
+        out.append("")
+
+    # Nullary-ctor singleton externs.
+    singletons: List[str] = []
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl) and in_module(d):
+            for c in d.ctors:
+                if c.arity == 0:
+                    singletons.append(
+                        f"extern deduce_value {ctx.ctor_singleton(c.name)};"
+                    )
+    if singletons:
+        out.extend(singletons)
+        out.append("")
+
+    # Function prototypes.
+    fn_protos: List[str] = []
+    for d in p.decls:
+        if isinstance(d, ir.Function) and in_module(d):
+            fn_protos.append(_emit_fn_decl(d, ctx) + ";")
+    if fn_protos:
+        out.extend(fn_protos)
+        out.append("")
+
+    # Globals.
+    global_externs: List[str] = []
+    for d in p.decls:
+        if isinstance(d, ir.Global) and in_module(d):
+            global_externs.append(
+                f"extern deduce_value {ctx.global_id(d.name)};"
+            )
+    if global_externs:
+        out.extend(global_externs)
+        out.append("")
+
+    out.append("#endif")
+    return "\n".join(out) + "\n"
+
+
+def modules_in(p: ir.Program) -> List[str]:
+    """Return the set of source modules that have at least one
+    top-level decl in `p`, sorted for stable iteration. Used by the
+    header-emit test runner to know which `emit_header` calls to
+    make per fixture."""
+    seen: Set[str] = set()
+    for d in p.decls:
+        m = getattr(d, "module", None)
+        if m is not None:
+            seen.add(m)
+    return sorted(seen)
+
+
 def _emit_fn_decl(f: ir.Function, ctx: EmitCtx) -> str:
     # Not `static`: a function may be unused at runtime if it's only
     # referenced by an erased proof (e.g. used inside a `terminates`

--- a/test/compile/lower/array.h
+++ b/test/compile/lower/array.h
@@ -1,0 +1,18 @@
+// === module array ===
+#ifndef DEDUCE_array_H
+#define DEDUCE_array_H
+#include "deduce.h"
+
+#define CTOR_array__zero_1 0
+#define CTOR_array__suc_2 1
+#define CTOR_array__empty_5 2
+#define CTOR_array__node_6 3
+
+extern deduce_value C_array__zero_1;
+extern deduce_value C_array__empty_5;
+
+extern deduce_value G_array__ns_7;
+extern deduce_value G_array__A_8;
+
+#endif
+

--- a/test/compile/lower/basic.h
+++ b/test/compile/lower/basic.h
@@ -1,0 +1,18 @@
+// === module basic ===
+#ifndef DEDUCE_basic_H
+#define DEDUCE_basic_H
+#include "deduce.h"
+
+#define CTOR_basic__zero_1 0
+#define CTOR_basic__suc_2 1
+
+extern deduce_value C_basic__zero_1;
+
+deduce_value F_basic__add_3(deduce_value* env, deduce_value* args);
+deduce_value F_basic__add_two_9(deduce_value* env, deduce_value* args);
+deduce_value F_basic__pick_13(deduce_value* env, deduce_value* args);
+
+extern deduce_value G_basic__two_7;
+
+#endif
+

--- a/test/compile/lower/closure.h
+++ b/test/compile/lower/closure.h
@@ -1,0 +1,15 @@
+// === module closure ===
+#ifndef DEDUCE_closure_H
+#define DEDUCE_closure_H
+#include "deduce.h"
+
+#define CTOR_closure__zero_1 0
+#define CTOR_closure__suc_2 1
+
+extern deduce_value C_closure__zero_1;
+
+deduce_value F_closure__add_3(deduce_value* env, deduce_value* args);
+deduce_value F_closure__adder_9(deduce_value* env, deduce_value* args);
+
+#endif
+

--- a/test/compile/lower/generic.h
+++ b/test/compile/lower/generic.h
@@ -1,0 +1,16 @@
+// === module generic ===
+#ifndef DEDUCE_generic_H
+#define DEDUCE_generic_H
+#include "deduce.h"
+
+#define CTOR_generic__box_2 0
+#define CTOR_generic__zero_12 1
+#define CTOR_generic__suc_13 2
+
+extern deduce_value C_generic__zero_12;
+
+deduce_value F_generic__unbox_6(deduce_value* env, deduce_value* args);
+deduce_value F_generic__id_10(deduce_value* env, deduce_value* args);
+
+#endif
+

--- a/test/compile/lower/genrecfun.h
+++ b/test/compile/lower/genrecfun.h
@@ -1,0 +1,16 @@
+// === module genrecfun ===
+#ifndef DEDUCE_genrecfun_H
+#define DEDUCE_genrecfun_H
+#include "deduce.h"
+
+#define CTOR_genrecfun__zero_1 0
+#define CTOR_genrecfun__suc_2 1
+
+extern deduce_value C_genrecfun__zero_1;
+
+deduce_value F_genrecfun__iszero_5(deduce_value* env, deduce_value* args);
+deduce_value F_genrecfun__pred_8(deduce_value* env, deduce_value* args);
+deduce_value F_genrecfun__count_down_22(deduce_value* env, deduce_value* args);
+
+#endif
+

--- a/test/compile/lower/pruning.h
+++ b/test/compile/lower/pruning.h
@@ -1,0 +1,14 @@
+// === module pruning ===
+#ifndef DEDUCE_pruning_H
+#define DEDUCE_pruning_H
+#include "deduce.h"
+
+#define CTOR_pruning__zero_1 0
+#define CTOR_pruning__suc_2 1
+
+extern deduce_value C_pruning__zero_1;
+
+deduce_value F_pruning__used_3(deduce_value* env, deduce_value* args);
+
+#endif
+

--- a/test/compile/lower/source_map.h
+++ b/test/compile/lower/source_map.h
@@ -1,0 +1,17 @@
+// === module source_map ===
+#ifndef DEDUCE_source_map_H
+#define DEDUCE_source_map_H
+#include "deduce.h"
+
+#define CTOR_source_map__zero_1 0
+#define CTOR_source_map__suc_2 1
+#define CTOR_source_map__empty_5 2
+#define CTOR_source_map__node_6 3
+
+extern deduce_value C_source_map__zero_1;
+extern deduce_value C_source_map__empty_5;
+
+extern deduce_value G_source_map__A_7;
+
+#endif
+

--- a/test/compile/lower/unbox.h
+++ b/test/compile/lower/unbox.h
@@ -1,0 +1,12 @@
+// === module unbox ===
+#ifndef DEDUCE_unbox_H
+#define DEDUCE_unbox_H
+#include "deduce.h"
+
+#define CTOR_unbox__zero_1 0
+#define CTOR_unbox__suc_2 1
+
+extern deduce_value C_unbox__zero_1;
+
+#endif
+

--- a/test/compile/prelude/hello_nat.h
+++ b/test/compile/prelude/hello_nat.h
@@ -1,0 +1,39 @@
+// === module Nat ===
+#ifndef DEDUCE_Nat_H
+#define DEDUCE_Nat_H
+#include "deduce.h"
+
+deduce_value F_Nat__gcd_2197(deduce_value* env, deduce_value* args);
+
+#endif
+
+// === module NatDefs ===
+#ifndef DEDUCE_NatDefs_H
+#define DEDUCE_NatDefs_H
+#include "deduce.h"
+
+#define CTOR_NatDefs__zero_96 0
+#define CTOR_NatDefs__suc_97 1
+
+extern deduce_value C_NatDefs__zero_96;
+
+deduce_value F_NatDefs___x2b_98(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2a_102(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2238_126(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2264_131(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x3c_138(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs__pow2_158(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs__lit_196(deduce_value* env, deduce_value* args);
+
+#endif
+
+// === module NatDiv ===
+#ifndef DEDUCE_NatDiv_H
+#define DEDUCE_NatDiv_H
+#include "deduce.h"
+
+deduce_value F_NatDiv___x2f_1523(deduce_value* env, deduce_value* args);
+deduce_value F_NatDiv___x25_1534(deduce_value* env, deduce_value* args);
+
+#endif
+

--- a/test/compile/run_headers.py
+++ b/test/compile/run_headers.py
@@ -1,0 +1,131 @@
+"""Header-emission tests.
+
+For each lowering fixture, compute its post-prune IR, walk every
+module that contributed a kept top-level decl, and emit a `.h` for
+each. Concatenate the per-module headers (in deterministic module
+order) into a single string and compare it against the fixture's
+sibling `.h` file.
+
+Step 26 of `docs/separate-compile-plan.md` — the acceptance check
+on header generation. Run from the repo root:
+
+    python3 test/compile/run_headers.py
+    python3 test/compile/run_headers.py --regenerate
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+
+from compiler import closure, emit_c, ir, lower, prune  # noqa: E402
+from abstract_syntax import (  # noqa: E402
+    add_import_directory,
+    init_import_directories,
+)
+from lsp.library import check_file  # noqa: E402
+
+LOWER_DIR = ROOT / "test" / "compile" / "lower"
+PRELUDE_DIR = ROOT / "test" / "compile" / "prelude"
+
+
+def headers_for(path: Path) -> str:
+    """Return the concatenated headers for every module that has at
+    least one top-level decl in `path`'s post-prune IR. Modules are
+    listed in alphabetical order so the output is reproducible."""
+    sys.argv = [str(ROOT / "deduce.py")]
+    init_import_directories()
+    add_import_directory(str(ROOT / "lib"))
+
+    needs_prelude = _needs_prelude(path)
+    prelude: list[str] = []
+    if needs_prelude:
+        prelude = sorted(
+            f.removesuffix(".pf")
+            for f in os.listdir(ROOT / "lib")
+            if f.endswith(".pf")
+        )
+
+    result = check_file(str(path), prelude=prelude)
+    if not result.ok:
+        raise RuntimeError(f"{path}: deduce check failed:\n{result.error_message}")
+    program = lower.lower_program(result.ast, main_module=path.stem)
+    program = closure.closure_convert(program)
+    program = prune.prune(program)
+
+    modules = emit_c.modules_in(program)
+    parts: list[str] = []
+    for m in modules:
+        parts.append(f"// === module {m} ===")
+        parts.append(emit_c.emit_header(program, m).rstrip("\n"))
+        parts.append("")
+    return "\n".join(parts) + ("\n" if parts else "")
+
+
+def _needs_prelude(pf: Path) -> bool:
+    for raw in pf.read_text().splitlines():
+        s = raw.strip()
+        if not s or s.startswith("//") or s.startswith("/*"):
+            continue
+        if s.startswith("import ") or s.startswith("public import "):
+            return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--regenerate", action="store_true",
+                    help="overwrite expected .h files with current output")
+    ap.add_argument("--filter", default=None,
+                    help="only run fixtures whose name contains this string")
+    args = ap.parse_args()
+
+    fixtures: list[Path] = []
+    for d in (LOWER_DIR, PRELUDE_DIR):
+        if d.exists():
+            fixtures.extend(sorted(d.glob("*.pf")))
+    if args.filter:
+        fixtures = [f for f in fixtures if args.filter in f.name]
+
+    failures: list[str] = []
+    for pf in fixtures:
+        try:
+            actual = headers_for(pf)
+        except Exception as e:
+            failures.append(f"{pf.name}: header emission raised: {e}")
+            continue
+
+        expect_path = pf.with_suffix(".h")
+        if args.regenerate:
+            expect_path.write_text(actual)
+            print(f"regenerated {expect_path.name}")
+            continue
+        if not expect_path.exists():
+            failures.append(
+                f"{pf.name}: missing expected file {expect_path.name}"
+            )
+            continue
+        expected = expect_path.read_text()
+        if actual != expected:
+            failures.append(
+                f"{pf.name}: header mismatch\n"
+                f"--- expected\n{expected}--- actual\n{actual}"
+            )
+            continue
+        print(f"ok {pf.name}")
+
+    if failures:
+        print("\nFAILURES:")
+        for msg in failures:
+            print(msg)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Step 26 of [`docs/separate-compile-plan.md`](docs/separate-compile-plan.md). Adds per-module C header generation. Step 27 will wire this into a per-`.pf` compile mode where each module compiles to its own `.c` + `.h`; here we just produce the `.h` content and regression-test its shape so the integration step can land cleanly.

**Stacks on [#359](https://github.com/jsiek/deduce/pull/359)** (Step 25). The base shows up as my Step 25 branch; once that merges, this rebases onto main and the diff drops to just the Step 26 piece.

## What's in the diff

- **`emit_c.emit_header(program, module_name)`** generates the `.h` for one module: `#ifndef`/`#define` guard, ctor-ID `#define`s, ctor-singleton externs, function prototypes, global externs.
- **`emit_c.modules_in(program)`** returns the sorted set of modules that have at least one top-level decl in the post-prune program — used by the test runner to know which `emit_header` calls to make per fixture.
- **`test/compile/run_headers.py`** runs every lowering/prelude fixture through lower → closure-convert → prune, emits one `.h` per module (concatenated, alphabetical), and diffs against `<fixture>.h`.
- Wired into `make tests-compile`. New target line is one of nine; existing checks are unchanged.

## Sample output

For `basic.pf` (one user module, no prelude imports):

```c
#ifndef DEDUCE_basic_H
#define DEDUCE_basic_H
#include "deduce.h"

#define CTOR_basic__zero_1 0
#define CTOR_basic__suc_2 1

extern deduce_value C_basic__zero_1;

deduce_value F_basic__add_3(deduce_value* env, deduce_value* args);
deduce_value F_basic__add_two_9(deduce_value* env, deduce_value* args);
deduce_value F_basic__pick_13(deduce_value* env, deduce_value* args);

extern deduce_value G_basic__two_7;

#endif
```

For `hello_nat.pf` (which uses prelude `Nat.gcd`, `+`, `pow2`), the runner produces three concatenated headers — one each for `Nat`, `NatDefs`, and `NatDiv` — exactly the modules that contributed kept symbols after pruning.

## What's *not* in this PR

- **Module init prototypes** (`void <Module>_init(void);`) — that's part of Step 28's runtime orchestration work. The `.h` describes static decls only.
- **The `.h` isn't actually written to disk yet from `--compile`.** Step 27's per-module compile mode introduces that. Today the `.h` is only exercised through the test runner.

## Test plan

- [x] `make tests-compile` — 77 ok lines (was 68): adds 9 header checks. Existing 24 lowering + 35 e2e + 9 determinism unchanged.
- [x] `make tests` — interpreter suite unchanged.
- [x] Spot-checked emitted headers for `basic.pf` (user-only module) and `hello_nat.pf` (prelude-using). Both have the expected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
