### PR TITLE
LSP Phase 3 / Step 14: dependency-aware invalidation

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -126,35 +126,44 @@ def maybe_pretty_print(o: Optional[str], indent, default='') -> str:
 class UniquifyContext:
   """Mutable state threaded through an ``uniquify_deduce`` call.
 
-  Currently holds a single counter for fresh-name allocation.  Two
-  uniquify runs with the same input AST and a fresh
+  Holds two pieces of state for fresh-name allocation:
+
+  * ``name_id`` -- a counter that increments on every ``generate_name``.
+  * ``scope`` -- a string prepended to the counter when forming the
+    name suffix.  ``uniquify_deduce`` resets ``name_id`` and pushes a
+    per-statement segment onto ``scope`` at each top-level statement,
+    so two top-level statements get *disjoint* suffix spaces and an
+    edit confined to statement N can no longer shift statement N+1's
+    bound-name suffixes.  Without this, Step 14's dependency-aware
+    invalidation never gets to fire -- the structural hash of an
+    unrelated downstream statement would change as a side-effect of
+    counter drift.
+
+  Two uniquify runs with the same input AST and a fresh
   ``UniquifyContext`` each produce byte-equal output -- that's the
   acceptance for Step 12 of ``docs/lsp-plan.md`` and the foundation
   Step 13's caching needs.
-
-  Subsequent Phase-3 steps may extend the context (per-module
-  sub-counters, statement-AST hashes, etc.) without changing the
-  thread-it-explicitly contract.
   """
 
-  def __init__(self, name_id: int = 0):
+  def __init__(self, name_id: int = 0, scope: str = ""):
     self.name_id = name_id
+    self.scope = scope
 
   def snapshot(self) -> "UniquifyContext":
-    """Return a fresh context with the same counter value.
+    """Return a fresh context with the same counter and scope.
 
     Used by the LSP pipeline to fork off a per-user-file context
     from the post-prelude baseline, so each user-file check starts
     from the same counter state and produces reproducible names.
     """
-    return UniquifyContext(name_id=self.name_id)
+    return UniquifyContext(name_id=self.name_id, scope=self.scope)
 
 
 def generate_name(name: str, ctx: UniquifyContext) -> str:
   base = name.split('.')[0]
   new_id = ctx.name_id
   ctx.name_id += 1
-  return base + '.' + str(new_id)
+  return base + '.' + ctx.scope + str(new_id)
 
 
 def base_name(name: str) -> str:
@@ -5377,13 +5386,34 @@ def uniquify_deduce(ast, ctx: UniquifyContext):
   freshly generated user-file names never collide with cached
   prelude names.  Tests typically pass a fresh context for
   reproducibility.
+
+  Each top-level statement gets its own scope segment (``"sN_"``
+  appended to the caller's scope, ``name_id`` reset to ``0``) so
+  edits confined to statement *N* don't perturb the bound-name
+  suffixes in statement *M > N*.  That edit-invariance is what
+  Phase-3 Step 14's dependency-aware cache invalidation relies on
+  -- without it, the structural hash of every downstream statement
+  drifts on every edit and the cache is useless.
   """
   env = {}
   env['≠'] = ['≠']
   env['='] = ['=']
   # Using a space in the name to not collide with deduce identifiers
   env['no overload'] = {}
-  result = [stmt.uniquify(env, ctx) for stmt in ast]
+  outer_scope = ctx.scope
+  outer_name_id = ctx.name_id
+  result = []
+  for i, stmt in enumerate(ast):
+    ctx.scope = outer_scope + 's' + str(i) + '_'
+    ctx.name_id = 0
+    result.append(stmt.uniquify(env, ctx))
+  # Restore the caller's scope/counter -- the per-statement reset is
+  # purely local to this call.  The caller's snapshot (e.g. the LSP
+  # post-prelude baseline) sees the same state it passed in, and a
+  # nested ``uniquify_deduce`` (called from ``Import.uniquify``)
+  # leaves no residue in the surrounding statement's scope.
+  ctx.scope = outer_scope
+  ctx.name_id = outer_name_id
   check_post_uniquify_invariants(result)
   return result
 

--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -94,8 +94,9 @@ Only if 3s/check turns out to be too slow. None of this is needed for a working 
 - [ ] **Step 13: Per-statement env caching.** In `check_deduce`'s three loops, record `(stmt_hash, env_in_hash) → env_out`. Skip cached entries on later runs. No dependency tracking yet.
   - *Acceptance:* edit one statement, recheck; instrumentation confirms untouched statements were cache hits. Sub-second for typical edits.
 
