### PR TITLE
Hole-fill: defend OpenAI-compat backend against malformed tool-call args

### DIFF
--- a/test/claude_fill_hole/test_openai_backend.py
+++ b/test/claude_fill_hole/test_openai_backend.py
@@ -436,3 +436,327 @@ def test_works_with_dict_shaped_responses():
     )
     assert result.ok is True
     assert result.proof == "reflexive"
+
+
+# ---------------------------------------------------------------------------
+# Defensive recovery for malformed tool-call arguments (issue #376)
+# ---------------------------------------------------------------------------
+
+
+class _CapturingChatCompletions:
+    """Like FakeChatCompletions but records the messages list passed
+    on every call so we can inspect transcript normalisation."""
+
+    def __init__(self, scripted: list[FakeResponse]) -> None:
+        self._scripted = scripted
+        self.calls = 0
+        self.messages_per_call: list[list[dict]] = []
+
+    def create(self, **kwargs):
+        self.messages_per_call.append([dict(m) for m in kwargs["messages"]])
+        if self.calls >= len(self._scripted):
+            raise AssertionError(
+                "fake client: loop made more API calls than scripted"
+            )
+        response = self._scripted[self.calls]
+        self.calls += 1
+        return response
+
+
+class _CapturingClient:
+    def __init__(self, scripted: list[FakeResponse]) -> None:
+        self.chat = type(
+            "FakeChat", (), {"completions": _CapturingChatCompletions(scripted)}
+        )()
+
+
+def test_malformed_args_are_normalized_in_next_request_transcript():
+    """Issue #376: when the model emits tool-call arguments without a
+    valid `proof_text`, the next request's `messages` array must
+    carry placeholder JSON (`{"proof_text": ""}`) rather than the
+    original malformed bytes -- LiteLLM/vLLM in front of Qwen3-Coder
+    re-validates the transcript and rejects malformed arguments with
+    a 400 before the model gets to retry."""
+    malformed_args = '{"proof_text": "unterminated'  # invalid JSON
+    client = _CapturingClient(
+        [
+            FakeResponse(
+                choices=[
+                    FakeChoice(
+                        message=FakeMessage(
+                            role="assistant",
+                            tool_calls=[
+                                FakeToolCall(
+                                    id="call_1",
+                                    function=FakeFunction(
+                                        name="validate_proof",
+                                        arguments=malformed_args,
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason="tool_calls",
+                    )
+                ]
+            ),
+            _response_with_tool_call("reflexive", id_="call_2"),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    result = OpenAICompatBackend(
+        client=client, model="Qwen3-Coder-Next"
+    ).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+    )
+    assert result.ok is True
+    assert result.attempts == 2
+
+    # Inspect the transcript of the second request: the assistant
+    # turn from attempt 1 must have placeholder arguments, NOT the
+    # original malformed bytes.
+    second_request_messages = client.chat.completions.messages_per_call[1]
+    assistant_turns = [
+        m for m in second_request_messages if m.get("role") == "assistant"
+    ]
+    assert len(assistant_turns) >= 1
+    serialized_args = assistant_turns[-1]["tool_calls"][0]["function"]["arguments"]
+    assert serialized_args != malformed_args
+    parsed = json.loads(serialized_args)
+    assert parsed == {"proof_text": ""}
+
+
+def test_well_formed_args_are_passed_through_unchanged():
+    """The normalisation must NOT touch arguments that already parse
+    cleanly with a `proof_text` field -- otherwise the model loses
+    its own context across turns."""
+    good_args = json.dumps({"proof_text": "bad-but-well-formed"})
+    client = _CapturingClient(
+        [
+            FakeResponse(
+                choices=[
+                    FakeChoice(
+                        message=FakeMessage(
+                            role="assistant",
+                            tool_calls=[
+                                FakeToolCall(
+                                    id="call_1",
+                                    function=FakeFunction(
+                                        name="validate_proof",
+                                        arguments=good_args,
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason="tool_calls",
+                    )
+                ]
+            ),
+            _response_with_tool_call("reflexive", id_="call_2"),
+        ]
+    )
+    validator = FakeValidator(
+        [
+            ValidationOutcome(ok=False, error="goal mismatch"),
+            ValidationOutcome(ok=True),
+        ]
+    )
+    OpenAICompatBackend(client=client, model="Qwen3-Coder-Next").run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+    )
+    second_request_messages = client.chat.completions.messages_per_call[1]
+    assistant_turns = [
+        m for m in second_request_messages if m.get("role") == "assistant"
+    ]
+    serialized_args = assistant_turns[-1]["tool_calls"][0]["function"]["arguments"]
+    assert serialized_args == good_args
+
+
+class _FakeBadRequestError(Exception):
+    """Mimics openai.BadRequestError for tests -- the backend matches
+    by class name, not by importing openai, so this works without the
+    real SDK installed."""
+
+
+_FakeBadRequestError.__name__ = "BadRequestError"
+
+
+class _FlakyChatCompletions:
+    """Returns a scripted response, raises on the second call, then
+    returns a scripted response on the third call."""
+
+    def __init__(
+        self,
+        scripted: list[FakeResponse],
+        raise_on_call: int,
+        exception: Exception,
+    ) -> None:
+        self._scripted = scripted
+        self.calls = 0
+        self._raise_on_call = raise_on_call
+        self._exception = exception
+        self.messages_per_call: list[list[dict]] = []
+
+    def create(self, **kwargs):
+        self.messages_per_call.append([dict(m) for m in kwargs["messages"]])
+        self.calls += 1
+        if self.calls == self._raise_on_call:
+            raise self._exception
+        idx = self.calls - 1 if self.calls < self._raise_on_call else self.calls - 2
+        return self._scripted[idx]
+
+
+class _FlakyClient:
+    def __init__(
+        self,
+        scripted: list[FakeResponse],
+        raise_on_call: int,
+        exception: Exception,
+    ) -> None:
+        self.chat = type(
+            "FakeChat",
+            (),
+            {
+                "completions": _FlakyChatCompletions(
+                    scripted, raise_on_call, exception
+                )
+            },
+        )()
+
+
+def test_recoverable_bad_request_continues_loop():
+    """Issue #376: when client.chat.completions.create raises a
+    BadRequestError that mentions malformed JSON in arguments, the
+    loop should record it as a failed attempt, replace the trailing
+    assistant turn with a synthetic note, and try again -- not bail
+    out as a hard error."""
+    exc = _FakeBadRequestError(
+        "Error code: 400 - {'error': {'message': "
+        "'litellm.BadRequestError: Hosted_vllmException - "
+        "{\"error\":{\"message\":\"Unterminated string starting at: "
+        "line 1 column 16 (char 15)\"}}'}}"
+    )
+    client = _FlakyClient(
+        scripted=[
+            _response_with_tool_call("bad1", id_="call_1"),  # call 1
+            _response_with_tool_call("reflexive", id_="call_2"),  # call 3
+        ],
+        raise_on_call=2,
+        exception=exc,
+    )
+    validator = FakeValidator(
+        [
+            ValidationOutcome(ok=False, error="goal mismatch"),
+            ValidationOutcome(ok=True),
+        ]
+    )
+    result = OpenAICompatBackend(
+        client=client, model="Qwen3-Coder-Next"
+    ).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+    )
+    assert result.ok is True
+    assert result.proof == "reflexive"
+    assert client.chat.completions.calls == 3
+
+    # The third request's transcript should have a synthetic
+    # assistant note replacing the prior failed turn -- no
+    # tool_calls in that assistant entry.
+    third_request_messages = client.chat.completions.messages_per_call[2]
+    assistant_turns = [
+        m for m in third_request_messages if m.get("role") == "assistant"
+    ]
+    assert any(
+        "tool_calls" not in m and "malformed" in (m.get("content") or "").lower()
+        for m in assistant_turns
+    )
+
+    # History should record both the malformed-args recovery and the
+    # subsequent successful attempt.
+    assert len(result.history) >= 2
+    recovery_record = next(
+        (h for h in result.history if "server rejected" in (h.outcome.error or "")),
+        None,
+    )
+    assert recovery_record is not None
+
+
+def test_non_recoverable_bad_request_still_returns_hard_error():
+    """A BadRequestError unrelated to malformed arguments (e.g.
+    auth/quota) must NOT be silently retried -- bail out as before."""
+    exc = _FakeBadRequestError("invalid api key")
+
+    class _AlwaysRaise:
+        def __init__(self):
+            self.calls = 0
+            self.messages_per_call = []
+
+        def create(self, **kwargs):
+            self.calls += 1
+            self.messages_per_call.append([dict(m) for m in kwargs["messages"]])
+            raise exc
+
+    raising = _AlwaysRaise()
+    client = type(
+        "FakeClient2",
+        (),
+        {"chat": type("FakeChat2", (), {"completions": raising})()},
+    )()
+    validator = FakeValidator([])
+    result = OpenAICompatBackend(
+        client=client, model="Qwen3-Coder-Next"
+    ).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P",
+        validator=validator,
+        max_attempts=5,
+    )
+    assert result.ok is False
+    assert "invalid api key" in (result.error or "")
+    # Loop should not have looped on this error.
+    assert raising.calls == 1
+
+
+def test_recoverable_bad_request_on_last_attempt_does_not_loop():
+    """If the malformed-args 400 lands on the final attempt of the
+    budget, there's no retry left -- return failure cleanly rather
+    than continuing past max_attempts."""
+    exc = _FakeBadRequestError(
+        "Error code: 400 - litellm.BadRequestError: "
+        "Unterminated string at line 1 column 16"
+    )
+
+    class _RaiseOnce:
+        def __init__(self):
+            self.calls = 0
+
+        def create(self, **kwargs):
+            self.calls += 1
+            raise exc
+
+    raising = _RaiseOnce()
+    client = type(
+        "FakeClient3",
+        (),
+        {"chat": type("FakeChat3", (), {"completions": raising})()},
+    )()
+    validator = FakeValidator([])
+    result = OpenAICompatBackend(
+        client=client, model="Qwen3-Coder-Next"
+    ).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P",
+        validator=validator,
+        max_attempts=1,
+    )
+    assert result.ok is False
+    assert "API call failed" in (result.error or "")
+    assert raising.calls == 1

--- a/tools/claude_fill_hole/openai_backend.py
+++ b/tools/claude_fill_hole/openai_backend.py
@@ -59,6 +59,25 @@ _VALIDATE_TOOL = {
 }
 
 
+# Substrings (lower-cased) that indicate a 400 response is the result
+# of malformed JSON in a tool-call's `arguments` field, which is
+# recoverable -- we can retry with a synthetic correction note.  Seen
+# in production against LiteLLM in front of vLLM serving Qwen3-Coder;
+# see https://github.com/jsiek/deduce/issues/376.
+_RECOVERABLE_BAD_REQUEST_MARKERS = (
+    "json parse",
+    "unterminated string",
+    "invalid arguments",
+    "invalid tool call",
+    "bad json",
+)
+
+_MALFORMED_RETRY_NOTE = (
+    "(previous tool call was rejected for malformed JSON in `arguments`; "
+    "retry with well-formed JSON, e.g. {\"proof_text\": \"...\"})"
+)
+
+
 class OpenAICompatBackend(Backend):
     """Drive a model through the validate_proof loop via an OpenAI client.
 
@@ -122,6 +141,27 @@ class OpenAICompatBackend(Backend):
                     messages=messages,
                 )
             except Exception as exc:
+                if (
+                    _is_recoverable_malformed_args_error(exc)
+                    and attempt < max_attempts
+                ):
+                    _progress(
+                        "malformed_args_recovery",
+                        attempt=attempt,
+                        error=preview(str(exc), 200),
+                    )
+                    history.append(
+                        AttemptRecord(
+                            attempt=attempt,
+                            proof_text="",
+                            outcome=ValidationOutcome(
+                                ok=False,
+                                error=f"server rejected malformed tool-call JSON: {exc}",
+                            ),
+                        )
+                    )
+                    messages = _strip_trailing_turn_with_synthetic_note(messages)
+                    continue
                 elapsed = int((time.monotonic() - started) * 1000)
                 _progress(
                     "finish",
@@ -365,20 +405,78 @@ def _extract_proof_text(args_raw: str) -> Optional[str]:
 
 def _serialize_tool_calls(tool_calls) -> list[dict]:
     """Re-serialise a list of tool_call objects (Pydantic models or dicts)
-    into a plain list of dicts safe to round-trip through the request."""
+    into a plain list of dicts safe to round-trip through the request.
+
+    For ``validate_proof`` calls whose ``arguments`` aren't well-formed
+    JSON containing ``proof_text``, we substitute a placeholder
+    ``{"proof_text": ""}`` -- some servers (LiteLLM-fronted vLLM
+    in particular) re-validate the message transcript on each
+    request and reject malformed bytes from a prior turn.  See
+    https://github.com/jsiek/deduce/issues/376.
+    """
     out: list[dict] = []
     for tc in tool_calls:
+        name = _tool_call_function_name(tc)
+        args_raw = _tool_call_function_arguments(tc)
         out.append(
             {
                 "id": _tool_call_id(tc),
                 "type": "function",
                 "function": {
-                    "name": _tool_call_function_name(tc),
-                    "arguments": _tool_call_function_arguments(tc),
+                    "name": name,
+                    "arguments": _normalize_args_for_request(name, args_raw),
                 },
             }
         )
     return out
+
+
+def _normalize_args_for_request(name: str, args_raw: str) -> str:
+    """Replace malformed/missing ``validate_proof`` arguments with a
+    placeholder so the next request's transcript is well-formed JSON.
+
+    Only touches ``validate_proof`` calls -- unknown tools are passed
+    through unchanged so the loop's existing unknown-tool error
+    response still describes what the model actually did.
+    """
+    if name != VALIDATE_TOOL_NAME:
+        return args_raw
+    if _extract_proof_text(args_raw) is not None:
+        return args_raw
+    return json.dumps({"proof_text": ""})
+
+
+def _is_recoverable_malformed_args_error(exc: BaseException) -> bool:
+    """True if ``exc`` looks like a server-side 400 caused by malformed
+    JSON inside a tool-call's ``arguments`` field.
+
+    Matched by class name (``BadRequestError``) so this module doesn't
+    need to import ``openai`` -- the same check works against the real
+    SDK exception and the test fakes.
+    """
+    if type(exc).__name__ != "BadRequestError":
+        return False
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _RECOVERABLE_BAD_REQUEST_MARKERS)
+
+
+def _strip_trailing_turn_with_synthetic_note(messages: list[dict]) -> list[dict]:
+    """Walk back to the last ``role: assistant`` entry, drop it (and
+    any tool messages that followed it), and replace it with a plain
+    synthetic note pointing the model at what went wrong.
+
+    Used after a recoverable malformed-args 400: the prior turn's
+    tool_calls are what the server choked on, so we can't carry them
+    forward into the next request.
+    """
+    cut = len(messages)
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].get("role") == "assistant":
+            cut = i
+            break
+    return messages[:cut] + [
+        {"role": "assistant", "content": _MALFORMED_RETRY_NOTE}
+    ]
 
 
 def _attr(obj, name, default=None):


### PR DESCRIPTION
Closes #376 (defensive — does not fix the underlying server-model interaction; insulates the sidecar from it).

## Summary

Two complementary defenses in `tools/claude_fill_hole/openai_backend.py` so that intermittent malformed tool-call arguments from a model (specifically observed with `Qwen3-Coder-Next` under REALLMs's LiteLLM/vLLM stack) don't take down the whole sidecar run:

- **Transcript normalisation.** `_serialize_tool_calls` now substitutes `{"proof_text": ""}` for any `validate_proof` arguments that don't parse cleanly with a `proof_text` field. The next request's `messages` array is therefore always well-formed JSON, even if the model emitted truncated/empty bytes earlier in the conversation. Well-formed args pass through untouched, so the model retains its own context across turns.
- **Recoverable BadRequestError.** The `except` around `client.chat.completions.create` now distinguishes a small whitelist of malformed-JSON markers (\"unterminated string\", \"json parse\", \"invalid arguments\", \"invalid tool call\", \"bad json\") on a `BadRequestError` from the rest. On a recoverable 400 the loop strips the trailing assistant turn, replaces it with a synthetic retry-note, records an attempt in `history`, and continues — so the user gets the remaining attempt budget instead of \"API call failed on attempt 2\".

The Anthropic backend doesn't expose this surface, so it isn't touched.

## Test plan

- [x] `python3 -m pytest test/claude_fill_hole/` — 48 passed (43 prior + 5 new).
- [x] Smoke-test the helper functions stand-alone: `_is_recoverable_malformed_args_error` matches by class name (no `openai` import dep), `_normalize_args_for_request` only normalises `validate_proof`.
- [ ] End-to-end repro against `Qwen3-Coder-Next` on `01_trivial.pf` — best done by the user with a live `REALLMS_API_KEY`; non-deterministic so may need a few runs to land on the malformed-args path.

## Notes

- Branched off `main` (commit `018950a`).
- Match on `BadRequestError` is by class name (`type(exc).__name__`) so the module doesn't hard-depend on `openai` at import time. The real `openai.BadRequestError` and the test fakes both satisfy it.
- The recoverable-error path uses one attempt of the budget — counting it ensures we don't loop forever if the server keeps rejecting.

Draft for review — do not merge before manual repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)