### PR TITLE
Separate compilation Step 27: --compile-module mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ tests-compile:
 	$(PYTHON) ./test/compile/run_e2e.py
 	$(PYTHON) ./test/compile/run_determinism.py
 	$(PYTHON) ./test/compile/run_headers.py
+	$(PYTHON) ./test/compile/run_separate.py
 
 package:
 	$(PYTHON) ./deduce.py ./lib

--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -20,7 +20,7 @@ Pure rewriting; no I/O, no globals.
 
 from __future__ import annotations
 
-from typing import List, Set
+from typing import Dict, List, Set
 
 from compiler import ir
 
@@ -35,33 +35,47 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 top_names.add(c.name)
 
     # The `lifted` list collects new top-level Functions produced by
-    # hoisting lambdas. Generated names use `$lam<n>` so they cannot
-    # collide with Deduce's uniquified names (which never contain `$`).
+    # hoisting lambdas. Generated names embed the enclosing module so
+    # link-time symbols don't collide across compilation units —
+    # `<module>$lam<n>` is the source-IR name; emit_c mangles `$` to
+    # `__`. The counter is per-module so per-module compiles produce
+    # the same names as monolithic compiles for the same module.
     lifted: List[ir.Function] = []
-    counter = [0]
+    new_name_to_module: Dict[str, str] = dict(p.name_to_module)
+    counters: Dict[str, int] = {}
 
-    def fresh_lam_name() -> str:
-        counter[0] += 1
-        return f"$lam{counter[0]}"
+    def fresh_lam_name(module: "str | None") -> str:
+        key = module if module is not None else ""
+        counters[key] = counters.get(key, 0) + 1
+        n = counters[key]
+        if module is None:
+            return f"$lam{n}"
+        # Place `$` between module and `lam` so `_mangle` produces a
+        # readable `<module>__lam<n>` identifier without an awkward
+        # `____` collision between the module/`$` separators.
+        return f"{module}$lam{n}"
 
-    def go(t: ir.Term) -> ir.Term:
+    def go(t: ir.Term, enclosing_module: "str | None") -> ir.Term:
         match t:
             case ir.Var(_) | ir.Bool(_) | ir.Int(_):
                 return t
             case ir.Lam(params, body):
                 # Convert the body first so any nested Lam is hoisted
                 # and the body is now lambda-free.
-                new_body = go(body)
+                new_body = go(body, enclosing_module)
                 # Free vars of the original lambda; deterministic order
                 # (sorted) so the generated `captures` list and the
                 # corresponding `MkClosure` args are stable across runs.
                 fvs = sorted(ir.free_vars(t) - top_names)
-                fn_name = fresh_lam_name()
+                fn_name = fresh_lam_name(enclosing_module)
+                if enclosing_module is not None:
+                    new_name_to_module[fn_name] = enclosing_module
                 lifted.append(ir.Function(
                     name=fn_name,
                     params=list(params),
                     body=new_body,
                     captures=list(fvs),
+                    module=enclosing_module,
                 ))
                 return ir.MkClosure(
                     fn_name=fn_name,
@@ -71,26 +85,35 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 # Already converted; recurse into capture expressions
                 # in case some are themselves complex terms (current
                 # converter only puts Vars there, but be defensive).
-                return ir.MkClosure(fn, [go(c) for c in caps])
+                return ir.MkClosure(fn, [go(c, enclosing_module) for c in caps])
             case ir.App(rator, args):
-                return ir.App(go(rator), [go(a) for a in args])
+                return ir.App(go(rator, enclosing_module),
+                              [go(a, enclosing_module) for a in args])
             case ir.Let(name, rhs, body):
-                return ir.Let(name, go(rhs), go(body))
+                return ir.Let(name, go(rhs, enclosing_module),
+                              go(body, enclosing_module))
             case ir.If(c, th, el):
-                return ir.If(go(c), go(th), go(el))
+                return ir.If(go(c, enclosing_module),
+                             go(th, enclosing_module),
+                             go(el, enclosing_module))
             case ir.Con(ctor, args):
-                return ir.Con(ctor, [go(a) for a in args])
+                return ir.Con(ctor, [go(a, enclosing_module) for a in args])
             case ir.Match(subj, arms, loc):
-                new_arms = [ir.MatchArm(arm.pattern, go(arm.body)) for arm in arms]
-                return ir.Match(go(subj), new_arms, loc=loc)
+                new_arms = [
+                    ir.MatchArm(arm.pattern, go(arm.body, enclosing_module))
+                    for arm in arms
+                ]
+                return ir.Match(go(subj, enclosing_module), new_arms, loc=loc)
             case ir.Eq(l, r):
-                return ir.Eq(go(l), go(r))
+                return ir.Eq(go(l, enclosing_module),
+                             go(r, enclosing_module))
             case ir.Panic(_, _):
                 return t
             case ir.MakeArray(s, loc):
-                return ir.MakeArray(go(s), loc=loc)
+                return ir.MakeArray(go(s, enclosing_module), loc=loc)
             case ir.ArrayGet(s, i, loc):
-                return ir.ArrayGet(go(s), go(i), loc=loc)
+                return ir.ArrayGet(go(s, enclosing_module),
+                                   go(i, enclosing_module), loc=loc)
         raise AssertionError(f"closure_convert: unknown term {type(t).__name__}")
 
     new_decls: List[ir.TopLevel] = []
@@ -106,22 +129,32 @@ def closure_convert(p: ir.Program) -> ir.Program:
                     )
                 new_decls.append(ir.Function(
                     name=name, params=list(params),
-                    body=go(body), captures=[], loc=loc,
+                    body=go(body, module), captures=[], loc=loc,
                     module=module,
                 ))
             case ir.Global(name, body, module):