-- [ ] **Step 14: Dependency-aware invalidation.** Walk each statement's post-uniquify AST to collect referenced names; invalidate dependents on edit.
+- [x] **Step 14: Dependency-aware invalidation.** Walk each statement's post-uniquify AST to collect referenced names; invalidate dependents on edit.
   - *Acceptance:* edit theorem `T1`; assert `T2` (which uses `T1`) is invalidated and rechecked.
+  - *Implementation:* `_collect_referenced_names` walks the post-uniquify AST gathering every `VarRef` / `PVar` name; `_collect_defined_names` returns the names a top-level statement introduces (its own name plus union constructors / predicate rules / synthesised induction lemmas). `check_deduce`'s third loop maintains a `defined_to_idx` map and replaces Step 13's `chain_hash` with `deps_fingerprint = hash(tuple(stmt_hashes_so_far[j] for j in sorted(dep_indices)))` — only the prior statements *this* one references contribute. `Import` and `Auto` are treated as global barriers (every later statement implicitly depends on them) since they have effects observable everywhere downstream. Required a foundational fix in `uniquify_deduce`: each top-level statement now gets its own `s<N>_` scope segment with `name_id` reset, so an edit confined to statement *N* no longer shifts the bound-name suffixes of statement *M > N* — without that, every downstream statement's stmt_hash drifts on every edit and the cache is useless. Acceptance test in `test/lsp/test_check_proofs_cache.py::test_editing_T1_invalidates_T2_that_uses_it`; complement test pins the negative direction (unrelated downstream stays a hit).
 
 ## Phase 4 — Structured proof-editing operations (Agda-like)
 

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -132,13 +132,90 @@ def _hash_ast(node) -> int:
     return hash(repr(node))
 
 
-def _chain(prev: int, stmt_hash: int) -> int:
-    """Fold a statement's hash into the running chain hash.
+def _collect_referenced_names(node, out=None) -> set:
+    """Walk a statement's post-uniquify AST and gather every uniquified
+    name it references via ``VarRef`` (``Var`` / ``OverloadedVar`` /
+    ``ResolvedVar``) or ``PVar``.
 
-    Stable across runs: same prefix -> same chain -> same key for
-    the next statement.  Uses ``hash()`` for symmetry with the
-    inner ``_hash_ast``."""
-    return hash((prev, stmt_hash))
+    Used by Step 14's dependency-aware invalidation: a statement's
+    cache verdict is keyed on the hashes of the prior statements that
+    introduced any of these names, so editing an unrelated theorem
+    leaves this statement's entry intact.
+
+    Skips ``location`` (irrelevant), ``__hash_cache__`` (memoisation
+    artefact), and ``Import.ast`` (the imported module is checked on
+    its own pass, and we treat ``Import`` as a global barrier in the
+    caller anyway)."""
+    if out is None:
+        out = set()
+    if node is None or isinstance(node, (str, int, bool, float)):
+        return out
+    if isinstance(node, (list, tuple)):
+        for x in node:
+            _collect_referenced_names(x, out)
+        return out
+    if isinstance(node, dict):
+        for v in node.values():
+            _collect_referenced_names(v, out)
+        return out
+    if isinstance(node, VarRef):
+        out.add(node.get_name())
+        return out
+    if isinstance(node, PVar):
+        out.add(node.name)
+        return out
+    if isinstance(node, Import):
+        # Imports are treated as a global barrier by the caller; we
+        # don't want to recurse into the imported module's AST here.
+        return out
+    if hasattr(node, "__dict__"):
+        for k, v in node.__dict__.items():
+            if k in ("location", "__hash_cache__"):
+                continue
+            _collect_referenced_names(v, out)
+    return out
+
+
+def _collect_defined_names(stmt) -> set:
+    """Return the uniquified names a top-level statement introduces.
+
+    Includes the statement's own name plus any auxiliary names it
+    creates (union constructors; ``predicate`` rules and the
+    auto-synthesised ``<pred>_rule_induction`` / ``_rule_inversion``
+    theorems). Statements that don't introduce names (``Assert``,
+    ``Print``, ``Auto``, ``Module``, ``Trace``, ``Import``) return
+    the empty set; ``Import`` and ``Auto`` are handled separately by
+    the caller as global barriers."""
+    names: set = set()
+    name = getattr(stmt, "name", None)
+    if isinstance(name, str):
+        names.add(name)
+    if isinstance(stmt, Union):
+        for con in stmt.alternatives:
+            if isinstance(con.name, str):
+                names.add(con.name)
+    elif isinstance(stmt, Predicate):
+        for rule in stmt.rules:
+            if isinstance(rule.name, str):
+                names.add(rule.name)
+        rule_ind = getattr(stmt, "rule_induction_name", None)
+        if isinstance(rule_ind, str):
+            names.add(rule_ind)
+        rule_inv = getattr(stmt, "rule_inversion_name", None)
+        if isinstance(rule_inv, str):
+            names.add(rule_inv)
+    return names
+
+
+def _is_global_barrier(stmt) -> bool:
+    """Statements with global side-effects on later checking.
+
+    ``Import`` brings a module's exports into the environment;
+    ``Auto`` registers a rewrite rule consulted by every later
+    proof. Conservatively treat both as a barrier: every later
+    statement implicitly depends on them, so editing or removing
+    one invalidates the cache for everything after."""
+    return isinstance(stmt, (Import, Auto))
   
 def check_implies(loc, frm1, frm2):
   if get_verbose():
