### PR TITLE
Separate compilation Steps 27+28: --compile-module mode and diamond imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ profile.png
 
 # Emacs byte-compiled files
 *.elc
+
+# C compilation artifacts from the deduce-to-C compiler
+*.o
+*.a
+compiler/runtime/libdeduce_prelude.*
+compiler/runtime/include/

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ tests-compile:
 	$(PYTHON) ./test/compile/run_e2e.py
 	$(PYTHON) ./test/compile/run_determinism.py
 	$(PYTHON) ./test/compile/run_headers.py
+	$(PYTHON) ./test/compile/run_separate.py
 
 package:
 	$(PYTHON) ./deduce.py ./lib

--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -20,7 +20,7 @@ Pure rewriting; no I/O, no globals.
 
 from __future__ import annotations
 
-from typing import List, Set
+from typing import Dict, List, Set
 
 from compiler import ir
 
@@ -35,33 +35,47 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 top_names.add(c.name)
 
     # The `lifted` list collects new top-level Functions produced by
-    # hoisting lambdas. Generated names use `$lam<n>` so they cannot
-    # collide with Deduce's uniquified names (which never contain `$`).
+    # hoisting lambdas. Generated names embed the enclosing module so
+    # link-time symbols don't collide across compilation units —
+    # `<module>$lam<n>` is the source-IR name; emit_c mangles `$` to
+    # `__`. The counter is per-module so per-module compiles produce
+    # the same names as monolithic compiles for the same module.
     lifted: List[ir.Function] = []
-    counter = [0]
+    new_name_to_module: Dict[str, str] = dict(p.name_to_module)
+    counters: Dict[str, int] = {}
 
-    def fresh_lam_name() -> str:
-        counter[0] += 1
-        return f"$lam{counter[0]}"
+    def fresh_lam_name(module: "str | None") -> str:
+        key = module if module is not None else ""
+        counters[key] = counters.get(key, 0) + 1
+        n = counters[key]
+        if module is None:
+            return f"$lam{n}"
+        # Place `$` between module and `lam` so `_mangle` produces a
+        # readable `<module>__lam<n>` identifier without an awkward
+        # `____` collision between the module/`$` separators.
+        return f"{module}$lam{n}"
 
-    def go(t: ir.Term) -> ir.Term:
+    def go(t: ir.Term, enclosing_module: "str | None") -> ir.Term:
         match t:
             case ir.Var(_) | ir.Bool(_) | ir.Int(_):
                 return t
             case ir.Lam(params, body):
                 # Convert the body first so any nested Lam is hoisted
                 # and the body is now lambda-free.
-                new_body = go(body)
+                new_body = go(body, enclosing_module)
                 # Free vars of the original lambda; deterministic order
                 # (sorted) so the generated `captures` list and the
                 # corresponding `MkClosure` args are stable across runs.
                 fvs = sorted(ir.free_vars(t) - top_names)
-                fn_name = fresh_lam_name()
+                fn_name = fresh_lam_name(enclosing_module)
+                if enclosing_module is not None:
+                    new_name_to_module[fn_name] = enclosing_module
                 lifted.append(ir.Function(
                     name=fn_name,
                     params=list(params),
                     body=new_body,
                     captures=list(fvs),
+                    module=enclosing_module,
                 ))
                 return ir.MkClosure(
                     fn_name=fn_name,
@@ -71,26 +85,35 @@ def closure_convert(p: ir.Program) -> ir.Program:
                 # Already converted; recurse into capture expressions
                 # in case some are themselves complex terms (current
                 # converter only puts Vars there, but be defensive).
-                return ir.MkClosure(fn, [go(c) for c in caps])
+                return ir.MkClosure(fn, [go(c, enclosing_module) for c in caps])
             case ir.App(rator, args):
-                return ir.App(go(rator), [go(a) for a in args])
+                return ir.App(go(rator, enclosing_module),
+                              [go(a, enclosing_module) for a in args])
             case ir.Let(name, rhs, body):
-                return ir.Let(name, go(rhs), go(body))
+                return ir.Let(name, go(rhs, enclosing_module),
+                              go(body, enclosing_module))
             case ir.If(c, th, el):
-                return ir.If(go(c), go(th), go(el))
+                return ir.If(go(c, enclosing_module),
+                             go(th, enclosing_module),
+                             go(el, enclosing_module))
             case ir.Con(ctor, args):
-                return ir.Con(ctor, [go(a) for a in args])
+                return ir.Con(ctor, [go(a, enclosing_module) for a in args])
             case ir.Match(subj, arms, loc):
-                new_arms = [ir.MatchArm(arm.pattern, go(arm.body)) for arm in arms]
-                return ir.Match(go(subj), new_arms, loc=loc)
+                new_arms = [
+                    ir.MatchArm(arm.pattern, go(arm.body, enclosing_module))
+                    for arm in arms
+                ]
+                return ir.Match(go(subj, enclosing_module), new_arms, loc=loc)
             case ir.Eq(l, r):
-                return ir.Eq(go(l), go(r))
+                return ir.Eq(go(l, enclosing_module),
+                             go(r, enclosing_module))
             case ir.Panic(_, _):
                 return t
             case ir.MakeArray(s, loc):
-                return ir.MakeArray(go(s), loc=loc)
+                return ir.MakeArray(go(s, enclosing_module), loc=loc)
             case ir.ArrayGet(s, i, loc):
-                return ir.ArrayGet(go(s), go(i), loc=loc)
+                return ir.ArrayGet(go(s, enclosing_module),
+                                   go(i, enclosing_module), loc=loc)
         raise AssertionError(f"closure_convert: unknown term {type(t).__name__}")
 
     new_decls: List[ir.TopLevel] = []
@@ -106,22 +129,32 @@ def closure_convert(p: ir.Program) -> ir.Program:
                     )
                 new_decls.append(ir.Function(
                     name=name, params=list(params),
-                    body=go(body), captures=[], loc=loc,
+                    body=go(body, module), captures=[], loc=loc,
                     module=module,
                 ))
             case ir.Global(name, body, module):