-                new_decls.append(ir.Global(name=name, body=go(body),
+                new_decls.append(ir.Global(name=name, body=go(body, module),
                                            module=module))
             case ir.Print(t):
-                new_decls.append(ir.Print(go(t)))
+                # Prints are top-level user-program code; their
+                # lambdas belong to the program's main module.
+                new_decls.append(ir.Print(go(t, p.main_module)))
             case ir.AssertEq(l, r):
-                new_decls.append(ir.AssertEq(go(l), go(r)))
+                new_decls.append(ir.AssertEq(go(l, p.main_module),
+                                             go(r, p.main_module)))
             case ir.AssertBool(t):
-                new_decls.append(ir.AssertBool(go(t)))
+                new_decls.append(ir.AssertBool(go(t, p.main_module)))
             case _:
                 raise AssertionError(
                     f"closure_convert: unknown top-level {type(d).__name__}"
                 )
 
-    return ir.Program(decls=new_decls + lifted,
-                      name_to_module=p.name_to_module)
+    return ir.Program(
+        decls=new_decls + lifted,
+        name_to_module=new_name_to_module,
+        main_module=p.main_module,
+        imports=p.imports,
+        import_funcs=p.import_funcs,
+        import_globals=p.import_globals,
+        import_ctors=p.import_ctors,
+    )

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -214,7 +214,191 @@ def emit_program(p: ir.Program) -> str:
     return "\n".join(out) + "\n"
 
 
-def emit_header(p: ir.Program, module_name: str) -> str:
+def _seed_ctx_with_imports(ctx: "EmitCtx", p: ir.Program,
+                           own_ctor_count: int) -> None:
+    """In per-module mode, register every imported decl in `ctx`
+    so reference sites in this module's code dispatch correctly.
+    Imported ctor IDs are assigned values past this module's
+    range — they're never emitted as `#define`s (the imported
+    `.h` does that), and emit_c only uses `ctor_id_macro` (a
+    string mangle) for them, but the dict-membership tests
+    elsewhere need an entry to be present."""
+    next_imp_id = own_ctor_count
+    for cname, carity in p.import_ctors.items():
+        ctx.ctor_ids[cname] = next_imp_id
+        ctx.ctor_arities[cname] = carity
+        next_imp_id += 1
+    for fname, arity in p.import_funcs.items():
+        ctx.top_funcs[fname] = arity
+    for gname in p.import_globals:
+        ctx.top_globals.add(gname)
+
+
+def emit_module(p: ir.Program, is_main: bool) -> "tuple[str, str]":
+    """Emit (c_source, h_source) for a single-module IR program.
+
+    Step 27 of `docs/separate-compile-plan.md`. The input program is
+    expected to have been lowered with `separate=True`: `p.decls`
+    contains only this module's declarations, `p.imports` lists the
+    direct imports, and `p.main_module` is the module name.
+
+    The `.c` file:
+    - `#include "deduce.h"` and the imported modules' headers.
+    - Defines this module's ctor singletons, functions, and globals.
+    - Defines `void <Module>_init(void)` — idempotent; calls each
+      direct import's `_init` (so the user only has to call the main
+      module's `_init`), then allocates the singletons and runs
+      global initialisers.
+    - If `is_main`, also defines `void deduce_program_main(void)`
+      that calls `<Module>_init()` and runs the prints in source
+      order.
+
+    The `.h` file is what `emit_header` produces, plus the module's
+    `_init` prototype so downstream consumers can call it (or
+    declare an extern dependency on it).
+    """
+    if p.main_module is None:
+        raise EmitError("emit_module: program has no main_module")
+
+    module = p.main_module
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
+    next_ctor_id = 0
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                ctx.ctor_ids[c.name] = next_ctor_id
+                ctx.ctor_arities[c.name] = c.arity
+                next_ctor_id += 1
+        elif isinstance(d, ir.Function):
+            ctx.top_funcs[d.name] = len(d.params)
+        elif isinstance(d, ir.Global):
+            ctx.top_globals.add(d.name)
+    own_ctor_count = next_ctor_id
+    _seed_ctx_with_imports(ctx, p, own_ctor_count)
+
+    # Imported modules' headers must be available before we use any
+    # of their functions, ctor IDs, or singletons. The corresponding
+    # `<import>_init` extern decls come from the same headers.
+    nullary_ctors = [
+        c.name for d in p.decls if isinstance(d, ir.UnionDecl)
+        for c in d.ctors if c.arity == 0
+    ]
+
+    # ----- the .c file -----
+    out: List[str] = []
+    out.append('#include "deduce.h"')
+    for imp in p.imports:
+        out.append(f'#include "{imp}.h"')
+    out.append("")
+
+    # Constructor id macros for THIS module's ctors only. Imported
+    # ctors' macros come from the corresponding `<import>.h` we
+    # already `#include`d above; redefining them here would conflict.
+    own_ctor_macros: List[str] = []
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                own_ctor_macros.append(
+                    f"#define {ctx.ctor_id_macro(c.name)} {ctx.ctor_ids[c.name]}"
+                )
+    if own_ctor_macros:
+        out.extend(own_ctor_macros)
+        out.append("")
+
+    # Forward declarations for this module's functions.
+    for d in p.decls:
+        if isinstance(d, ir.Function):
+            out.append(_emit_fn_decl(d, ctx) + ";")
+    if any(isinstance(d, ir.Function) for d in p.decls):
+        out.append("")
+
+    # Ctor singleton storage (definitions, not externs — the .h
+    # declares them extern; here we provide the storage).
+    for name in nullary_ctors:
+        out.append(f"deduce_value {ctx.ctor_singleton(name)};")
+    if nullary_ctors:
+        out.append("")
+
+    # Global storage.
+    for d in p.decls:
+        if isinstance(d, ir.Global):
+            out.append(f"deduce_value {ctx.global_id(d.name)};")
+    if any(isinstance(d, ir.Global) for d in p.decls):
+        out.append("")
+
+    # Function bodies.
+    for d in p.decls:
+        if isinstance(d, ir.Function):
+            out.append(_emit_function(d, ctx))
+            out.append("")
+
+    # Per-module init: idempotent (per-module flag), calls direct
+    # imports' inits first so any singletons / globals they own are
+    # ready before this module's globals try to reference them.
+    init_name = _module_init_name(module)
+    out.append(f"static int {init_name}__inited;")
+    out.append(f"void {init_name}(void) {{")
+    out.append(f"    if ({init_name}__inited) return;")
+    out.append(f"    {init_name}__inited = 1;")
+    for imp in p.imports:
+        out.append(f"    {_module_init_name(imp)}();")
+    for name in nullary_ctors:
+        out.append(
+            f"    {ctx.ctor_singleton(name)} = deduce_make_ctor("
+            f"{ctx.ctor_id_macro(name)}, {_c_string(_base_name(name))}, 0, NULL);"
+        )
+    for d in p.decls:
+        if isinstance(d, ir.Global):
+            stmts, expr = _emit_term(d.body, ctx, locals_in_scope=set())
+            for s in stmts:
+                out.append("    " + s)
+            out.append(f"    {ctx.global_id(d.name)} = {expr};")
+    out.append("}")
+    out.append("")
+
+    # Main-module entry point: calls our init, then runs prints.
+    if is_main:
+        out.append("void deduce_program_main(void) {")
+        out.append(f"    {init_name}();")
+        for d in p.decls:
+            if isinstance(d, ir.Print):
+                stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
+                for s in stmts:
+                    out.append("    " + s)
+                out.append(f"    deduce_println({expr});")
+            elif isinstance(d, ir.AssertEq):
+                sl, el = _emit_term(d.lhs, ctx, locals_in_scope=set())
+                sr, er = _emit_term(d.rhs, ctx, locals_in_scope=set())
+                for s in sl + sr:
+                    out.append("    " + s)
+                out.append(f"    deduce_assert_eq({el}, {er}, NULL);")
+            elif isinstance(d, ir.AssertBool):
+                stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
+                for s in stmts:
+                    out.append("    " + s)
+                out.append(f"    deduce_assert_bool({expr}, NULL);")
+        out.append("}")
+
+    c_source = "\n".join(out) + "\n"
+
+    # ----- the .h file -----
+    h_source = emit_header(p, module, init_name=init_name, imports=p.imports)
+
+    return c_source, h_source
+
+
+def _module_init_name(module: str) -> str:
+    """Mangle a module name to its `_init` function symbol."""
+    return _mangle(module) + "_init"
+
+
+def emit_header(
+    p: ir.Program,
+    module_name: str,
+    *,
+    init_name: "str | None" = None,
+    imports: "list[str] | None" = None,
+) -> str:
     """Generate the C header for a single module of an IR program.
 
     Declares (forward-decl / extern) every top-level decl whose
@@ -225,9 +409,14 @@ def emit_header(p: ir.Program, module_name: str) -> str:
     without redefinition errors.
 
     The constructor IDs match the IDs `emit_program` assigns for the
-    same `Program`, so a `.c` and its `.h` agree. Step 27 will use
-    this to wire up per-module compilation; Step 26 exposes it for
-    fixture-based testing of the header's shape.
+    same `Program`, so a `.c` and its `.h` agree.
+
+    `init_name` and `imports` are filled in by `emit_module`: when
+    the header is part of a per-module compile pair, it also
+    re-includes the imported modules' headers and prototypes the
+    module's `_init` function. In monolithic mode (Step 26's
+    fixture testing) these are None and the header is just static
+    declarations.
     """
     ctx = EmitCtx(name_to_module=dict(p.name_to_module))
     next_ctor_id = 0
@@ -250,8 +439,11 @@ def emit_header(p: ir.Program, module_name: str) -> str:
         f"#ifndef {guard}",
         f"#define {guard}",
         '#include "deduce.h"',
-        "",
     ]
+    if imports:
+        for imp in imports:
+            out.append(f'#include "{imp}.h"')
+    out.append("")
 
     # Constructor ID macros — one per ctor of any union in this module.
     macros: List[str] = []
@@ -296,6 +488,10 @@ def emit_header(p: ir.Program, module_name: str) -> str:
             )
     if global_externs:
         out.extend(global_externs)
