### PR TITLE
Hole-fill: 6 progressively-harder example fixtures

### DIFF
--- a/tools/claude_fill_hole/examples/01_trivial.pf
+++ b/tools/claude_fill_hole/examples/01_trivial.pf
@@ -1,0 +1,7 @@
+// Level 1 / 6 -- the lowest possible bar.
+// The goal `true' is satisfied by `.', the proof of true.
+
+theorem t01_trivial: true
+proof
+  ?
+end

--- a/tools/claude_fill_hole/examples/02_reflexive.pf
+++ b/tools/claude_fill_hole/examples/02_reflexive.pf
@@ -1,0 +1,9 @@
+// Level 2 / 6 -- reflexive equality.
+// After `arbitrary P:bool', the goal is `P = P', satisfied by
+// `reflexive' (or `.' since `P = P' reduces to `true').
+
+theorem t02_reflexive: all P:bool. P = P
+proof
+  arbitrary P:bool
+  ?
+end

--- a/tools/claude_fill_hole/examples/03_assumption.pf
+++ b/tools/claude_fill_hole/examples/03_assumption.pf
@@ -1,0 +1,11 @@
+// Level 3 / 6 -- use a hypothesis.
+// After `assume p: P', the goal is `P' and the hypothesis `p' is in
+// scope.  The proof is just `p' (or `conclude P by p').  Tests
+// whether the model can read the goal and pick the matching binding.
+
+theorem t03_assumption: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  ?
+end

--- a/tools/claude_fill_hole/examples/04_conj_swap.pf
+++ b/tools/claude_fill_hole/examples/04_conj_swap.pf
@@ -1,0 +1,11 @@
+// Level 4 / 6 -- destructure a conjunction and reconstruct the swap.
+// Hypothesis `pq: P and Q'.  Goal `Q and P'.  Tests whether the model
+// knows Deduce's `conjunct N of H' destructure and the comma-pair
+// proof of an `and' goal.
+
+theorem t04_conj_swap: all P:bool, Q:bool. if P and Q then Q and P
+proof
+  arbitrary P:bool, Q:bool
+  assume pq: P and Q
+  ?
+end

--- a/tools/claude_fill_hole/examples/05_disj_swap.pf
+++ b/tools/claude_fill_hole/examples/05_disj_swap.pf
@@ -1,0 +1,12 @@
+// Level 5 / 6 -- case-split on a disjunction.
+// Hypothesis `pq: P or Q'.  Goal `Q or P'.  Tests whether the model
+// knows to use `cases pq' (or `apply' on the disjunction) and proves
+// each branch -- in each case we have one side, and need to inject
+// it into the swapped disjunction.
+
+theorem t05_disj_swap: all P:bool, Q:bool. if P or Q then Q or P
+proof
+  arbitrary P:bool, Q:bool
+  assume pq: P or Q
+  ?
+end

--- a/tools/claude_fill_hole/examples/06_induction.pf
+++ b/tools/claude_fill_hole/examples/06_induction.pf
@@ -1,0 +1,24 @@
+// Level 6 / 6 -- induction on a self-defined inductive type.
+// `add' is defined by recursion on its FIRST argument, so `add(n, zero)
+// = n' (zero on the right) doesn't reduce by computation -- it
+// requires structural induction on `n'.  This is the simplest proof
+// in the sequence that genuinely needs induction.
+//
+// Self-contained (no `import') so it works whether or not the user
+// has the standard library prelude enabled.
+
+union UnaryNat {
+  zero
+  succ(UnaryNat)
+}
+
+recursive add(UnaryNat, UnaryNat) -> UnaryNat {
+  add(zero, m) = m
+  add(succ(n), m) = succ(add(n, m))
+}
+
+theorem t06_add_zero_right: all n:UnaryNat. add(n, zero) = n
+proof
+  arbitrary n:UnaryNat
+  ?
+end

