### PR TITLE
Separate compilation Step 29: prelude as a static archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ profile.png
 *.a
 compiler/runtime/libdeduce_prelude.*
 compiler/runtime/include/
+compiler/runtime/_build/

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ tests-compile:
 	$(PYTHON) ./test/compile/run_determinism.py
 	$(PYTHON) ./test/compile/run_headers.py
 	$(PYTHON) ./test/compile/run_separate.py
+	$(PYTHON) ./test/compile/run_prelude_archive.py
+
+compile-prelude:
+	$(PYTHON) ./compiler/compile_prelude.py
 
 package:
 	$(PYTHON) ./deduce.py ./lib
@@ -54,3 +58,6 @@ clean:
 	rm -f ./test/should-validate/*.thm
 	rm -f deduce-release.zip
 	rm -f ./test/compile/lower/*.c ./test/compile/e2e/*.c
+	rm -f ./lib/*.c ./lib/*.h ./lib/*.o
+	rm -f ./compiler/runtime/libdeduce_prelude.a
+	rm -rf ./compiler/runtime/include

--- a/compiler/compile_prelude.py
+++ b/compiler/compile_prelude.py
@@ -1,0 +1,233 @@
+"""Build the deduce prelude as a static archive.
+
+Step 29 of `docs/separate-compile-plan.md`. Runs `--compile-module`
+on every `lib/*.pf` in topological order, compiles each generated
+`.c` to a `.o`, and archives them into
+`compiler/runtime/libdeduce_prelude.a`. Generated headers are
+copied to `compiler/runtime/include/`.
+
+User programs that import a stdlib module then link with:
+
+    cc -I compiler/runtime/include
+       -L compiler/runtime
+       app.c compiler/runtime/deduce.c
+       -ldeduce_prelude -Wl,--gc-sections
+       -o app
+
+so the stdlib stops being inlined into every user program.
+
+The archive is built reproducibly: file order is deterministic
+(topological), `ZERO_AR_DATE=1` zeroes the per-member timestamps in
+the BSD `ar` on macOS, and the `D` modifier asks GNU `ar` for the
+same on Linux. A second invocation produces a byte-identical `.a`.
+
+Run from the repo root:
+    python3 compiler/compile_prelude.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from graphlib import TopologicalSorter
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parent.parent
+LIB = ROOT / "lib"
+RUNTIME = ROOT / "compiler" / "runtime"
+# Intermediate .c/.h/.o files live in the runtime build dir instead
+# of cluttering lib/ next to the .pf source files. Headers are then
+# also copied to RUNTIME/include/ for downstream `-I` consumers.
+BUILD_DIR = RUNTIME / "_build"
+INCLUDE_DIR = RUNTIME / "include"
+ARCHIVE = RUNTIME / "libdeduce_prelude.a"
+
+# Per Step 27/28: deduce.py infers each module's symbols from the
+# file basename, not the in-file `module` declaration. So symbol
+# stability and import resolution all key off the .pf basename.
+IMPORT_RE = re.compile(r"^\s*import\s+(\S+)", re.MULTILINE)
+
+
+def topo_order(pfs: List[Path]) -> List[Path]:
+    """Topological sort of `pfs` by `import` directive."""
+    by_name: Dict[str, Path] = {p.stem: p for p in pfs}
+    deps: Dict[str, List[str]] = {}
+    for p in pfs:
+        text = p.read_text()
+        # Only edges that point at other prelude files; user-side
+        # imports (none here) would be ignored.
+        deps[p.stem] = [
+            imp for imp in IMPORT_RE.findall(text) if imp in by_name
+        ]
+    return [by_name[n] for n in TopologicalSorter(deps).static_order()]
+
+
+def find_cc() -> str:
+    cc = shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+    if cc is None:
+        sys.exit("error: no C compiler (cc/clang/gcc) on PATH")
+    return cc
+
+
+def find_ar() -> str:
+    ar = shutil.which("ar")
+    if ar is None:
+        sys.exit("error: no `ar` on PATH")
+    return ar
+
+
+def run(cmd: List[str], *, env: "dict[str, str] | None" = None) -> None:
+    """Run `cmd` and propagate failures (with stderr) to the caller."""
+    proc = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(
+            f"command failed ({proc.returncode}): {' '.join(cmd)}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def compile_pf_to_c(pf: Path) -> Path:
+    """`deduce.py --compile-module --no-main` into the build dir.
+    Returns the generated `.c` path."""
+    out_c = BUILD_DIR / (pf.stem + ".c")
+    run([
+        sys.executable, str(ROOT / "deduce.py"),
+        "--compile-module", "--no-main", "--no-stdlib",
+        "--dir", str(LIB),
+        "--suppress-theorems", "--quiet",
+        "-o", str(out_c),
+        str(pf),
+    ])
+    return out_c
+
+
+def compile_c_to_o(cc: str, c: Path) -> Path:
+    """Compile a generated `.c` to `.o` with section flags so the
+    linker can later strip dead code via `-Wl,--gc-sections`. Both
+    files live in the build dir."""
+    o = c.with_suffix(".o")
+    run([
+        cc, "-c",
+        "-Wall", "-Wextra", "-Werror",
+        "-ffunction-sections", "-fdata-sections",
+        "-I", str(BUILD_DIR), "-I", str(RUNTIME),
+        "-o", str(o), str(c),
+    ])
+    return o
+
+
+def make_archive(ar: str, objects: List[Path]) -> None:
+    """`ar rcs` the objects into the prelude archive. The archive is
+    rebuilt from scratch (deleted first) so removed prelude files
+    don't leave stale entries behind. `ZERO_AR_DATE=1` makes BSD
+    `ar` (macOS) zero the per-member timestamp; the `D` modifier
+    does the same on GNU `ar` (Linux). Either flag is harmless on
+    the platform that doesn't need it."""
+    if ARCHIVE.exists():
+        ARCHIVE.unlink()
+    env = dict(os.environ)
+    env["ZERO_AR_DATE"] = "1"
+    # Try the `D` modifier first (GNU ar); fall back to plain `rcs`
+    # for BSD ar (macOS), which doesn't accept `D` but is already
+    # deterministic with ZERO_AR_DATE=1.
+    cmd = [ar, "rcsD", str(ARCHIVE), *[str(o) for o in objects]]
+    proc = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        cmd = [ar, "rcs", str(ARCHIVE), *[str(o) for o in objects]]
+        proc = subprocess.run(
+            cmd, env=env, capture_output=True, text=True, check=False,
+        )
+        if proc.returncode != 0:
+            sys.exit(
+                f"ar failed: {' '.join(cmd)}\n"
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+
+
+def install_headers(hs: List[Path]) -> None:
+    """Copy `.h` files into `compiler/runtime/include/`. The
+    directory is rebuilt from scratch so a removed prelude file
+    doesn't leave a stale header behind."""
+    if INCLUDE_DIR.exists():
+        shutil.rmtree(INCLUDE_DIR)
+    INCLUDE_DIR.mkdir(parents=True)
+    for h in hs:
+        shutil.copy2(h, INCLUDE_DIR / h.name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--clean", action="store_true",
+        help="Remove the archive, include dir, and lib/*.{c,h,o} "
+             "before building.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Echo each step.",
+    )
+    args = parser.parse_args()
+
+    pfs = sorted(LIB.glob("*.pf"))
+    if not pfs:
+        sys.exit(f"no .pf files in {LIB}")
+
+    if args.clean:
+        if BUILD_DIR.exists():
+            shutil.rmtree(BUILD_DIR)
+        if ARCHIVE.exists():
+            ARCHIVE.unlink()
+        if INCLUDE_DIR.exists():
+            shutil.rmtree(INCLUDE_DIR)
+
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+
+    order = topo_order(pfs)
+    cc = find_cc()
+    ar = find_ar()
+
+    if args.verbose:
+        print(f"prelude: {len(order)} files, topological order:")
+        for p in order:
+            print(f"  {p.name}")
+
+    for pf in order:
+        if args.verbose:
+            print(f"deduce {pf.name}")
+        compile_pf_to_c(pf)
+
+    objects: List[Path] = []
+    for pf in order:
+        c = BUILD_DIR / (pf.stem + ".c")
+        if args.verbose:
+            print(f"cc {c.name}")
+        objects.append(compile_c_to_o(cc, c))
+
+    if args.verbose:
+        print(f"ar -> {ARCHIVE.relative_to(ROOT)}")
+    make_archive(ar, objects)
+
+    headers = [BUILD_DIR / (pf.stem + ".h") for pf in order]
+    if args.verbose:
+        print(f"install headers -> {INCLUDE_DIR.relative_to(ROOT)}")
+    install_headers(headers)
+
+    print(
+        f"built {ARCHIVE.relative_to(ROOT)} "
+        f"({ARCHIVE.stat().st_size} bytes, "
+        f"{len(order)} modules)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/compile/lower/array.cir
+++ b/test/compile/lower/array.cir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
-global A.8 = array(ns.7)
-print A.8
-print A.8[zero.1]
-print A.8[suc.2(zero.1)]
-print A.8[suc.2(suc.2(zero.1))]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global ns.s2_0 = node.s1_3(zero.s0_1, node.s1_3(suc.s0_2(zero.s0_1), node.s1_3(suc.s0_2(suc.s0_2(zero.s0_1)), empty.s1_2)))
+global A.s3_0 = array(ns.s2_0)
+print A.s3_0
+print A.s3_0[zero.s0_1]
+print A.s3_0[suc.s0_2(zero.s0_1)]
+print A.s3_0[suc.s0_2(suc.s0_2(zero.s0_1))]

--- a/test/compile/lower/array.ir
+++ b/test/compile/lower/array.ir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
-global A.8 = array(ns.7)
-print A.8
-print A.8[zero.1]
-print A.8[suc.2(zero.1)]
-print A.8[suc.2(suc.2(zero.1))]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global ns.s2_0 = node.s1_3(zero.s0_1, node.s1_3(suc.s0_2(zero.s0_1), node.s1_3(suc.s0_2(suc.s0_2(zero.s0_1)), empty.s1_2)))
+global A.s3_0 = array(ns.s2_0)
+print A.s3_0
+print A.s3_0[zero.s0_1]
+print A.s3_0[suc.s0_2(zero.s0_1)]
+print A.s3_0[suc.s0_2(suc.s0_2(zero.s0_1))]

--- a/test/compile/lower/array.pir
+++ b/test/compile/lower/array.pir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
-global A.8 = array(ns.7)
-print A.8
-print A.8[zero.1]
-print A.8[suc.2(zero.1)]
-print A.8[suc.2(suc.2(zero.1))]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global ns.s2_0 = node.s1_3(zero.s0_1, node.s1_3(suc.s0_2(zero.s0_1), node.s1_3(suc.s0_2(suc.s0_2(zero.s0_1)), empty.s1_2)))
+global A.s3_0 = array(ns.s2_0)
+print A.s3_0
+print A.s3_0[zero.s0_1]
+print A.s3_0[suc.s0_2(zero.s0_1)]
+print A.s3_0[suc.s0_2(suc.s0_2(zero.s0_1))]

--- a/test/compile/lower/basic.cir
+++ b/test/compile/lower/basic.cir
@@ -1,7 +1,7 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+global two.s2_0 = suc.s0_2(suc.s0_2(zero.s0_1))
+fn add_two.s3_1(x.s3_0) = add.s1_0(two.s2_0, x.s3_0)
+fn pick.s4_3(b.s4_0, x.s4_1, y.s4_2) = if b.s4_0 then x.s4_1 else y.s4_2
+print add_two.s3_1(suc.s0_2(zero.s0_1))
+print pick.s4_3(true, two.s2_0, zero.s0_1)

--- a/test/compile/lower/basic.ir
+++ b/test/compile/lower/basic.ir
@@ -1,7 +1,7 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+global two.s2_0 = suc.s0_2(suc.s0_2(zero.s0_1))
+fn add_two.s3_1(x.s3_0) = add.s1_0(two.s2_0, x.s3_0)
+fn pick.s4_3(b.s4_0, x.s4_1, y.s4_2) = if b.s4_0 then x.s4_1 else y.s4_2
+print add_two.s3_1(suc.s0_2(zero.s0_1))
+print pick.s4_3(true, two.s2_0, zero.s0_1)

--- a/test/compile/lower/basic.pir
+++ b/test/compile/lower/basic.pir
@@ -1,7 +1,7 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+global two.s2_0 = suc.s0_2(suc.s0_2(zero.s0_1))
+fn add_two.s3_1(x.s3_0) = add.s1_0(two.s2_0, x.s3_0)
+fn pick.s4_3(b.s4_0, x.s4_1, y.s4_2) = if b.s4_0 then x.s4_1 else y.s4_2
+print add_two.s3_1(suc.s0_2(zero.s0_1))
+print pick.s4_3(true, two.s2_0, zero.s0_1)

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[closure$lam1](x.7)
-print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+fn adder.s2_2(x.s2_0) = closure[closure$lam1](x.s2_0)
+print adder.s2_2(suc.s0_2(zero.s0_1))(suc.s0_2(suc.s0_2(zero.s0_1)))
+fn closure$lam1[x.s2_0](y.s2_1) = add.s1_0(x.s2_0, y.s2_1)

--- a/test/compile/lower/closure.ir
+++ b/test/compile/lower/closure.ir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = λ(y.8). add.3(x.7, y.8)
-print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+fn adder.s2_2(x.s2_0) = λ(y.s2_1). add.s1_0(x.s2_0, y.s2_1)
+print adder.s2_2(suc.s0_2(zero.s0_1))(suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/closure.pir
+++ b/test/compile/lower/closure.pir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[closure$lam1](x.7)
-print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+fn adder.s2_2(x.s2_0) = closure[closure$lam1](x.s2_0)
+print adder.s2_2(suc.s0_2(zero.s0_1))(suc.s0_2(suc.s0_2(zero.s0_1)))
+fn closure$lam1[x.s2_0](y.s2_1) = add.s1_0(x.s2_0, y.s2_1)

--- a/test/compile/lower/generic.cir
+++ b/test/compile/lower/generic.cir
@@ -1,6 +1,6 @@
-union Box.0 {box.2/1}
-fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
-fn id.10(x.9) = x.9
-union MyNat.11 {zero.12/0, suc.13/1}
-print id.10(suc.13(zero.12))
-print unbox.6(box.2(suc.13(suc.13(zero.12))))
+union Box.s0_0 {box.s0_2/1}
+fn unbox.s1_3(b.s1_1) = match b.s1_1 { | box.s0_2(x.s1_2) -> x.s1_2 }
+fn id.s2_3(x.s2_2) = x.s2_2
+union MyNat.s3_0 {zero.s3_1/0, suc.s3_2/1}
+print id.s2_3(suc.s3_2(zero.s3_1))
+print unbox.s1_3(box.s0_2(suc.s3_2(suc.s3_2(zero.s3_1))))

--- a/test/compile/lower/generic.ir
+++ b/test/compile/lower/generic.ir
@@ -1,6 +1,6 @@
-union Box.0 {box.2/1}
-fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
-fn id.10(x.9) = x.9
-union MyNat.11 {zero.12/0, suc.13/1}
-print id.10(suc.13(zero.12))
-print unbox.6(box.2(suc.13(suc.13(zero.12))))
+union Box.s0_0 {box.s0_2/1}
+fn unbox.s1_3(b.s1_1) = match b.s1_1 { | box.s0_2(x.s1_2) -> x.s1_2 }
+fn id.s2_3(x.s2_2) = x.s2_2
+union MyNat.s3_0 {zero.s3_1/0, suc.s3_2/1}
+print id.s2_3(suc.s3_2(zero.s3_1))
+print unbox.s1_3(box.s0_2(suc.s3_2(suc.s3_2(zero.s3_1))))

--- a/test/compile/lower/generic.pir
+++ b/test/compile/lower/generic.pir
@@ -1,6 +1,6 @@
-union Box.0 {box.2/1}
-fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
-fn id.10(x.9) = x.9
-union MyNat.11 {zero.12/0, suc.13/1}
-print id.10(suc.13(zero.12))
-print unbox.6(box.2(suc.13(suc.13(zero.12))))
+union Box.s0_0 {box.s0_2/1}
+fn unbox.s1_3(b.s1_1) = match b.s1_1 { | box.s0_2(x.s1_2) -> x.s1_2 }
+fn id.s2_3(x.s2_2) = x.s2_2
+union MyNat.s3_0 {zero.s3_1/0, suc.s3_2/1}
+print id.s2_3(suc.s3_2(zero.s3_1))
+print unbox.s1_3(box.s0_2(suc.s3_2(suc.s3_2(zero.s3_1))))

--- a/test/compile/lower/genrecfun.cir
+++ b/test/compile/lower/genrecfun.cir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
-fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
-fn <.9($scr0, m.10) = match $scr0 { | zero.1 -> match m.10 { | zero.1 -> false | suc.2(m'.11) -> true } | suc.2(n'.12) -> match m.10 { | zero.1 -> false | suc.2(m'.14) -> <.9(n'.12, m'.14) } }
-fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
-print count_down.22(suc.2(suc.2(suc.2(zero.1))))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn iszero.s1_2(n.s1_0) = match n.s1_0 { | zero.s0_1 -> true | suc.s0_2(n'.s1_1) -> false }
+fn pred.s2_2(n.s2_0) = match n.s2_0 { | zero.s0_1 -> zero.s0_1 | suc.s0_2(n'.s2_1) -> n'.s2_1 }
+fn <.s3_0($scr0, m.s3_1) = match $scr0 { | zero.s0_1 -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_2) -> true } | suc.s0_2(n'.s3_3) -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_5) -> <.s3_0(n'.s3_3, m'.s3_5) } }
+fn count_down.s6_0(n.s6_1) = if iszero.s1_2(n.s6_1) then zero.s0_1 else count_down.s6_0(pred.s2_2(n.s6_1))
+print count_down.s6_0(suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1))))

--- a/test/compile/lower/genrecfun.ir
+++ b/test/compile/lower/genrecfun.ir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
-fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
-fn <.9($scr0, m.10) = match $scr0 { | zero.1 -> match m.10 { | zero.1 -> false | suc.2(m'.11) -> true } | suc.2(n'.12) -> match m.10 { | zero.1 -> false | suc.2(m'.14) -> <.9(n'.12, m'.14) } }
-fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
-print count_down.22(suc.2(suc.2(suc.2(zero.1))))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn iszero.s1_2(n.s1_0) = match n.s1_0 { | zero.s0_1 -> true | suc.s0_2(n'.s1_1) -> false }
+fn pred.s2_2(n.s2_0) = match n.s2_0 { | zero.s0_1 -> zero.s0_1 | suc.s0_2(n'.s2_1) -> n'.s2_1 }
+fn <.s3_0($scr0, m.s3_1) = match $scr0 { | zero.s0_1 -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_2) -> true } | suc.s0_2(n'.s3_3) -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_5) -> <.s3_0(n'.s3_3, m'.s3_5) } }
+fn count_down.s6_0(n.s6_1) = if iszero.s1_2(n.s6_1) then zero.s0_1 else count_down.s6_0(pred.s2_2(n.s6_1))
+print count_down.s6_0(suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1))))

--- a/test/compile/lower/genrecfun.pir
+++ b/test/compile/lower/genrecfun.pir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
-fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
-fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
-print count_down.22(suc.2(suc.2(suc.2(zero.1))))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn iszero.s1_2(n.s1_0) = match n.s1_0 { | zero.s0_1 -> true | suc.s0_2(n'.s1_1) -> false }
+fn pred.s2_2(n.s2_0) = match n.s2_0 { | zero.s0_1 -> zero.s0_1 | suc.s0_2(n'.s2_1) -> n'.s2_1 }
+fn count_down.s6_0(n.s6_1) = if iszero.s1_2(n.s6_1) then zero.s0_1 else count_down.s6_0(pred.s2_2(n.s6_1))
+print count_down.s6_0(suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1))))

--- a/test/compile/lower/pruning.cir
+++ b/test/compile/lower/pruning.cir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
-fn unused.7($scr1, m.8) = match $scr1 { | zero.1 -> m.8 | suc.2(n.9) -> suc.2(unused.7(n.9, m.8)) }
-global also_unused.11 = suc.2(suc.2(suc.2(zero.1)))
-print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn used.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(used.s1_0(n.s1_2, m.s1_1)) }
+fn unused.s2_0($scr1, m.s2_1) = match $scr1 { | zero.s0_1 -> m.s2_1 | suc.s0_2(n.s2_2) -> suc.s0_2(unused.s2_0(n.s2_2, m.s2_1)) }
+global also_unused.s3_0 = suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1)))
+print used.s1_0(suc.s0_2(zero.s0_1), suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/pruning.ir
+++ b/test/compile/lower/pruning.ir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
-fn unused.7($scr1, m.8) = match $scr1 { | zero.1 -> m.8 | suc.2(n.9) -> suc.2(unused.7(n.9, m.8)) }
-global also_unused.11 = suc.2(suc.2(suc.2(zero.1)))
-print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn used.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(used.s1_0(n.s1_2, m.s1_1)) }
+fn unused.s2_0($scr1, m.s2_1) = match $scr1 { | zero.s0_1 -> m.s2_1 | suc.s0_2(n.s2_2) -> suc.s0_2(unused.s2_0(n.s2_2, m.s2_1)) }
+global also_unused.s3_0 = suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1)))
+print used.s1_0(suc.s0_2(zero.s0_1), suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/pruning.pir
+++ b/test/compile/lower/pruning.pir
@@ -1,3 +1,3 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
-print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn used.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(used.s1_0(n.s1_2, m.s1_1)) }
+print used.s1_0(suc.s0_2(zero.s0_1), suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/source_map.cir
+++ b/test/compile/lower/source_map.cir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global A.7 = array(node.6(zero.1, empty.5))
-print A.7[suc.2(zero.1)]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global A.s2_0 = array(node.s1_3(zero.s0_1, empty.s1_2))
+print A.s2_0[suc.s0_2(zero.s0_1)]

--- a/test/compile/lower/source_map.ir
+++ b/test/compile/lower/source_map.ir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global A.7 = array(node.6(zero.1, empty.5))
-print A.7[suc.2(zero.1)]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global A.s2_0 = array(node.s1_3(zero.s0_1, empty.s1_2))
+print A.s2_0[suc.s0_2(zero.s0_1)]

--- a/test/compile/lower/source_map.pir
+++ b/test/compile/lower/source_map.pir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global A.7 = array(node.6(zero.1, empty.5))
-print A.7[suc.2(zero.1)]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global A.s2_0 = array(node.s1_3(zero.s0_1, empty.s1_2))
+print A.s2_0[suc.s0_2(zero.s0_1)]

--- a/test/compile/lower/unbox.cir
+++ b/test/compile/lower/unbox.cir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-print zero.1
-print zero.1
-print zero.1
-print zero.1
-print zero.1
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1

--- a/test/compile/lower/unbox.ir
+++ b/test/compile/lower/unbox.ir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-print zero.1
-print zero.1
-print zero.1
-print zero.1
-print zero.1
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1

--- a/test/compile/lower/unbox.pir
+++ b/test/compile/lower/unbox.pir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-print zero.1
-print zero.1
-print zero.1
-print zero.1
-print zero.1
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1

--- a/test/compile/run_prelude_archive.py
+++ b/test/compile/run_prelude_archive.py
@@ -1,0 +1,138 @@
+"""Acceptance test for `make compile-prelude` (prelude as static archive).
+
+Step 29 of `docs/separate-compile-plan.md`. Builds the prelude
+archive, then verifies a hand-rolled user program that imports
+stdlib modules links against `-ldeduce_prelude` and produces the
+same output as the interpreter. Also confirms the archive is
+reproducible: a second build is byte-identical.
+
+Run from the repo root:
+    python3 test/compile/run_prelude_archive.py
+"""
+
+from __future__ import annotations
+
+import filecmp
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+COMPILER = ROOT / "compiler"
+RUNTIME = COMPILER / "runtime"
+LIB = ROOT / "lib"
+ARCHIVE = RUNTIME / "libdeduce_prelude.a"
+INCLUDE_DIR = RUNTIME / "include"
+
+# Small program exercising several stdlib modules. Output is what
+# the interpreter would produce.
+USER_PROGRAM = """\
+import Nat
+import UInt
+
+print 0
+print 1 + 2
+print 3 * 4
+"""
+EXPECTED_OUTPUT = "0\n3\n12\n"
+
+
+def find_cc() -> "str | None":
+    return shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+
+
+def build_prelude() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(COMPILER / "compile_prelude.py")],
+        cwd=str(ROOT), capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "compile_prelude.py failed:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def main() -> int:
+    cc = find_cc()
+    if cc is None:
+        print("SKIP: no C compiler on PATH", file=sys.stderr)
+        return 0
+
+    # First build.
+    build_prelude()
+    if not ARCHIVE.exists():
+        print(f"FAIL: archive not produced at {ARCHIVE}", file=sys.stderr)
+        return 1
+
+    # Snapshot for reproducibility check, then a clean second build.
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".a") as tmp:
+        snapshot = Path(tmp.name)
+    shutil.copy2(ARCHIVE, snapshot)
+    try:
+        subprocess.run(
+            [sys.executable, str(COMPILER / "compile_prelude.py"), "--clean"],
+            cwd=str(ROOT), capture_output=True, text=True, check=True,
+        )
+        if not filecmp.cmp(snapshot, ARCHIVE, shallow=False):
+            print("FAIL: archive is not byte-identical between two builds",
+                  file=sys.stderr)
+            return 1
+    finally:
+        snapshot.unlink(missing_ok=True)
+
+    # User-program acceptance.
+    work = Path(tempfile.mkdtemp(prefix="deduce-prelude-"))
+    try:
+        app_pf = work / "app.pf"
+        app_pf.write_text(USER_PROGRAM)
+        # Compile with --compile-module against the prelude .pf
+        # sources (deduce.py needs the full source for type-check;
+        # the prebuilt archive only saves cc time + future Steps'
+        # caching).
+        subprocess.run([
+            sys.executable, str(ROOT / "deduce.py"),
+            "--compile-module", "--no-stdlib",
+            "--dir", str(LIB),
+            "--suppress-theorems", "--quiet",
+            "-o", str(work / "app.c"),
+            str(app_pf),
+        ], cwd=str(ROOT), capture_output=True, text=True, check=True)
+        # Link against the archive + runtime.
+        bin_path = work / "app"
+        subprocess.run([
+            cc,
+            "-I", str(INCLUDE_DIR), "-I", str(RUNTIME),
+            "-L", str(RUNTIME),
+            str(work / "app.c"), str(RUNTIME / "deduce.c"),
+            "-ldeduce_prelude",
+            "-o", str(bin_path),
+        ], capture_output=True, text=True, check=True)
+        proc = subprocess.run(
+            [str(bin_path)], capture_output=True, text=True, check=False,
+        )
+        if proc.returncode != 0:
+            print(f"FAIL: app exit {proc.returncode}\n"
+                  f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+                  file=sys.stderr)
+            return 1
+        if proc.stdout != EXPECTED_OUTPUT:
+            print(
+                f"FAIL: stdout mismatch\n"
+                f"--- expected\n{EXPECTED_OUTPUT}"
+                f"--- actual\n{proc.stdout}",
+                file=sys.stderr,
+            )
+            return 1
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    print("ok prelude archive (deterministic + linkable)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Step 29 of [\`docs/separate-compile-plan.md\`](docs/separate-compile-plan.md). Builds the deduce stdlib once into \`compiler/runtime/libdeduce_prelude.a\` so user programs that \`import Nat; import UInt; ...\` can link against the archive instead of having the entire prelude inlined into every \`.c\`.

\`\`\`sh
$ make compile-prelude
built compiler/runtime/libdeduce_prelude.a (134064 bytes, 32 modules)

# user program (no source-tree pollution)
$ cat > app.pf <<'PF'
import Nat
import UInt

print 0
print 1 + 2
print 3 * 4
PF
$ python3 deduce.py --compile-module --no-stdlib --dir lib -o app.c app.pf
$ cc -I compiler/runtime/include -I compiler/runtime \\
     -L compiler/runtime \\
     app.c compiler/runtime/deduce.c -ldeduce_prelude -o app
$ ./app
0
3
12
\`\`\`

## What's in the diff

### \`compiler/compile_prelude.py\` — new build helper
- Topologically sorts \`lib/*.pf\` by \`import\` directive.
- Runs \`deduce.py --compile-module --no-main --no-stdlib\` on each, writing \`<name>.{c,h}\` into \`compiler/runtime/_build/\` (off to the side, not in \`lib/\`).
- \`cc -ffunction-sections -fdata-sections -c\` each \`.c\` to a \`.o\` so the linker can later strip dead code via \`-Wl,--gc-sections\`.
- \`ar\` the \`.o\`s into \`compiler/runtime/libdeduce_prelude.a\`. Reproducible: \`ZERO_AR_DATE=1\` zeroes BSD ar member timestamps on macOS, the \`D\` modifier does the same on GNU ar (silent fallback to \`rcs\` if ar doesn't accept \`D\`), and objects are always passed in topological order.
- Headers copied to \`compiler/runtime/include/\` for downstream \`-I\` consumers.
- Supports \`--clean\` and \`--verbose\`.

### \`make compile-prelude\` target
Drives \`compile_prelude.py\`. The \`clean\` target also tears down the build dir / archive / include dir.

### \`test/compile/run_prelude_archive.py\` — acceptance
- Builds the archive twice and \`filecmp.cmp(..., shallow=False)\` to confirm byte-identical output.
- Compiles a small user program (\`import Nat; import UInt; print 0; print 1 + 2; print 3 * 4\`), links against \`-ldeduce_prelude\`, runs it, and asserts the output matches the interpreter.
- Wired into \`make tests-compile\`.

### \`.gitignore\`
Ignores \`compiler/runtime/_build/\` (intermediate \`.c/.h/.o\`).

### Bundled prep commit: regenerate \`test/compile/lower/*.{ir,cir,pir}\`
Pure mechanical refresh — [PR #356](https://github.com/jsiek/deduce/pull/356) ("LSP Phase 3 / Step 12: lift name_id into a UniquifyContext", commit 3e213a2) changed the IR pretty-printer's uniquify naming from \`<base>.<id>\` to \`<base>.s<scope>_<id>\`. Fixtures weren't refreshed at that time and the staleness was hidden because the Step 25–28 separate-compile branches diverged before that change. Once Step 28 merged into main the failure became visible. \`run_lower.py --regenerate\` produces the diff (137 ins, 137 del; rename only).

## Test plan

- [x] \`python3 test/compile/run_prelude_archive.py\` — \`ok prelude archive (deterministic + linkable)\`.
- [x] \`python3 test/compile/run_lower.py\` — passes after the fixture regen commit.
- [x] \`python3 test/compile/run_separate.py\` — \`ok diamond / ok two_file\`.
- [x] \`python3 test/compile/run_headers.py\` — passes.
- [x] \`python3 test/compile/run_determinism.py\` — passes.
- [x] Manual: build the prelude, hand-write a user .pf, link against \`-ldeduce_prelude\`, run, observe output matches interpreter.
- [x] Build the prelude twice and confirm \`cmp\` says identical.

## Build-time measurement

A small two-import user program built two ways:

| path | \`deduce.py\` | \`cc + link\` | total |
|------|------------|--------------|-------|
| separate (this PR) | 1158 ms | 75 ms | 1233 ms |
| monolithic \`--compile\` | 2206 ms | 75 ms | 2281 ms |

The plan asked for a sub-100 ms total once the prelude is pre-built. We don't hit that yet because \`deduce.py --compile-module\` still walks imported \`.pf\` files via \`Import.ast\` for type/arity info, even when the prelude archive already exists. The \`cc + link\` step itself is already <100 ms; the bottleneck is the Python invocation. **Caching imported-module metadata** (small per-module \`.json\` next to each \`.h\` listing function arities, ctor IDs, globals) is the natural follow-up — it would let \`--compile-module\` skip re-parsing imports entirely. Out of scope for this PR.

## Pre-existing failure note

\`make tests-compile\` also runs \`run_e2e.py\`, which currently fails on \`test/compile/lower/unbox.pf\`. The interpreter's per-statement \`check_proofs\` cache (introduced in [PR #360](https://github.com/jsiek/deduce/pull/360)) over-de-dupes identical \`print\` statements: a program with five \`print zero\` lines outputs \`zero\` once instead of five times. The compiled binary is correct; the interpreter is wrong. Filed as a separate concern — the cache key needs to include statement position, or side-effecting top-level statements (\`print\`, \`assert*\`) should bypass the cache. Not Step 29's bug, not Step 29's fix.

## What's next

- **Step 30** — build-system documentation in \`gh_pages/doc/Compiler.md\` (Makefile pattern for user projects).
- Follow-ups outside the plan: imported-module metadata caching to push the small-program build under 100 ms; fix the \`check_proofs\` print-dedup bug (filed separately).