+        out.append("")
+
+    if init_name is not None:
+        out.append(f"void {init_name}(void);")
         out.append("")
 
     out.append("#endif")

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -251,10 +251,32 @@ class Program:
     uniquified name (function/global/union/constructor) to its source
     module. emit_c consults it to mangle reference sites — calls,
     constructor applications, pattern matches — without needing to
-    chase parents. Synthesised names (closure-conversion `$lam<N>`)
-    are intentionally absent; emit_c handles them as module-less."""
+    chase parents.
+
+    `main_module` is the module name attached to user-file
+    statements that aren't inside any `Import.ast`. Used by closure
+    conversion to module-prefix lifted lambdas inside Print/Global
+    bodies, and by emit_c to know which module's `_init` to call
+    from `deduce_program_main`.
+
+    `imports` lists the directly-imported module names, in source
+    order with duplicates removed. Only populated in per-module
+    mode (Step 27 of `docs/separate-compile-plan.md`); empty in
+    monolithic mode.
+
+    `import_funcs` / `import_globals` / `import_ctors` describe
+    decls that live in imported modules. emit_c needs to know
+    these so calls and ctor applications dispatch correctly
+    (direct call vs. closure call, ctor IDs available via the
+    imported header). All three are empty in monolithic mode
+    (where the decls are flattened into `decls` directly)."""
     decls: List[TopLevel] = field(default_factory=list)
     name_to_module: Dict[str, str] = field(default_factory=dict)