@@ -4718,23 +4795,44 @@ def check_deduce(ast, module_name, modified, tracing_functions):
   if module_name not in checked_modules:
     if get_verbose() and needs_checking[0]:
         print('checking ' + module_name)
-    # Per-statement cache for ``check_proofs`` (Step 13).  Earlier
-    # loops (``process_declaration``, ``type_check_stmt``) emit AST
-    # nodes whose ``Meta`` locations participate in side-effecting
-    # behaviour (e.g. the ``target_hole_location`` flag used by
-    # ``goal_at`` to single out which `?` raises), so caching their
-    # outputs across calls would let stale locations leak into a new
-    # run.  ``check_proofs`` itself is the bulk of the time and its
-    # only persistent effect is "verified" -- safe to cache.
+    # Per-statement cache for ``check_proofs`` (Steps 13 + 14).
+    # Earlier loops (``process_declaration``, ``type_check_stmt``)
+    # emit AST nodes whose ``Meta`` locations participate in
+    # side-effecting behaviour (e.g. the ``target_hole_location``
+    # flag used by ``goal_at`` to single out which `?` raises), so
+    # caching their outputs across calls would let stale locations
+    # leak into a new run.  ``check_proofs`` itself is the bulk of
+    # the time and its only persistent effect is "verified" -- safe
+    # to cache.
     #
-    # Key includes ``target_hole_location``: a different target means
-    # a `?` that was previously treated as ``sorry`` should now raise
-    # (or vice versa), so we mustn't reuse the prior verdict.
+    # Step 14: the cache key is ``(stmt_hash, deps_fingerprint,
+    # target, module_name)`` where ``deps_fingerprint`` folds in
+    # only the prior statements *this* statement actually references
+    # (plus any global-barrier statements -- ``Import`` / ``Auto``
+    # -- whose effects are observable everywhere downstream).
+    # Editing an unrelated theorem leaves ``deps_fingerprint``
+    # unchanged, so the entry hits.
+    #
+    # ``target`` is in the key so a different ``goal_at`` target
+    # doesn't reuse a verdict made under the previous target (a `?`
+    # that was previously treated as ``sorry`` should now raise, or
+    # vice versa).
     target = get_target_hole_location()
-    proof_chain = hash(("check_proofs_seed", module_name, target))
-    for s, sh in zip(ast3, ast3_hashes):
+    defined_to_idx: dict = {}
+    barrier_idxs: set = set()
+    stmt_hashes_so_far: list = []
+    for i, (s, sh) in enumerate(zip(ast3, ast3_hashes)):
       env = collect_env(s, env)
-      key = ("check_proofs", sh, proof_chain)
+      referenced = _collect_referenced_names(s)
+      dep_idxs = set(barrier_idxs)
+      for n in referenced:
+        j = defined_to_idx.get(n)
+        if j is not None:
+          dep_idxs.add(j)
+      deps_fingerprint = hash(
+        tuple(stmt_hashes_so_far[j] for j in sorted(dep_idxs))
+      )
+      key = ("check_proofs", sh, deps_fingerprint, target, module_name)
       if needs_checking[0]:
         if key in _stmt_cache:
           _record_hit("check_proofs")
@@ -4742,7 +4840,16 @@ def check_deduce(ast, module_name, modified, tracing_functions):
           check_proofs(s, env)
           _stmt_cache[key] = True
           _record_miss("check_proofs")
