### PR TITLE
Switch hole-fill default to gemma-4-31B-it

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -195,7 +195,7 @@ in your `init.el` returning whatever list eglot should spawn.
 | ------------------------------------- | ----------------------------- | ----------------------------------------------------------- |
 | `deduce-fill-hole-backend`            | `'anthropic`                  | `'anthropic` (Claude via Anthropic API) or `'openai-compat` (REALLMs / OpenAI / Ollama) |
 | `deduce-fill-hole-base-url`           | `nil`                         | OpenAI-compat endpoint URL; e.g. `"https://reallms.rescloud.iu.edu/direct/v1"`. Ignored when backend is `'anthropic`. |
-| `deduce-fill-hole-model`              | `nil` (backend default)       | Model id; backend default is `"claude-opus-4-7"` (anthropic) or `"Qwen3-Coder-Next"` (openai-compat) |
+| `deduce-fill-hole-model`              | `nil` (backend default)       | Model id; backend default is `"claude-opus-4-7"` (anthropic) or `"gemma-4-31B-it"` (openai-compat) |
 | `deduce-fill-hole-api-key-env`        | `nil` (backend default)       | Env var name; backend default is `"ANTHROPIC_API_KEY"` or `"OPENAI_API_KEY"`. IU REALLMs users override to `"REALLMS_API_KEY"`. |
 | `deduce-fill-hole-python-program`     | `"python3"`                   | Python interpreter used to launch the sidecar               |
 | `deduce-fill-hole-deduce-root`        | `nil`                         | Path to a Deduce checkout; falls back to `deduce-lsp-deduce-root`, then `project-root`, then cwd |

--- a/editor/emacs/deduce-fill-hole.el
+++ b/editor/emacs/deduce-fill-hole.el
@@ -107,8 +107,9 @@ When you switch backends, you typically also want to update
 `deduce-fill-hole-model' and `deduce-fill-hole-api-key-env' to
 match.  Sensible defaults shift with this variable: setting it
 to `openai-compat' makes the sidecar default to model
-\"Qwen3-Coder-Next\" (REALLMs' top coding model) and reads
-`OPENAI_API_KEY' if you don't override the env var name."
+\"gemma-4-31B-it\" (a fast REALLMs model that scored well on
+the hole-fill benchmark) and reads `OPENAI_API_KEY' if you
+don't override the env var name."
   :type '(choice (const :tag "Anthropic API" anthropic)
                  (const :tag "OpenAI-compatible (REALLMs / OpenAI / Ollama)"
                         openai-compat))
@@ -133,11 +134,11 @@ Ignored when `deduce-fill-hole-backend' is `anthropic'."
   "Model id the sidecar uses, or nil to pick a backend-appropriate default.
 
 When nil, the default is `claude-opus-4-7' for
-`deduce-fill-hole-backend' = `anthropic', or `Qwen3-Coder-Next'
+`deduce-fill-hole-backend' = `anthropic', or `gemma-4-31B-it'
 for `openai-compat'.  When set explicitly, this overrides the
 default.  Examples: `claude-sonnet-4-6' for cheaper Claude;
-`gpt-oss-120b' or `llama-4-scout' for REALLMs alternatives;
-`gpt-4o' or `gpt-5' for real OpenAI."
+`gpt-oss-120b', `Qwen3-Coder-Next', or `llama-4-scout' for
+REALLMs alternatives; `gpt-4o' or `gpt-5' for real OpenAI."
   :type '(choice (const :tag "Backend default" nil)
                  (string :tag "Model id"))
   :group 'deduce-fill-hole)
@@ -585,7 +586,7 @@ in the success message."
 `deduce-fill-hole-model' is nil."
   (pcase deduce-fill-hole-backend
     ('anthropic "claude-opus-4-7")
-    ('openai-compat "Qwen3-Coder-Next")
+    ('openai-compat "gemma-4-31B-it")
     (_ "claude-opus-4-7")))
 
 

--- a/editor/emacs/test/deduce-fill-hole-test.el
+++ b/editor/emacs/test/deduce-fill-hole-test.el
@@ -140,7 +140,7 @@ override the backend defaults."
 
 
 (ert-deftest deduce-fill-hole/build-cli-args-openai-compat-defaults ()
-  "Switching backend to openai-compat picks Qwen3-Coder-Next + OPENAI_API_KEY
+  "Switching backend to openai-compat picks gemma-4-31B-it + OPENAI_API_KEY
 defaults; setting base-url adds --base-url."
   (let ((deduce-fill-hole-backend 'openai-compat)
         (deduce-fill-hole-base-url
@@ -154,7 +154,7 @@ defaults; setting base-url adds --base-url."
         (deduce-lsp-deduce-root nil))
     (let ((args (deduce-fill-hole--build-cli-args)))
       (should (member "openai-compat" args))
-      (should (member "Qwen3-Coder-Next" args))
+      (should (member "gemma-4-31B-it" args))
       (should (member "OPENAI_API_KEY" args))
       (should (member "--base-url" args))
       (should (member "https://reallms.rescloud.iu.edu/direct/v1" args)))))

--- a/tools/claude_fill_hole/README.md
+++ b/tools/claude_fill_hole/README.md
@@ -76,7 +76,7 @@ an API key.
 |---|---|---|
 | `--backend NAME` | `anthropic` | Model backend: `anthropic` or `openai-compat`. |
 | `--base-url URL` | `nil` (real OpenAI) | OpenAI-compat endpoint; ignored for `--backend anthropic`. |
-| `--model MODEL` | backend-dependent | Model id. Defaults: `claude-opus-4-7` for anthropic, `Qwen3-Coder-Next` for openai-compat. |
+| `--model MODEL` | backend-dependent | Model id. Defaults: `claude-opus-4-7` for anthropic, `gemma-4-31B-it` for openai-compat. |
 | `--api-key-env NAME` | backend-dependent | Env var name. Defaults: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`. |
 | `--max-attempts N` | 5 | Maximum number of `validate_proof` calls. |
 | `--deduce-cmd CMD` | `python3 deduce.py` | Command used to invoke the checker (space-separated). |