+    main_module: "str | None" = None
+    imports: List[str] = field(default_factory=list)
+    import_funcs: Dict[str, int] = field(default_factory=dict)
+    import_globals: "set[str]" = field(default_factory=set)
+    import_ctors: Dict[str, int] = field(default_factory=dict)
 
 
 # ---------- pretty printer ----------

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -64,25 +64,35 @@ def _ast_loc(loc) -> "str | None":
 # --------------------------------------------------------------------------
 
 def lower_program(stmts: List[ast.Statement],
-                  main_module: str = "main") -> ir.Program:
-    """Entry point. Walks the top-level statement list, recursing into
-    each `Import.ast` so the imported module's declarations end up in
-    the same flat list. Each module is recursed into at most once
-    (matching how the interpreter populates `imported_modules`).
-    Then collects constructor names (so `Call(Var(ctor), ...)` can
-    become `Con` rather than `App`) and lowers each statement.
+                  main_module: str = "main",
+                  separate: bool = False) -> ir.Program:
+    """Entry point. Walks the top-level statement list, lowering each
+    statement to an IR node.
 
     `main_module` is the module name attached to user-file statements
     (those not inside any `Import.ast`). Used for symbol mangling in
     the C emitter — `<Module>__<base_name>` keeps two compilation
-    units' names from colliding at link time. Defaults to `"main"`
-    so callers that don't care (e.g. test harnesses) can ignore it.
+    units' names from colliding at link time.
 
