### PR TITLE
Separate compilation Step 30: docs for per-module workflow + Index discoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ profile.png
 *.a
 compiler/runtime/libdeduce_prelude.*
 compiler/runtime/include/
+compiler/runtime/_build/

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ tests-compile:
 	$(PYTHON) ./test/compile/run_determinism.py
 	$(PYTHON) ./test/compile/run_headers.py
 	$(PYTHON) ./test/compile/run_separate.py
+	$(PYTHON) ./test/compile/run_prelude_archive.py
+
+compile-prelude:
+	$(PYTHON) ./compiler/compile_prelude.py
 
 package:
 	$(PYTHON) ./deduce.py ./lib
@@ -54,3 +58,6 @@ clean:
 	rm -f ./test/should-validate/*.thm
 	rm -f deduce-release.zip
 	rm -f ./test/compile/lower/*.c ./test/compile/e2e/*.c
+	rm -f ./lib/*.c ./lib/*.h ./lib/*.o
+	rm -f ./compiler/runtime/libdeduce_prelude.a
+	rm -rf ./compiler/runtime/include

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The web page for Deduce is at the following link:
 **[https://jsiek.github.io/deduce/](https://jsiek.github.io/deduce/)**
 
 The directory structure:
+* `/compiler` Deduce-to-C compiler ([user guide](https://jsiek.github.io/deduce/pages/compiler.html))
 * `/docs` Documentation for contributing to Deduce
 * `/gh_pages` Source code for the [Deduce website](https://jsiek.github.io/deduce/)
 * `/lib` Deduce library files. This includes Nat, List, etc.

--- a/compiler/compile_prelude.py
+++ b/compiler/compile_prelude.py
@@ -1,0 +1,233 @@
+"""Build the deduce prelude as a static archive.
+
+Step 29 of `docs/separate-compile-plan.md`. Runs `--compile-module`
+on every `lib/*.pf` in topological order, compiles each generated
+`.c` to a `.o`, and archives them into
+`compiler/runtime/libdeduce_prelude.a`. Generated headers are
+copied to `compiler/runtime/include/`.
+
+User programs that import a stdlib module then link with:
+
+    cc -I compiler/runtime/include
+       -L compiler/runtime
+       app.c compiler/runtime/deduce.c
+       -ldeduce_prelude -Wl,--gc-sections
+       -o app
+
+so the stdlib stops being inlined into every user program.
+
+The archive is built reproducibly: file order is deterministic
+(topological), `ZERO_AR_DATE=1` zeroes the per-member timestamps in
+the BSD `ar` on macOS, and the `D` modifier asks GNU `ar` for the
+same on Linux. A second invocation produces a byte-identical `.a`.
+
+Run from the repo root:
+    python3 compiler/compile_prelude.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from graphlib import TopologicalSorter
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parent.parent
+LIB = ROOT / "lib"
+RUNTIME = ROOT / "compiler" / "runtime"
+# Intermediate .c/.h/.o files live in the runtime build dir instead
+# of cluttering lib/ next to the .pf source files. Headers are then
+# also copied to RUNTIME/include/ for downstream `-I` consumers.
+BUILD_DIR = RUNTIME / "_build"
+INCLUDE_DIR = RUNTIME / "include"
+ARCHIVE = RUNTIME / "libdeduce_prelude.a"
+
+# Per Step 27/28: deduce.py infers each module's symbols from the
+# file basename, not the in-file `module` declaration. So symbol
+# stability and import resolution all key off the .pf basename.
+IMPORT_RE = re.compile(r"^\s*import\s+(\S+)", re.MULTILINE)
+
+
+def topo_order(pfs: List[Path]) -> List[Path]:
+    """Topological sort of `pfs` by `import` directive."""
+    by_name: Dict[str, Path] = {p.stem: p for p in pfs}
+    deps: Dict[str, List[str]] = {}
+    for p in pfs:
+        text = p.read_text()
+        # Only edges that point at other prelude files; user-side
+        # imports (none here) would be ignored.
+        deps[p.stem] = [
+            imp for imp in IMPORT_RE.findall(text) if imp in by_name
+        ]
+    return [by_name[n] for n in TopologicalSorter(deps).static_order()]
+
+
+def find_cc() -> str:
+    cc = shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+    if cc is None:
+        sys.exit("error: no C compiler (cc/clang/gcc) on PATH")
+    return cc
+
+
+def find_ar() -> str:
+    ar = shutil.which("ar")
+    if ar is None:
+        sys.exit("error: no `ar` on PATH")
+    return ar
+
+
+def run(cmd: List[str], *, env: "dict[str, str] | None" = None) -> None:
+    """Run `cmd` and propagate failures (with stderr) to the caller."""
+    proc = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(
+            f"command failed ({proc.returncode}): {' '.join(cmd)}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def compile_pf_to_c(pf: Path) -> Path:
+    """`deduce.py --compile-module --no-main` into the build dir.
+    Returns the generated `.c` path."""
+    out_c = BUILD_DIR / (pf.stem + ".c")
+    run([
+        sys.executable, str(ROOT / "deduce.py"),
+        "--compile-module", "--no-main", "--no-stdlib",
+        "--dir", str(LIB),
+        "--suppress-theorems", "--quiet",
+        "-o", str(out_c),
+        str(pf),
+    ])
+    return out_c
+
+
+def compile_c_to_o(cc: str, c: Path) -> Path:
+    """Compile a generated `.c` to `.o` with section flags so the
+    linker can later strip dead code via `-Wl,--gc-sections`. Both
+    files live in the build dir."""
+    o = c.with_suffix(".o")
+    run([
+        cc, "-c",
+        "-Wall", "-Wextra", "-Werror",
+        "-ffunction-sections", "-fdata-sections",
+        "-I", str(BUILD_DIR), "-I", str(RUNTIME),
+        "-o", str(o), str(c),
+    ])
+    return o
+
+
+def make_archive(ar: str, objects: List[Path]) -> None:
+    """`ar rcs` the objects into the prelude archive. The archive is
+    rebuilt from scratch (deleted first) so removed prelude files
+    don't leave stale entries behind. `ZERO_AR_DATE=1` makes BSD
+    `ar` (macOS) zero the per-member timestamp; the `D` modifier
+    does the same on GNU `ar` (Linux). Either flag is harmless on
+    the platform that doesn't need it."""
+    if ARCHIVE.exists():
+        ARCHIVE.unlink()
+    env = dict(os.environ)
+    env["ZERO_AR_DATE"] = "1"
+    # Try the `D` modifier first (GNU ar); fall back to plain `rcs`
+    # for BSD ar (macOS), which doesn't accept `D` but is already
+    # deterministic with ZERO_AR_DATE=1.
+    cmd = [ar, "rcsD", str(ARCHIVE), *[str(o) for o in objects]]
+    proc = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        cmd = [ar, "rcs", str(ARCHIVE), *[str(o) for o in objects]]
+        proc = subprocess.run(
+            cmd, env=env, capture_output=True, text=True, check=False,
+        )
+        if proc.returncode != 0:
+            sys.exit(
+                f"ar failed: {' '.join(cmd)}\n"
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+
+
+def install_headers(hs: List[Path]) -> None:
+    """Copy `.h` files into `compiler/runtime/include/`. The
+    directory is rebuilt from scratch so a removed prelude file
+    doesn't leave a stale header behind."""
+    if INCLUDE_DIR.exists():
+        shutil.rmtree(INCLUDE_DIR)
+    INCLUDE_DIR.mkdir(parents=True)
+    for h in hs:
+        shutil.copy2(h, INCLUDE_DIR / h.name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--clean", action="store_true",
+        help="Remove the archive, include dir, and lib/*.{c,h,o} "
+             "before building.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Echo each step.",
+    )
+    args = parser.parse_args()
+
+    pfs = sorted(LIB.glob("*.pf"))
+    if not pfs:
+        sys.exit(f"no .pf files in {LIB}")
+
+    if args.clean:
+        if BUILD_DIR.exists():
+            shutil.rmtree(BUILD_DIR)
+        if ARCHIVE.exists():
+            ARCHIVE.unlink()
+        if INCLUDE_DIR.exists():
+            shutil.rmtree(INCLUDE_DIR)
+
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+
+    order = topo_order(pfs)
+    cc = find_cc()
+    ar = find_ar()
+
+    if args.verbose:
+        print(f"prelude: {len(order)} files, topological order:")
+        for p in order:
+            print(f"  {p.name}")
+
+    for pf in order:
+        if args.verbose:
+            print(f"deduce {pf.name}")
+        compile_pf_to_c(pf)
+
+    objects: List[Path] = []
+    for pf in order:
+        c = BUILD_DIR / (pf.stem + ".c")
+        if args.verbose:
+            print(f"cc {c.name}")
+        objects.append(compile_c_to_o(cc, c))
+
+    if args.verbose:
+        print(f"ar -> {ARCHIVE.relative_to(ROOT)}")
+    make_archive(ar, objects)
+
+    headers = [BUILD_DIR / (pf.stem + ".h") for pf in order]
+    if args.verbose:
+        print(f"install headers -> {INCLUDE_DIR.relative_to(ROOT)}")
+    install_headers(headers)
+
+    print(
+        f"built {ARCHIVE.relative_to(ROOT)} "
+        f"({ARCHIVE.stat().st_size} bytes, "
+        f"{len(order)} modules)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gh_pages/doc/Compiler.md
+++ b/gh_pages/doc/Compiler.md
@@ -11,6 +11,7 @@ This page walks through how to use it.
 * [The CLI flags](#the-cli-flags)
 * [Linking against the runtime](#linking-against-the-runtime)
 * [Programs that use the standard library](#programs-that-use-the-standard-library)
+* [Building larger programs](#building-larger-programs) — per-module compile and the prelude archive
 * [What compiles, what doesn't](#what-compiles-what-doesnt)
 * [Pruning unused definitions](#pruning-unused-definitions)
 * [Allocation tracing](#allocation-tracing)
@@ -58,9 +59,11 @@ Compile-related flags on `python3 deduce.py`:
 
 | Flag | Effect |
 | --- | --- |
-| `--compile` | Compile the `.pf` file to C instead of just checking it. The output goes to a sibling `.c` file by default. |
-| `-o <path>` | Override the output path. Use `-o -` to write to stdout. |
-| `--no-prune` | Skip the dead-code-elimination pass. Useful for debugging emitter issues; otherwise leave it on. |
+| `--compile` | Compile the `.pf` file to a single self-contained `.c` (the prelude and any imports are inlined). Output defaults to a sibling `.c`. |
+| `--compile-module` | Per-module compile: write both `<file>.c` and `<file>.h`. Imports become `#include` lines instead of inlined definitions. See [Building larger programs](#building-larger-programs). |
+| `--no-main` | Pairs with `--compile-module`. Treat this file as a library — skip emitting `deduce_program_main`. The module's `_init` is still emitted. |
+| `-o <path>` | Override the output path. Use `-o -` to write to stdout (`--compile` only — `--compile-module` always writes a sibling `.h` so it needs a real path). |
+| `--no-prune` | Skip the dead-code-elimination pass. Useful for debugging emitter issues; otherwise leave it on. (`--compile-module` already skips pruning — cross-module DCE is the linker's job via `-Wl,--gc-sections`.) |
 | `--no-stdlib` | Don't auto-import the standard library. Useful when your program defines its own primitives, or when you want to keep the generated C as small as possible. |
 | `--suppress-theorems` | Quiet the post-check theorem listing; nice for scripts. |
 | `--quiet` | Suppress informational chatter. |
@@ -129,6 +132,193 @@ other prelude definition.
 If your program defines its own primitives and doesn't need the
 prelude, pass `--no-stdlib` to skip auto-importing. The generated
 output is smaller and the compile is faster.
+
+## Building larger programs
+
+`--compile` produces one big self-contained `.c` per source file.
+That's the simplest path and the right default for short
+programs, but as a project grows you'll want to:
+
+1. compile each `.pf` file into its own `.c` and `.h`, and
+2. link against a pre-built archive of the standard library
+   instead of inlining it into every binary.
+
+Both are supported.
+
+### Per-module compile (`--compile-module`)
+
+`--compile-module` produces a `.c` and `.h` next to each `.pf`,
+each containing only that file's definitions. Imports become
+`#include "<other>.h"` lines and the linker stitches the modules
+together at link time.
+
+A minimal two-file example (no stdlib involved):
+
+```deduce
+// lib.pf
+union MyNat {
+  zero
+  suc(MyNat)
+}
+
+fun two() {
+  suc(suc(zero))
+}
+```
+
+```deduce
+// app.pf
+import lib
+
+print two()
+print suc(two())
+```
+
+```
+$ python3 deduce.py --compile-module --no-main --no-stdlib --dir . lib.pf
+$ python3 deduce.py --compile-module --no-stdlib --dir . app.pf
+$ cc -I . -I compiler/runtime app.c lib.c compiler/runtime/deduce.c -o app
+$ ./app
+suc(suc(zero))
+suc(suc(suc(zero)))
+```
+
+Programs that use the standard library follow the same shape but
+link against the pre-built prelude archive — see the next section.
+
+Two extra flags pair with `--compile-module`:
+
+| Flag | Effect |
+| --- | --- |
+| `--compile-module` | Per-module compile mode. Both `<file>.c` and `<file>.h` are written; imported `.h`s are `#include`d. |
+| `--no-main` | This file is a library, not the entry point. Skip emitting `deduce_program_main` and the `print` body. The module's `_init` function is still emitted so other modules can call it. |
+
+Each module's `<Module>_init()` is **idempotent**: it allocates
+the module's nullary-constructor singletons, runs its
+module-level globals, and recursively initialises its direct
+imports. The main module's `deduce_program_main()` calls its own
+`_init` once at startup. Diamond imports are safe — each module
+inits exactly once regardless of how many transitive paths reach
+it.
+
+Symbols are mangled as `<Module>__<name>_<seq>` where `<seq>` is
+a per-module ordinal computed from the source file. The mangling
+is stable across compilation contexts: a module produces the
+same C symbol names whether it was compiled standalone or
+walked-through-imports as part of another module's compile.
+
+### The prelude as a static archive (`make compile-prelude`)
+
+For larger programs, building the standard library once into a
+static archive saves work on every subsequent build.
+
+```
+$ make compile-prelude
+built compiler/runtime/libdeduce_prelude.a (134064 bytes, 32 modules)
+```
+
+This produces:
+
+- `compiler/runtime/libdeduce_prelude.a` — every prelude module
+  pre-compiled, packaged as an `ar` archive.
+- `compiler/runtime/include/*.h` — the matching headers.
+
+The archive is **reproducible**: a second run produces a
+byte-identical `.a`.
+
+A user program that imports stdlib modules then links against
+the archive instead of inlining the prelude:
+
+```
+$ cat > app.pf <<'PF'
+import Nat
+import UInt
+
+print 0
+print 1 + 2
+print 3 * 4
+PF
+$ python3 deduce.py --compile-module --no-stdlib --dir lib -o app.c app.pf
+$ cc -I compiler/runtime/include -I compiler/runtime \
+     -L compiler/runtime \
+     app.c compiler/runtime/deduce.c -ldeduce_prelude \
+     -o app
+$ ./app
+0
+3
+12
+```
+
+Adding `-ffunction-sections -fdata-sections` to your `cc` flags
+and `-Wl,--gc-sections` (Linux) or `-Wl,-dead_strip` (macOS) to
+the linker lets the toolchain drop archive members your program
+doesn't reference, so the binary stays small.
+
+### A reusable Makefile
+
+Drop this into your project (alongside your `.pf` files) to drive
+the per-module flow. Set `DEDUCE_ROOT` to wherever the Deduce
+checkout lives — it points at `lib/`, `compiler/runtime/`, and
+the prelude archive you built with `make compile-prelude`.
+
+```make
+DEDUCE_ROOT ?= ../deduce
+DEDUCE       = python3 $(DEDUCE_ROOT)/deduce.py
+LIB          = $(DEDUCE_ROOT)/lib
+RUNTIME      = $(DEDUCE_ROOT)/compiler/runtime
+CC           = cc
+CFLAGS       = -I$(RUNTIME)/include -I$(RUNTIME) \
+               -ffunction-sections -fdata-sections
+LDFLAGS      = -L$(RUNTIME) -ldeduce_prelude -Wl,--gc-sections
+# macOS uses -dead_strip instead of --gc-sections:
+#   LDFLAGS = -L$(RUNTIME) -ldeduce_prelude -Wl,-dead_strip
+
+.DEFAULT_GOAL := app
+
+# Library modules: pass --no-main so deduce_program_main isn't
+# emitted. Each rule must explicitly list its .pf so make picks
+# the right --no-main set.
+lib.c lib.h: lib.pf
+	$(DEDUCE) --compile-module --no-main --no-stdlib \
+	          --dir $(LIB) --dir . -o lib.c lib.pf
+
+# Main module: depends on every library .h it imports.
+app.c app.h: app.pf lib.h
+	$(DEDUCE) --compile-module --no-stdlib \
+	          --dir $(LIB) --dir . -o app.c app.pf
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+# Compile the runtime locally so we don't pollute the Deduce
+# checkout with a .o.
+deduce_runtime.o: $(RUNTIME)/deduce.c
+	$(CC) -I$(RUNTIME) -ffunction-sections -fdata-sections \
+	      -c -o $@ $<
+
+app: app.o lib.o deduce_runtime.o
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f *.c *.h *.o app
+```
+
+One-time setup: in the Deduce checkout, run `make compile-prelude`
+(this produces the archive + headers). Then in your project,
+`make` builds and links incrementally — touching `app.pf` only
+recompiles the app, the prelude archive is reused untouched.
+
+### When to use which mode
+
+| You're | Use |
+| --- | --- |
+| Sketching a one-file program | `--compile` (monolithic) |
+| Building a multi-file project | `--compile-module` per file + the Makefile above |
+| Iterating on a single module | `--compile-module` + `make` (incremental) |
+| Shipping a binary | either; `--compile-module` + `--gc-sections` produces smaller binaries |
+
+Both modes produce identical output for the same source — they
+only differ in where the prelude lives at link time.
 
 ## What compiles, what doesn't
 
@@ -274,13 +464,15 @@ These are the rough edges to be aware of:
   Python recursion-depth thing); the compiled binary inherits a
   similar limit from the C stack.
 - **Peano `Nat` is slow** — see above.
-- **One file per compile.** The compiler currently produces a single
-  self-contained `.c` per top-level `.pf`, with the prelude inlined
-  every time. Separate compilation (one `.o` per module) isn't yet
-  supported.
+- **The runtime ABI is unstable.** `compiler/runtime/deduce.h` may
+  change between commits. Rebuild every `.o` and the prelude
+  archive together when you upgrade Deduce — don't carry old
+  objects forward.
 - **Only C output.** The IR is intentionally retargetable, but C is
   the only emitter implemented today. JavaScript and Rust backends
   are planned.
 
 The compile plan in [`docs/compile-plan.md`](../../docs/compile-plan.md)
-tracks the open items.
+tracks the open performance/runtime items, and the separate-compile
+plan in [`docs/separate-compile-plan.md`](../../docs/separate-compile-plan.md)
+covers the per-module / archive workflow described above.

--- a/gh_pages/doc/Index.md
+++ b/gh_pages/doc/Index.md
@@ -161,10 +161,13 @@ The Deduce Reference manual provides an alphabetical list of all the features in
 
 The Cheat Sheet gives some advice regarding proof strategy and which Deduce keyword to use next in a proof.
 
+The Compiler page walks through translating a checked Deduce program into a self-contained C binary.
+
 <!-- buttons -->
 [Reference Manual](./pages/reference.html)
 [Cheat Sheet](./pages/cheat-sheet.html)
 [Tactics Cheat Sheet](./pages/tactics-cheat-sheet.html)
+[Compile to C](./pages/compiler.html)
 <!-- end buttons -->
 <!-- end block -->
 <!-- end section -->

--- a/test/compile/lower/array.cir
+++ b/test/compile/lower/array.cir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
-global A.8 = array(ns.7)
-print A.8
-print A.8[zero.1]
-print A.8[suc.2(zero.1)]
-print A.8[suc.2(suc.2(zero.1))]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global ns.s2_0 = node.s1_3(zero.s0_1, node.s1_3(suc.s0_2(zero.s0_1), node.s1_3(suc.s0_2(suc.s0_2(zero.s0_1)), empty.s1_2)))
+global A.s3_0 = array(ns.s2_0)
+print A.s3_0
+print A.s3_0[zero.s0_1]
+print A.s3_0[suc.s0_2(zero.s0_1)]
+print A.s3_0[suc.s0_2(suc.s0_2(zero.s0_1))]

--- a/test/compile/lower/array.ir
+++ b/test/compile/lower/array.ir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
-global A.8 = array(ns.7)
-print A.8
-print A.8[zero.1]
-print A.8[suc.2(zero.1)]
-print A.8[suc.2(suc.2(zero.1))]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global ns.s2_0 = node.s1_3(zero.s0_1, node.s1_3(suc.s0_2(zero.s0_1), node.s1_3(suc.s0_2(suc.s0_2(zero.s0_1)), empty.s1_2)))
+global A.s3_0 = array(ns.s2_0)
+print A.s3_0
+print A.s3_0[zero.s0_1]
+print A.s3_0[suc.s0_2(zero.s0_1)]
+print A.s3_0[suc.s0_2(suc.s0_2(zero.s0_1))]

--- a/test/compile/lower/array.pir
+++ b/test/compile/lower/array.pir
@@ -1,8 +1,8 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global ns.7 = node.6(zero.1, node.6(suc.2(zero.1), node.6(suc.2(suc.2(zero.1)), empty.5)))
-global A.8 = array(ns.7)
-print A.8
-print A.8[zero.1]
-print A.8[suc.2(zero.1)]
-print A.8[suc.2(suc.2(zero.1))]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global ns.s2_0 = node.s1_3(zero.s0_1, node.s1_3(suc.s0_2(zero.s0_1), node.s1_3(suc.s0_2(suc.s0_2(zero.s0_1)), empty.s1_2)))
+global A.s3_0 = array(ns.s2_0)
+print A.s3_0
+print A.s3_0[zero.s0_1]
+print A.s3_0[suc.s0_2(zero.s0_1)]
+print A.s3_0[suc.s0_2(suc.s0_2(zero.s0_1))]

--- a/test/compile/lower/basic.cir
+++ b/test/compile/lower/basic.cir
@@ -1,7 +1,7 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+global two.s2_0 = suc.s0_2(suc.s0_2(zero.s0_1))
+fn add_two.s3_1(x.s3_0) = add.s1_0(two.s2_0, x.s3_0)
+fn pick.s4_3(b.s4_0, x.s4_1, y.s4_2) = if b.s4_0 then x.s4_1 else y.s4_2
+print add_two.s3_1(suc.s0_2(zero.s0_1))
+print pick.s4_3(true, two.s2_0, zero.s0_1)

--- a/test/compile/lower/basic.ir
+++ b/test/compile/lower/basic.ir
@@ -1,7 +1,7 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+global two.s2_0 = suc.s0_2(suc.s0_2(zero.s0_1))
+fn add_two.s3_1(x.s3_0) = add.s1_0(two.s2_0, x.s3_0)
+fn pick.s4_3(b.s4_0, x.s4_1, y.s4_2) = if b.s4_0 then x.s4_1 else y.s4_2
+print add_two.s3_1(suc.s0_2(zero.s0_1))
+print pick.s4_3(true, two.s2_0, zero.s0_1)

--- a/test/compile/lower/basic.pir
+++ b/test/compile/lower/basic.pir
@@ -1,7 +1,7 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-global two.7 = suc.2(suc.2(zero.1))
-fn add_two.9(x.8) = add.3(two.7, x.8)
-fn pick.13(b.10, x.11, y.12) = if b.10 then x.11 else y.12
-print add_two.9(suc.2(zero.1))
-print pick.13(true, two.7, zero.1)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+global two.s2_0 = suc.s0_2(suc.s0_2(zero.s0_1))
+fn add_two.s3_1(x.s3_0) = add.s1_0(two.s2_0, x.s3_0)
+fn pick.s4_3(b.s4_0, x.s4_1, y.s4_2) = if b.s4_0 then x.s4_1 else y.s4_2
+print add_two.s3_1(suc.s0_2(zero.s0_1))
+print pick.s4_3(true, two.s2_0, zero.s0_1)

--- a/test/compile/lower/closure.cir
+++ b/test/compile/lower/closure.cir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[closure$lam1](x.7)
-print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+fn adder.s2_2(x.s2_0) = closure[closure$lam1](x.s2_0)
+print adder.s2_2(suc.s0_2(zero.s0_1))(suc.s0_2(suc.s0_2(zero.s0_1)))
+fn closure$lam1[x.s2_0](y.s2_1) = add.s1_0(x.s2_0, y.s2_1)

--- a/test/compile/lower/closure.ir
+++ b/test/compile/lower/closure.ir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = λ(y.8). add.3(x.7, y.8)
-print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+fn adder.s2_2(x.s2_0) = λ(y.s2_1). add.s1_0(x.s2_0, y.s2_1)
+print adder.s2_2(suc.s0_2(zero.s0_1))(suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/closure.pir
+++ b/test/compile/lower/closure.pir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn add.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(add.3(n.5, m.4)) }
-fn adder.9(x.7) = closure[closure$lam1](x.7)
-print adder.9(suc.2(zero.1))(suc.2(suc.2(zero.1)))
-fn closure$lam1[x.7](y.8) = add.3(x.7, y.8)
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn add.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(add.s1_0(n.s1_2, m.s1_1)) }
+fn adder.s2_2(x.s2_0) = closure[closure$lam1](x.s2_0)
+print adder.s2_2(suc.s0_2(zero.s0_1))(suc.s0_2(suc.s0_2(zero.s0_1)))
+fn closure$lam1[x.s2_0](y.s2_1) = add.s1_0(x.s2_0, y.s2_1)

--- a/test/compile/lower/generic.cir
+++ b/test/compile/lower/generic.cir
@@ -1,6 +1,6 @@
-union Box.0 {box.2/1}
-fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
-fn id.10(x.9) = x.9
-union MyNat.11 {zero.12/0, suc.13/1}
-print id.10(suc.13(zero.12))
-print unbox.6(box.2(suc.13(suc.13(zero.12))))
+union Box.s0_0 {box.s0_2/1}
+fn unbox.s1_3(b.s1_1) = match b.s1_1 { | box.s0_2(x.s1_2) -> x.s1_2 }
+fn id.s2_3(x.s2_2) = x.s2_2
+union MyNat.s3_0 {zero.s3_1/0, suc.s3_2/1}
+print id.s2_3(suc.s3_2(zero.s3_1))
+print unbox.s1_3(box.s0_2(suc.s3_2(suc.s3_2(zero.s3_1))))

--- a/test/compile/lower/generic.ir
+++ b/test/compile/lower/generic.ir
@@ -1,6 +1,6 @@
-union Box.0 {box.2/1}
-fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
-fn id.10(x.9) = x.9
-union MyNat.11 {zero.12/0, suc.13/1}
-print id.10(suc.13(zero.12))
-print unbox.6(box.2(suc.13(suc.13(zero.12))))
+union Box.s0_0 {box.s0_2/1}
+fn unbox.s1_3(b.s1_1) = match b.s1_1 { | box.s0_2(x.s1_2) -> x.s1_2 }
+fn id.s2_3(x.s2_2) = x.s2_2
+union MyNat.s3_0 {zero.s3_1/0, suc.s3_2/1}
+print id.s2_3(suc.s3_2(zero.s3_1))
+print unbox.s1_3(box.s0_2(suc.s3_2(suc.s3_2(zero.s3_1))))

--- a/test/compile/lower/generic.pir
+++ b/test/compile/lower/generic.pir
@@ -1,6 +1,6 @@
-union Box.0 {box.2/1}
-fn unbox.6(b.4) = match b.4 { | box.2(x.5) -> x.5 }
-fn id.10(x.9) = x.9
-union MyNat.11 {zero.12/0, suc.13/1}
-print id.10(suc.13(zero.12))
-print unbox.6(box.2(suc.13(suc.13(zero.12))))
+union Box.s0_0 {box.s0_2/1}
+fn unbox.s1_3(b.s1_1) = match b.s1_1 { | box.s0_2(x.s1_2) -> x.s1_2 }
+fn id.s2_3(x.s2_2) = x.s2_2
+union MyNat.s3_0 {zero.s3_1/0, suc.s3_2/1}
+print id.s2_3(suc.s3_2(zero.s3_1))
+print unbox.s1_3(box.s0_2(suc.s3_2(suc.s3_2(zero.s3_1))))

--- a/test/compile/lower/genrecfun.cir
+++ b/test/compile/lower/genrecfun.cir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
-fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
-fn <.9($scr0, m.10) = match $scr0 { | zero.1 -> match m.10 { | zero.1 -> false | suc.2(m'.11) -> true } | suc.2(n'.12) -> match m.10 { | zero.1 -> false | suc.2(m'.14) -> <.9(n'.12, m'.14) } }
-fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
-print count_down.22(suc.2(suc.2(suc.2(zero.1))))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn iszero.s1_2(n.s1_0) = match n.s1_0 { | zero.s0_1 -> true | suc.s0_2(n'.s1_1) -> false }
+fn pred.s2_2(n.s2_0) = match n.s2_0 { | zero.s0_1 -> zero.s0_1 | suc.s0_2(n'.s2_1) -> n'.s2_1 }
+fn <.s3_0($scr0, m.s3_1) = match $scr0 { | zero.s0_1 -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_2) -> true } | suc.s0_2(n'.s3_3) -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_5) -> <.s3_0(n'.s3_3, m'.s3_5) } }
+fn count_down.s6_0(n.s6_1) = if iszero.s1_2(n.s6_1) then zero.s0_1 else count_down.s6_0(pred.s2_2(n.s6_1))
+print count_down.s6_0(suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1))))

--- a/test/compile/lower/genrecfun.ir
+++ b/test/compile/lower/genrecfun.ir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
-fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
-fn <.9($scr0, m.10) = match $scr0 { | zero.1 -> match m.10 { | zero.1 -> false | suc.2(m'.11) -> true } | suc.2(n'.12) -> match m.10 { | zero.1 -> false | suc.2(m'.14) -> <.9(n'.12, m'.14) } }
-fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
-print count_down.22(suc.2(suc.2(suc.2(zero.1))))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn iszero.s1_2(n.s1_0) = match n.s1_0 { | zero.s0_1 -> true | suc.s0_2(n'.s1_1) -> false }
+fn pred.s2_2(n.s2_0) = match n.s2_0 { | zero.s0_1 -> zero.s0_1 | suc.s0_2(n'.s2_1) -> n'.s2_1 }
+fn <.s3_0($scr0, m.s3_1) = match $scr0 { | zero.s0_1 -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_2) -> true } | suc.s0_2(n'.s3_3) -> match m.s3_1 { | zero.s0_1 -> false | suc.s0_2(m'.s3_5) -> <.s3_0(n'.s3_3, m'.s3_5) } }
+fn count_down.s6_0(n.s6_1) = if iszero.s1_2(n.s6_1) then zero.s0_1 else count_down.s6_0(pred.s2_2(n.s6_1))
+print count_down.s6_0(suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1))))

--- a/test/compile/lower/genrecfun.pir
+++ b/test/compile/lower/genrecfun.pir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn iszero.5(n.3) = match n.3 { | zero.1 -> true | suc.2(n'.4) -> false }
-fn pred.8(n.6) = match n.6 { | zero.1 -> zero.1 | suc.2(n'.7) -> n'.7 }
-fn count_down.22(n.23) = if iszero.5(n.23) then zero.1 else count_down.22(pred.8(n.23))
-print count_down.22(suc.2(suc.2(suc.2(zero.1))))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn iszero.s1_2(n.s1_0) = match n.s1_0 { | zero.s0_1 -> true | suc.s0_2(n'.s1_1) -> false }
+fn pred.s2_2(n.s2_0) = match n.s2_0 { | zero.s0_1 -> zero.s0_1 | suc.s0_2(n'.s2_1) -> n'.s2_1 }
+fn count_down.s6_0(n.s6_1) = if iszero.s1_2(n.s6_1) then zero.s0_1 else count_down.s6_0(pred.s2_2(n.s6_1))
+print count_down.s6_0(suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1))))

--- a/test/compile/lower/pruning.cir
+++ b/test/compile/lower/pruning.cir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
-fn unused.7($scr1, m.8) = match $scr1 { | zero.1 -> m.8 | suc.2(n.9) -> suc.2(unused.7(n.9, m.8)) }
-global also_unused.11 = suc.2(suc.2(suc.2(zero.1)))
-print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn used.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(used.s1_0(n.s1_2, m.s1_1)) }
+fn unused.s2_0($scr1, m.s2_1) = match $scr1 { | zero.s0_1 -> m.s2_1 | suc.s0_2(n.s2_2) -> suc.s0_2(unused.s2_0(n.s2_2, m.s2_1)) }
+global also_unused.s3_0 = suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1)))
+print used.s1_0(suc.s0_2(zero.s0_1), suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/pruning.ir
+++ b/test/compile/lower/pruning.ir
@@ -1,5 +1,5 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
-fn unused.7($scr1, m.8) = match $scr1 { | zero.1 -> m.8 | suc.2(n.9) -> suc.2(unused.7(n.9, m.8)) }
-global also_unused.11 = suc.2(suc.2(suc.2(zero.1)))
-print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn used.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(used.s1_0(n.s1_2, m.s1_1)) }
+fn unused.s2_0($scr1, m.s2_1) = match $scr1 { | zero.s0_1 -> m.s2_1 | suc.s0_2(n.s2_2) -> suc.s0_2(unused.s2_0(n.s2_2, m.s2_1)) }
+global also_unused.s3_0 = suc.s0_2(suc.s0_2(suc.s0_2(zero.s0_1)))
+print used.s1_0(suc.s0_2(zero.s0_1), suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/pruning.pir
+++ b/test/compile/lower/pruning.pir
@@ -1,3 +1,3 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-fn used.3($scr0, m.4) = match $scr0 { | zero.1 -> m.4 | suc.2(n.5) -> suc.2(used.3(n.5, m.4)) }
-print used.3(suc.2(zero.1), suc.2(suc.2(zero.1)))
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+fn used.s1_0($scr0, m.s1_1) = match $scr0 { | zero.s0_1 -> m.s1_1 | suc.s0_2(n.s1_2) -> suc.s0_2(used.s1_0(n.s1_2, m.s1_1)) }
+print used.s1_0(suc.s0_2(zero.s0_1), suc.s0_2(suc.s0_2(zero.s0_1)))

--- a/test/compile/lower/source_map.cir
+++ b/test/compile/lower/source_map.cir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global A.7 = array(node.6(zero.1, empty.5))
-print A.7[suc.2(zero.1)]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global A.s2_0 = array(node.s1_3(zero.s0_1, empty.s1_2))
+print A.s2_0[suc.s0_2(zero.s0_1)]

--- a/test/compile/lower/source_map.ir
+++ b/test/compile/lower/source_map.ir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global A.7 = array(node.6(zero.1, empty.5))
-print A.7[suc.2(zero.1)]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global A.s2_0 = array(node.s1_3(zero.s0_1, empty.s1_2))
+print A.s2_0[suc.s0_2(zero.s0_1)]

--- a/test/compile/lower/source_map.pir
+++ b/test/compile/lower/source_map.pir
@@ -1,4 +1,4 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-union List.3 {empty.5/0, node.6/2}
-global A.7 = array(node.6(zero.1, empty.5))
-print A.7[suc.2(zero.1)]
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+union List.s1_0 {empty.s1_2/0, node.s1_3/2}
+global A.s2_0 = array(node.s1_3(zero.s0_1, empty.s1_2))
+print A.s2_0[suc.s0_2(zero.s0_1)]

--- a/test/compile/lower/unbox.cir
+++ b/test/compile/lower/unbox.cir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-print zero.1
-print zero.1
-print zero.1
-print zero.1
-print zero.1
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1

--- a/test/compile/lower/unbox.ir
+++ b/test/compile/lower/unbox.ir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-print zero.1
-print zero.1
-print zero.1
-print zero.1
-print zero.1
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1

--- a/test/compile/lower/unbox.pir
+++ b/test/compile/lower/unbox.pir
@@ -1,6 +1,6 @@
-union MyNat.0 {zero.1/0, suc.2/1}
-print zero.1
-print zero.1
-print zero.1
-print zero.1
-print zero.1
+union MyNat.s0_0 {zero.s0_1/0, suc.s0_2/1}
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1
+print zero.s0_1

--- a/test/compile/run_prelude_archive.py
+++ b/test/compile/run_prelude_archive.py
@@ -1,0 +1,138 @@
+"""Acceptance test for `make compile-prelude` (prelude as static archive).
+
+Step 29 of `docs/separate-compile-plan.md`. Builds the prelude
+archive, then verifies a hand-rolled user program that imports
+stdlib modules links against `-ldeduce_prelude` and produces the
+same output as the interpreter. Also confirms the archive is
+reproducible: a second build is byte-identical.
+
+Run from the repo root:
+    python3 test/compile/run_prelude_archive.py
+"""
+
+from __future__ import annotations
+
+import filecmp
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+COMPILER = ROOT / "compiler"
+RUNTIME = COMPILER / "runtime"
+LIB = ROOT / "lib"
+ARCHIVE = RUNTIME / "libdeduce_prelude.a"
+INCLUDE_DIR = RUNTIME / "include"
+
+# Small program exercising several stdlib modules. Output is what
+# the interpreter would produce.
+USER_PROGRAM = """\
+import Nat
+import UInt
+
+print 0
+print 1 + 2
+print 3 * 4
+"""
+EXPECTED_OUTPUT = "0\n3\n12\n"
+
+
+def find_cc() -> "str | None":
+    return shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+
+
+def build_prelude() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(COMPILER / "compile_prelude.py")],
+        cwd=str(ROOT), capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "compile_prelude.py failed:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def main() -> int:
+    cc = find_cc()
+    if cc is None:
+        print("SKIP: no C compiler on PATH", file=sys.stderr)
+        return 0
+
+    # First build.
+    build_prelude()
+    if not ARCHIVE.exists():
+        print(f"FAIL: archive not produced at {ARCHIVE}", file=sys.stderr)
+        return 1
+
+    # Snapshot for reproducibility check, then a clean second build.
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".a") as tmp:
+        snapshot = Path(tmp.name)
+    shutil.copy2(ARCHIVE, snapshot)
+    try:
+        subprocess.run(
+            [sys.executable, str(COMPILER / "compile_prelude.py"), "--clean"],
+            cwd=str(ROOT), capture_output=True, text=True, check=True,
+        )
+        if not filecmp.cmp(snapshot, ARCHIVE, shallow=False):
+            print("FAIL: archive is not byte-identical between two builds",
+                  file=sys.stderr)
+            return 1
+    finally:
+        snapshot.unlink(missing_ok=True)
+
+    # User-program acceptance.
+    work = Path(tempfile.mkdtemp(prefix="deduce-prelude-"))
+    try:
+        app_pf = work / "app.pf"
+        app_pf.write_text(USER_PROGRAM)
+        # Compile with --compile-module against the prelude .pf
+        # sources (deduce.py needs the full source for type-check;
+        # the prebuilt archive only saves cc time + future Steps'
+        # caching).
+        subprocess.run([
+            sys.executable, str(ROOT / "deduce.py"),
+            "--compile-module", "--no-stdlib",
+            "--dir", str(LIB),
+            "--suppress-theorems", "--quiet",
+            "-o", str(work / "app.c"),
+            str(app_pf),
+        ], cwd=str(ROOT), capture_output=True, text=True, check=True)
+        # Link against the archive + runtime.
+        bin_path = work / "app"
+        subprocess.run([
+            cc,
+            "-I", str(INCLUDE_DIR), "-I", str(RUNTIME),
+            "-L", str(RUNTIME),
+            str(work / "app.c"), str(RUNTIME / "deduce.c"),
+            "-ldeduce_prelude",
+            "-o", str(bin_path),
+        ], capture_output=True, text=True, check=True)
+        proc = subprocess.run(
+            [str(bin_path)], capture_output=True, text=True, check=False,
+        )
+        if proc.returncode != 0:
+            print(f"FAIL: app exit {proc.returncode}\n"
+                  f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+                  file=sys.stderr)
+            return 1
+        if proc.stdout != EXPECTED_OUTPUT:
+            print(
+                f"FAIL: stdout mismatch\n"
+                f"--- expected\n{EXPECTED_OUTPUT}"
+                f"--- actual\n{proc.stdout}",
+                file=sys.stderr,
+            )
+            return 1
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    print("ok prelude archive (deterministic + linkable)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Step 30 of [\`docs/separate-compile-plan.md\`](docs/separate-compile-plan.md). Documents the workflow that landed in Steps 25–29, and makes the compiler page reachable from the site landing page (the user noticed it wasn't).

**Stacked on [#372](https://github.com/jsiek/deduce/pull/372)** (Step 29).

## What's in the diff

### \`gh_pages/doc/Compiler.md\`
- New **Building larger programs** section, covering:
  - **Per-module compile** (\`--compile-module\`): per-file \`.c\`+\`.h\`, \`#include\` for imports, idempotent \`<Module>_init\`, diamond-import safety, stable \`<Module>__<name>_<seq>\` symbol mangling.
  - **Prelude as a static archive** (\`make compile-prelude\`): deterministic \`libdeduce_prelude.a\` + \`compiler/runtime/include/\`, link with \`-ldeduce_prelude\`. \`-ffunction-sections\`/\`-fdata-sections\` + \`-Wl,--gc-sections\` (or \`-dead_strip\` on macOS) note.
  - **A reusable Makefile**: \`DEDUCE_ROOT ?= ../deduce\` pointing at the Deduce checkout, separate \`deduce_runtime.o\` so user builds don't write into the Deduce tree, and \`.DEFAULT_GOAL := app\`.
  - **When to use which mode** table comparing \`--compile\` (monolithic) vs \`--compile-module\` (per-module).
- CLI flag table updated with \`--compile-module\` and \`--no-main\`; \`-o\` and \`--no-prune\` clarifications.
- **Limitations** loses the stale "one file per compile" claim and gains a note that the runtime ABI is unstable.
- Footer cross-links both [\`docs/compile-plan.md\`](docs/compile-plan.md) and [\`docs/separate-compile-plan.md\`](docs/separate-compile-plan.md).

### \`gh_pages/doc/Index.md\`
Adds a "Compile to C" button to the **Need Help?** block. Compiler doc is now one click from the landing page.

### \`README.md\`
Adds \`/compiler\` to the directory-structure list with a link to [pages/compiler.html](https://jsiek.github.io/deduce/pages/compiler.html).

## Worked examples — tested before documenting

Every command block in the new section was run end-to-end. Two scenarios:

**1. Two-file project, no stdlib** — \`lib.pf\` defines \`MyNat\` and a \`two()\` helper, \`app.pf\` imports \`lib\` and prints \`two()\` and \`suc(two())\`:

\`\`\`
$ python3 deduce.py --compile-module --no-main --no-stdlib --dir . lib.pf
$ python3 deduce.py --compile-module --no-stdlib --dir . app.pf
$ cc -I . -I compiler/runtime app.c lib.c compiler/runtime/deduce.c -o app
$ ./app
suc(suc(zero))
suc(suc(suc(zero)))
\`\`\`

**2. Stdlib-using program** — \`app.pf\` with \`import Nat; import UInt\`:

\`\`\`
$ make compile-prelude
$ python3 deduce.py --compile-module --no-stdlib --dir lib -o app.c app.pf
$ cc -I compiler/runtime/include -I compiler/runtime -L compiler/runtime app.c compiler/runtime/deduce.c -ldeduce_prelude -o app
$ ./app
0
3
12
\`\`\`

**3. Reusable Makefile** — set \`DEDUCE_ROOT\`, \`make app\`, then \`touch app.pf && make\` — only \`app.{c,o}\` and the link step rerun, \`lib.o\` and the prelude archive are reused.

## Test plan

- [x] Run the worked examples (above) end-to-end.
- [x] Run the documented Makefile against a real two-module project; confirm full + incremental builds.
- [x] Regenerate \`gh_pages/pages/*.html\` via \`python3 gh_pages/scripts/convert.py\` to confirm the Markdown still renders cleanly.
- [x] Audit the rest of \`gh_pages/doc/*.md\` and the README for stale compiler claims; only the README needed an update (added a directory entry).

## Plan status

Plan ([\`docs/separate-compile-plan.md\`](docs/separate-compile-plan.md)) Steps 25–30 are complete after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)