-                new_decls.append(ir.Global(name=name, body=go(body),
+                new_decls.append(ir.Global(name=name, body=go(body, module),
                                            module=module))
             case ir.Print(t):
-                new_decls.append(ir.Print(go(t)))
+                # Prints are top-level user-program code; their
+                # lambdas belong to the program's main module.
+                new_decls.append(ir.Print(go(t, p.main_module)))
             case ir.AssertEq(l, r):
-                new_decls.append(ir.AssertEq(go(l), go(r)))
+                new_decls.append(ir.AssertEq(go(l, p.main_module),
+                                             go(r, p.main_module)))
             case ir.AssertBool(t):
-                new_decls.append(ir.AssertBool(go(t)))
+                new_decls.append(ir.AssertBool(go(t, p.main_module)))
             case _:
                 raise AssertionError(
                     f"closure_convert: unknown top-level {type(d).__name__}"
                 )
 
-    return ir.Program(decls=new_decls + lifted,
-                      name_to_module=p.name_to_module)
+    return ir.Program(
+        decls=new_decls + lifted,
+        name_to_module=new_name_to_module,
+        main_module=p.main_module,
+        imports=p.imports,
+        import_funcs=p.import_funcs,
+        import_globals=p.import_globals,
+        import_ctors=p.import_ctors,
+    )

--- a/compiler/closure.py
+++ b/compiler/closure.py
@@ -152,6 +152,7 @@ def closure_convert(p: ir.Program) -> ir.Program:
     return ir.Program(
         decls=new_decls + lifted,
         name_to_module=new_name_to_module,
+        name_to_seq=p.name_to_seq,
         main_module=p.main_module,
         imports=p.imports,
         import_funcs=p.import_funcs,

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -214,7 +214,191 @@ def emit_program(p: ir.Program) -> str:
     return "\n".join(out) + "\n"
 
 
-def emit_header(p: ir.Program, module_name: str) -> str:
+def _seed_ctx_with_imports(ctx: "EmitCtx", p: ir.Program,
+                           own_ctor_count: int) -> None:
+    """In per-module mode, register every imported decl in `ctx`
+    so reference sites in this module's code dispatch correctly.
+    Imported ctor IDs are assigned values past this module's
+    range — they're never emitted as `#define`s (the imported
+    `.h` does that), and emit_c only uses `ctor_id_macro` (a
+    string mangle) for them, but the dict-membership tests
+    elsewhere need an entry to be present."""
+    next_imp_id = own_ctor_count
+    for cname, carity in p.import_ctors.items():
+        ctx.ctor_ids[cname] = next_imp_id
+        ctx.ctor_arities[cname] = carity
+        next_imp_id += 1
+    for fname, arity in p.import_funcs.items():
+        ctx.top_funcs[fname] = arity
+    for gname in p.import_globals:
+        ctx.top_globals.add(gname)
+
+
+def emit_module(p: ir.Program, is_main: bool) -> "tuple[str, str]":
+    """Emit (c_source, h_source) for a single-module IR program.
+
+    Step 27 of `docs/separate-compile-plan.md`. The input program is
+    expected to have been lowered with `separate=True`: `p.decls`
+    contains only this module's declarations, `p.imports` lists the
+    direct imports, and `p.main_module` is the module name.
+
+    The `.c` file:
+    - `#include "deduce.h"` and the imported modules' headers.
+    - Defines this module's ctor singletons, functions, and globals.
+    - Defines `void <Module>_init(void)` — idempotent; calls each
+      direct import's `_init` (so the user only has to call the main
+      module's `_init`), then allocates the singletons and runs
+      global initialisers.
+    - If `is_main`, also defines `void deduce_program_main(void)`
+      that calls `<Module>_init()` and runs the prints in source
+      order.
+
+    The `.h` file is what `emit_header` produces, plus the module's
+    `_init` prototype so downstream consumers can call it (or
+    declare an extern dependency on it).
+    """
+    if p.main_module is None:
+        raise EmitError("emit_module: program has no main_module")
+
+    module = p.main_module
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
+    next_ctor_id = 0
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                ctx.ctor_ids[c.name] = next_ctor_id
+                ctx.ctor_arities[c.name] = c.arity
+                next_ctor_id += 1
+        elif isinstance(d, ir.Function):
+            ctx.top_funcs[d.name] = len(d.params)
+        elif isinstance(d, ir.Global):
+            ctx.top_globals.add(d.name)
+    own_ctor_count = next_ctor_id
+    _seed_ctx_with_imports(ctx, p, own_ctor_count)
+
+    # Imported modules' headers must be available before we use any
+    # of their functions, ctor IDs, or singletons. The corresponding
+    # `<import>_init` extern decls come from the same headers.
+    nullary_ctors = [
+        c.name for d in p.decls if isinstance(d, ir.UnionDecl)
+        for c in d.ctors if c.arity == 0
+    ]
+
+    # ----- the .c file -----
+    out: List[str] = []
+    out.append('#include "deduce.h"')
+    for imp in p.imports:
+        out.append(f'#include "{imp}.h"')
+    out.append("")
+
+    # Constructor id macros for THIS module's ctors only. Imported
+    # ctors' macros come from the corresponding `<import>.h` we
+    # already `#include`d above; redefining them here would conflict.
+    own_ctor_macros: List[str] = []
+    for d in p.decls:
+        if isinstance(d, ir.UnionDecl):
+            for c in d.ctors:
+                own_ctor_macros.append(
+                    f"#define {ctx.ctor_id_macro(c.name)} {ctx.ctor_ids[c.name]}"
+                )
+    if own_ctor_macros:
+        out.extend(own_ctor_macros)
+        out.append("")
+
+    # Forward declarations for this module's functions.
+    for d in p.decls:
+        if isinstance(d, ir.Function):
+            out.append(_emit_fn_decl(d, ctx) + ";")
+    if any(isinstance(d, ir.Function) for d in p.decls):
+        out.append("")
+
+    # Ctor singleton storage (definitions, not externs — the .h
+    # declares them extern; here we provide the storage).
+    for name in nullary_ctors:
+        out.append(f"deduce_value {ctx.ctor_singleton(name)};")
+    if nullary_ctors:
+        out.append("")
+
+    # Global storage.
+    for d in p.decls:
+        if isinstance(d, ir.Global):
+            out.append(f"deduce_value {ctx.global_id(d.name)};")
+    if any(isinstance(d, ir.Global) for d in p.decls):
+        out.append("")
+
+    # Function bodies.
+    for d in p.decls:
+        if isinstance(d, ir.Function):
+            out.append(_emit_function(d, ctx))
+            out.append("")
+
+    # Per-module init: idempotent (per-module flag), calls direct
+    # imports' inits first so any singletons / globals they own are
+    # ready before this module's globals try to reference them.
+    init_name = _module_init_name(module)
+    out.append(f"static int {init_name}__inited;")
+    out.append(f"void {init_name}(void) {{")
+    out.append(f"    if ({init_name}__inited) return;")
+    out.append(f"    {init_name}__inited = 1;")
+    for imp in p.imports:
+        out.append(f"    {_module_init_name(imp)}();")
+    for name in nullary_ctors:
+        out.append(
+            f"    {ctx.ctor_singleton(name)} = deduce_make_ctor("
+            f"{ctx.ctor_id_macro(name)}, {_c_string(_base_name(name))}, 0, NULL);"
+        )
+    for d in p.decls:
+        if isinstance(d, ir.Global):
+            stmts, expr = _emit_term(d.body, ctx, locals_in_scope=set())
+            for s in stmts:
+                out.append("    " + s)
+            out.append(f"    {ctx.global_id(d.name)} = {expr};")
+    out.append("}")
+    out.append("")
+
+    # Main-module entry point: calls our init, then runs prints.
+    if is_main:
+        out.append("void deduce_program_main(void) {")
+        out.append(f"    {init_name}();")
+        for d in p.decls:
+            if isinstance(d, ir.Print):
+                stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
+                for s in stmts:
+                    out.append("    " + s)
+                out.append(f"    deduce_println({expr});")
+            elif isinstance(d, ir.AssertEq):
+                sl, el = _emit_term(d.lhs, ctx, locals_in_scope=set())
+                sr, er = _emit_term(d.rhs, ctx, locals_in_scope=set())
+                for s in sl + sr:
+                    out.append("    " + s)
+                out.append(f"    deduce_assert_eq({el}, {er}, NULL);")
+            elif isinstance(d, ir.AssertBool):
+                stmts, expr = _emit_term(d.term, ctx, locals_in_scope=set())
+                for s in stmts:
+                    out.append("    " + s)
+                out.append(f"    deduce_assert_bool({expr}, NULL);")
+        out.append("}")
+
+    c_source = "\n".join(out) + "\n"
+
+    # ----- the .h file -----
+    h_source = emit_header(p, module, init_name=init_name, imports=p.imports)
+
+    return c_source, h_source
+
+
+def _module_init_name(module: str) -> str:
+    """Mangle a module name to its `_init` function symbol."""
+    return _mangle(module) + "_init"
+
+
+def emit_header(
+    p: ir.Program,
+    module_name: str,
+    *,
+    init_name: "str | None" = None,
+    imports: "list[str] | None" = None,
+) -> str:
     """Generate the C header for a single module of an IR program.
 
     Declares (forward-decl / extern) every top-level decl whose
@@ -225,9 +409,14 @@ def emit_header(p: ir.Program, module_name: str) -> str:
     without redefinition errors.
 
     The constructor IDs match the IDs `emit_program` assigns for the
-    same `Program`, so a `.c` and its `.h` agree. Step 27 will use
-    this to wire up per-module compilation; Step 26 exposes it for
-    fixture-based testing of the header's shape.
+    same `Program`, so a `.c` and its `.h` agree.
+
+    `init_name` and `imports` are filled in by `emit_module`: when
+    the header is part of a per-module compile pair, it also
+    re-includes the imported modules' headers and prototypes the
+    module's `_init` function. In monolithic mode (Step 26's
+    fixture testing) these are None and the header is just static
+    declarations.
     """
     ctx = EmitCtx(name_to_module=dict(p.name_to_module))
     next_ctor_id = 0
@@ -250,8 +439,11 @@ def emit_header(p: ir.Program, module_name: str) -> str:
         f"#ifndef {guard}",
         f"#define {guard}",
         '#include "deduce.h"',
-        "",
     ]
+    if imports:
+        for imp in imports:
+            out.append(f'#include "{imp}.h"')
+    out.append("")
 
     # Constructor ID macros — one per ctor of any union in this module.
     macros: List[str] = []
@@ -296,6 +488,10 @@ def emit_header(p: ir.Program, module_name: str) -> str:
             )
     if global_externs:
         out.extend(global_externs)
+        out.append("")
+
+    if init_name is not None:
+        out.append(f"void {init_name}(void);")
         out.append("")
 
     out.append("#endif")

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -84,9 +84,14 @@ class EmitCtx:
     ctor_arities: Dict[str, int] = field(default_factory=dict)
     # Per-name source module for `<Module>__<base_name>` symbol
     # mangling (Step 25 of separate-compile-plan.md). Names absent
-    # from this map (closure-conversion `$lam<N>` lifts, etc.)
-    # mangle without a module prefix.
+    # from this map (closure-conversion `$lam<N>` lifts) mangle
+    # without a module prefix.
     name_to_module: Dict[str, str] = field(default_factory=dict)
+    # Per-module ordinal disambiguator. Used in place of the uniquify
+    # counter so a module's symbols are stable regardless of what
+    # other modules were processed in the same compile (Step 28 of
+    # separate-compile-plan.md).
+    name_to_seq: Dict[str, int] = field(default_factory=dict)
     tmp_counter: int = 0
 
     def fresh_tmp(self) -> str:
@@ -96,10 +101,18 @@ class EmitCtx:
 
     def _mangle_top(self, name: str) -> str:
         """Mangle a top-level name. If we know its source module,
-        prefix with `<Module>__`; otherwise mangle the uniquified name
-        directly."""
+        prefix with `<Module>__`. The within-module disambiguator is
+        the per-module ordinal from `name_to_seq` (stable across
+        compile contexts) when available; otherwise fall back to
+        mangling the uniquified name directly (covers closure-lifted
+        lambdas and any synthesised name that was never assigned an
+        ordinal during lowering)."""
         module = self.name_to_module.get(name)
-        if module:
+        seq = self.name_to_seq.get(name)
+        base = _mangle(_base_name(name))
+        if module is not None and seq is not None:
+            return _mangle(module) + "__" + base + f"_{seq}"
+        if module is not None:
             return _mangle(module) + "__" + _mangle(name)
         return _mangle(name)
 
@@ -119,7 +132,7 @@ class EmitCtx:
 
 
 def emit_program(p: ir.Program) -> str:
-    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module), name_to_seq=dict(p.name_to_seq))
     next_ctor_id = 0
     for d in p.decls:
         if isinstance(d, ir.UnionDecl):
@@ -261,7 +274,7 @@ def emit_module(p: ir.Program, is_main: bool) -> "tuple[str, str]":
         raise EmitError("emit_module: program has no main_module")
 
     module = p.main_module
-    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module), name_to_seq=dict(p.name_to_seq))
     next_ctor_id = 0
     for d in p.decls:
         if isinstance(d, ir.UnionDecl):
@@ -418,7 +431,7 @@ def emit_header(
     fixture testing) these are None and the header is just static
     declarations.
     """
-    ctx = EmitCtx(name_to_module=dict(p.name_to_module))
+    ctx = EmitCtx(name_to_module=dict(p.name_to_module), name_to_seq=dict(p.name_to_seq))
     next_ctor_id = 0
     for d in p.decls:
         if isinstance(d, ir.UnionDecl):

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -251,10 +251,32 @@ class Program:
     uniquified name (function/global/union/constructor) to its source
     module. emit_c consults it to mangle reference sites — calls,
     constructor applications, pattern matches — without needing to
-    chase parents. Synthesised names (closure-conversion `$lam<N>`)
-    are intentionally absent; emit_c handles them as module-less."""
+    chase parents.
+
+    `main_module` is the module name attached to user-file
+    statements that aren't inside any `Import.ast`. Used by closure
+    conversion to module-prefix lifted lambdas inside Print/Global
+    bodies, and by emit_c to know which module's `_init` to call
+    from `deduce_program_main`.
+
+    `imports` lists the directly-imported module names, in source
+    order with duplicates removed. Only populated in per-module
+    mode (Step 27 of `docs/separate-compile-plan.md`); empty in
+    monolithic mode.
+
+    `import_funcs` / `import_globals` / `import_ctors` describe
+    decls that live in imported modules. emit_c needs to know
+    these so calls and ctor applications dispatch correctly
+    (direct call vs. closure call, ctor IDs available via the
+    imported header). All three are empty in monolithic mode
+    (where the decls are flattened into `decls` directly)."""
     decls: List[TopLevel] = field(default_factory=list)
     name_to_module: Dict[str, str] = field(default_factory=dict)
+    main_module: "str | None" = None
+    imports: List[str] = field(default_factory=list)
+    import_funcs: Dict[str, int] = field(default_factory=dict)
+    import_globals: "set[str]" = field(default_factory=set)
+    import_ctors: Dict[str, int] = field(default_factory=dict)
 
 
 # ---------- pretty printer ----------

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -272,6 +272,15 @@ class Program:
     (where the decls are flattened into `decls` directly)."""
     decls: List[TopLevel] = field(default_factory=list)
     name_to_module: Dict[str, str] = field(default_factory=dict)
+    # Per-module ordinal of each top-level uniquified name (function /
+    # global / union / constructor). emit_c uses this as the
+    # within-module symbol disambiguator instead of the uniquify
+    # counter, because the uniquify counter shifts with the import
+    # set seen during one compile while the ordinal is computed by
+    # walking the module's AST in source order — stable regardless
+    # of whether the module was compiled standalone or pulled in via
+    # `Import.ast`.
+    name_to_seq: Dict[str, int] = field(default_factory=dict)
     main_module: "str | None" = None
     imports: List[str] = field(default_factory=list)
     import_funcs: Dict[str, int] = field(default_factory=dict)

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -64,25 +64,35 @@ def _ast_loc(loc) -> "str | None":
 # --------------------------------------------------------------------------
 
 def lower_program(stmts: List[ast.Statement],
-                  main_module: str = "main") -> ir.Program:
-    """Entry point. Walks the top-level statement list, recursing into
-    each `Import.ast` so the imported module's declarations end up in
-    the same flat list. Each module is recursed into at most once
-    (matching how the interpreter populates `imported_modules`).
-    Then collects constructor names (so `Call(Var(ctor), ...)` can
-    become `Con` rather than `App`) and lowers each statement.
+                  main_module: str = "main",
+                  separate: bool = False) -> ir.Program:
+    """Entry point. Walks the top-level statement list, lowering each
+    statement to an IR node.
 
     `main_module` is the module name attached to user-file statements
     (those not inside any `Import.ast`). Used for symbol mangling in
     the C emitter — `<Module>__<base_name>` keeps two compilation
-    units' names from colliding at link time. Defaults to `"main"`
-    so callers that don't care (e.g. test harnesses) can ignore it.
+    units' names from colliding at link time.
 
-    Pruning (compiler/prune.py) downstream removes everything that
-    isn't transitively reached from the user's `print` statements;
-    this lets us inline the entire prelude without paying for the
-    parts the user doesn't touch."""
-    flat, name_to_module = _flatten_imports(stmts, main_module)
+    `separate` controls how imports are handled:
+
+    - `False` (default — monolithic mode): walks each `Import.ast`
+      recursively and splices the imported module's declarations
+      into the same flat list. Each module is recursed into at most
+      once (matching the interpreter's `imported_modules`). Pruning
+      downstream removes whatever isn't reached from a `print`.
+
+    - `True` (per-module mode, Step 27): imports are NOT inlined.
+      Only the user's own statements are lowered. The set of
+      directly-imported modules is collected on `Program.imports`
+      so the emitter can `#include` their headers and the runtime
+      can call their `_init` functions in the right order.
+      Pruning is skipped — cross-module reachability is the
+      linker's job (`-Wl,--gc-sections`)."""
+    (flat, name_to_module, imports,
+     import_funcs, import_globals, import_ctors) = _flatten_imports(
+        stmts, main_module, separate=separate,
+    )
 
     ctors: Set[str] = set()
     arities: Dict[str, int] = {}
@@ -91,6 +101,13 @@ def lower_program(stmts: List[ast.Statement],
             for c in s.alternatives:
                 ctors.add(c.name)
                 arities[c.name] = len(c.parameters)
+    # In per-module mode, lower_call still needs to identify
+    # imported ctors so `Call(Var(suc), args)` lowers to `Con(suc, args)`
+    # rather than a function call. The ctor's body isn't ours to emit;
+    # the macro and singleton come from the imported header.
+    for cname, carity in import_ctors.items():
+        ctors.add(cname)
+        arities[cname] = carity
 
     lc = LoweringCtx(ctors=ctors, ctor_arities=arities)
     out: List[ir.TopLevel] = []
@@ -101,27 +118,99 @@ def lower_program(stmts: List[ast.Statement],
                 out.extend(d)
             else:
                 out.append(d)
-    return ir.Program(decls=out, name_to_module=name_to_module)
+    return ir.Program(
+        decls=out,
+        name_to_module=name_to_module,
+        main_module=main_module,
+        imports=imports,
+        import_funcs=import_funcs,
+        import_globals=import_globals,
+        import_ctors=import_ctors,
+    )
 
 
 def _flatten_imports(
     stmts: List[ast.Statement],
     main_module: str,
-) -> "tuple[list[tuple[ast.Statement, str]], Dict[str, str]]":
-    """Walk `stmts`, splicing each `Import.ast` (the imported module's
-    post-typecheck statement list — see `process_declaration` in
-    proof_checker.py) in place of the import itself, while tracking
-    each statement's source module. Imports are deduplicated by
-    module name; only the first occurrence's nested statements are
-    emitted, matching `imported_modules` semantics in the interpreter.
+    separate: bool = False,
+):
+    """Walk `stmts` and produce a flat list of (statement, module).
 
-    Returns (statements paired with their module names,
-    name → module map covering every uniquified top-level name a
-    decl exposes — function/global/union/constructor names).
+    In monolithic mode (`separate=False`) splices each `Import.ast`
+    (the imported module's post-typecheck statement list — see
+    `process_declaration` in proof_checker.py) in place of the
+    import itself, deduplicating by module name. In per-module mode
+    (`separate=True`) records the direct imports' names and stops —
+    the imported modules are compiled separately.
+
+    Returns:
+      - statements paired with their module names,
+      - name → module map covering every uniquified top-level name
+        the lowered statements expose (function/global/union/
+        constructor),
+      - list of directly-imported module names, in source order
+        with duplicates removed (only meaningful in per-module
+        mode; empty in monolithic mode since there's no separate
+        compilation unit boundary to record).
     """
     seen: Set[str] = set()
     out: List[tuple[ast.Statement, str]] = []
     name_to_module: Dict[str, str] = {}
+    direct_imports: List[str] = []
+    import_funcs: Dict[str, int] = {}
+    import_globals: Set[str] = set()
+    import_ctors: Dict[str, int] = {}
+
+    def record_decl_module(s: ast.Statement, module: str) -> None:
+        if isinstance(s, ast.Define):
+            name_to_module[s.name] = module
+        elif isinstance(s, ast.RecFun):
+            name_to_module[s.name] = module
+        elif isinstance(s, ast.GenRecFun):
+            name_to_module[s.name] = module
+        elif isinstance(s, ast.Union):
+            name_to_module[s.name] = module
+            for c in s.alternatives:
+                name_to_module[c.name] = module
+
+    def record_imported_kind(s: ast.Statement) -> None:
+        """In per-module mode we additionally need the kind/arity of
+        every imported decl so emit_c can pick the right call shape
+        and look up ctor macros via the imported `.h`."""
+        if isinstance(s, ast.Define):
+            unwrapped = s.body
+            if isinstance(unwrapped, ast.Generic):
+                unwrapped = unwrapped.body
+            if isinstance(unwrapped, ast.Lambda):
+                import_funcs[s.name] = len(unwrapped.vars)
+            else:
+                import_globals.add(s.name)
+        elif isinstance(s, ast.RecFun):
+            import_funcs[s.name] = len(s.params)
+        elif isinstance(s, ast.GenRecFun):
+            import_funcs[s.name] = len(s.vars)
+        elif isinstance(s, ast.Union):
+            for c in s.alternatives:
+                import_ctors[c.name] = len(c.parameters)
+
+    def register_imported(items: List[ast.Statement], current_module: str) -> None:
+        """Walk an imported module's AST recording each top-level
+        decl's name → module mapping plus its kind/arity. We don't
+        emit anything for these statements — that happens in their
+        own per-module compile — but we DO need both maps so
+        references from the importing module's code mangle the
+        same way as the definitions in the imported module's `.c`
+        and dispatch through the right call shape."""
+        for s in items:
+            if isinstance(s, ast.Import):
+                if s.name in seen:
+                    continue
+                seen.add(s.name)
+                if s.ast is not None:
+                    register_imported(s.ast, s.name)
+            else:
+                record_decl_module(s, current_module)
+                record_imported_kind(s)
 
     def walk(items: List[ast.Statement], current_module: str) -> None:
         for s in items:
@@ -129,23 +218,31 @@ def _flatten_imports(
                 if s.name in seen:
                     continue
                 seen.add(s.name)
+                if separate and current_module == main_module:
+                    # Direct import: record so emit_c emits the
+                    # right `#include` and the right module-init
+                    # call, then recurse just to populate
+                    # name_to_module so references mangle correctly.
+                    direct_imports.append(s.name)
+                    if s.ast is not None:
+                        register_imported(s.ast, s.name)
+                    continue
+                if separate:
+                    # Indirect import inside an already-handled
+                    # module: don't recurse — it's the imported
+                    # module's build-system dependency, not ours.
+                    continue
                 if s.ast is not None:
                     walk(s.ast, s.name)
             else:
                 out.append((s, current_module))
-                if isinstance(s, ast.Define):
-                    name_to_module[s.name] = current_module
-                elif isinstance(s, ast.RecFun):
-                    name_to_module[s.name] = current_module
-                elif isinstance(s, ast.GenRecFun):
-                    name_to_module[s.name] = current_module
-                elif isinstance(s, ast.Union):
-                    name_to_module[s.name] = current_module
-                    for c in s.alternatives:
-                        name_to_module[c.name] = current_module
+                record_decl_module(s, current_module)
 
     walk(stmts, main_module)
-    return out, name_to_module
+    return (
+        out, name_to_module, direct_imports,
+        import_funcs, import_globals, import_ctors,
+    )
 
 
 class LoweringCtx:

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -89,7 +89,7 @@ def lower_program(stmts: List[ast.Statement],
       can call their `_init` functions in the right order.
       Pruning is skipped — cross-module reachability is the
       linker's job (`-Wl,--gc-sections`)."""
-    (flat, name_to_module, imports,
+    (flat, name_to_module, name_to_seq, imports,
      import_funcs, import_globals, import_ctors) = _flatten_imports(
         stmts, main_module, separate=separate,
     )
@@ -121,6 +121,7 @@ def lower_program(stmts: List[ast.Statement],
     return ir.Program(
         decls=out,
         name_to_module=name_to_module,
+        name_to_seq=name_to_seq,
         main_module=main_module,
         imports=imports,
         import_funcs=import_funcs,
@@ -156,22 +157,42 @@ def _flatten_imports(
     seen: Set[str] = set()
     out: List[tuple[ast.Statement, str]] = []
     name_to_module: Dict[str, str] = {}
+    name_to_seq: Dict[str, int] = {}
     direct_imports: List[str] = []
     import_funcs: Dict[str, int] = {}
     import_globals: Set[str] = set()
     import_ctors: Dict[str, int] = {}
+    counters_by_module: Dict[str, int] = {}
+
+    def assign_seq(uniq_name: str, module: str) -> None:
+        """Per-module ordinal for `uniq_name` based on order of
+        encounter inside `module`. The ordinal is stable across
+        compilation contexts because we walk a module's AST in the
+        same order regardless of whether we're compiling that module
+        standalone or pulling it in via `Import.ast` from another
+        module's lowering. emit_c uses this as the within-module
+        symbol disambiguator instead of the uniquify counter (whose
+        values shift with the import set seen during one compile)."""
+        n = counters_by_module.get(module, 0)
+        name_to_seq[uniq_name] = n
+        counters_by_module[module] = n + 1
 
     def record_decl_module(s: ast.Statement, module: str) -> None:
         if isinstance(s, ast.Define):
             name_to_module[s.name] = module
+            assign_seq(s.name, module)
         elif isinstance(s, ast.RecFun):
             name_to_module[s.name] = module
+            assign_seq(s.name, module)
         elif isinstance(s, ast.GenRecFun):
             name_to_module[s.name] = module
+            assign_seq(s.name, module)
         elif isinstance(s, ast.Union):
             name_to_module[s.name] = module
+            assign_seq(s.name, module)
             for c in s.alternatives:
                 name_to_module[c.name] = module
+                assign_seq(c.name, module)
 
     def record_imported_kind(s: ast.Statement) -> None:
         """In per-module mode we additionally need the kind/arity of
@@ -240,7 +261,7 @@ def _flatten_imports(
 
     walk(stmts, main_module)
     return (
-        out, name_to_module, direct_imports,
+        out, name_to_module, name_to_seq, direct_imports,
         import_funcs, import_globals, import_ctors,
     )
 

--- a/compiler/prune.py
+++ b/compiler/prune.py
@@ -82,7 +82,15 @@ def prune(p: ir.Program) -> ir.Program:
             # the roots themselves (and asserts are normally dropped in
             # lowering, so they shouldn't be here anyway).
             new_decls.append(d)
-    return ir.Program(decls=new_decls, name_to_module=p.name_to_module)
+    return ir.Program(
+        decls=new_decls,
+        name_to_module=p.name_to_module,
+        main_module=p.main_module,
+        imports=p.imports,
+        import_funcs=p.import_funcs,
+        import_globals=p.import_globals,
+        import_ctors=p.import_ctors,
+    )
 
 
 def _referenced(t: ir.Term) -> Set[str]:

--- a/compiler/prune.py
+++ b/compiler/prune.py
@@ -85,6 +85,7 @@ def prune(p: ir.Program) -> ir.Program:
     return ir.Program(
         decls=new_decls,
         name_to_module=p.name_to_module,
+        name_to_seq=p.name_to_seq,
         main_module=p.main_module,
         imports=p.imports,
         import_funcs=p.import_funcs,

--- a/deduce.py
+++ b/deduce.py
@@ -37,18 +37,27 @@ def deduce_file(filename, error_expected, tracing_functions, prelude: list[str] 
             exit(1)
 
 def compile_file(filename: str, output: str, prelude: list[str],
-                 no_prune: bool = False) -> None:
-    """Compile a checked .pf file to a single .c source file.
+                 no_prune: bool = False,
+                 separate: bool = False,
+                 is_main: bool = True) -> None:
+    """Compile a checked .pf file.
 
-    Pipeline: parse + uniquify + type-check via the existing front-end,
-    then lower → closure-convert → (prune) → emit_c. The runtime in
-    compiler/runtime/ supplies the matching deduce.h / deduce.c that
-    callers must compile alongside the generated source.
-
-    Pruning drops definitions not transitively reached from a `print`
-    statement. Pass `no_prune=True` to keep every lowered decl in the
-    output — useful when debugging an emitter issue on code the
+    In monolithic mode (`separate=False`, the default): inlines every
+    transitively-imported module's declarations, prunes everything
+    not reached from a `print`, and emits a single self-contained
+    `.c` file. Pass `no_prune=True` to keep every lowered decl in
+    the output — useful when debugging an emitter issue on code the
     pruner would normally have removed.
+
+    In per-module mode (`separate=True`, Step 27 of
+    `docs/separate-compile-plan.md`): treats `filename` as one
+    compilation unit. Imports are NOT inlined; the emitted `.c`
+    includes the headers of its directly-imported modules, and the
+    linker resolves cross-module symbols. Both `.c` and `.h` are
+    written; pruning is skipped (the C linker handles dead-code
+    elimination via `-Wl,--gc-sections`). `is_main=True` (default)
+    means the module emits `deduce_program_main`; pass `False` for
+    library modules with no `print` statements of their own.
     """
     from compiler import closure as _closure, emit_c, ir, lower
     from compiler import prune as _prune
@@ -60,10 +69,23 @@ def compile_file(filename: str, output: str, prelude: list[str],
             print(result.error_traceback)
         exit(1)
     main_module = Path(filename).stem
-    program = lower.lower_program(result.ast, main_module=main_module)
+    program = lower.lower_program(
+        result.ast, main_module=main_module, separate=separate,
+    )
     ir.verify(program)
     program = _closure.closure_convert(program)
     ir.verify(program)
+    if separate:
+        c_src, h_src = emit_c.emit_module(program, is_main=is_main)
+        if output == "-":
+            sys.stdout.write(c_src)
+        else:
+            with open(output, "w", encoding="utf-8") as f:
+                f.write(c_src)
+            h_out = Path(output).with_suffix(".h")
+            with open(h_out, "w", encoding="utf-8") as f:
+                f.write(h_src)
+        return
     if not no_prune:
         program = _prune.prune(program)
         ir.verify(program)
@@ -113,6 +135,8 @@ if __name__ == "__main__":
     compile_target = None
     compile_output = None
     no_prune = False
+    separate_compile = False
+    is_main_module = True
     init_import_directories()
 
     # TODO: Cleanup 
@@ -163,6 +187,11 @@ if __name__ == "__main__":
             set_check_imports(False)
         elif argument == '--compile':
             compile_target = '__pending__'
+        elif argument == '--compile-module':
+            compile_target = '__pending__'
+            separate_compile = True
+        elif argument == '--no-main':
+            is_main_module = False
         elif argument == '-o' and i + 1 < len(sys.argv):
             compile_output = sys.argv[i + 1]
             already_processed_next = True
@@ -210,7 +239,12 @@ if __name__ == "__main__":
                 exit(1)
             out = compile_output if compile_output is not None \
                 else os.path.splitext(deducable)[0] + ".c"
-            compile_file(deducable, out, deducable_prelude, no_prune=no_prune)
+            compile_file(
+                deducable, out, deducable_prelude,
+                no_prune=no_prune,
+                separate=separate_compile,
+                is_main=is_main_module,
+            )
         elif os.path.isfile(deducable):
             deduce_file(deducable, error_expected, tracing_functions, deducable_prelude)
         elif os.path.isdir(deducable):

--- a/test/compile/lower/array.h
+++ b/test/compile/lower/array.h
@@ -5,14 +5,14 @@
 
 #define CTOR_array__zero_1 0
 #define CTOR_array__suc_2 1
-#define CTOR_array__empty_5 2
-#define CTOR_array__node_6 3
+#define CTOR_array__empty_4 2
+#define CTOR_array__node_5 3
 
 extern deduce_value C_array__zero_1;
-extern deduce_value C_array__empty_5;
+extern deduce_value C_array__empty_4;
 
-extern deduce_value G_array__ns_7;
-extern deduce_value G_array__A_8;
+extern deduce_value G_array__ns_6;
+extern deduce_value G_array__A_7;
 
 #endif
 

--- a/test/compile/lower/basic.h
+++ b/test/compile/lower/basic.h
@@ -9,10 +9,10 @@
 extern deduce_value C_basic__zero_1;
 
 deduce_value F_basic__add_3(deduce_value* env, deduce_value* args);
-deduce_value F_basic__add_two_9(deduce_value* env, deduce_value* args);
-deduce_value F_basic__pick_13(deduce_value* env, deduce_value* args);
+deduce_value F_basic__add_two_5(deduce_value* env, deduce_value* args);
+deduce_value F_basic__pick_6(deduce_value* env, deduce_value* args);
 
-extern deduce_value G_basic__two_7;
+extern deduce_value G_basic__two_4;
 
 #endif
 

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,5 +1,5 @@
 union MyNat.0 {zero.1/0, suc.2/1}
 fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[$lam1](x.7)
+fn adder.9(x.7) = closure[closure$lam1](x.7)
 print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn $lam1[x.7](y.8) = add.3(x.7, y.8)
+fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)

--- a/test/compile/lower/closure.h
+++ b/test/compile/lower/closure.h
@@ -10,6 +10,7 @@ extern deduce_value C_closure__zero_1;
 
 deduce_value F_closure__add_3(deduce_value* env, deduce_value* args);
 deduce_value F_closure__adder_9(deduce_value* env, deduce_value* args);
+deduce_value F_closure__closure__lam1(deduce_value* env, deduce_value* args);
 
 #endif
 

--- a/test/compile/lower/closure.h
+++ b/test/compile/lower/closure.h
@@ -9,7 +9,7 @@
 extern deduce_value C_closure__zero_1;
 
 deduce_value F_closure__add_3(deduce_value* env, deduce_value* args);
-deduce_value F_closure__adder_9(deduce_value* env, deduce_value* args);
+deduce_value F_closure__adder_4(deduce_value* env, deduce_value* args);
 deduce_value F_closure__closure__lam1(deduce_value* env, deduce_value* args);
 
 #endif

--- a/test/compile/lower/closure.pir
+++ b/test/compile/lower/closure.pir
@@ -1,5 +1,5 @@
 union MyNat.0 {zero.1/0, suc.2/1}
 fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[$lam1](x.7)
+fn adder.9(x.7) = closure[closure$lam1](x.7)
 print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn $lam1[x.7](y.8) = add.3(x.7, y.8)
+fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)

--- a/test/compile/lower/generic.h
+++ b/test/compile/lower/generic.h
@@ -3,14 +3,14 @@
 #define DEDUCE_generic_H
 #include "deduce.h"
 
-#define CTOR_generic__box_2 0
-#define CTOR_generic__zero_12 1
-#define CTOR_generic__suc_13 2
+#define CTOR_generic__box_1 0
+#define CTOR_generic__zero_5 1
+#define CTOR_generic__suc_6 2
 
-extern deduce_value C_generic__zero_12;
+extern deduce_value C_generic__zero_5;
 
-deduce_value F_generic__unbox_6(deduce_value* env, deduce_value* args);
-deduce_value F_generic__id_10(deduce_value* env, deduce_value* args);
+deduce_value F_generic__unbox_2(deduce_value* env, deduce_value* args);
+deduce_value F_generic__id_3(deduce_value* env, deduce_value* args);
 
 #endif
 

--- a/test/compile/lower/genrecfun.h
+++ b/test/compile/lower/genrecfun.h
@@ -8,9 +8,9 @@
 
 extern deduce_value C_genrecfun__zero_1;
 
-deduce_value F_genrecfun__iszero_5(deduce_value* env, deduce_value* args);
-deduce_value F_genrecfun__pred_8(deduce_value* env, deduce_value* args);
-deduce_value F_genrecfun__count_down_22(deduce_value* env, deduce_value* args);
+deduce_value F_genrecfun__iszero_3(deduce_value* env, deduce_value* args);
+deduce_value F_genrecfun__pred_4(deduce_value* env, deduce_value* args);
+deduce_value F_genrecfun__count_down_6(deduce_value* env, deduce_value* args);
 
 #endif
 

--- a/test/compile/lower/source_map.h
+++ b/test/compile/lower/source_map.h
@@ -5,13 +5,13 @@
 
 #define CTOR_source_map__zero_1 0
 #define CTOR_source_map__suc_2 1
-#define CTOR_source_map__empty_5 2
-#define CTOR_source_map__node_6 3
+#define CTOR_source_map__empty_4 2
+#define CTOR_source_map__node_5 3
 
 extern deduce_value C_source_map__zero_1;
-extern deduce_value C_source_map__empty_5;
+extern deduce_value C_source_map__empty_4;
 
-extern deduce_value G_source_map__A_7;
+extern deduce_value G_source_map__A_6;
 
 #endif
 

--- a/test/compile/prelude/hello_nat.h
+++ b/test/compile/prelude/hello_nat.h
@@ -3,7 +3,7 @@
 #define DEDUCE_Nat_H
 #include "deduce.h"
 
-deduce_value F_Nat__gcd_2197(deduce_value* env, deduce_value* args);
+deduce_value F_Nat__gcd_0(deduce_value* env, deduce_value* args);
 
 #endif
 
@@ -12,18 +12,18 @@ deduce_value F_Nat__gcd_2197(deduce_value* env, deduce_value* args);
 #define DEDUCE_NatDefs_H
 #include "deduce.h"
 
-#define CTOR_NatDefs__zero_96 0
-#define CTOR_NatDefs__suc_97 1
+#define CTOR_NatDefs__zero_1 0
+#define CTOR_NatDefs__suc_2 1
 
-extern deduce_value C_NatDefs__zero_96;
+extern deduce_value C_NatDefs__zero_1;
 
-deduce_value F_NatDefs___x2b_98(deduce_value* env, deduce_value* args);
-deduce_value F_NatDefs___x2a_102(deduce_value* env, deduce_value* args);
-deduce_value F_NatDefs___x2238_126(deduce_value* env, deduce_value* args);
-deduce_value F_NatDefs___x2264_131(deduce_value* env, deduce_value* args);
-deduce_value F_NatDefs___x3c_138(deduce_value* env, deduce_value* args);
-deduce_value F_NatDefs__pow2_158(deduce_value* env, deduce_value* args);
-deduce_value F_NatDefs__lit_196(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2b_3(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2a_4(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2238_10(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x2264_11(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs___x3c_12(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs__pow2_17(deduce_value* env, deduce_value* args);
+deduce_value F_NatDefs__lit_27(deduce_value* env, deduce_value* args);
 
 #endif
 
@@ -32,8 +32,8 @@ deduce_value F_NatDefs__lit_196(deduce_value* env, deduce_value* args);
 #define DEDUCE_NatDiv_H
 #include "deduce.h"
 
-deduce_value F_NatDiv___x2f_1523(deduce_value* env, deduce_value* args);
-deduce_value F_NatDiv___x25_1534(deduce_value* env, deduce_value* args);
+deduce_value F_NatDiv___x2f_0(deduce_value* env, deduce_value* args);
+deduce_value F_NatDiv___x25_1(deduce_value* env, deduce_value* args);
 
 #endif
 

--- a/test/compile/run_separate.py
+++ b/test/compile/run_separate.py
@@ -1,0 +1,150 @@
+"""End-to-end test for `--compile-module` (per-module compilation).
+
+Step 27 of `docs/separate-compile-plan.md` — the integration check.
+For each scenario in `test/compile/separate/`, compile every `.pf`
+to its own `.c`+`.h`, link them all together with `cc`, run the
+binary, and diff stdout against what the interpreter produces for
+the program's entry-point file.
+
+Each scenario lives in a directory with at least an `app.pf`
+(the main module — has the `print` statements). Other `.pf`
+files in the directory are compiled as library modules
+(`--no-main`).
+
+Run from the repo root:
+    python3 test/compile/run_separate.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCENARIOS_DIR = ROOT / "test" / "compile" / "separate"
+RUNTIME_DIR = ROOT / "compiler" / "runtime"
+
+
+def find_cc() -> "str | None":
+    return shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+
+
+def run_interpreter(scenario: Path, app_pf: Path) -> str:
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "deduce.py"),
+         "--no-stdlib", "--dir", str(scenario),
+         "--suppress-theorems", "--quiet", str(app_pf)],
+        cwd=str(ROOT), capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"interpreter failed on {app_pf.name}:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    lines = proc.stdout.splitlines()
+    if lines and lines[-1].endswith("is valid"):
+        lines = lines[:-1]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def run_compiled(scenario: Path, cc: str, build_dir: Path) -> str:
+    """Compile every .pf in the scenario directory separately, link
+    the resulting .c files together, run, return stdout."""
+    pfs = sorted(scenario.glob("*.pf"))
+    app_pf = scenario / "app.pf"
+    if not app_pf.exists():
+        raise RuntimeError(f"{scenario}: no app.pf")
+
+    # Stage .pf files into the build dir so the compiler's
+    # `--dir <build_dir>` finds the imports next to the file
+    # being compiled.
+    for pf in pfs:
+        shutil.copy(pf, build_dir / pf.name)
+
+    for pf in pfs:
+        is_app = pf.name == "app.pf"
+        cmd = [
+            sys.executable, str(ROOT / "deduce.py"),
+            "--compile-module",
+            "--no-stdlib",
+            "--dir", str(build_dir),
+            "--suppress-theorems", "--quiet",
+            "-o", str(build_dir / (pf.stem + ".c")),
+            str(build_dir / pf.name),
+        ]
+        if not is_app:
+            cmd.insert(3, "--no-main")
+        subprocess.run(cmd, cwd=str(ROOT), check=True,
+                       capture_output=True, text=True)
+
+    # Link
+    bin_path = build_dir / "app"
+    sources = [str(build_dir / (pf.stem + ".c")) for pf in pfs]
+    cmd = [cc, "-Wall", "-Wextra", "-Werror",
+           "-I", str(build_dir), "-I", str(RUNTIME_DIR),
+           "-o", str(bin_path),
+           *sources, str(RUNTIME_DIR / "deduce.c")]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+    proc = subprocess.run(
+        [str(bin_path)], capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{scenario.name}: compiled binary exit {proc.returncode}:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return proc.stdout
+
+
+def main() -> int:
+    cc = find_cc()
+    if cc is None:
+        print("SKIP: no C compiler (cc/clang/gcc) on PATH", file=sys.stderr)
+        return 0
+
+    if not SCENARIOS_DIR.exists():
+        print(f"no scenarios at {SCENARIOS_DIR}", file=sys.stderr)
+        return 1
+
+    scenarios = [d for d in sorted(SCENARIOS_DIR.iterdir()) if d.is_dir()]
+    # If there's no subdir but there is an `app.pf` in the top dir,
+    # treat it as a single inline scenario.
+    if not scenarios and (SCENARIOS_DIR / "app.pf").exists():
+        scenarios = [SCENARIOS_DIR]
+
+    failures: list[str] = []
+    tmp = Path(tempfile.mkdtemp(prefix="deduce-separate-"))
+    for scenario in scenarios:
+        build_dir = tmp / scenario.name
+        build_dir.mkdir()
+        try:
+            interp_out = run_interpreter(scenario, scenario / "app.pf")
+            compiled_out = run_compiled(scenario, cc, build_dir)
+        except Exception as e:
+            failures.append(f"{scenario.name}: {e}")
+            continue
+        if interp_out != compiled_out:
+            failures.append(
+                f"{scenario.name}: stdout mismatch\n"
+                f"--- interpreter ({len(interp_out)} bytes)\n{interp_out}"
+                f"--- compiled ({len(compiled_out)} bytes)\n{compiled_out}"
+            )
+            continue
+        print(f"ok {scenario.name}")
+
+    if failures:
+        print(f"\nFAILURES (workdir kept at {tmp}):")
+        for msg in failures:
+            print(msg)
+        return 1
+    shutil.rmtree(tmp, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/compile/run_separate.py
+++ b/test/compile/run_separate.py
@@ -101,6 +101,27 @@ def run_compiled(scenario: Path, cc: str, build_dir: Path) -> str:
     return proc.stdout
 
 
+def check_diamond_init(build_dir: Path) -> "str | None":
+    """For the diamond scenario, verify D's singletons are allocated
+    exactly once. Concretely:
+      - d.c contains an idempotent `_inited` guard inside `d_init`,
+      - the line that assigns `C_d__zero_1` appears in exactly one
+        .c file (d.c) — neither b.c, c.c, nor app.c re-runs it.
+    Step 28 acceptance criterion."""
+    d_c = (build_dir / "d.c").read_text()
+    if "d_init__inited" not in d_c or "if (d_init__inited) return;" not in d_c:
+        return "d.c missing idempotent d_init guard"
+    assigns = []
+    for c_path in sorted(build_dir.glob("*.c")):
+        text = c_path.read_text()
+        if "C_d__zero_1 =" in text:
+            assigns.append(c_path.name)
+    if assigns != ["d.c"]:
+        return (f"C_d__zero_1 should only be assigned in d.c, "
+                f"but found in: {assigns}")
+    return None
+
+
 def main() -> int:
     cc = find_cc()
     if cc is None:
@@ -135,6 +156,11 @@ def main() -> int:
                 f"--- compiled ({len(compiled_out)} bytes)\n{compiled_out}"
             )
             continue
+        if scenario.name == "diamond":
+            err = check_diamond_init(build_dir)
+            if err is not None:
+                failures.append(f"diamond: {err}")
+                continue
         print(f"ok {scenario.name}")
 
     if failures:

--- a/test/compile/separate/diamond/app.pf
+++ b/test/compile/separate/diamond/app.pf
@@ -1,0 +1,7 @@
+import d
+import b
+import c
+
+print incr(zero)
+print add_two(zero)
+print add(incr(zero), add_two(zero))

--- a/test/compile/separate/diamond/b.pf
+++ b/test/compile/separate/diamond/b.pf
@@ -1,0 +1,7 @@
+module b
+
+import d
+
+fun incr(n : MyNat) {
+  suc(n)
+}

--- a/test/compile/separate/diamond/c.pf
+++ b/test/compile/separate/diamond/c.pf
@@ -1,0 +1,7 @@
+module c
+
+import d
+
+fun add_two(n : MyNat) {
+  suc(suc(n))
+}

--- a/test/compile/separate/diamond/d.pf
+++ b/test/compile/separate/diamond/d.pf
@@ -1,0 +1,13 @@
+module d
+
+// Bottom of the diamond. Defines the type that B and C both share.
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+recursive add(MyNat, MyNat) -> MyNat {
+  add(zero, m) = m
+  add(suc(n), m) = suc(add(n, m))
+}

--- a/test/compile/separate/two_file/app.pf
+++ b/test/compile/separate/two_file/app.pf
@@ -1,0 +1,3 @@
+import lib
+
+print add(suc(zero), suc(suc(zero)))

--- a/test/compile/separate/two_file/lib.pf
+++ b/test/compile/separate/two_file/lib.pf
@@ -1,0 +1,11 @@
+module lib
+
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+recursive add(MyNat, MyNat) -> MyNat {
+  add(zero, m) = m
+  add(suc(n), m) = suc(add(n, m))
+}


### PR DESCRIPTION
## Summary

Bundles **Step 27** (per-module compile mode) and **Step 28** (module init orchestration / diamond imports) of [`docs/separate-compile-plan.md`](docs/separate-compile-plan.md). Step 27 was previously merged onto its stacked base; this retargets to `main` so both land together.

### Step 27 — `--compile-module`

Each `.pf` compiles to its own `.c`+`.h`; `cc` links them. Acceptance:

```sh
$ python3 deduce.py --compile-module --no-main --no-stdlib --dir lib lib.pf
$ python3 deduce.py --compile-module --no-stdlib --dir lib app.pf
$ cc -I . -I compiler/runtime app.c lib.c compiler/runtime/deduce.c -o app
$ ./app
suc(suc(suc(zero)))
```

- `lower.lower_program(stmts, main_module, separate=True)` — imports stay un-flattened. Direct imports go on `Program.imports`; their decls are walked just enough to populate `name_to_module` and kind/arity (`import_funcs` / `import_globals` / `import_ctors`) so emit_c can dispatch reference sites without seeing the bodies.
- `closure.closure_convert` — per-module lambda counter; lifted lambdas named `<module>$lam<n>` and tagged with their enclosing module so two modules' lambdas don't collide at link time.
- `emit_c.emit_module(p, is_main) -> (c, h)` — new per-module emit. `.c` `#include`s `"deduce.h"` plus each imported header; defines this module's ctor singletons / globals / functions; emits a guarded `<Module>_init()` that recursively calls direct imports' inits and allocates singletons / runs Globals. When `is_main`, also emits `deduce_program_main()`. Pruning is skipped — `-Wl,--gc-sections` handles cross-module DCE.
- New CLI flags on `deduce.py`: `--compile-module` (writes `.c` and `.h` together) and `--no-main` (this module is a library; don't emit `deduce_program_main`).
- New `test/compile/separate/two_file/` scenario + `test/compile/run_separate.py` runner; wired into `make tests-compile`.

### Step 28 — diamond imports + stable cross-context mangling

Adding the diamond scenario (D defines `MyNat`+`add`; B and C `import d`; `app` imports all three) exposed a real bug: `app.c` referenced `F_c__add_two_10` but `c.h` declared `F_c__add_two_8`. The within-module disambiguator was the uniquify counter, whose value depends on the import set seen during one compile — when `c.pf` compiles standalone vs. when it's pulled in via app's `Import.ast`, the counter has different values.

Fix: replace the uniquify counter with a per-module ordinal computed by walking each module's AST in source order. Stored on `ir.Program` as `name_to_seq` and threaded through closure / prune / emit_c. Symbols mangle as `<Module>__<base>_<seq>` where `seq` is stable across compile contexts.

`run_separate.py` gains a `check_diamond_init` assertion confirming D's nullary singleton (`zero`) is only assigned in `d.c` — not re-run from `b/c/app`.

### gitignore

Adds `*.o`, `*.a`, `compiler/runtime/libdeduce_prelude.*`, `compiler/runtime/include/`. Preparation for Step 29 (prelude as a static archive) and to keep `git status` clean once anyone runs `cc` in-tree.

## Test plan

- [x] `make tests-compile` — separate, lower, e2e, determinism, and headers all green; runner reports `ok diamond` and `ok two_file`.
- [x] `make tests` — interpreter suite unchanged.
- [x] Manual: two-file scenario and diamond scenario both compile, link, and run end-to-end matching the interpreter.
- [x] Diamond's `app.c` calls `d_init(); b_init(); c_init();` — each is idempotent so `C_d__zero_1` is allocated once.
- [x] Header fixtures regenerated (per-module ordinal differs from uniquify counter for some); `.ir/.cir/.pir` fixtures unaffected (they show uniquified names, not mangled C names).

## What's next

- **Step 29** — prelude as a static archive (`compiler/runtime/libdeduce_prelude.a`).
- **Step 30** — build-system documentation in `gh_pages/doc/Compiler.md`.