-      proof_chain = _chain(proof_chain, sh)
+      # Bookkeeping for the next iteration -- happens regardless of
+      # ``needs_checking`` so the dependency map stays consistent.
+      # ``defined_to_idx`` is updated *after* the dep lookup so a
+      # statement's self-references (e.g. recursive functions) do
+      # not get treated as a self-dependency.
+      if _is_global_barrier(s):
+        barrier_idxs.add(i)
+      for n in _collect_defined_names(s):
+        defined_to_idx[n] = i
+      stmt_hashes_so_far.append(sh)
     checked_modules.add(module_name)
   # Sanity-check the post-typecheck AST: every variable reference
   # should be ``ResolvedVar`` (or, if a real overload couldn't be

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -4820,10 +4820,20 @@ def check_deduce(ast, module_name, modified, tracing_functions):
     target = get_target_hole_location()
     defined_to_idx: dict = {}
     barrier_idxs: set = set()
+    auto_idxs: list = []
     stmt_hashes_so_far: list = []
     for i, (s, sh) in enumerate(zip(ast3, ast3_hashes)):
       env = collect_env(s, env)
       referenced = _collect_referenced_names(s)
+      # ``auto`` declarations register theorems as implicit rewrite
+      # rules consulted by every later proof.  A proof can rely on
+      # an auto'd theorem without textually referencing it, so each
+      # prior ``Auto``'s referenced names also contribute to this
+      # statement's dependency set -- editing the auto'd theorem
+      # then invalidates downstream proofs that relied on it
+      # implicitly.
+      for j in auto_idxs:
+        referenced |= _collect_referenced_names(ast3[j])
       dep_idxs = set(barrier_idxs)
       for n in referenced:
         j = defined_to_idx.get(n)
@@ -4847,6 +4857,8 @@ def check_deduce(ast, module_name, modified, tracing_functions):
       # not get treated as a self-dependency.
       if _is_global_barrier(s):
         barrier_idxs.add(i)
+      if isinstance(s, Auto):
+        auto_idxs.append(i)
       for n in _collect_defined_names(s):
         defined_to_idx[n] = i
       stmt_hashes_so_far.append(sh)

--- a/test/lsp/test_check_proofs_cache.py
+++ b/test/lsp/test_check_proofs_cache.py
@@ -239,6 +239,74 @@ def test_editing_T1_invalidates_T2_that_uses_it() -> None:
     assert _misses() == 2
 
 
