### PR TITLE
Fix per-statement cache deduping print/assert side effects

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -4844,7 +4844,18 @@ def check_deduce(ast, module_name, modified, tracing_functions):
       )
       key = ("check_proofs", sh, deps_fingerprint, target, module_name)
       if needs_checking[0]:
-        if key in _stmt_cache:
+        # ``Print`` and ``Assert`` have observable side effects in
+        # ``check_proofs`` (printing a value, raising on a failed
+        # assertion).  Their cache key is fully determined by the
+        # statement's text and its dependency set, so two identical
+        # ``print zero`` lines hash to the same key -- caching the
+        # verdict would skip the side effect on every duplicate.
+        # Bypass the cache for them; ``check_proofs`` on these is
+        # cheap anyway.
+        if isinstance(s, (Print, Assert)):
+          check_proofs(s, env)
+          _record_miss("check_proofs")
+        elif key in _stmt_cache:
           _record_hit("check_proofs")
         else:
           check_proofs(s, env)


### PR DESCRIPTION
## Summary
- The `check_proofs` cache added in #360 keys entries on `(stmt_hash, deps_fingerprint, target, module_name)` with no positional component. Repeated identical side-effecting statements (e.g. `print zero` × 5) all produce the same key, so positions 2–5 hit the cache entry from position 1 and skip `check_proofs` — which is where `Print` actually runs. `Assert` has the same issue.
- Fix: bypass the cache for `Print` and `Assert`. Their effect is observable, the "verified" verdict isn't reusable, and running them is cheap. The cache continues to do its job for theorems.

## Repro

```
union MyNat { zero, suc(MyNat) }
print zero
print zero
print zero
print zero
print zero
```
`python3.13 deduce.py --no-stdlib repro.pf` previously printed `zero` once; now prints it 5 times.

This also unblocks the interpreter side of `test/compile/lower/unbox.pf` (e2e fixture that prints `zero` 5×): the compiled binary was already emitting 5 lines, the interpreter only 1.

## Test plan
- [x] `python3.13 -m pytest test/lsp/test_check_proofs_cache.py` — 9/9 pass (cache still hits for theorems)
- [x] `python3.13 test-deduce.py` — full suite passes
- [x] `python3.13 -m pytest test/lsp/` — 704/704 pass
- [x] `python3.13 test/compile/run_e2e.py` — passes (interpreter vs compiled binary diff on `unbox.pf` and 28 others)
- [x] Manual repros: 5× `print zero` → 5 lines; non-uniform `print zero / suc(zero) / zero / suc(suc(zero)) / zero` → all 5 in order

## Reviewer notes
- Pre-existing `run_lower.py` failure on `unbox.pf` (IR-format mismatch: `.s0_*` vs `.0` mangling, a Step 12 leftover in the expected fixture) is **not** addressed here — present before this change too. Fixture refresh is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)