--- a/tools/claude_fill_hole/examples/README.md
+++ b/tools/claude_fill_hole/examples/README.md
@@ -1,0 +1,78 @@
+# Hole-fill examples
+
+Six progressively-harder Deduce theorems for benchmarking LLM
+backends through `deduce-fill-hole`.  Each file is a self-contained
+proof with one `?` for the model to fill.  Run each level, note
+whether the model succeeds and how many attempts it took, and
+compare across models.
+
+## How to run
+
+In emacs, with `deduce-fill-hole` configured:
+
+1. `M-x find-file RET tools/claude_fill_hole/examples/01_trivial.pf RET`
+2. Move point onto the `?`.
+3. `C-c C-a` (`deduce-fill-hole`).
+4. Watch for `deduce-fill-hole: filled in N attempt(s)` (success) or
+   the failure message + `*deduce-fill-hole debug*` buffer.
+
+Repeat for `02_reflexive.pf` through `06_induction.pf`.
+
+The CLI shape, if you want to drive the sidecar without emacs, is in
+`../README.md`.
+
+## Levels
+
+| # | File | Theorem | What it tests | Reference proof |
+|---|------|---------|---------------|-----------------|
+| 1 | [`01_trivial.pf`](01_trivial.pf) | `true` | "I can write `.`" | `.` |
+| 2 | [`02_reflexive.pf`](02_reflexive.pf) | `all P:bool. P = P` (after `arbitrary P`) | Reflexive equality. | `reflexive` (or `.`) |
+| 3 | [`03_assumption.pf`](03_assumption.pf) | `all P:bool. if P then P` (after `assume p: P`) | Reading the goal and finding the matching binding in scope. | `p` |
+| 4 | [`04_conj_swap.pf`](04_conj_swap.pf) | `if P and Q then Q and P` | Destructure a conjunction (`conjunct N of pq`, zero-indexed) and reconstruct the swapped pair. | `have q: Q by conjunct 1 of pq` then `have p: P by conjunct 0 of pq` then `q, p` |
+| 5 | [`05_disj_swap.pf`](05_disj_swap.pf) | `if P or Q then Q or P` | Case-split a disjunction with `cases pq case n: T { ... }` and inject each branch into the swapped goal. | `cases pq` `case p: P { p }` `case q: Q { q }` |
+| 6 | [`06_induction.pf`](06_induction.pf) | `all n:UnaryNat. add(n, zero) = n` for a self-defined `UnaryNat` and recursive `add` | Structural `induction T case ctor(args) suppose IH: ... { ... }` and using the IH via `replace IH`. | `induction UnaryNat`, base case `expand add.`, succ case `equations add(succ(n'), zero) = succ(add(n', zero)) by expand add. ... = succ(n') by replace IH.` |
+
+## Difficulty progression
+
+What each level adds over the previous:
+
+- **1 → 2**: introduce a quantifier and the `arbitrary` step (already in
+  the file; the model just has to discharge the residual `P = P`).
+- **2 → 3**: introduce a hypothesis the model has to read off the
+  givens list.
+- **3 → 4**: introduce a connective the model has to destructure
+  (`conjunct N of`) and reconstruct (`,` for `and`).
+- **4 → 5**: switch from a single-proof tactic to a multi-branch
+  case split.  Each branch is now its own subgoal.
+- **5 → 6**: introduce structural induction over a user-defined type.
+  Adds the `induction`, `suppose IH`, `expand`, `replace`, and
+  `equations` tactics in one step -- a real jump in tactic
+  vocabulary.
+
+## Cleaning up after a model run
+
+`C-c C-a` mutates the buffer.  After running a level, **don't save
+the changed buffer** -- to retest, `M-x revert-buffer RET yes RET`
+restores the `?`.
+
+If you want to keep a model's answer for comparison, copy the
+filled-in proof out of the buffer (or save under a different name)
+before reverting.
+
+## Adding more levels
+
+The natural next steps would be:
+
+- **Level 7**: a theorem requiring a hypothesis transformation along
+  the way -- e.g. `if (P or Q) and R then (P and R) or (Q and R)`.
+- **Level 8**: induction over a type with more than one recursive
+  parameter, e.g. binary trees.
+- **Level 9**: a proof that needs a `have` lemma stated and discharged
+  mid-proof.
+- **Level 10**: a proof requiring stdlib lemmas (drop `--no-stdlib`,
+  prove something about `Nat` or `List`).
+
+If you add levels, mirror the structure above: each `.pf` is
+self-contained, has exactly one `?`, has a reference proof in this
+README, and progresses one tactic-vocabulary step from the
+previous level.

