### PR TITLE
gh_pages: in-repo Emacs mode + AI-assistant setup in GettingStarted

### DIFF
--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -4,7 +4,8 @@ Here are some resources to help you get started with Deduce.
 
 * [Installing Deduce](#installation)
 * [Running Programs](#running-deduce-programs)
-* [Using Deduce with an AI Assistant](#using-deduce-with-an-ai-assistant)
+* [AI-assisted proof completion in Emacs (`C-c C-a`)](#ai-assisted-proof-completion-in-emacs)
+* [Letting an AI assistant call Deduce (MCP)](#letting-an-ai-assistant-call-deduce-mcp)
 * [Learning Deduce](#deduce-introduction)
 
 ## Installation
@@ -14,7 +15,6 @@ To get started with Deduce, follow these steps:
 1. [Install Prerequisites](#install-prerequisites)
 2. [Install Deduce](#install-deduce)
 3. [Choose a Text Editor](#install-and-configure-a-text-editor)
-4. [Set up an AI Assistant](#using-deduce-with-an-ai-assistant) (optional)
 
 ### Install Prerequisites
 
@@ -156,7 +156,7 @@ for its API-key / model configuration.
 | `C-c C-i` | Induction skeleton. Cursor on a `?` whose goal is `all x:T. P(x)` with `T` a union; replaces the `?` with `induction T` and one case per constructor, including `IH<N>` bindings on recursive arguments. |
 | `C-c C-e` | Eliminate / use-fact. Cursor on a `?`; prompts for a hypothesis label and replaces the `?` with a tactic chosen by the hypothesis's shape (destructure for `and`, `cases` for `or`, `apply ... to ?` for `if then`, `H[?]` for `all`, `obtain ... from H` for `some`, `replace H` for equality). |
 | `C-c C-f` | Fill hole with a given. Cursor on a `?`; replaces it with `conclude <goal> by <label>` for an in-scope hypothesis whose formula equals the goal. Auto-applies on a single match; otherwise prompts. |
-| `C-c C-a` | **Ask AI** to fill the `?` at point. Spawns an LLM-driven proof-completion sidecar; emacs stays interactive while the model iterates (up to 5 attempts, first valid proof wins). Requires API-key configuration — see [Set up an AI Assistant](#using-deduce-with-an-ai-assistant) below. |
+| `C-c C-a` | **Ask AI** to fill the `?` at point. Spawns an LLM-driven proof-completion sidecar; emacs stays interactive while the model iterates (up to 5 attempts, first valid proof wins). Requires API-key configuration — see [AI-assisted proof completion in Emacs](#ai-assisted-proof-completion-in-emacs) below. |
 
 For full details — including troubleshooting, customization, and a
 manual smoke test — see
@@ -212,32 +212,21 @@ hello.pf is valid
 ```
 
 
-## Using Deduce with an AI Assistant
+## AI-assisted proof completion in Emacs
 
-Deduce ships two complementary AI integrations. They're independent —
-pick whichever fits your workflow (or use both):
-
-* [**In-editor proof completion (`C-c C-a`)**](#in-editor-proof-completion-c-c-c-a)
-  — press a key, an LLM proposes a proof for the `?` at point and
-  Deduce validates it before it lands in your buffer. Stays inside
-  Emacs. Best when you want the AI as a focused tactic, not a
-  conversational partner.
-* [**MCP server for external assistants**](#mcp-server-for-external-ai-assistants)
-  — exposes Deduce's checking and proof-editing helpers as MCP tools
-  so a separate assistant (Claude Code, Claude Desktop, etc.) can
-  inspect goals and edit proofs in conversation. Best when you want
-  the AI to plan across multiple proofs, refactor, or explain.
-
-### In-editor proof completion (`C-c C-a`)
-
-The Emacs mode bundles `deduce-fill-hole` (loaded with `(require
-'deduce-fill-hole)` per the install snippet above). When you press
-`C-c C-a` on a `?`, it spawns the
+In this flow **Deduce calls a language model**: you press `C-c C-a`
+on a `?`, the Emacs mode spawns the
 [`tools/claude_fill_hole`](https://github.com/jsiek/deduce/tree/main/tools/claude_fill_hole)
-sidecar, which talks to a model, validates each candidate proof
-against `deduce.py`, and splices the first valid one back into your
-buffer. Emacs stays interactive while the model iterates (up to five
-attempts by default).
+sidecar, which asks a model for a candidate proof, validates each
+candidate against `deduce.py`, and splices the first valid one back
+into your buffer. Emacs stays interactive while the model iterates
+(up to five attempts by default; the first valid proof wins). The
+binding is provided by `deduce-fill-hole` — make sure your init file
+has `(require 'deduce-fill-hole)` from the
+[Emacs setup](#emacs) above.
+
+Because Deduce is the one calling the model here, **you need an API
+key** for whichever provider you point the sidecar at.
 
 **1. Install the sidecar's Python dependencies:**
 
@@ -311,23 +300,29 @@ model returns a valid proof, it replaces the `?` automatically. If
 none of the attempts validate, the buffer is left untouched and the
 sidecar's last error surfaces in the echo area.
 
-### MCP server for external AI assistants
 
-Deduce ships an [MCP](https://modelcontextprotocol.io) (Model Context
-Protocol) server at `lsp/mcp_server.py`. It exposes Deduce's checking
-and proof-editing helpers as *tools* a separate AI assistant can call,
-so the assistant can inspect goals, navigate definitions, refine
-holes, and case-split without you having to copy-paste source back
-and forth.
+## Letting an AI assistant call Deduce (MCP)
 
-Unlike the in-editor `C-c C-a` flow, **the MCP server itself doesn't
-talk to any LLM and doesn't need credentials of its own.** It's a
-bridge; the LLM credentials and model choice live in whatever MCP
-client you point at it (Claude Code, Claude Desktop, Cursor, …). The
-instructions below assume
-[Claude Code](https://docs.anthropic.com/claude/docs/claude-code); the
-shape is similar for other clients (consult their docs for the exact
-config-file location).
+This is the *opposite* direction from the previous section: instead
+of Deduce asking a model to fill a hole, **an AI assistant calls
+Deduce** as a tool. The assistant (e.g. Claude Code, Claude Desktop,
+Cursor) lives in its own window and uses Deduce to check a file,
+inspect a proof goal, refine a hole, case-split, and so on — driven by
+whatever conversation you're having with it.
+
+Deduce supplies the bridge: an
+[MCP](https://modelcontextprotocol.io) (Model Context Protocol)
+server at `lsp/mcp_server.py` that exposes its checking and
+proof-editing helpers as MCP tools. **The MCP server doesn't talk to
+any language model itself, so it needs no API key of its own** — it
+just speaks JSON-RPC on stdio. The model credentials and model choice
+belong to whatever MCP client you connect: that's part of *that*
+client's setup, not Deduce's.
+
+The instructions below assume
+[Claude Code](https://docs.anthropic.com/claude/docs/claude-code) is
+already installed and authenticated; the shape is similar for other
+MCP clients (check their docs for the exact config-file location).
 
 **1. Install the MCP server's Python dependencies.** If you didn't
 install the LSP requirements above, do it now:
@@ -339,42 +334,10 @@ python3 -m pip install -r requirements-lsp.txt
 
 This pulls in the `mcp` Python package.
 
-**2. Install Claude Code.** See the [Claude Code installation
-guide](https://docs.anthropic.com/claude/docs/claude-code/install) for
-your platform; the TL;DR is `npm install -g
-@anthropic-ai/claude-code`. After install, run `claude` once and
-follow the login prompts.
-
-**3. Configure API access.** Claude Code authenticates either via a
-Claude.ai account (the default) or via an Anthropic API key:
-
-```sh
-export ANTHROPIC_API_KEY=sk-ant-…
-```
-
-Add the line to your shell init so it's available in every shell.
-
-**4. Choose a model.** Claude Code defaults to a recent Claude Sonnet
-model. To pin a specific one:
-
-```sh
-claude --model sonnet      # alias for the latest Sonnet
-claude --model opus        # most capable, more expensive
-claude --model haiku       # fastest, cheapest
-# or a full model id, e.g.:
-claude --model claude-sonnet-4-5-20250929
-```
-
-Equivalent persistent setting in `~/.claude/settings.json`:
-
-```json
-{ "model": "sonnet" }
-```
-
-**5. Register the Deduce MCP server with Claude Code.** Create (or
-edit) `.mcp.json` in the directory where you'll run `claude` —
-typically your Deduce checkout or the directory containing your `.pf`
-files:
+**2. Register the Deduce MCP server with your assistant.** For Claude
+Code: create (or edit) `.mcp.json` in the directory where you'll run
+`claude` — typically your Deduce checkout or the directory containing
+your `.pf` files:
 
 ```json
 {
@@ -400,7 +363,7 @@ CLI registration:
 claude mcp add deduce -- python3 -m lsp.mcp_server
 ```
 
-**6. Try it out.** Start `claude` in the directory with your `.pf`
+**3. Try it out.** Start `claude` in the directory with your `.pf`
 file and ask something concrete:
 
 ```
@@ -428,8 +391,8 @@ diagnostics, and respond. The full tool list:
 | `matching_givens_at`       | List in-scope hypotheses whose formula equals the goal.       |
 
 These are the same operations the Emacs mode binds to `C-c C-r`,
-`C-c C-c`, `C-c C-i`, `C-c C-e`, and `C-c C-f` — Claude (or any other
-MCP client) has the same proof-editing toolkit you do.
+`C-c C-c`, `C-c C-i`, `C-c C-e`, and `C-c C-f` — the assistant has
+the same proof-editing toolkit you do.
 
 
 ## Deduce Introduction

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -114,6 +114,7 @@ syntax highlighting.
 (add-to-list 'load-path "/path/to/deduce/editor/emacs")
 (require 'deduce-mode)
 (require 'deduce-lsp)         ; optional: omit for syntax highlighting only
+(require 'deduce-fill-hole)   ; optional: enables `C-c C-a' (ask AI to fill a hole)
 
 ;; If your .pf files live OUTSIDE the deduce repo, point the LSP
 ;; server at your checkout so `python3 -m lsp.lsp_server' resolves:
@@ -130,11 +131,18 @@ With `use-package`:
 (use-package deduce-lsp
   :load-path "/path/to/deduce/editor/emacs"
   :after (deduce-mode eglot))
+
+(use-package deduce-fill-hole
+  :load-path "/path/to/deduce/editor/emacs"
+  :after deduce-lsp)
 ```
 
 Opening any `.pf` file then enters `deduce-mode` automatically. With
 `deduce-lsp` loaded, `eglot` connects on first save (the first
 connection bootstraps the standard library; subsequent calls are warm).
+`deduce-fill-hole` is independent — see
+[Set up an AI Assistant](#using-deduce-with-an-ai-assistant) below
+for its API-key / model configuration.
 
 **3. Try the keybindings.** Inside a `.pf` buffer:
 
@@ -148,6 +156,7 @@ connection bootstraps the standard library; subsequent calls are warm).
 | `C-c C-i` | Induction skeleton. Cursor on a `?` whose goal is `all x:T. P(x)` with `T` a union; replaces the `?` with `induction T` and one case per constructor, including `IH<N>` bindings on recursive arguments. |
 | `C-c C-e` | Eliminate / use-fact. Cursor on a `?`; prompts for a hypothesis label and replaces the `?` with a tactic chosen by the hypothesis's shape (destructure for `and`, `cases` for `or`, `apply ... to ?` for `if then`, `H[?]` for `all`, `obtain ... from H` for `some`, `replace H` for equality). |
 | `C-c C-f` | Fill hole with a given. Cursor on a `?`; replaces it with `conclude <goal> by <label>` for an in-scope hypothesis whose formula equals the goal. Auto-applies on a single match; otherwise prompts. |
+| `C-c C-a` | **Ask AI** to fill the `?` at point. Spawns an LLM-driven proof-completion sidecar; emacs stays interactive while the model iterates (up to 5 attempts, first valid proof wins). Requires API-key configuration — see [Set up an AI Assistant](#using-deduce-with-an-ai-assistant) below. |
 
 For full details — including troubleshooting, customization, and a
 manual smoke test — see
@@ -205,60 +214,148 @@ hello.pf is valid
 
 ## Using Deduce with an AI Assistant
 
+Deduce ships two complementary AI integrations. They're independent —
+pick whichever fits your workflow (or use both):
+
+* [**In-editor proof completion (`C-c C-a`)**](#in-editor-proof-completion-c-c-c-a)
+  — press a key, an LLM proposes a proof for the `?` at point and
+  Deduce validates it before it lands in your buffer. Stays inside
+  Emacs. Best when you want the AI as a focused tactic, not a
+  conversational partner.
+* [**MCP server for external assistants**](#mcp-server-for-external-ai-assistants)
+  — exposes Deduce's checking and proof-editing helpers as MCP tools
+  so a separate assistant (Claude Code, Claude Desktop, etc.) can
+  inspect goals and edit proofs in conversation. Best when you want
+  the AI to plan across multiple proofs, refactor, or explain.
+
+### In-editor proof completion (`C-c C-a`)
+
+The Emacs mode bundles `deduce-fill-hole` (loaded with `(require
+'deduce-fill-hole)` per the install snippet above). When you press
+`C-c C-a` on a `?`, it spawns the
+[`tools/claude_fill_hole`](https://github.com/jsiek/deduce/tree/main/tools/claude_fill_hole)
+sidecar, which talks to a model, validates each candidate proof
+against `deduce.py`, and splices the first valid one back into your
+buffer. Emacs stays interactive while the model iterates (up to five
+attempts by default).
+
+**1. Install the sidecar's Python dependencies:**
+
+```sh
+cd /path/to/deduce
+python3 -m pip install -r requirements-fill-hole.txt
+```
+
+This pulls in `anthropic` and `openai` (the sidecar picks one at run
+time depending on your backend choice).
+
+**2. Pick a backend and set its API key.** Three common setups:
+
+*Anthropic / Claude (default; best quality, paid):*
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-…
+```
+
+*Indiana University REALLMs (free for IU researchers/faculty/staff,
+hosted on-prem):*
+
+```sh
+export REALLMS_API_KEY=…
+```
+
+```elisp
+;; In your init.el, after (require 'deduce-fill-hole):
+(setq deduce-fill-hole-backend 'openai-compat
+      deduce-fill-hole-base-url "https://reallms.rescloud.iu.edu/direct/v1"
+      deduce-fill-hole-api-key-env "REALLMS_API_KEY"
+      deduce-fill-hole-model "Qwen3-Coder-Next")
+```
+
+*OpenAI (paid):*
+
+```sh
+export OPENAI_API_KEY=sk-…
+```
+
+```elisp
+(setq deduce-fill-hole-backend 'openai-compat
+      deduce-fill-hole-model "gpt-4o")
+```
+
+Add the `export` line to your shell init file (`~/.zshrc`,
+`~/.bashrc`, …) so the variable is available in every Emacs session.
+On macOS GUI Emacs, where shell variables don't always propagate, the
+[`exec-path-from-shell`](https://github.com/purcell/exec-path-from-shell)
+package is a reliable fix.
+
+**3. (Optional) Pin the model and tune attempts.** When the model
+variable is unset, the sidecar picks `claude-opus-4-7` for the
+Anthropic backend and `gemma-4-31B-it` for OpenAI-compat. Override
+either:
+
+```elisp
+(setq deduce-fill-hole-model "claude-sonnet-4-6")  ; cheaper Claude
+(setq deduce-fill-hole-max-attempts 3)             ; default is 5
+(setq deduce-fill-hole-timeout 60)                 ; per validate_proof, seconds
+```
+
+The full set of `defcustom`s (with defaults) is reachable via `M-x
+customize-group RET deduce-fill-hole RET`, and documented in the
+[`editor/emacs/README.md`](https://github.com/jsiek/deduce/blob/main/editor/emacs/README.md#deduce-fill-hole)
+customization table.
+
+**4. Try it.** Open a `.pf` file with a `?` to fill, place point on
+the `?`, and press `C-c C-a`. The mode line shows progress; when the
+model returns a valid proof, it replaces the `?` automatically. If
+none of the attempts validate, the buffer is left untouched and the
+sidecar's last error surfaces in the echo area.
+
+### MCP server for external AI assistants
+
 Deduce ships an [MCP](https://modelcontextprotocol.io) (Model Context
 Protocol) server at `lsp/mcp_server.py`. It exposes Deduce's checking
-and proof-editing helpers as *tools* an AI assistant can call directly,
-so the assistant can inspect goals, navigate definitions, refine holes,
-and case-split without you having to copy-paste source back and forth.
+and proof-editing helpers as *tools* a separate AI assistant can call,
+so the assistant can inspect goals, navigate definitions, refine
+holes, and case-split without you having to copy-paste source back
+and forth.
 
-The MCP server is **just the bridge**: you also need an MCP-aware
-client (such as [Claude Code](https://docs.anthropic.com/claude/docs/claude-code)
-or [Claude Desktop](https://claude.ai/download)) to talk to it. The
-client is what holds the API key / model choice; the Deduce MCP server
-itself doesn't talk to any LLM and doesn't need credentials of its
-own.
+Unlike the in-editor `C-c C-a` flow, **the MCP server itself doesn't
+talk to any LLM and doesn't need credentials of its own.** It's a
+bridge; the LLM credentials and model choice live in whatever MCP
+client you point at it (Claude Code, Claude Desktop, Cursor, …). The
+instructions below assume
+[Claude Code](https://docs.anthropic.com/claude/docs/claude-code); the
+shape is similar for other clients (consult their docs for the exact
+config-file location).
 
-The instructions below assume Claude Code; the configuration shape is
-similar for Claude Desktop and other MCP-compatible clients (consult
-their docs for the exact config-file location).
-
-### 1. Install the MCP Python dependencies
-
-If you didn't install the LSP requirements above, do it now:
+**1. Install the MCP server's Python dependencies.** If you didn't
+install the LSP requirements above, do it now:
 
 ```sh
 cd /path/to/deduce
 python3 -m pip install -r requirements-lsp.txt
 ```
 
-This pulls in the `mcp` Python package the server needs.
+This pulls in the `mcp` Python package.
 
-### 2. Install Claude Code
-
-See the [Claude Code installation
+**2. Install Claude Code.** See the [Claude Code installation
 guide](https://docs.anthropic.com/claude/docs/claude-code/install) for
-your platform. The TL;DR is `npm install -g @anthropic-ai/claude-code`.
-After install, run `claude` once and follow the login prompts.
+your platform; the TL;DR is `npm install -g
+@anthropic-ai/claude-code`. After install, run `claude` once and
+follow the login prompts.
 
-### 3. Configure API access
-
-Claude Code authenticates either via a Claude.ai account (the default,
-no API key required for individual use under
-[Anthropic's terms](https://www.anthropic.com/legal/aup)) or via an
-Anthropic API key. To use an API key:
+**3. Configure API access.** Claude Code authenticates either via a
+Claude.ai account (the default) or via an Anthropic API key:
 
 ```sh
 export ANTHROPIC_API_KEY=sk-ant-…
 ```
 
-Add the line to your shell init file (`~/.zshrc`, `~/.bashrc`, …) so
-the key is available in every shell.
+Add the line to your shell init so it's available in every shell.
 
-### 4. Choose a model
-
-Claude Code defaults to a recent Claude Sonnet model. To pin a
-specific one (e.g. for cost or capability reasons), pass `--model` on
-the command line or set it persistently:
+**4. Choose a model.** Claude Code defaults to a recent Claude Sonnet
+model. To pin a specific one:
 
 ```sh
 claude --model sonnet      # alias for the latest Sonnet
@@ -271,16 +368,13 @@ claude --model claude-sonnet-4-5-20250929
 Equivalent persistent setting in `~/.claude/settings.json`:
 
 ```json
-{
-  "model": "sonnet"
-}
+{ "model": "sonnet" }
 ```
 
-### 5. Register the Deduce MCP server with Claude Code
-
-Create (or edit) `.mcp.json` in the directory where you'll run
-`claude` — typically your Deduce checkout or the directory containing
-your `.pf` files:
+**5. Register the Deduce MCP server with Claude Code.** Create (or
+edit) `.mcp.json` in the directory where you'll run `claude` —
+typically your Deduce checkout or the directory containing your `.pf`
+files:
 
 ```json
 {
@@ -297,26 +391,17 @@ your `.pf` files:
 ```
 
 `DEDUCE_ROOT` tells the server where to find `lib/` (the standard
-library prelude) and `Deduce.lark` (the parser grammar). Set it to
-your Deduce checkout. If you launch `claude` *from* the Deduce
-checkout, `DEDUCE_ROOT` is optional — the server falls back to the
-parent directory of `lsp/mcp_server.py`. To skip the prelude entirely
-(faster startup, no standard library), add `"DEDUCE_NO_STDLIB": "1"`
-alongside `DEDUCE_ROOT`.
-
-Alternatively, register the server via the CLI:
+library prelude) and `Deduce.lark` (the parser grammar). If you launch
+`claude` *from* the Deduce checkout, `DEDUCE_ROOT` is optional. To
+skip the prelude entirely, add `"DEDUCE_NO_STDLIB": "1"`. Alternative
+CLI registration:
 
 ```sh
 claude mcp add deduce -- python3 -m lsp.mcp_server
 ```
 
-(Run this from your Deduce checkout, or pass `-e DEDUCE_ROOT=...`
-before the `--`.)
-
-### 6. Try it out
-
-Start `claude` in the directory with your `.pf` file and ask the
-assistant something concrete:
+**6. Try it out.** Start `claude` in the directory with your `.pf`
+file and ask something concrete:
 
 ```
 $ cd /path/to/your/proofs
@@ -343,8 +428,8 @@ diagnostics, and respond. The full tool list:
 | `matching_givens_at`       | List in-scope hypotheses whose formula equals the goal.       |
 
 These are the same operations the Emacs mode binds to `C-c C-r`,
-`C-c C-c`, `C-c C-i`, `C-c C-e`, and `C-c C-f` — Claude has the
-same proof-editing toolkit you do.
+`C-c C-c`, `C-c C-i`, `C-c C-e`, and `C-c C-f` — Claude (or any other
+MCP client) has the same proof-editing toolkit you do.
 
 
 ## Deduce Introduction

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -4,6 +4,7 @@ Here are some resources to help you get started with Deduce.
 
 * [Installing Deduce](#installation)
 * [Running Programs](#running-deduce-programs)
+* [Using Deduce with an AI Assistant](#using-deduce-with-an-ai-assistant)
 * [Learning Deduce](#deduce-introduction)
 
 ## Installation
@@ -13,6 +14,7 @@ To get started with Deduce, follow these steps:
 1. [Install Prerequisites](#install-prerequisites)
 2. [Install Deduce](#install-deduce)
 3. [Choose a Text Editor](#install-and-configure-a-text-editor)
+4. [Set up an AI Assistant](#using-deduce-with-an-ai-assistant) (optional)
 
 ### Install Prerequisites
 
@@ -75,13 +77,93 @@ source code for Deduce and for the Deduce web site.
 ### Install and Configure a Text Editor
 
 You can write Deduce in any text editor you want, and run Deduce through
-the terminal.
+the terminal. For the editors below, we ship extensions that add syntax
+highlighting and (for Emacs) an interactive proof-editing experience
+backed by Deduce's Language Server Protocol (LSP) implementation.
 
-For the following editors, we have developed extensions that improve
-the experience of writing Deduce code.
+* [Emacs](#emacs) — bundled in the Deduce repo at
+  [`editor/emacs/`](https://github.com/jsiek/deduce/tree/main/editor/emacs).
+  Includes both a major mode (highlighting + indentation) and an LSP
+  client with goal-at-cursor, refine-hole, case-split, induction
+  skeleton, and more.
+* [VS Code](#vs-code) — separate
+  [`HalflingHelper/deduce-mode`](https://github.com/HalflingHelper/deduce-mode)
+  repo. LSP integration is on the roadmap but not yet wired up.
 
-* VSCode ([deduce-mode](https://github.com/HalflingHelper/deduce-mode))
-* Emacs ([deduce-mode](https://github.com/mateidragony/deduce-mode))
+#### Emacs
+
+Requires **Emacs 29.1 or newer** (older Emacs would need a third-party
+`eglot` package, which is unsupported).
+
+**1. Install the Python LSP dependencies** (only required if you want
+the interactive features beyond syntax highlighting):
+
+```sh
+cd /path/to/deduce
+python3 -m pip install -r requirements-lsp.txt
+```
+
+This installs `pygls` (for the LSP server) and `mcp` (for the MCP
+server documented in the next section). Skip this if you only want
+syntax highlighting.
+
+**2. Add to your Emacs init file.** Without `use-package`:
+
+```elisp
+;; ~/.emacs.d/init.el  (or ~/.emacs)
+(add-to-list 'load-path "/path/to/deduce/editor/emacs")
+(require 'deduce-mode)
+(require 'deduce-lsp)         ; optional: omit for syntax highlighting only
+
+;; If your .pf files live OUTSIDE the deduce repo, point the LSP
+;; server at your checkout so `python3 -m lsp.lsp_server' resolves:
+;; (setq deduce-lsp-deduce-root "~/src/deduce")
+```
+
+With `use-package`:
+
+```elisp
+(use-package deduce-mode
+  :load-path "/path/to/deduce/editor/emacs"
+  :mode "\\.pf\\'")
+
+(use-package deduce-lsp
+  :load-path "/path/to/deduce/editor/emacs"
+  :after (deduce-mode eglot))
+```
+
+Opening any `.pf` file then enters `deduce-mode` automatically. With
+`deduce-lsp` loaded, `eglot` connects on first save (the first
+connection bootstraps the standard library; subsequent calls are warm).
+
+**3. Try the keybindings.** Inside a `.pf` buffer:
+
+| Key       | Action                                                                |
+| --------- | --------------------------------------------------------------------- |
+| `M-.`     | Jump to a symbol's definition.                                        |
+| `M-x imenu` | Outline of top-level theorems / definitions / unions.               |
+| `C-c C-g` | Show the proof goal at point in a popup buffer.                       |
+| `C-c C-r` | Refine the hole `?` at point. Picks a tactic template by goal shape (e.g. `arbitrary x:T` for `all x:T. ...`, `?, ?` for `P and Q`, `reflexive` for an obvious equality). |
+| `C-c C-c` | Case split. Cursor on a `?`; prompts (with TAB completion) for an in-scope variable, then replaces the `?` with a `switch` skeleton (one branch per constructor) or `cases` (for `or`-shaped hypotheses). |
+| `C-c C-i` | Induction skeleton. Cursor on a `?` whose goal is `all x:T. P(x)` with `T` a union; replaces the `?` with `induction T` and one case per constructor, including `IH<N>` bindings on recursive arguments. |
+| `C-c C-e` | Eliminate / use-fact. Cursor on a `?`; prompts for a hypothesis label and replaces the `?` with a tactic chosen by the hypothesis's shape (destructure for `and`, `cases` for `or`, `apply ... to ?` for `if then`, `H[?]` for `all`, `obtain ... from H` for `some`, `replace H` for equality). |
+| `C-c C-f` | Fill hole with a given. Cursor on a `?`; replaces it with `conclude <goal> by <label>` for an in-scope hypothesis whose formula equals the goal. Auto-applies on a single match; otherwise prompts. |
+
+For full details — including troubleshooting, customization, and a
+manual smoke test — see
+[`editor/emacs/README.md`](https://github.com/jsiek/deduce/blob/main/editor/emacs/README.md).
+
+#### VS Code
+
+The VS Code extension lives in a separate repo:
+[HalflingHelper/deduce-mode](https://github.com/HalflingHelper/deduce-mode).
+It currently provides syntax highlighting only; the interactive
+LSP-backed features (goal-at-cursor, refine, case split, etc.) are not
+yet wired up. If you want them today, use the Emacs mode above; if you
+want to help build the VS Code client, the Deduce LSP server lives at
+`lsp/lsp_server.py` and speaks standard LSP plus a few custom
+`deduce/...` requests documented in
+[`docs/lsp-plan.md`](https://github.com/jsiek/deduce/blob/main/docs/lsp-plan.md).
 
 
 ## Running Deduce Programs
@@ -120,6 +202,149 @@ hello
 hello.pf is valid
 ```
 
+
+## Using Deduce with an AI Assistant
+
+Deduce ships an [MCP](https://modelcontextprotocol.io) (Model Context
+Protocol) server at `lsp/mcp_server.py`. It exposes Deduce's checking
+and proof-editing helpers as *tools* an AI assistant can call directly,
+so the assistant can inspect goals, navigate definitions, refine holes,
+and case-split without you having to copy-paste source back and forth.
+
+The MCP server is **just the bridge**: you also need an MCP-aware
+client (such as [Claude Code](https://docs.anthropic.com/claude/docs/claude-code)
+or [Claude Desktop](https://claude.ai/download)) to talk to it. The
+client is what holds the API key / model choice; the Deduce MCP server
+itself doesn't talk to any LLM and doesn't need credentials of its
+own.
+
+The instructions below assume Claude Code; the configuration shape is
+similar for Claude Desktop and other MCP-compatible clients (consult
+their docs for the exact config-file location).
+
+### 1. Install the MCP Python dependencies
+
+If you didn't install the LSP requirements above, do it now:
+
+```sh
+cd /path/to/deduce
+python3 -m pip install -r requirements-lsp.txt
+```
+
+This pulls in the `mcp` Python package the server needs.
+
+### 2. Install Claude Code
+
+See the [Claude Code installation
+guide](https://docs.anthropic.com/claude/docs/claude-code/install) for
+your platform. The TL;DR is `npm install -g @anthropic-ai/claude-code`.
+After install, run `claude` once and follow the login prompts.
+
+### 3. Configure API access
+
+Claude Code authenticates either via a Claude.ai account (the default,
+no API key required for individual use under
+[Anthropic's terms](https://www.anthropic.com/legal/aup)) or via an
+Anthropic API key. To use an API key:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-…
+```
+
+Add the line to your shell init file (`~/.zshrc`, `~/.bashrc`, …) so
+the key is available in every shell.
+
+### 4. Choose a model
+
+Claude Code defaults to a recent Claude Sonnet model. To pin a
+specific one (e.g. for cost or capability reasons), pass `--model` on
+the command line or set it persistently:
+
+```sh
+claude --model sonnet      # alias for the latest Sonnet
+claude --model opus        # most capable, more expensive
+claude --model haiku       # fastest, cheapest
+# or a full model id, e.g.:
+claude --model claude-sonnet-4-5-20250929
+```
+
+Equivalent persistent setting in `~/.claude/settings.json`:
+
+```json
+{
+  "model": "sonnet"
+}
+```
+
+### 5. Register the Deduce MCP server with Claude Code
+
+Create (or edit) `.mcp.json` in the directory where you'll run
+`claude` — typically your Deduce checkout or the directory containing
+your `.pf` files:
+
+```json
+{
+  "mcpServers": {
+    "deduce": {
+      "command": "python3",
+      "args": ["-m", "lsp.mcp_server"],
+      "env": {
+        "DEDUCE_ROOT": "/path/to/deduce"
+      }
+    }
+  }
+}
+```
+
+`DEDUCE_ROOT` tells the server where to find `lib/` (the standard
+library prelude) and `Deduce.lark` (the parser grammar). Set it to
+your Deduce checkout. If you launch `claude` *from* the Deduce
+checkout, `DEDUCE_ROOT` is optional — the server falls back to the
+parent directory of `lsp/mcp_server.py`. To skip the prelude entirely
+(faster startup, no standard library), add `"DEDUCE_NO_STDLIB": "1"`
+alongside `DEDUCE_ROOT`.
+
+Alternatively, register the server via the CLI:
+
+```sh
+claude mcp add deduce -- python3 -m lsp.mcp_server
+```
+
+(Run this from your Deduce checkout, or pass `-e DEDUCE_ROOT=...`
+before the `--`.)
+
+### 6. Try it out
+
+Start `claude` in the directory with your `.pf` file and ask the
+assistant something concrete:
+
+```
+$ cd /path/to/your/proofs
+$ claude
+> Please check hello.pf and explain any errors.
+```
+
+Claude will call the Deduce MCP server's `check_file` tool, see the
+diagnostics, and respond. The full tool list:
+
+| Tool                       | What it does                                                  |
+| -------------------------- | ------------------------------------------------------------- |
+| `check_file`               | Type-check and proof-check a `.pf` file; returns diagnostics. |
+| `goal_at`                  | Return the proof goal + givens at a cursor position.          |
+| `definition_of`            | Jump from a symbol to its declaration.                        |
+| `list_symbols`             | Outline of top-level theorems / definitions in a file.        |
+| `refine_at`                | Refine a `?` based on the goal's shape.                       |
+| `case_split_at`            | Replace a `?` with a `switch` / `cases` skeleton on a chosen variable. |
+| `splittable_vars_at`       | List in-scope variables that `case_split_at` can target.      |
+| `induction_skeleton_at`    | Replace a `?` with an `induction T` skeleton.                 |
+| `eliminate_at`             | Replace a `?` with a tactic that uses a chosen hypothesis.    |
+| `eliminable_vars_at`       | List in-scope hypotheses that `eliminate_at` can target.      |
+| `fill_from_given_at`       | Replace a `?` with `conclude <goal> by <label>`.              |
+| `matching_givens_at`       | List in-scope hypotheses whose formula equals the goal.       |
+
+These are the same operations the Emacs mode binds to `C-c C-r`,
+`C-c C-c`, `C-c C-i`, `C-c C-e`, and `C-c C-f` — Claude has the
+same proof-editing toolkit you do.
 
 
 ## Deduce Introduction

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -5,7 +5,7 @@ Here are some resources to help you get started with Deduce.
 * [Installing Deduce](#installation)
 * [Running Programs](#running-deduce-programs)
 * [AI-assisted proof completion in Emacs (`C-c C-a`)](#ai-assisted-proof-completion-in-emacs)
-* [Letting an AI assistant call Deduce (MCP)](#letting-an-ai-assistant-call-deduce-mcp)
+* [Calling Deduce from an AI assistant (MCP)](#calling-deduce-from-an-ai-assistant-mcp)
 * [Learning Deduce](#deduce-introduction)
 
 ## Installation
@@ -214,19 +214,18 @@ hello.pf is valid
 
 ## AI-assisted proof completion in Emacs
 
-In this flow **Deduce calls a language model**: you press `C-c C-a`
-on a `?`, the Emacs mode spawns the
+`C-c C-a` asks a language model to fill the `?` at point. The Emacs
+mode spawns the
 [`tools/claude_fill_hole`](https://github.com/jsiek/deduce/tree/main/tools/claude_fill_hole)
-sidecar, which asks a model for a candidate proof, validates each
-candidate against `deduce.py`, and splices the first valid one back
-into your buffer. Emacs stays interactive while the model iterates
-(up to five attempts by default; the first valid proof wins). The
-binding is provided by `deduce-fill-hole` — make sure your init file
-has `(require 'deduce-fill-hole)` from the
-[Emacs setup](#emacs) above.
+sidecar, which requests a candidate proof, validates it against
+`deduce.py`, and splices the first valid one back into your buffer.
+Emacs stays interactive while the model iterates (up to five
+attempts; the first valid proof wins).
 
-Because Deduce is the one calling the model here, **you need an API
-key** for whichever provider you point the sidecar at.
+The binding comes from `deduce-fill-hole` — make sure your init file
+has `(require 'deduce-fill-hole)` from the [Emacs setup](#emacs)
+above. You'll also need an API key for whichever model provider you
+point the sidecar at.
 
 **1. Install the sidecar's Python dependencies:**
 
@@ -235,8 +234,8 @@ cd /path/to/deduce
 python3 -m pip install -r requirements-fill-hole.txt
 ```
 
-This pulls in `anthropic` and `openai` (the sidecar picks one at run
-time depending on your backend choice).
+This pulls in `anthropic` and `openai`; the sidecar picks one at run
+time based on your backend choice.
 
 **2. Pick a backend and set its API key.** Three common setups:
 
@@ -274,14 +273,14 @@ export OPENAI_API_KEY=sk-…
 
 Add the `export` line to your shell init file (`~/.zshrc`,
 `~/.bashrc`, …) so the variable is available in every Emacs session.
-On macOS GUI Emacs, where shell variables don't always propagate, the
+On macOS GUI Emacs, where shell variables sometimes fail to propagate
+into the GUI environment, the
 [`exec-path-from-shell`](https://github.com/purcell/exec-path-from-shell)
 package is a reliable fix.
 
-**3. (Optional) Pin the model and tune attempts.** When the model
-variable is unset, the sidecar picks `claude-opus-4-7` for the
-Anthropic backend and `gemma-4-31B-it` for OpenAI-compat. Override
-either:
+**3. (Optional) Pin the model and tune attempts.** By default the
+sidecar uses `claude-opus-4-7` (Anthropic backend) or
+`gemma-4-31B-it` (OpenAI-compat). To override:
 
 ```elisp
 (setq deduce-fill-hole-model "claude-sonnet-4-6")  ; cheaper Claude
@@ -297,35 +296,32 @@ customization table.
 **4. Try it.** Open a `.pf` file with a `?` to fill, place point on
 the `?`, and press `C-c C-a`. The mode line shows progress; when the
 model returns a valid proof, it replaces the `?` automatically. If
-none of the attempts validate, the buffer is left untouched and the
-sidecar's last error surfaces in the echo area.
+every attempt fails validation, the sidecar surfaces its last error
+in the echo area and leaves the buffer as it was.
 
 
-## Letting an AI assistant call Deduce (MCP)
+## Calling Deduce from an AI assistant (MCP)
 
-This is the *opposite* direction from the previous section: instead
-of Deduce asking a model to fill a hole, **an AI assistant calls
-Deduce** as a tool. The assistant (e.g. Claude Code, Claude Desktop,
-Cursor) lives in its own window and uses Deduce to check a file,
-inspect a proof goal, refine a hole, case-split, and so on — driven by
-whatever conversation you're having with it.
+An AI assistant like
+[Claude Code](https://docs.anthropic.com/claude/docs/claude-code),
+Claude Desktop, or Cursor can call Deduce as a tool — checking a
+file, inspecting a proof goal, refining a hole, case-splitting — all
+driven by your conversation with the assistant.
 
 Deduce supplies the bridge: an
 [MCP](https://modelcontextprotocol.io) (Model Context Protocol)
-server at `lsp/mcp_server.py` that exposes its checking and
-proof-editing helpers as MCP tools. **The MCP server doesn't talk to
-any language model itself, so it needs no API key of its own** — it
-just speaks JSON-RPC on stdio. The model credentials and model choice
-belong to whatever MCP client you connect: that's part of *that*
-client's setup, not Deduce's.
+server at `lsp/mcp_server.py` that speaks JSON-RPC on stdio and
+exposes Deduce's checking and proof-editing helpers as MCP tools.
+Your assistant brings its own login and model choice; on the Deduce
+side you install the server's Python dependencies, register the
+server with your assistant, and you're set.
 
-The instructions below assume
-[Claude Code](https://docs.anthropic.com/claude/docs/claude-code) is
-already installed and authenticated; the shape is similar for other
-MCP clients (check their docs for the exact config-file location).
+The instructions below assume Claude Code is installed and
+authenticated; the shape is similar for other MCP clients (check
+their docs for the exact config-file location).
 
-**1. Install the MCP server's Python dependencies.** If you didn't
-install the LSP requirements above, do it now:
+**1. Install the MCP server's Python dependencies.** Skip this if
+you already installed the LSP requirements above:
 
 ```sh
 cd /path/to/deduce
@@ -335,7 +331,7 @@ python3 -m pip install -r requirements-lsp.txt
 This pulls in the `mcp` Python package.
 
 **2. Register the Deduce MCP server with your assistant.** For Claude
-Code: create (or edit) `.mcp.json` in the directory where you'll run
+Code, create (or edit) `.mcp.json` in the directory where you'll run
 `claude` — typically your Deduce checkout or the directory containing
 your `.pf` files:
 

--- a/gh_pages/js/script.js
+++ b/gh_pages/js/script.js
@@ -151,7 +151,7 @@ class DeduceFooter extends HTMLElement {
                     <a href="${urlPrefix}/sandbox.html">Live Code</a>
                     <a href="https://github.com/jsiek/deduce" target="_blank">Source Code</a>
                     <a href="https://github.com/HalflingHelper/deduce-mode" target="_blank">VS-Code deduce-mode</a>
-                    <a href="https://github.com/mateidragony/deduce-mode" target="_blank">Emacs deduce-mode</a>
+                    <a href="https://github.com/jsiek/deduce/tree/main/editor/emacs" target="_blank">Emacs deduce-mode</a>
                 </div>
                 <div class="footer-col">
                     <a href="${urlPrefix}/pages/reference.html">Reference</a>


### PR DESCRIPTION
The user-facing docs still pointed at the third-party
[mateidragony/deduce-mode](https://github.com/mateidragony/deduce-mode)
repo for Emacs.  That mode is superseded by the in-repo \`editor/emacs/\`
directory, which ships both a syntax-highlighting major mode and an
LSP client wired into all of Phase 4's structured-editing features
(refine / case-split / induction / eliminate / fill-from-given).

## Summary

- Footer link in \`gh_pages/js/script.js\` now points to \`editor/emacs/\`
  on github.com/jsiek/deduce.

- \`gh_pages/doc/GettingStarted.md\` rewrites the \"Install and Configure
  a Text Editor\" section:
  - Pointer to \`editor/emacs/\` (with both \`use-package\` and bare
    \`init.el\` snippets), \`pip install -r requirements-lsp.txt\`, and
    a keybinding reference table for the LSP commands.
  - VS Code retained as a separate section pointing at
    HalflingHelper/deduce-mode with a note that LSP integration is
    still on the roadmap there.
  - Defers to \`editor/emacs/README.md\` for the full troubleshooting +
    manual smoke test.

- New top-level section: **Using Deduce with an AI Assistant** —
  covers the MCP server: install (\`pip install -r requirements-lsp.txt\`),
  Claude Code install, API-key / Claude.ai-login flow, model selection,
  \`.mcp.json\` registration, the \`DEDUCE_ROOT\` / \`DEDUCE_NO_STDLIB\` env
  knobs, and a tool-by-tool table of what the MCP server exposes (the
  same operations the Emacs mode binds to \`C-c C-r\` / \`C-c C-c\` /
  \`C-c C-i\` / \`C-c C-e\` / \`C-c C-f\`).

## Test plan

- [x] Doc-only change; renders as plain Markdown.
- [ ] Verify the doc renders correctly on the live site (manual).
- [ ] Verify the in-repo emacs install snippet works on a fresh Emacs config (manual; user has the live setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)