-    Pruning (compiler/prune.py) downstream removes everything that
-    isn't transitively reached from the user's `print` statements;
-    this lets us inline the entire prelude without paying for the
-    parts the user doesn't touch."""
-    flat, name_to_module = _flatten_imports(stmts, main_module)
+    `separate` controls how imports are handled:
+
+    - `False` (default — monolithic mode): walks each `Import.ast`
+      recursively and splices the imported module's declarations
+      into the same flat list. Each module is recursed into at most
+      once (matching the interpreter's `imported_modules`). Pruning
+      downstream removes whatever isn't reached from a `print`.
+
+    - `True` (per-module mode, Step 27): imports are NOT inlined.
+      Only the user's own statements are lowered. The set of
+      directly-imported modules is collected on `Program.imports`
+      so the emitter can `#include` their headers and the runtime
+      can call their `_init` functions in the right order.
+      Pruning is skipped — cross-module reachability is the
+      linker's job (`-Wl,--gc-sections`)."""
+    (flat, name_to_module, imports,
+     import_funcs, import_globals, import_ctors) = _flatten_imports(
+        stmts, main_module, separate=separate,
+    )
 
     ctors: Set[str] = set()
     arities: Dict[str, int] = {}
@@ -91,6 +101,13 @@ def lower_program(stmts: List[ast.Statement],
             for c in s.alternatives:
                 ctors.add(c.name)
                 arities[c.name] = len(c.parameters)
+    # In per-module mode, lower_call still needs to identify
+    # imported ctors so `Call(Var(suc), args)` lowers to `Con(suc, args)`
+    # rather than a function call. The ctor's body isn't ours to emit;
+    # the macro and singleton come from the imported header.
+    for cname, carity in import_ctors.items():
+        ctors.add(cname)
+        arities[cname] = carity
 
     lc = LoweringCtx(ctors=ctors, ctor_arities=arities)
     out: List[ir.TopLevel] = []
@@ -101,27 +118,99 @@ def lower_program(stmts: List[ast.Statement],
                 out.extend(d)
             else:
                 out.append(d)
-    return ir.Program(decls=out, name_to_module=name_to_module)
+    return ir.Program(
+        decls=out,
+        name_to_module=name_to_module,
+        main_module=main_module,
+        imports=imports,
+        import_funcs=import_funcs,
+        import_globals=import_globals,
+        import_ctors=import_ctors,
+    )
 
 
 def _flatten_imports(
     stmts: List[ast.Statement],
     main_module: str,
-) -> "tuple[list[tuple[ast.Statement, str]], Dict[str, str]]":
-    """Walk `stmts`, splicing each `Import.ast` (the imported module's
-    post-typecheck statement list — see `process_declaration` in
-    proof_checker.py) in place of the import itself, while tracking
-    each statement's source module. Imports are deduplicated by
-    module name; only the first occurrence's nested statements are
-    emitted, matching `imported_modules` semantics in the interpreter.
+    separate: bool = False,
+):
+    """Walk `stmts` and produce a flat list of (statement, module).
 
-    Returns (statements paired with their module names,
-    name → module map covering every uniquified top-level name a
-    decl exposes — function/global/union/constructor names).
+    In monolithic mode (`separate=False`) splices each `Import.ast`
+    (the imported module's post-typecheck statement list — see
+    `process_declaration` in proof_checker.py) in place of the
+    import itself, deduplicating by module name. In per-module mode
+    (`separate=True`) records the direct imports' names and stops —
+    the imported modules are compiled separately.
+
+    Returns:
+      - statements paired with their module names,
+      - name → module map covering every uniquified top-level name
+        the lowered statements expose (function/global/union/
+        constructor),
+      - list of directly-imported module names, in source order
+        with duplicates removed (only meaningful in per-module
+        mode; empty in monolithic mode since there's no separate
+        compilation unit boundary to record).
     """
     seen: Set[str] = set()
     out: List[tuple[ast.Statement, str]] = []
     name_to_module: Dict[str, str] = {}
+    direct_imports: List[str] = []
+    import_funcs: Dict[str, int] = {}
+    import_globals: Set[str] = set()
+    import_ctors: Dict[str, int] = {}
+
+    def record_decl_module(s: ast.Statement, module: str) -> None:
+        if isinstance(s, ast.Define):
+            name_to_module[s.name] = module
+        elif isinstance(s, ast.RecFun):
+            name_to_module[s.name] = module
+        elif isinstance(s, ast.GenRecFun):
+            name_to_module[s.name] = module
+        elif isinstance(s, ast.Union):
+            name_to_module[s.name] = module
+            for c in s.alternatives:
+                name_to_module[c.name] = module
+
+    def record_imported_kind(s: ast.Statement) -> None:
+        """In per-module mode we additionally need the kind/arity of
+        every imported decl so emit_c can pick the right call shape
+        and look up ctor macros via the imported `.h`."""
+        if isinstance(s, ast.Define):
+            unwrapped = s.body
+            if isinstance(unwrapped, ast.Generic):
+                unwrapped = unwrapped.body
+            if isinstance(unwrapped, ast.Lambda):
+                import_funcs[s.name] = len(unwrapped.vars)
+            else:
+                import_globals.add(s.name)
+        elif isinstance(s, ast.RecFun):
+            import_funcs[s.name] = len(s.params)
+        elif isinstance(s, ast.GenRecFun):
+            import_funcs[s.name] = len(s.vars)
+        elif isinstance(s, ast.Union):
+            for c in s.alternatives:
+                import_ctors[c.name] = len(c.parameters)
+
+    def register_imported(items: List[ast.Statement], current_module: str) -> None:
+        """Walk an imported module's AST recording each top-level
+        decl's name → module mapping plus its kind/arity. We don't
+        emit anything for these statements — that happens in their
+        own per-module compile — but we DO need both maps so
+        references from the importing module's code mangle the
+        same way as the definitions in the imported module's `.c`
+        and dispatch through the right call shape."""
+        for s in items:
+            if isinstance(s, ast.Import):
+                if s.name in seen:
+                    continue
+                seen.add(s.name)
+                if s.ast is not None:
+                    register_imported(s.ast, s.name)
+            else:
+                record_decl_module(s, current_module)
+                record_imported_kind(s)
 
     def walk(items: List[ast.Statement], current_module: str) -> None:
         for s in items:
@@ -129,23 +218,31 @@ def _flatten_imports(
                 if s.name in seen:
                     continue
                 seen.add(s.name)
+                if separate and current_module == main_module:
+                    # Direct import: record so emit_c emits the
+                    # right `#include` and the right module-init
+                    # call, then recurse just to populate
+                    # name_to_module so references mangle correctly.
+                    direct_imports.append(s.name)
+                    if s.ast is not None:
+                        register_imported(s.ast, s.name)
+                    continue
+                if separate:
+                    # Indirect import inside an already-handled
+                    # module: don't recurse — it's the imported
+                    # module's build-system dependency, not ours.
+                    continue
                 if s.ast is not None:
                     walk(s.ast, s.name)
             else:
                 out.append((s, current_module))
-                if isinstance(s, ast.Define):
-                    name_to_module[s.name] = current_module
-                elif isinstance(s, ast.RecFun):
-                    name_to_module[s.name] = current_module
-                elif isinstance(s, ast.GenRecFun):
-                    name_to_module[s.name] = current_module
-                elif isinstance(s, ast.Union):
-                    name_to_module[s.name] = current_module
-                    for c in s.alternatives:
-                        name_to_module[c.name] = current_module
+                record_decl_module(s, current_module)
 
     walk(stmts, main_module)
-    return out, name_to_module
+    return (
+        out, name_to_module, direct_imports,
+        import_funcs, import_globals, import_ctors,
+    )
 
 
 class LoweringCtx:

--- a/compiler/prune.py
+++ b/compiler/prune.py
@@ -82,7 +82,15 @@ def prune(p: ir.Program) -> ir.Program:
             # the roots themselves (and asserts are normally dropped in
             # lowering, so they shouldn't be here anyway).
             new_decls.append(d)
-    return ir.Program(decls=new_decls, name_to_module=p.name_to_module)
+    return ir.Program(
+        decls=new_decls,
+        name_to_module=p.name_to_module,
+        main_module=p.main_module,
+        imports=p.imports,
+        import_funcs=p.import_funcs,
+        import_globals=p.import_globals,
+        import_ctors=p.import_ctors,
+    )
 
 
 def _referenced(t: ir.Term) -> Set[str]:

--- a/deduce.py
+++ b/deduce.py
@@ -37,18 +37,27 @@ def deduce_file(filename, error_expected, tracing_functions, prelude: list[str] 
             exit(1)
 
 def compile_file(filename: str, output: str, prelude: list[str],
-                 no_prune: bool = False) -> None:
-    """Compile a checked .pf file to a single .c source file.
+                 no_prune: bool = False,
+                 separate: bool = False,
+                 is_main: bool = True) -> None:
+    """Compile a checked .pf file.
 
-    Pipeline: parse + uniquify + type-check via the existing front-end,
-    then lower → closure-convert → (prune) → emit_c. The runtime in
-    compiler/runtime/ supplies the matching deduce.h / deduce.c that
-    callers must compile alongside the generated source.
-
-    Pruning drops definitions not transitively reached from a `print`
-    statement. Pass `no_prune=True` to keep every lowered decl in the
-    output — useful when debugging an emitter issue on code the
+    In monolithic mode (`separate=False`, the default): inlines every
+    transitively-imported module's declarations, prunes everything
+    not reached from a `print`, and emits a single self-contained
+    `.c` file. Pass `no_prune=True` to keep every lowered decl in
+    the output — useful when debugging an emitter issue on code the
     pruner would normally have removed.
+
+    In per-module mode (`separate=True`, Step 27 of
+    `docs/separate-compile-plan.md`): treats `filename` as one
+    compilation unit. Imports are NOT inlined; the emitted `.c`
+    includes the headers of its directly-imported modules, and the
+    linker resolves cross-module symbols. Both `.c` and `.h` are
+    written; pruning is skipped (the C linker handles dead-code
+    elimination via `-Wl,--gc-sections`). `is_main=True` (default)
+    means the module emits `deduce_program_main`; pass `False` for
+    library modules with no `print` statements of their own.
     """
     from compiler import closure as _closure, emit_c, ir, lower
     from compiler import prune as _prune
@@ -60,10 +69,23 @@ def compile_file(filename: str, output: str, prelude: list[str],
             print(result.error_traceback)
         exit(1)
     main_module = Path(filename).stem
-    program = lower.lower_program(result.ast, main_module=main_module)
+    program = lower.lower_program(
+        result.ast, main_module=main_module, separate=separate,
+    )
     ir.verify(program)
     program = _closure.closure_convert(program)
     ir.verify(program)
+    if separate:
+        c_src, h_src = emit_c.emit_module(program, is_main=is_main)
+        if output == "-":
+            sys.stdout.write(c_src)
+        else:
+            with open(output, "w", encoding="utf-8") as f:
+                f.write(c_src)
+            h_out = Path(output).with_suffix(".h")
+            with open(h_out, "w", encoding="utf-8") as f:
+                f.write(h_src)
+        return
     if not no_prune:
         program = _prune.prune(program)
         ir.verify(program)
@@ -113,6 +135,8 @@ if __name__ == "__main__":
     compile_target = None
     compile_output = None
     no_prune = False
+    separate_compile = False
+    is_main_module = True
     init_import_directories()
 
     # TODO: Cleanup 
@@ -163,6 +187,11 @@ if __name__ == "__main__":
             set_check_imports(False)
         elif argument == '--compile':
             compile_target = '__pending__'
+        elif argument == '--compile-module':
+            compile_target = '__pending__'
+            separate_compile = True
+        elif argument == '--no-main':
+            is_main_module = False
         elif argument == '-o' and i + 1 < len(sys.argv):
             compile_output = sys.argv[i + 1]
             already_processed_next = True
@@ -210,7 +239,12 @@ if __name__ == "__main__":
                 exit(1)
             out = compile_output if compile_output is not None \
                 else os.path.splitext(deducable)[0] + ".c"
-            compile_file(deducable, out, deducable_prelude, no_prune=no_prune)
+            compile_file(
+                deducable, out, deducable_prelude,
+                no_prune=no_prune,
+                separate=separate_compile,
+                is_main=is_main_module,
+            )
         elif os.path.isfile(deducable):
             deduce_file(deducable, error_expected, tracing_functions, deducable_prelude)
         elif os.path.isdir(deducable):

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,5 +1,5 @@
 union MyNat.0 {zero.1/0, suc.2/1}
 fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[$lam1](x.7)
+fn adder.9(x.7) = closure[closure$lam1](x.7)
 print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn $lam1[x.7](y.8) = add.3(x.7, y.8)
+fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)

--- a/test/compile/lower/closure.h
+++ b/test/compile/lower/closure.h
@@ -10,6 +10,7 @@ extern deduce_value C_closure__zero_1;
 
 deduce_value F_closure__add_3(deduce_value* env, deduce_value* args);
 deduce_value F_closure__adder_9(deduce_value* env, deduce_value* args);
+deduce_value F_closure__closure__lam1(deduce_value* env, deduce_value* args);
 
 #endif
 

--- a/test/compile/lower/closure.pir
+++ b/test/compile/lower/closure.pir
@@ -1,5 +1,5 @@
 union MyNat.0 {zero.1/0, suc.2/1}
 fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[$lam1](x.7)
+fn adder.9(x.7) = closure[closure$lam1](x.7)
 print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn $lam1[x.7](y.8) = add.3(x.7, y.8)
+fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)

--- a/test/compile/run_separate.py
+++ b/test/compile/run_separate.py
@@ -1,0 +1,150 @@
+"""End-to-end test for `--compile-module` (per-module compilation).
+
+Step 27 of `docs/separate-compile-plan.md` — the integration check.
+For each scenario in `test/compile/separate/`, compile every `.pf`
+to its own `.c`+`.h`, link them all together with `cc`, run the
+binary, and diff stdout against what the interpreter produces for
+the program's entry-point file.
+
+Each scenario lives in a directory with at least an `app.pf`
+(the main module — has the `print` statements). Other `.pf`
+files in the directory are compiled as library modules
+(`--no-main`).
+
+Run from the repo root:
+    python3 test/compile/run_separate.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCENARIOS_DIR = ROOT / "test" / "compile" / "separate"
+RUNTIME_DIR = ROOT / "compiler" / "runtime"
+
+
+def find_cc() -> "str | None":
+    return shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+
+
+def run_interpreter(scenario: Path, app_pf: Path) -> str:
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "deduce.py"),
+         "--no-stdlib", "--dir", str(scenario),
+         "--suppress-theorems", "--quiet", str(app_pf)],
+        cwd=str(ROOT), capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"interpreter failed on {app_pf.name}:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    lines = proc.stdout.splitlines()
+    if lines and lines[-1].endswith("is valid"):
+        lines = lines[:-1]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def run_compiled(scenario: Path, cc: str, build_dir: Path) -> str:
+    """Compile every .pf in the scenario directory separately, link
+    the resulting .c files together, run, return stdout."""
+    pfs = sorted(scenario.glob("*.pf"))
+    app_pf = scenario / "app.pf"
+    if not app_pf.exists():
+        raise RuntimeError(f"{scenario}: no app.pf")
+
+    # Stage .pf files into the build dir so the compiler's
+    # `--dir <build_dir>` finds the imports next to the file
+    # being compiled.
+    for pf in pfs:
+        shutil.copy(pf, build_dir / pf.name)
+
+    for pf in pfs:
+        is_app = pf.name == "app.pf"
+        cmd = [
+            sys.executable, str(ROOT / "deduce.py"),
+            "--compile-module",
+            "--no-stdlib",
+            "--dir", str(build_dir),
+            "--suppress-theorems", "--quiet",
+            "-o", str(build_dir / (pf.stem + ".c")),
+            str(build_dir / pf.name),
+        ]
+        if not is_app:
+            cmd.insert(3, "--no-main")
+        subprocess.run(cmd, cwd=str(ROOT), check=True,
+                       capture_output=True, text=True)
+
+    # Link
+    bin_path = build_dir / "app"
+    sources = [str(build_dir / (pf.stem + ".c")) for pf in pfs]
+    cmd = [cc, "-Wall", "-Wextra", "-Werror",
+           "-I", str(build_dir), "-I", str(RUNTIME_DIR),
+           "-o", str(bin_path),
+           *sources, str(RUNTIME_DIR / "deduce.c")]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+    proc = subprocess.run(
+        [str(bin_path)], capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{scenario.name}: compiled binary exit {proc.returncode}:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return proc.stdout
+
+
+def main() -> int:
+    cc = find_cc()
+    if cc is None:
+        print("SKIP: no C compiler (cc/clang/gcc) on PATH", file=sys.stderr)
+        return 0
+
+    if not SCENARIOS_DIR.exists():
+        print(f"no scenarios at {SCENARIOS_DIR}", file=sys.stderr)
+        return 1
+
+    scenarios = [d for d in sorted(SCENARIOS_DIR.iterdir()) if d.is_dir()]
+    # If there's no subdir but there is an `app.pf` in the top dir,
+    # treat it as a single inline scenario.
+    if not scenarios and (SCENARIOS_DIR / "app.pf").exists():
+        scenarios = [SCENARIOS_DIR]
+
+    failures: list[str] = []
+    tmp = Path(tempfile.mkdtemp(prefix="deduce-separate-"))
+    for scenario in scenarios:
+        build_dir = tmp / scenario.name
+        build_dir.mkdir()
+        try:
+            interp_out = run_interpreter(scenario, scenario / "app.pf")
+            compiled_out = run_compiled(scenario, cc, build_dir)
+        except Exception as e:
+            failures.append(f"{scenario.name}: {e}")
+            continue
+        if interp_out != compiled_out:
+            failures.append(
+                f"{scenario.name}: stdout mismatch\n"
+                f"--- interpreter ({len(interp_out)} bytes)\n{interp_out}"
+                f"--- compiled ({len(compiled_out)} bytes)\n{compiled_out}"
+            )
+            continue
+        print(f"ok {scenario.name}")
+
+    if failures:
+        print(f"\nFAILURES (workdir kept at {tmp}):")
+        for msg in failures:
+            print(msg)
+        return 1
+    shutil.rmtree(tmp, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/compile/separate/two_file/app.pf
+++ b/test/compile/separate/two_file/app.pf
@@ -1,0 +1,3 @@
+import lib
+
+print add(suc(zero), suc(suc(zero)))

--- a/test/compile/separate/two_file/lib.pf
+++ b/test/compile/separate/two_file/lib.pf
@@ -1,0 +1,11 @@
+module lib
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+recursive add(MyNat, MyNat) -> MyNat {
+  add(zero, m) = m
+  add(suc(n), m) = suc(add(n, m))
+}


### PR DESCRIPTION
## Summary

Step 27 of [`docs/separate-compile-plan.md`](docs/separate-compile-plan.md). The integration milestone — separate compilation actually works end-to-end. With `--compile-module`, each `.pf` compiles to its own `.c`+`.h` pair, and `cc` links them together.

**Stacks on [#363](https://github.com/jsiek/deduce/pull/363)** (Step 26).

The acceptance test:

```sh
$ python3 deduce.py --compile-module --no-main --no-stdlib --dir lib lib.pf
$ python3 deduce.py --compile-module --no-stdlib --dir lib app.pf
$ cc -I . -I compiler/runtime app.c lib.c compiler/runtime/deduce.c -o app
$ ./app
suc(suc(suc(zero)))
```

— `app.pf` and `lib.pf` see each other only through `lib.h`; their `.c`s never share an AST.

## What's in the diff

- **`lower.lower_program(stmts, main_module, separate=True)`** — imports are NOT flattened. Direct imports go on `Program.imports`; their decls are walked just enough to record `name_to_module` and kind/arity (`import_funcs` / `import_globals` / `import_ctors`) so emit_c can dispatch reference sites correctly without seeing the bodies.

- **`closure.closure_convert`** — per-module lambda counter. Lifted lambdas are now named `<module>$lam<n>` and tagged with their enclosing module, so two modules' lambdas don't collide at link time and per-module compiles produce the same names as monolithic compiles for the same module.

- **`emit_c.emit_module(program, is_main) -> (c, h)`** — new per-module emit. The `.c` `#include`s `"deduce.h"` plus each imported header, defines this module's ctor singletons / globals / functions, then emits a `<Module>_init()` that is idempotent (per-module `_inited` flag), calls each direct import's `_init` first, and finally allocates the singletons and runs global initialisers. When `is_main`, also defines `deduce_program_main()` which calls `<Module>_init()` and then the prints. Pruning is skipped — `-Wl,--gc-sections` handles cross-module dead-code elimination.

- **`emit_c.emit_header`** learns about the module's `_init` prototype and re-includes the imported `.h`s when called from `emit_module`, so a downstream consumer who `#include`s `lib.h` gets everything they need.

- **New CLI flags on `deduce.py`:**
  - `--compile-module` — per-module compile (writes both `.c` and `.h` next to each other).
  - `--no-main` — this module is a library; don't emit `deduce_program_main`.

- **New `test/compile/separate/two_file/` scenario:**
  - `lib.pf` defines a custom `MyNat` + `add`.
  - `app.pf` imports `lib` and prints `add(suc(zero), suc(suc(zero)))`.
  - `test/compile/run_separate.py` compiles each `.pf` separately, links with `cc`, runs, and diffs against the interpreter. Wired into `make tests-compile`.

## Test plan

- [x] `make tests-compile` — **78 ok lines** (was 77): adds 1 separate-compile scenario. The 24 lowering / 35 e2e / 9 determinism / 9 header checks are unchanged.
- [x] `make tests` — interpreter suite unchanged.
- [x] Manual: the two-file scenario compiles, links, and runs end-to-end producing the same output as the interpreter.

Closure-IR `.cir` fixture regenerated for the new module-prefixed lambda name (one-line diff: `$lam1` → `closure$lam1`).

## What's next

- **Step 28** is the formal init-orchestration polish. The mechanism here works (each module's `_init` calls direct imports' inits with a per-module guard, main calls only its own module's init), so Step 28 may end up being mostly documentation.
- **Step 29** is "prelude as a static archive" — pre-build `lib/*.pf` once into `libdeduce_prelude.a` so user programs link against it without re-emitting the stdlib every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