--- a/tools/claude_fill_hole/__main__.py
+++ b/tools/claude_fill_hole/__main__.py
@@ -44,7 +44,7 @@ from .validator import SubprocessValidator, ValidationOutcome
 _BACKEND_CHOICES = ("anthropic", "openai-compat")
 _DEFAULT_MODELS = {
     "anthropic": "claude-opus-4-7",
-    "openai-compat": "Qwen3-Coder-Next",  # IU REALLMs default
+    "openai-compat": "gemma-4-31B-it",  # IU REALLMs default
 }
 _DEFAULT_API_KEY_ENVS = {
     "anthropic": "ANTHROPIC_API_KEY",
@@ -286,7 +286,7 @@ def _parse_args(argv: Optional[list[str]]) -> argparse.Namespace:
         default=None,
         help=(
             "model id; defaults to claude-opus-4-7 (anthropic) or "
-            "Qwen3-Coder-Next (openai-compat)"
+            "gemma-4-31B-it (openai-compat)"
         ),
     )
     p.add_argument(


### PR DESCRIPTION
## Summary

Switches the default model used by the hole-fill sidecar's `openai-compat` backend from `Qwen3-Coder-Next` to `gemma-4-31B-it`. Two places hold the default — the Python sidecar's `_DEFAULT_MODELS` dict (`tools/claude_fill_hole/__main__.py`) and the elisp `deduce-fill-hole--default-model` defun (`editor/emacs/deduce-fill-hole.el`) — both are flipped together, along with the docstrings, `--help` text, README tables, and the ert assertion that locks the openai-compat default.

Examples that explicitly override `--model` (the IU REALLMs invocation in the sidecar README, the `(setq deduce-fill-hole-model …)` customize preset in the emacs README, and the unit tests in `test/claude_fill_hole/test_openai_backend.py` that pass an arbitrary model string into `OpenAICompatBackend`) are intentionally left as-is.

## Why

Benchmarked the four chat models REALLMs hosts against the 6 example fixtures introduced in #371 (`tools/claude_fill_hole/examples/run_benchmark.py`):

| Fixture | Qwen3-Coder-Next | gpt-oss-120b | llama-4-scout | gemma-4-31B-it |
|---|---|---|---|---|
| 01_trivial | ✗ (empty-arg → LiteLLM 400) | ✓ | ✗ (no tool calls) | ✓ |
| 02_reflexive | ✓ | ✓ | ✗ | ✓ |
| 03_assumption | ✓ | ✓ | ✗ | ✓ |
| 04_conj_swap | ✗ | ✓ | ✗ | ✗ |
| 05_disj_swap | ✓ | ✗ | ✗ | ✓ |
| 06_induction | ✗ | ✗ | ✗ | ✗ |
| **total** | 3/6 | 4/6 | 0/6 | **4/6** |

`gemma-4-31B-it` ties `gpt-oss-120b` at 4/6 but at ~2s/attempt vs gpt-oss-120b's ~5s (sometimes 65s). Latency matters for an interactive editor command. Switching off Qwen also drops a particularly nasty failure mode where the model emitted an empty `proof_text` argument and the next attempt hit a LiteLLM server-side 400 (`Unterminated string starting at: line 1 column 16`).

See #371 for the benchmark driver and full per-fixture transcripts.

## Test plan

- [x] `python3 -m pytest test/claude_fill_hole/` — 43 passed
- [x] `python3 -m pytest test/lsp/test_query.py` — 31 passed (signature-lock test still green)
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-fill-hole-test -f ert-run-tests-batch-and-exit` — 25 passed (including the `build-cli-args-openai-compat-defaults` assertion which now expects `gemma-4-31B-it` in the args list)
- [ ] Manual: `M-x customize-variable RET deduce-fill-hole-backend RET` — docstring should still read sensibly with the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)