+_T1_AUTO_T2 = (
+    "theorem t1: true = true\n"
+    "proof\n"
+    "  reflexive\n"
+    "end\n"
+    "\n"
+    "auto t1\n"
+    "\n"
+    "theorem t2: true = true\n"
+    "proof\n"
+    "  reflexive\n"
+    "end\n"
+)
+
+
+def test_editing_an_autod_theorem_invalidates_later_proofs() -> None:
+    """``auto`` registers a theorem as an implicit rewrite rule;
+    a later proof can rely on it without ever mentioning the
+    theorem's name.  Editing the auto'd theorem must therefore
+    invalidate every subsequent proof, even ones that don't
+    textually reference it.
+
+    Without the auto-aware deps machinery, t2's
+    ``deps_fingerprint`` would only include the ``Auto`` barrier's
+    own ``stmt_hash`` -- and the ``Auto`` stmt's hash doesn't
+    change when the theorem it points to changes (the reference
+    is by uniquified name, which stays the same).  The fix folds
+    each prior ``Auto``'s referenced names into the current
+    statement's dependency set."""
+    check("test.pf", _T1_AUTO_T2)
+
+    # Edit t1's body. Its statement type is still ``true = true``
+    # -- so ``auto t1`` and ``t2`` both still type-check -- but
+    # t1's stmt_hash changes.
+    edited = _T1_AUTO_T2.replace(
+        "theorem t1: true = true\n"
+        "proof\n"
+        "  reflexive\n"
+        "end\n",
+        "theorem t1: true = true\n"
+        "proof\n"
+        "  have h: true = true by reflexive\n"
+        "  h\n"
+        "end\n",
+    )
+
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", edited)
+    assert diags == []
+    # t1 edited -> miss.  ``auto t1`` references t1 directly so
+    # picks up t1 as a dep -> miss.  t2 doesn't reference t1
+    # textually but transitively depends on it via the prior
+    # ``auto`` -> miss.
+    #
+    # The key thing this pins is t2 missing.  Without the
+    # auto-transitive dep, t2 would have hit (it references
+    # nothing, and the ``auto`` barrier's own stmt_hash also
+    # doesn't change since the reference is by unchanged
+    # uniquified name).
+    assert _hits() == 0, (
+        f"expected 0 hits -- editing an auto'd theorem must "
+        f"invalidate later proofs that rely on it implicitly; "
+        f"got hits={_hits()}, misses={_misses()}"
+    )
+    assert _misses() == 3
+
+
 def test_editing_T1_leaves_unrelated_T2_a_hit() -> None:
     """The complement of the above: if T2 does *not* reference T1,
     editing T1 leaves T2's verdict in the cache.  Pins the

--- a/test/lsp/test_check_proofs_cache.py
+++ b/test/lsp/test_check_proofs_cache.py
@@ -1,21 +1,38 @@
-"""Acceptance test for the per-statement ``check_proofs`` cache (Phase 3 / Step 13).
+"""Acceptance tests for the per-statement ``check_proofs`` cache.
 
-Plan acceptance: ``edit one statement, recheck; instrumentation
-confirms untouched statements were cache hits``.
+Phase 3 / Steps 13 and 14.  Plan acceptances:
+
+- *Step 13:* ``edit one statement, recheck; instrumentation confirms
+  untouched statements were cache hits``.
+- *Step 14:* ``edit theorem T1; assert T2 (which uses T1) is
+  invalidated and rechecked``.
 
 The cache lives in ``proof_checker._stmt_cache`` and is keyed by
-``(stmt_hash, chain_hash)``.  ``stmt_hash`` is a structural hash
-that skips the ``location`` (``Meta``) field, so adding/removing
-*other* statements doesn't perturb the hash of an unchanged one.
-``chain_hash`` is a fold over prior statements' hashes -- it
-identifies the cumulative state at this position in the AST.
+``(stmt_hash, deps_fingerprint, target, module_name)``.
+
+- ``stmt_hash`` is a structural hash that skips ``location``
+  (``Meta``) so adding/removing *other* statements doesn't perturb
+  the hash of an unchanged one.  Per-statement scoping in
+  ``uniquify_deduce`` (Step 14) keeps the structural hash stable
+  even when an earlier statement's body changes size.
+- ``deps_fingerprint`` folds in the structural hashes of just the
+  prior statements *this* statement actually references (plus any
+  global-barrier ``Import`` / ``Auto`` statements).  Editing an
+  unrelated theorem leaves ``deps_fingerprint`` unchanged.
+- ``target`` is the ``goal_at`` target-hole location (so a `?` that
+  was previously treated as ``sorry`` doesn't reuse a stale
+  verdict).
+- ``module_name`` keeps two files in the same process from
+  cross-contaminating each other.
 
 What this file pins:
 
 - a clean run populates the cache with all-misses,
 - a re-run on the same content is all-hits,
-- editing a statement near the end leaves the unchanged prefix
-  cache-hits and only the touched statement misses.
+- editing one statement leaves untouched prefix entries hit,
+- editing a middle statement leaves later statements that don't
+  reference it as hits (Step 14's deps-fingerprint kicking in),
+- editing T1 invalidates T2 that uses it (Step 14 acceptance).
 
 The earlier two loops (``process_declaration``, ``type_check_stmt``)
 are deliberately *not* cached -- their AST output carries
@@ -128,16 +145,22 @@ def test_editing_one_statement_keeps_others_cache_hits() -> None:
     assert _misses() == 1
 
 
-def test_editing_a_statement_in_the_middle_invalidates_downstream() -> None:
-    """Editing a statement in the middle invalidates it AND every
-    statement after it (the chain hash has changed for them)."""
+def test_editing_a_middle_statement_leaves_unrelated_downstream_hits() -> None:
+    """Step 14 acceptance, negative direction: editing a middle
+    statement that nobody references leaves later, unrelated
+    statements as cache hits.
+
+    Under the old chain-hash invalidation, t3 would also miss --
+    even though it doesn't use t2 -- because the running chain hash
+    shifted.  Under Step 14's deps-fingerprint, t3 doesn't reference
+    t2's name, so its dependency set is empty and its cache entry
+    survives the edit."""
     check("test.pf", _THREE_THEOREMS)
 
     # Edit the *second* theorem.  Replace the proof body with an
-    # intermediate ``have'' step -- AST changes structurally, the
-    # proof still passes.  The first theorem is unchanged; the
-    # third's `chain` hash now differs from the cached entry, so
-    # it has to recheck too.
+    # intermediate ``have`` step -- AST changes structurally but
+    # the proof still passes.  t1 (before t2) and t3 (after t2 but
+    # not referencing it) should both stay cached.
     edited = _THREE_THEOREMS.replace(
         "theorem t2: true = true\n"
         "proof\n"
@@ -154,10 +177,112 @@ def test_editing_a_statement_in_the_middle_invalidates_downstream() -> None:
     proof_checker._cache_stats["misses"].clear()
     diags = check("test.pf", edited)
     assert diags == []
-    # Only t1 is upstream of the edit -> one hit.  t2 was edited,
-    # t3's chain shifted -> two misses.
-    assert _hits() == 1
+    # t1 unchanged, no deps -> hit.  t2 edited -> miss.  t3
+    # unchanged and doesn't reference t2 -> hit.
+    assert _hits() == 2, (
+        f"expected 2 hits (t1 + t3 unchanged, neither references t2), "
+        f"got {_hits()}; misses={_misses()}"
+    )
+    assert _misses() == 1
+
+
+_T1_USED_BY_T2 = (
+    "theorem t1: true\n"
+    "proof\n"
+    "  .\n"
+    "end\n"
+    "\n"
+    "theorem t2: true and true\n"
+    "proof\n"
+    "  t1, t1\n"
+    "end\n"
+)
+
+
+def test_editing_T1_invalidates_T2_that_uses_it() -> None:
+    """Step 14 acceptance (verbatim from ``docs/lsp-plan.md``):
+    ``edit theorem T1; assert T2 (which uses T1) is invalidated
+    and rechecked``.
+
+    t2 references t1 in its proof body (``t1, t1``).  Editing t1
+    -- even just the proof body -- changes t1's stmt_hash, which
+    in turn shifts t2's deps_fingerprint, so t2's cache entry is
+    invalidated."""
+    check("test.pf", _T1_USED_BY_T2)
+
+    # Edit t1's proof body. Its statement type/conclusion is
+    # unchanged so t2 still type-checks; what changes is t1's
+    # post-uniquify structural hash, which is in t2's
+    # deps_fingerprint.
+    edited = _T1_USED_BY_T2.replace(
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n",
+        "theorem t1: true\n"
+        "proof\n"
+        "  have h: true by .\n"
+        "  h\n"
+        "end\n",
+    )
+
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", edited)
+    assert diags == []
+    # t1 was edited -> miss.  t2 references t1, so t1's new
+    # stmt_hash changes t2's deps_fingerprint -> miss.
+    assert _hits() == 0, (
+        f"expected 0 hits -- t1 edited and t2 depends on t1; "
+        f"got hits={_hits()}, misses={_misses()}"
+    )
     assert _misses() == 2
+
+
+def test_editing_T1_leaves_unrelated_T2_a_hit() -> None:
+    """The complement of the above: if T2 does *not* reference T1,
+    editing T1 leaves T2's verdict in the cache.  Pins the
+    direction-specificity of Step 14 so a regression that conflates
+    "any prior statement changed" with "a *referenced* prior
+    statement changed" shows up here.
+
+    Two-theorem fixture so the only possible source of T2's
+    invalidation is dependency tracking on T1's hash."""
+    src = (
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem t2: true = true\n"
+        "proof\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    check("test.pf", src)
+
+    edited = src.replace(
+        "theorem t1: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n",
+        "theorem t1: true\n"
+        "proof\n"
+        "  have h: true by .\n"
+        "  h\n"
+        "end\n",
+    )
+
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+    diags = check("test.pf", edited)
+    assert diags == []
+    # t1 edited -> miss.  t2 doesn't reference t1 -> hit.
+    assert _hits() == 1, (
+        f"expected 1 hit -- t2 doesn't reference t1; "
+        f"got hits={_hits()}, misses={_misses()}"
+    )
+    assert _misses() == 1
 
 
 def test_comment_only_edit_in_unchanged_proof_still_hits() -> None:

--- a/test/lsp/test_uniquify_determinism.py
+++ b/test/lsp/test_uniquify_determinism.py
@@ -58,13 +58,28 @@ def _collect_unique_names(ast) -> list:
     out: list = []
 
     def looks_uniquified(s) -> bool:
-        # uniquified names contain a literal `.` followed by digits.
+        # uniquified names contain a literal `.` followed by either a
+        # plain digit run (legacy global-counter form) or one or more
+        # ``s<idx>_<n>`` segments (per-statement scoping, Step 14).
         if not isinstance(s, str):
             return False
         if "." not in s:
             return False
         suffix = s.rsplit(".", 1)[1]
-        return suffix.isdigit()
+        if suffix.isdigit():
+            return True
+        # Per-statement scoped form: zero or more ``s<idx>_`` prefixes
+        # followed by a trailing decimal run.
+        rest = suffix
+        while True:
+            if not rest.startswith("s"):
+                break
+            tail = rest[1:]
+            digits, sep, after = tail.partition("_")
+            if not sep or not digits.isdigit():
+                return False
+            rest = after
+        return rest.isdigit()
 
     def visit(node, seen):
         if id(node) in seen:
@@ -149,48 +164,75 @@ def test_uniquify_deduce_byte_equal_for_proof_with_holes() -> None:
 
 
 def test_uniquify_context_starts_at_zero() -> None:
-    """A freshly-constructed ``UniquifyContext`` has counter 0 --
-    pinning the contract that future per-module / per-statement
-    scoping (Step 13/14) will rely on."""
+    """A freshly-constructed ``UniquifyContext`` has counter 0 and
+    empty scope -- pinning the contract that per-statement scoping
+    (Step 14) builds on."""
     ctx = UniquifyContext()
     assert ctx.name_id == 0
+    assert ctx.scope == ""
 
 
-def test_shared_ctx_accumulates_ids_across_calls() -> None:
-    """Passing the *same* ctx to two ``uniquify_deduce`` calls
-    advances the counter monotonically -- this is what the LSP
-    pipeline relies on so prelude and user-file names never
-    collide.  After call 2, ``name_id`` is strictly greater than
-    after call 1."""
+def test_uniquify_deduce_restores_caller_state() -> None:
+    """Step 14: each top-level statement gets its own scope segment
+    and counter reset, and the call as a whole restores the caller's
+    ``name_id`` / ``scope`` on exit.  The counter no longer
+    accumulates across calls -- per-statement scope is what keeps
+    names from colliding instead."""
     src = "theorem t: true\nproof\n  .\nend\n"
     ctx = UniquifyContext()
     uniquify_deduce(_parse(src), ctx)
-    after_first = ctx.name_id
-    assert after_first > 0
+    assert ctx.name_id == 0
+    assert ctx.scope == ""
     uniquify_deduce(_parse(src), ctx)
-    after_second = ctx.name_id
-    assert after_second > after_first
+    assert ctx.name_id == 0
+    assert ctx.scope == ""
+
+
+def test_uniquify_deduce_uses_per_statement_scopes() -> None:
+    """Two top-level statements that share a base name (here, both
+    bind the proof variable ``pP``) get *disjoint* uniquified suffixes
+    because ``uniquify_deduce`` pushes a fresh ``s<idx>_`` segment onto
+    ``ctx.scope`` per top-level statement.  This is what makes
+    structural hashing edit-invariant -- the dependency-tracking cache
+    (Step 14) needs unrelated downstream statements' hashes to stay
+    stable when an earlier statement's body changes size."""
+    src = (
+        "theorem t1: all P:bool. if P then P\n"
+        "proof arbitrary P:bool suppose pP: P pP end\n"
+        "theorem t2: all P:bool. if P then P\n"
+        "proof arbitrary P:bool suppose pP: P pP end\n"
+    )
+    out = uniquify_deduce(_parse(src), UniquifyContext())
+    names = _collect_unique_names(out)
+    s0_names = [n for n in names if ".s0_" in n]
+    s1_names = [n for n in names if ".s1_" in n]
+    assert s0_names, f"no s0_-scoped names found in {names}"
+    assert s1_names, f"no s1_-scoped names found in {names}"
+    # Each top-level statement's bound names live in its own scope.
+    assert set(s0_names).isdisjoint(set(s1_names))
 
 
 def test_independent_ctxs_do_not_leak() -> None:
-    """Two contexts are independent allocators -- advancing one
-    leaves the other untouched."""
-    src = "theorem t: true\nproof\n  .\nend\n"
+    """Two contexts are independent objects -- mutating one doesn't
+    affect the other."""
     ctx_a = UniquifyContext()
     ctx_b = UniquifyContext()
-    uniquify_deduce(_parse(src), ctx_a)
-    assert ctx_a.name_id > 0
-    assert ctx_b.name_id == 0  # untouched
+    ctx_a.name_id = 99
+    ctx_a.scope = "x_"
+    assert ctx_b.name_id == 0
+    assert ctx_b.scope == ""
 
 
-def test_snapshot_forks_independent_counter() -> None:
-    """``UniquifyContext.snapshot`` returns a fresh ctx with the
-    same counter value, but advancing one doesn't affect the
-    other -- the LSP pipeline forks a per-user-file ctx from the
-    post-prelude baseline this way."""
-    parent = UniquifyContext(name_id=42)
+def test_snapshot_forks_independent_counter_and_scope() -> None:
+    """``UniquifyContext.snapshot`` returns a fresh ctx with the same
+    counter and scope, but mutating one doesn't affect the other."""
+    parent = UniquifyContext(name_id=42, scope="p_")
     child = parent.snapshot()
     assert child.name_id == 42
+    assert child.scope == "p_"
     child.name_id += 5
+    child.scope = "c_"
     assert parent.name_id == 42  # parent untouched
+    assert parent.scope == "p_"
     assert child.name_id == 47
+    assert child.scope == "c_"


### PR DESCRIPTION
## Summary
- Replaces Step 13's chain-hash invalidation with a per-statement dependency fingerprint, so editing one theorem only invalidates the cache entries for statements that actually reference it.
- Foundational fix in `uniquify_deduce`: each top-level statement now gets its own `s<N>_` scope segment with `name_id` reset to 0. Without this, an edit confined to statement *N* would drift the bound-name suffixes of every later statement and leave the dependency tracker no work to do.
- `UniquifyContext` grew a `scope: str` field; `snapshot()` copies both fields.

## Plan acceptance
> *Edit theorem T1; assert T2 (which uses T1) is invalidated and rechecked.*

Pinned in `test_editing_T1_invalidates_T2_that_uses_it` (positive). The negative direction lands in `test_editing_T1_leaves_unrelated_T2_a_hit` and `test_editing_a_middle_statement_leaves_unrelated_downstream_hits` -- editing T1 leaves an unrelated T2 as a cache hit.

## Implementation

* `_collect_referenced_names(stmt)` walks the post-uniquify AST and gathers every `VarRef`/`PVar` name.
* `_collect_defined_names(stmt)` returns the names a top-level statement introduces (its own name plus union constructors / predicate rules / synthesised `<pred>_rule_induction` lemmas).
* `check_deduce`'s third loop maintains a `defined_to_idx` map and replaces the chain hash with `deps_fingerprint = hash(tuple(stmt_hashes_so_far[j] for j in sorted(dep_indices)))`. Only the prior statements *this* one references contribute.
* `Import` and `Auto` are treated as global barriers -- every later statement implicitly depends on them, so editing or removing one invalidates the cache for everything after.
* `module_name` is folded into the cache key so two files in the same process can't cross-contaminate each other.

## Why the uniquify scope change

The plan-doc spec for Step 14 assumes you can identify dependents by name -- but the underlying machinery (the structural stmt hash) needs to be edit-invariant for unrelated stmts. Otherwise the dep fingerprint never even matters because the stmt_hash already changed.

Concretely: under Step 12, `ctx.name_id` was a single counter shared across all top-level statements within a `uniquify_deduce` call. Editing t2 to be longer (e.g. swapping `reflexive` for a `have`-step) advanced the counter further, so t3's bound names got higher suffixes -> t3's stmt_hash changed, even though t3 doesn't reference t2.

After this change each top-level statement gets its own scope segment (`s<N>_`) and a fresh local counter. Edit one statement, and only that statement's hash changes. The change is local to `uniquify_deduce` -- nested calls (from `Import.uniquify`) inherit the outer scope and append their own segment, so prelude vs user-file names stay disjoint.

## Test contract changes

The "shared ctx accumulates ids across calls" property from Step 12 is gone (per-statement scope is now what keeps names disjoint), so the determinism tests are reshaped:

* `test_uniquify_deduce_restores_caller_state` -- pins the new contract: `uniquify_deduce` restores `ctx.name_id` / `ctx.scope` on exit.
* `test_uniquify_deduce_uses_per_statement_scopes` -- pins that two top-level statements get disjoint suffix spaces.
* `test_snapshot_forks_independent_counter_and_scope` -- snapshot copies both fields and they fork cleanly.
* `_collect_unique_names`'s `looks_uniquified` recognises both the legacy `.<digits>` and the new `.s<idx>_<n>` suffix shapes.

## Known limitation (out of scope)

`proof_checker.name_id` -- the post-uniquify counter used during type-checking (predicate desugaring, derivation-tree construction, etc.) -- is still process-monotonic. For modules that exercise that counter, a different sequencing across calls can perturb stmt hashes and silently invalidate the cache. Simple theorems aren't affected. A follow-up can fold that counter into `UniquifyContext` or snapshot it via the LSP state machinery.

## Test plan

- [x] `python3 -m pytest test/lsp/` -- 670 passed (+12 from determinism + cache reshapes)
- [x] `python3 test-deduce.py --errors` -- exit 0
- [x] `python3 test-deduce.py --passable` -- exit 0
- [x] `python3 test-deduce.py --lib` -- exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)