--- a/tools/claude_fill_hole/examples/run_benchmark.py
+++ b/tools/claude_fill_hole/examples/run_benchmark.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Run all hole-fill example fixtures against a list of models, print a table.
+
+Usage::
+
+    REALLMS_API_KEY=... \\
+      python3 -m tools.claude_fill_hole.examples.run_benchmark [model ...]
+
+Defaults to the four chat models REALLMs currently exposes
+(``Qwen3-Coder-Next``, ``gpt-oss-120b``, ``llama-4-scout``,
+``gemma-4-31B-it``).  Pass model names as positional args to
+override.
+
+For each (model, fixture) pair the script:
+
+1. Asks ``lsp.query.hole_context_at`` for the fixture's goal /
+   givens / lemmas in scope (so we don't need a running LSP daemon
+   to drive this).
+2. Builds the JSON request shape the sidecar expects on stdin.
+3. Spawns ``python -m tools.claude_fill_hole`` with the openai-compat
+   backend pointed at REALLMs.
+4. Captures the JSON response and the elapsed wall time.
+
+Output is a markdown table summarising success / attempts / elapsed
+seconds per cell, plus a per-fixture detail block listing the
+candidate proofs each model produced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+THIS = Path(__file__).resolve()
+EXAMPLES_DIR = THIS.parent
+REPO_ROOT = THIS.parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Bootstrap the Deduce checker the same way `lsp.lsp_server' does at
+# import.  Without this, the first `check_file' call inside
+# `hole_context_at' runs against an unconfigured environment and
+# silently produces unexpected results (e.g. None responses when a
+# real HoleContext should come back).
+sys.argv = [str(REPO_ROOT / "deduce.py")] + sys.argv[1:]
+sys.setrecursionlimit(10000)
+from abstract_syntax import (  # noqa: E402
+    add_import_directory,
+    init_import_directories,
+)
+from flags import set_quiet_mode  # noqa: E402
+
+set_quiet_mode(True)
+init_import_directories()
+add_import_directory(str(REPO_ROOT / "lib"))
+
+from lsp.query import Position, hole_context_at  # noqa: E402
+
+
+DEFAULT_MODELS = (
+    "Qwen3-Coder-Next",
+    "gpt-oss-120b",
+    "llama-4-scout",
+    "gemma-4-31B-it",
+)
+BASE_URL = "https://reallms.rescloud.iu.edu/direct/v1"
+API_KEY_ENV = "REALLMS_API_KEY"
+
+
+def find_first_question_mark(content: str) -> tuple[int, int]:
+    """Return 0-indexed (line, character) of the first ``?`` in CONTENT."""
+    for line_no, line in enumerate(content.splitlines()):
+        col = line.find("?")
+        if col >= 0:
+            return line_no, col
+    raise ValueError("no `?` in fixture")
+
+
+def build_request(fixture: Path) -> dict:
+    content = fixture.read_text()
+    line0, char0 = find_first_question_mark(content)
+    pos = Position(line=line0 + 1, column=char0 + 1)  # query is 1-indexed
+    ctx = hole_context_at(
+        str(fixture),
+        content,
+        pos,
+        prelude=(),
+        include_lemmas=True,
+    )
+    if ctx is None:
+        raise RuntimeError(
+            f"hole_context_at returned None for {fixture.name} -- "
+            "fixture may have changed, or the prelude needs adjusting."
+        )
+    return {
+        "file": str(fixture),
+        "holeRange": {
+            "start": {"line": line0, "character": char0},
+            "end": {"line": line0, "character": char0 + 1},
+        },
+        "goal": ctx.goal,
+        "givens": [
+            {"label": g.label, "formula": g.formula} for g in ctx.givens
+        ],
+        "lemmasInScope": [
+            {"name": lemma.name, "kind": lemma.kind.value,
+             "signature": lemma.signature}
+            for lemma in ctx.lemmas_in_scope
+        ],
+        "fingerprint": ctx.fingerprint,
+        "content": content,
+    }
+
+
+def run_one(fixture: Path, model: str, max_attempts: int, timeout: int) -> dict:
+    request = build_request(fixture)
+    cmd = [
+        sys.executable, "-m", "tools.claude_fill_hole",
+        "--backend", "openai-compat",
+        "--base-url", BASE_URL,
+        "--api-key-env", API_KEY_ENV,
+        "--model", model,
+        "--no-stdlib",
+        "--deduce-root", str(REPO_ROOT),
+        "--max-attempts", str(max_attempts),
+        "--timeout", str(timeout),
+    ]
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=json.dumps(request),
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            env=env,
+            timeout=max_attempts * timeout + 60,
+        )
+    except subprocess.TimeoutExpired as e:
+        return {
+            "ok": False,
+            "error": f"sidecar wall-clock timeout: {e}",
+            "attempts": 0,
+            "elapsed_s": round(time.monotonic() - started, 1),
+            "validations": [],
+        }
+    elapsed = round(time.monotonic() - started, 1)
+    if not proc.stdout.strip():
+        return {
+            "ok": False,
+            "error": f"sidecar exit {proc.returncode}, no stdout",
+            "attempts": 0,
+            "elapsed_s": elapsed,
+            "stderr_tail": proc.stderr[-500:],
+            "validations": [],
+        }
+    try:
+        result = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return {
+            "ok": False,
+            "error": f"bad json from sidecar: {e}",
+            "attempts": 0,
+            "elapsed_s": elapsed,
+            "validations": [],
+        }
+    result["elapsed_s"] = elapsed
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "models", nargs="*", default=list(DEFAULT_MODELS),
+        help="Models to benchmark (defaults to the four REALLMs chat models)",
+    )
+    p.add_argument("--max-attempts", type=int, default=5)
+    p.add_argument("--timeout", type=int, default=60)
+    args = p.parse_args(argv)
+
+    if not os.environ.get(API_KEY_ENV):
+        print(f"error: {API_KEY_ENV} not set in environment", file=sys.stderr)
+        return 2
+
+    fixtures = sorted(EXAMPLES_DIR.glob("0*_*.pf"))
+    if not fixtures:
+        print("error: no fixtures found", file=sys.stderr)
+        return 2
+
+    results: dict[tuple[str, str], dict] = {}
+    for model in args.models:
+        for fixture in fixtures:
+            print(f"[{model}] {fixture.name} ...",
+                  file=sys.stderr, flush=True)
+            r = run_one(fixture, model, args.max_attempts, args.timeout)
+            results[(model, fixture.name)] = r
+            status = "ok" if r.get("ok") else "fail"
+            print(f"  -> {status} ({r.get('attempts', 0)} attempts, "
+                  f"{r['elapsed_s']}s)", file=sys.stderr, flush=True)
+
+    # Markdown summary table
+    print("# Hole-fill benchmark\n")
+    print("Each cell: ✓/✗ + attempts + elapsed seconds.\n")
+    header = ["Fixture"] + list(args.models)
+    print("| " + " | ".join(header) + " |")
+    print("|" + "|".join(["---"] * len(header)) + "|")
+    for fixture in fixtures:
+        row = [fixture.name]
+        for model in args.models:
+            r = results[(model, fixture.name)]
+            tick = "✓" if r.get("ok") else "✗"
+            row.append(
+                f"{tick} {r.get('attempts', 0)}/{args.max_attempts} "
+                f"({r['elapsed_s']}s)"
+            )
+        print("| " + " | ".join(row) + " |")
+
+    # Per-fixture detail
+    print("\n# Per-fixture detail\n")
+    for fixture in fixtures:
+        print(f"## {fixture.name}\n")
+        for model in args.models:
+            r = results[(model, fixture.name)]
+            print(f"### {model}\n")
+            if r.get("ok"):
+                print(f"  - **success** in {r['attempts']} attempt(s), "
+                      f"{r['elapsed_s']}s")
+                print(f"  - proof: `{r.get('proof', '?')}`")
+            else:
+                print(f"  - **failed** after {r.get('attempts', 0)} "
+                      f"attempt(s), {r['elapsed_s']}s")
+                if r.get("error"):
+                    err = r["error"][:200]
+                    print(f"  - error: `{err}`")
+            for v in r.get("validations") or []:
+                ok = "✓" if v.get("ok") else "✗"
+                preview = (v.get("proofPreview") or "").strip()
+                err_tail = (v.get("errorTail") or "").splitlines()
+                err_first = err_tail[0] if err_tail else ""
+                print(f"    - {ok} attempt {v.get('attempt')}: "
+                      f"`{preview[:60]}`"
+                      + (f" -- {err_first[:80]}" if err_first else ""))
+            print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Six self-contained Deduce theorems (one `?` each) for benchmarking LLM backends through `deduce-fill-hole` (the feature added in #357).

Each level adds exactly one new tactic concept over the previous, so a model's failure point pinpoints what it's missing:

| # | File | Tests |
|---|------|-------|
| 1 | `01_trivial.pf` | `.` (proof of `true`) |
| 2 | `02_reflexive.pf` | `reflexive` |
| 3 | `03_assumption.pf` | reading goal, picking matching binding |
| 4 | `04_conj_swap.pf` | `conjunct N of` destructure + comma reconstruct |
| 5 | `05_disj_swap.pf` | `cases pq case n: T { ... }` multi-branch |
| 6 | `06_induction.pf` | `induction T case ctor(args) suppose IH: ... { ... }` + `expand` + `replace IH` + `equations` |

Each fixture verified:
- Parses and raises clean `IncompleteProof` on the `?`.
- Reference proof (in [README.md](tools/claude_fill_hole/examples/README.md)) checks under `--no-stdlib`.

## Test plan

- [ ] `M-x find-file` each `0N_*.pf`, `C-c C-a` on the `?`, note success/failure + attempts.
- [ ] Run the same with `(setq deduce-fill-hole-model "gpt-oss-120b")` for an A/B against `Qwen3-Coder-Next`.
- [ ] If a model fails repeatedly at level N, check the `*deduce-fill-hole debug*` buffer to see whether it's a tactic-vocabulary gap or a syntax misstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)