### PR TITLE
Hole-fill: replace CheatSheet.md with worked examples in the system prompt

### DIFF
--- a/gh_pages/doc/WorkedExamples.md
+++ b/gh_pages/doc/WorkedExamples.md
@@ -302,6 +302,49 @@ Three Deduce-specific tactics from this example:
 
 ---
 
+## Using `query_goal` to plan a multi-step proof
+
+For multi-step proofs (especially induction), don't try to write the whole thing in one shot. Build a skeleton with `?` placeholders inside each branch, call `query_goal` to see the goal + givens at each `?`, then fill them in one at a time.
+
+For example, to prove `add(n, zero) = n` by induction:
+
+**Step 1 — write the skeleton.** Each case body is just `?`:
+
+```
+induction UnaryNat
+case zero { ? }
+case succ(n') suppose IH: add(n', zero) = n' { ? }
+```
+
+**Step 2 — call `query_goal` on that skeleton.** It splices the partial proof at the hole, finds the first `?` in the result, and returns its goal + givens. For the `case zero` `?`, you'd see:
+
+```
+{"goal": "add(zero, zero) = zero", "givens": []}
+```
+
+That's discharged by `expand add.`. Update the skeleton:
+
+```
+induction UnaryNat
+case zero { expand add. }
+case succ(n') suppose IH: add(n', zero) = n' { ? }
+```
+
+**Step 3 — `query_goal` again.** Now the first remaining `?` is in the `succ` branch:
+
+```
+{"goal": "add(succ(n'), zero) = succ(n')",
+ "givens": [{"label": "IH", "formula": "add(n', zero) = n'"}]}
+```
+
+That's a one-step `equations` chain using `expand add.` then `replace IH.`. Fill it in.
+
+**Step 4 — `validate_proof` the complete proof.** When there are no more `?` markers in the body, hand the whole thing to `validate_proof`.
+
+`query_goal` does not count toward your `validate_proof` budget — call it freely as you refine. The first `?` in the spliced text is what gets reported, so you don't need to remove earlier branches' `?` markers as you fill them; just leave the skeleton structure intact and `query_goal` will walk through them in order on subsequent calls.
+
+---
+
 ## `switch` on a term (vs `cases` on a hypothesis)
 
 Use `switch x` to case-split on a value of a union type. `cases p` is for splitting a *hypothesis* of disjunction shape; `switch` is for splitting on an inductive *value*.

--- a/gh_pages/doc/WorkedExamples.md
+++ b/gh_pages/doc/WorkedExamples.md
@@ -1,0 +1,407 @@
+# Worked Examples
+
+Concrete short proofs demonstrating each construct in [TacticsCheatSheet.md](./TacticsCheatSheet.md) and [CheatSheet.md](./CheatSheet.md). Each example is self-contained and checks under `deduce.py --no-stdlib` (no prelude required).
+
+If you want to look up "given a goal of shape X, what tactic do I use?" you can search by the heading of the section below, since they're organised by goal shape (matching CheatSheet's lookup table) and then by non-shape-keyed tactics.
+
+---
+
+## Goal: `true`
+
+The trivial proof `.` discharges `true`, reflexive equalities, and any goal that auto-rules have already collapsed to `true`.
+
+```
+theorem ex_true: true
+proof
+  .
+end
+```
+
+---
+
+## Goal: `false` (via contradiction)
+
+You don't usually prove `false` directly — you derive it from a contradictory pair of hypotheses.
+
+```
+theorem ex_false: all P:bool. if P and not P then false
+proof
+  arbitrary P:bool
+  assume both: P and not P
+  contradict (conjunct 0 of both), (conjunct 1 of both)
+end
+```
+
+A hypothesis `H: false` implicitly proves any goal:
+
+```
+theorem ex_false_anything: all P:bool. if false then P
+proof
+  arbitrary P:bool
+  assume f: false
+  conclude P by f
+end
+```
+
+---
+
+## Goal: `P and Q` (intro via comma; destructure with `conjunct N of`)
+
+To **prove** `P and Q`, give a comma-separated pair of proofs.
+
+```
+theorem ex_and_intro: all P:bool, Q:bool. if P then if Q then P and Q
+proof
+  arbitrary P:bool, Q:bool
+  assume p: P
+  assume q: Q
+  p, q
+end
+```
+
+To **use** a hypothesis `pq: P and Q`, destructure it. `conjunct N of pq` is **zero-indexed** — `conjunct 0 of pq : P`, `conjunct 1 of pq : Q`. The comma binds tighter than `conjunct ... of`, so an inline `(conjunct 1 of pq, conjunct 0 of pq)` parses wrong. Use `have ... by` to name the pieces:
+
+```
+theorem ex_and_swap: all P:bool, Q:bool. if P and Q then Q and P
+proof
+  arbitrary P:bool, Q:bool
+  assume pq: P and Q
+  have q: Q by conjunct 1 of pq
+  have p: P by conjunct 0 of pq
+  q, p
+end
+```
+
+---
+
+## Goal: `P or Q` (intro: provide one side; elim: `cases`)
+
+To **prove** `P or Q`, give a proof of either side directly. There is no `or_left`/`or_right`/`inl`/`inr` constructor.
+
+```
+theorem ex_or_intro: all P:bool, Q:bool. if P then P or Q
+proof
+  arbitrary P:bool, Q:bool
+  assume p: P
+  conclude P or Q by p
+end
+```
+
+To **use** a hypothesis `pq: P or Q`, case-split with `cases`. Each case's body must prove the goal under that branch's hypothesis.
+
+```
+theorem ex_or_swap: all P:bool, Q:bool. if P or Q then Q or P
+proof
+  arbitrary P:bool, Q:bool
+  assume pq: P or Q
+  cases pq
+  case h_p: P { conclude Q or P by h_p }
+  case h_q: Q { conclude Q or P by h_q }
+end
+```
+
+---
+
+## Goal: `if P then Q` (intro: `assume`/`suppose`; elim: `apply ... to`)
+
+To **prove** `if P then Q`, introduce the antecedent and prove the consequent. `assume` and `suppose` are synonyms.
+
+```
+theorem ex_impl_intro: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  p
+end
+```
+
+To **use** a hypothesis `H: if P then Q` together with `p: P`, write `apply H to p` (modus ponens). When the antecedent is itself a conjunction `if P1 and P2 then Q`, write `apply H to p1, p2` — the comma constructs the conjunction; no parentheses needed.
+
+```
+theorem ex_apply_to: all P:bool, Q:bool, R:bool.
+  if (if P then Q) and (if Q then R) then if P then R
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  assume both: (if P then Q) and (if Q then R)
+  assume p: P
+  have pq: if P then Q  by conjunct 0 of both
+  have qr: if Q then R  by conjunct 1 of both
+  have q: Q  by apply pq to p
+  apply qr to q
+end
+```
+
+---
+
+## Goal: `not P`
+
+`not P` is sugar for `if P then false`. Prove it the same way.
+
+```
+theorem ex_not_intro: all P:bool. if P then not (not P)
+proof
+  arbitrary P:bool
+  assume p: P
+  assume np: not P
+  contradict p, np
+end
+```
+
+To **use** `H: not P` together with `p: P`, write `contradict p, H` — that proves `false` (and so any goal).
+
+---
+
+## Goal: `all x:T. P(x)` (intro: `arbitrary` or `induction`; elim: brackets)
+
+For a non-recursive use of the universal, `arbitrary x:T` introduces `x` and the goal becomes `P(x)`:
+
+```
+theorem ex_forall_arbitrary: all x:bool. x = x
+proof
+  arbitrary x:bool
+  reflexive
+end
+```
+
+When `x` appears as the recursion target of a function in the goal, use **induction** instead — see the [Induction over a union type](#induction-over-a-union-type) section below.
+
+To **instantiate** a universal lemma `H: all x:T. P(x)`, write `H[t]` (a proof of `P(t)`). Multiple variables: `H[t1, t2]`.
+
+```
+theorem ex_forall_elim:
+  if (all x:bool. x = x) then true = true
+proof
+  assume H: all x:bool. x = x
+  H[true]
+end
+```
+
+---
+
+## Goal: `some x:T. P(x)` (intro: `choose`; elim: `obtain`)
+
+To **prove** `some x:T. P(x)`, pick a witness with `choose t` and prove `P[x:=t]`.
+
+```
+theorem ex_exists_intro: some x:bool. x = true
+proof
+  choose true
+  reflexive
+end
+```
+
+To **use** a hypothesis `H: some x:T. P(x)`, write `obtain x where eq: P from H` — this introduces a fresh `x` and a proof `eq` of `P(x)` into scope.
+
+```
+theorem ex_exists_elim:
+  if (some x:bool. x = true) then some y:bool. y = true
+proof
+  assume H: some x:bool. x = true
+  obtain x where eq: x = true from H
+  choose x
+  conclude x = true by eq
+end
+```
+
+---
+
+## Goal: `e1 = e2` (reflexivity, equations chains, replace)
+
+When the two sides are identical (or reduce to the same normal form), `.` or `reflexive` suffices.
+
+```
+theorem ex_eq_refl: all x:bool. x = x
+proof
+  arbitrary x:bool
+  reflexive
+end
+```
+
+For a non-trivial chain, use `equations`. Each step is justified by a proof of the previous-step-to-this-step equality. `expand fn` unfolds a function's definition by one step.
+
+```
+union UN {
+  z
+  s(UN)
+}
+
+recursive plus(UN, UN) -> UN {
+  plus(z, m) = m
+  plus(s(n), m) = s(plus(n, m))
+}
+
+theorem ex_eq_equations: all m:UN. plus(s(z), m) = s(m)
+proof
+  arbitrary m:UN
+  equations
+    plus(s(z), m) = s(plus(z, m))   by expand plus.
+              ... = s(m)             by expand plus.
+end
+```
+
+To rewrite the goal using an equality `eq: a = b`, use `replace eq` (rewrites left-to-right, `a → b`). For right-to-left, use `replace symmetric eq`. To rewrite *inside* a proof term, use `replace eq in p` — produces a new proof with the rewritten formula.
+
+`symmetric` and `transitive` build new proofs from existing equalities:
+
+```
+theorem ex_eq_symmetric: all P:bool, Q:bool. if P = Q then Q = P
+proof
+  arbitrary P:bool, Q:bool
+  assume eq: P = Q
+  symmetric eq
+end
+
+theorem ex_eq_transitive:
+  all P:bool, Q:bool, R:bool.
+  if P = Q and Q = R then P = R
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  assume both: P = Q and Q = R
+  have pq: P = Q by conjunct 0 of both
+  have qr: Q = R by conjunct 1 of both
+  transitive pq qr
+end
+```
+
+---
+
+## Induction over a union type
+
+Use `induction T` (note: pass the **type** name, not the variable) to do structural induction. Recursive constructors get an induction hypothesis bound by `suppose IH:`. Non-recursive constructors (the base cases) have **no IH** — don't write `suppose IH` on them.
+
+```
+union UnaryNat {
+  zero
+  succ(UnaryNat)
+}
+
+recursive add(UnaryNat, UnaryNat) -> UnaryNat {
+  add(zero, m) = m
+  add(succ(n), m) = succ(add(n, m))
+}
+
+theorem ex_induction: all n:UnaryNat. add(n, zero) = n
+proof
+  induction UnaryNat
+  case zero {
+    expand add.
+  }
+  case succ(n') suppose IH: add(n', zero) = n' {
+    equations
+      add(succ(n'), zero) = succ(add(n', zero))   by expand add.
+                      ... = succ(n')               by replace IH.
+  }
+end
+```
+
+Three Deduce-specific tactics from this example:
+
+- `expand <fn>` unfolds the named function's definition by one step on every occurrence in the goal. Append a trailing `.` to discharge the goal if the resulting equation is trivially true.
+- `replace IH` rewrites the goal left-to-right using `IH`'s equation.
+- `equations LHS = step1 by reason1 ... = end by reasonN` is the readable form of nested `transitive`. Each `... = next` continues the chain.
+
+---
+
+## `switch` on a term (vs `cases` on a hypothesis)
+
+Use `switch x` to case-split on a value of a union type. `cases p` is for splitting a *hypothesis* of disjunction shape; `switch` is for splitting on an inductive *value*.
+
+```
+theorem ex_switch: all b:bool. b or not b
+proof
+  arbitrary b:bool
+  switch b {
+    case true { conclude true or not true by . }
+    case false {
+      have nf: not false by assume f: false  f
+      nf
+    }
+  }
+end
+```
+
+When you need to remember the equation between the scrutinee and the case's pattern, use `switch x { case ctor(args) assume eq { ... } }` — `eq : x = ctor(args)` is in scope inside the branch.
+
+---
+
+## `have` for forward reasoning
+
+`have name: P by proof` introduces a named fact into scope without changing the goal. Useful for splitting work or naming intermediate results.
+
+```
+theorem ex_have: all P:bool, Q:bool. if P and Q then P
+proof
+  arbitrary P:bool, Q:bool
+  assume pq: P and Q
+  have p: P by conjunct 0 of pq
+  p
+end
+```
+
+---
+
+## `suffices` for backward reasoning
+
+`suffices Q by reason` replaces the current goal with `Q`, where `reason` proves `Q → originalGoal`. Often `Q` is the goal *after* a rewrite you want to make explicit.
+
+```
+theorem ex_suffices: all P:bool. if P then (P and true)
+proof
+  arbitrary P:bool
+  assume p: P
+  suffices P by .
+  p
+end
+```
+
+In the above, `(P and true)` reduces to `P`, so `suffices P by .` re-states the goal in the simpler form.
+
+---
+
+## `apply lemma[t] to p` (combined instantiation + modus ponens)
+
+When using a universally-quantified implication, you can instantiate and apply in one step:
+
+```
+theorem ex_apply_inst:
+  if (all x:bool. if x = true then x or false) then true or false
+proof
+  assume H: all x:bool. if x = true then x or false
+  have eq: true = true by reflexive
+  apply H[true] to eq
+end
+```
+
+`H[true]` instantiates the `all`, giving `if true = true then true or false`. `apply ... to eq` discharges the antecedent.
+
+---
+
+## Predicates and rule induction
+
+The `predicate` keyword (synonym: `relation`) declares an inductively-defined set. Each rule's name doubles as a proof-term: `ev0` is a proof of `even(zero)`; `ev_ss[n]` (instantiated) is a proof of `if even(n) then even(succ(succ(n)))`.
+
+`rule induction P` proves a goal of the form `all x1, ..., xn. if P(x1, ..., xn) then Q(x1, ..., xn)` by induction on `P`'s derivation. Note: the induction sits *before* any `arbitrary`/`assume` — the goal must include the outer `all` and `if P(...)` premise.
+
+```
+union N { z  succ(N) }
+
+predicate even : fn N -> bool {
+  ev0   : even(z)
+  ev_ss : all n:N. if even(n) then even(succ(succ(n)))
+}
+
+theorem ex_rule_induction: all n:N. if even(n) then even(n)
+proof
+  rule induction even
+  case ev0 { ev0 }
+  case ev_ss {
+    arbitrary k:N
+    assume hyp: even(k) and even(k)
+    apply ev_ss[k] to (conjunct 0 of hyp)
+  }
+end
+```
+
+In the `ev_ss` case, the assumed hypothesis is `even(k) and even(k)` — the rule's recursive premise paired with the motive's induction hypothesis (the motive here is `even` itself, since the goal is `if even(n) then even(n)`).
+
+`rule inversion` has the same shape as `rule induction` but does NOT pair recursive premises with an induction hypothesis. Use it when you need to invert a derivation without the recursive case carrying its own conclusion as IH.

--- a/gh_pages/doc/WorkedExamples.md
+++ b/gh_pages/doc/WorkedExamples.md
@@ -300,6 +300,182 @@ Three Deduce-specific tactics from this example:
 - `replace IH` rewrites the goal left-to-right using `IH`'s equation.
 - `equations LHS = step1 by reason1 ... = end by reasonN` is the readable form of nested `transitive`. Each `... = next` continues the chain.
 
+### Pitfall: don't `arbitrary` before `induction`
+
+`induction T` consumes a leading `all x:T.` in the current goal — it introduces the variable for you, one fresh name per case. If you write `arbitrary n:T` first, the `all` is gone and `induction T` no longer matches.
+
+```
+// WRONG — induction has nothing to bind to
+theorem bad: all n:UnaryNat. add(n, zero) = n
+proof
+  arbitrary n:UnaryNat   // strips the `all`
+  induction UnaryNat     // FAILS: goal is not `all ...`
+  ...
+end
+
+// RIGHT — go straight to induction
+theorem good: all n:UnaryNat. add(n, zero) = n
+proof
+  induction UnaryNat
+  case zero { expand add. }
+  case succ(n') suppose IH: add(n', zero) = n' {
+    equations
+      add(succ(n'), zero) = succ(add(n', zero))   by expand add.
+                      ... = succ(n')               by replace IH.
+  }
+end
+```
+
+If the goal has *several* leading `all`s and you only want to induct on one of them, `arbitrary` the *outer* universals first, then `induction` the one you want. The induction variable's `all` must be the *outermost* `all` left in the goal at the moment you call `induction`.
+
+### Three-step `equations` chain
+
+`equations` chains can be any length. Each `... = next  by reason` extends the previous step. The `by reason` justifies the *previous* equality; the final `by reason` closes the chain.
+
+```
+union UnaryNat {
+  zero
+  succ(UnaryNat)
+}
+
+recursive add(UnaryNat, UnaryNat) -> UnaryNat {
+  add(zero, m) = m
+  add(succ(n), m) = succ(add(n, m))
+}
+
+theorem ex_induction_three_step: all n:UnaryNat. add(n, succ(zero)) = succ(n)
+proof
+  induction UnaryNat
+  case zero {
+    expand add.
+  }
+  case succ(n') suppose IH: add(n', succ(zero)) = succ(n') {
+    equations
+      add(succ(n'), succ(zero))
+          = succ(add(n', succ(zero)))   by expand add.
+      ... = succ(succ(n'))              by replace IH.
+  }
+end
+```
+
+The first step's `by` justifies `add(succ(n'), succ(zero)) = succ(add(n', succ(zero)))` — that's the unfolding of `add` on a `succ` argument. The second step's `by replace IH.` rewrites `add(n', succ(zero))` to `succ(n')` inside the right-hand side and the resulting equation `succ(succ(n')) = succ(succ(n'))` discharges by reflexivity (the trailing `.` does it).
+
+### Induction whose goal involves a predicate
+
+When the goal mentions an inductively-defined predicate (`even`, `≤`, etc.), the case bodies often need to invoke the predicate's rules to construct the conclusion. Drop the trailing `.` on `expand` when you want the unfolding to land but you still need a follow-up tactic to close the goal.
+
+```
+union UnaryNat {
+  zero
+  succ(UnaryNat)
+}
+
+recursive double(UnaryNat) -> UnaryNat {
+  double(zero) = zero
+  double(succ(n)) = succ(succ(double(n)))
+}
+
+predicate even : fn UnaryNat -> bool {
+  ev_zero : even(zero)
+  ev_ss   : all n:UnaryNat. if even(n) then even(succ(succ(n)))
+}
+
+theorem ex_induction_predicate:
+  all n:UnaryNat. even(double(n))
+proof
+  induction UnaryNat
+  case zero {
+    expand double
+    ev_zero
+  }
+  case succ(n') suppose IH: even(double(n')) {
+    expand double
+    apply ev_ss[double(n')] to IH
+  }
+end
+```
+
+Two things worth pinning down:
+
+- `expand double` *without* a trailing `.` unfolds `double(...)` in the goal but does NOT try to discharge it. Use the no-`.` form whenever the unfolded goal is not yet the trivial equation. The `.` form is only correct when the unfolded equation is reflexive.
+- `apply ev_ss[double(n')] to IH` instantiates `ev_ss` at `double(n')` (giving `if even(double(n')) then even(succ(succ(double(n'))))`), then applies it to `IH : even(double(n'))` — yielding `even(succ(succ(double(n'))))`, which matches the post-`expand` goal.
+
+### Induction over a list type
+
+Induction works on any union type, not just numerics. Lists are the second-most common scrutinee.
+
+```
+union MyList<T> {
+  empty
+  node(T, MyList<T>)
+}
+
+recursive append<T>(MyList<T>, MyList<T>) -> MyList<T> {
+  append(empty, ys) = ys
+  append(node(x, xs), ys) = node(x, append(xs, ys))
+}
+
+theorem ex_induction_list:
+  all U:type. all xs:MyList<U>.
+  append(xs, empty) = xs
+proof
+  arbitrary U:type
+  induction MyList<U>
+  case empty {
+    expand append.
+  }
+  case node(x, xs') suppose IH: append(xs', empty) = xs' {
+    equations
+      append(node(x, xs'), empty)
+          = node(x, append(xs', empty))   by expand append.
+      ... = node(x, xs')                   by replace IH.
+  }
+end
+```
+
+Two details to notice:
+
+- The theorem has `all U:type. all xs:MyList<U>.` — two nested universals. `arbitrary U:type` fixes the element type, then `induction MyList<U>` binds `xs`, splitting into the `empty` and `node` constructor cases.
+- The IH in the `node` case is `append(xs', empty) = xs'` — about the smaller list `xs'`, not about `node(x, xs')`. The `equations` chain rewrites the `succ`-case's LHS into the IH's LHS, then applies `replace IH` to swap it for the IH's RHS.
+
+### Induction with a quantified IH
+
+When the theorem has a leading `all x:T.` *plus* additional `all m:T'.` quantifiers inside the body, induct on `x` first; then in each case, `arbitrary m:T'` to introduce the inner variable. The IH is then *quantified* (`all m:T'. ...`) and you instantiate it with `IH[m]`.
+
+```
+union UnaryNat {
+  zero
+  succ(UnaryNat)
+}
+
+recursive add(UnaryNat, UnaryNat) -> UnaryNat {
+  add(zero, m) = m
+  add(succ(n), m) = succ(add(n, m))
+}
+
+theorem ex_induction_quantified_ih:
+  all n:UnaryNat. all m:UnaryNat. add(n, succ(m)) = succ(add(n, m))
+proof
+  induction UnaryNat
+  case zero {
+    arbitrary m:UnaryNat
+    expand add.
+  }
+  case succ(n') suppose IH:
+    all m:UnaryNat. add(n', succ(m)) = succ(add(n', m)) {
+    arbitrary m:UnaryNat
+    expand add
+    equations
+      succ(add(n', succ(m))) = succ(succ(add(n', m)))   by replace IH[m].
+  }
+end
+```
+
+Two patterns to notice:
+
+- **Quantified IH.** `IH` has shape `all m:UnaryNat. add(n', succ(m)) = succ(add(n', m))` because the second `all` was *inside* the inductive `all`. To use it on a specific `m`, write `IH[m]`. (For `if-then`-shaped IHs, write `apply IH[m] to <proof-of-antecedent>`.)
+- **`expand` to reshape, then `equations`.** `expand add` (no trailing `.`) on the `succ` case rewrites the goal from `add(succ(n'), succ(m)) = succ(add(succ(n'), m))` to `succ(add(n', succ(m))) = succ(succ(add(n', m)))`. The `equations` chain then closes the rewritten goal in one step. Reaching for `expand` *before* `equations` is a useful trick when both sides need unfolding.
+
 ---
 
 ## Using `query_goal` to plan a multi-step proof

--- a/gh_pages/scripts/convert.py
+++ b/gh_pages/scripts/convert.py
@@ -15,6 +15,7 @@ html_dir = './gh_pages/pages'
 mdToHtmlName = {
     'CheatSheet' : 'cheat-sheet',
     'TacticsCheatSheet' : 'tactics-cheat-sheet',
+    'WorkedExamples' : 'worked-examples',
     'FunctionalProgramming' : 'deduce-programming',
     'ProofIntro' : 'deduce-proofs',
     'Reference' : 'reference',
@@ -28,6 +29,7 @@ mdToHtmlName = {
 mdToTitle = {
     'CheatSheet' : 'Cheat Sheet',
     'TacticsCheatSheet' : 'Tactics Cheat Sheet',
+    'WorkedExamples' : 'Worked Examples',
     'FunctionalProgramming' : 'Programming',
     'ProofIntro' : 'Proofs',
     'Reference' : 'Reference Manual',
@@ -41,6 +43,7 @@ mdToTitle = {
 mdToDescription = {
     'CheatSheet' : 'Cheat sheet for advice on deduce proofs.',
     'TacticsCheatSheet' : 'Concise reference for every Deduce tactic, with common pitfalls.',
+    'WorkedExamples' : 'Concrete short proofs demonstrating each Deduce construct, organized by goal shape.',
     'FunctionalProgramming' : 'A guide on deduce programming with exercises.',
     'ProofIntro' : 'A guide on writing proofs in deduce with exercises.',
     'Reference' : 'Full reference manual for the deduce language.',
@@ -54,6 +57,7 @@ mdToDescription = {
 mdToDeduceCode = {
     'CheatSheet' : 'cheat-sheet',
     'TacticsCheatSheet' : 'tactics-cheat-sheet',
+    'WorkedExamples' : 'worked-examples',
     'FunctionalProgramming' : 'programming',
     'ProofIntro' : 'proof',
     'Reference' : 'reference',

--- a/test/claude_fill_hole/test_anthropic_backend.py
+++ b/test/claude_fill_hole/test_anthropic_backend.py
@@ -21,7 +21,7 @@ import pytest
 
 from tools.claude_fill_hole.agent import AgentResult
 from tools.claude_fill_hole.anthropic_backend import AnthropicBackend
-from tools.claude_fill_hole.validator import ValidationOutcome
+from tools.claude_fill_hole.validator import QueryOutcome, ValidationOutcome
 
 
 # ---------------------------------------------------------------------------
@@ -33,6 +33,7 @@ from tools.claude_fill_hole.validator import ValidationOutcome
 class Block:
     type: str
     id: str = ""
+    name: str = ""  # tool name when type == "tool_use"
     input: dict = field(default_factory=dict)
     text: str = ""
 
@@ -80,8 +81,27 @@ class FakeValidator:
         return self._outcomes[idx]
 
 
-def _tool_use(proof: str, *, id_: str = "tu_1") -> Block:
-    return Block(type="tool_use", id=id_, input={"proof_text": proof})
+def _tool_use(proof: str, *, id_: str = "tu_1",
+              name: str = "validate_proof") -> Block:
+    return Block(type="tool_use", id=id_, name=name,
+                 input={"proof_text": proof})
+
+
+class FakeQuerier:
+    """Mock HoleQuerier: returns scripted QueryOutcomes per call."""
+
+    def __init__(self, outcomes: list[QueryOutcome]) -> None:
+        self._outcomes = outcomes
+        self.calls: list[str] = []
+
+    def query(self, proof_text: str) -> QueryOutcome:
+        self.calls.append(proof_text)
+        idx = len(self.calls) - 1
+        if idx >= len(self._outcomes):
+            raise AssertionError(
+                "fake querier: more query() calls than scripted outcomes"
+            )
+        return self._outcomes[idx]
 
 
 _SYSTEM_TEXT = "stub system prompt"
@@ -183,7 +203,7 @@ def test_no_tool_call_returns_failure_immediately():
         max_attempts=5,
     )
     assert result.ok is False
-    assert "no validate_proof" in (result.error or "")
+    assert "no tool call" in (result.error or "")
     assert validator.calls == []
 
 
@@ -193,7 +213,8 @@ def test_malformed_tool_input_is_recoverable():
     client = FakeClient(
         [
             FakeResponse(
-                content=[Block(type="tool_use", id="tu_1", input={})]
+                content=[Block(type="tool_use", id="tu_1",
+                               name="validate_proof", input={})]
             ),
             FakeResponse(content=[_tool_use("reflexive", id_="tu_2")]),
         ]
@@ -284,3 +305,120 @@ def test_dispatches_required_request_kwargs():
             "cache_control": {"type": "ephemeral"},
         }
     ]
+
+
+# ---------------------------------------------------------------------------
+# query_goal tool tests.
+#
+# Three things worth pinning down:
+#   1) When ``querier`` is passed, the API receives BOTH tools.
+#   2) A query_goal call doesn't burn a validate_proof attempt.
+#   3) The loop interleaves correctly: query, then validate, then stop.
+# ---------------------------------------------------------------------------
+
+
+def _query_use(proof: str, *, id_: str = "tu_q1",
+               name: str = "query_goal") -> Block:
+    return Block(type="tool_use", id=id_, name=name,
+                 input={"proof_text": proof})
+
+
+def test_querier_exposes_both_tools_to_api():
+    """When a querier is passed, both validate_proof and query_goal
+    are advertised in the request's tools array."""
+    client = FakeClient([FakeResponse(content=[_tool_use("reflexive")])])
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    querier = FakeQuerier([])
+    _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=querier,
+    )
+    tool_names = [t["name"] for t in client.messages.last_kwargs["tools"]]
+    assert tool_names == ["validate_proof", "query_goal"]
+
+
+def test_query_goal_call_does_not_burn_validate_attempt():
+    """The model calls query_goal first, sees the goal, then commits
+    a validate_proof.  attempts on the result reflects ONLY the
+    validate_proof call -- query_goal is free."""
+    client = FakeClient(
+        [
+            FakeResponse(content=[_query_use("?", id_="tu_q1")]),
+            FakeResponse(content=[_tool_use("reflexive", id_="tu_v1")]),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    querier = FakeQuerier(
+        [QueryOutcome(ok=True, goal="P = P", givens=())]
+    )
+    result = _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=querier,
+    )
+    assert result.ok is True
+    assert result.proof == "reflexive"
+    # Two API turns (one query, one validate) but only one validate attempt.
+    assert result.attempts == 1
+    assert client.messages.calls == 2
+    assert querier.calls == ["?"]
+    assert validator.calls == ["reflexive"]
+
+
+def test_query_goal_failure_is_reported_to_model_and_loop_continues():
+    """If the querier returns ok=False, the loop hands the error to
+    the model as a tool_result and lets it try again -- it doesn't
+    fail the whole run."""
+    client = FakeClient(
+        [
+            FakeResponse(content=[_query_use("no_marker", id_="tu_q1")]),
+            FakeResponse(content=[_tool_use("reflexive", id_="tu_v1")]),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    querier = FakeQuerier(
+        [QueryOutcome(ok=False, error="proof_text contains no `?'")]
+    )
+    result = _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=querier,
+    )
+    assert result.ok is True
+    assert result.attempts == 1
+    assert querier.calls == ["no_marker"]
+
+
+def test_query_goal_unavailable_when_querier_is_none():
+    """Without a querier, the tools array contains only validate_proof,
+    and a model that tries to call query_goal anyway gets an
+    unknown-tool error back (does NOT crash the loop).
+
+    We script the model to call query_goal first; the loop should
+    surface 'unknown tool' and let the model recover with
+    validate_proof on the next turn."""
+    client = FakeClient(
+        [
+            FakeResponse(content=[_query_use("?", id_="tu_q1")]),
+            FakeResponse(content=[_tool_use("reflexive", id_="tu_v1")]),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    result = _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=None,
+    )
+    assert result.ok is True
+    # Only validate_proof should appear in the tools list.
+    tool_names = [t["name"] for t in client.messages.last_kwargs["tools"]]
+    assert tool_names == ["validate_proof"]

--- a/test/claude_fill_hole/test_openai_backend.py
+++ b/test/claude_fill_hole/test_openai_backend.py
@@ -17,7 +17,7 @@ import pytest
 
 from tools.claude_fill_hole.agent import AgentResult
 from tools.claude_fill_hole.openai_backend import OpenAICompatBackend
-from tools.claude_fill_hole.validator import ValidationOutcome
+from tools.claude_fill_hole.validator import QueryOutcome, ValidationOutcome
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +97,46 @@ class FakeValidator:
                 "fake validator: more validate() calls than scripted outcomes"
             )
         return self._outcomes[idx]
+
+
+class FakeQuerier:
+    def __init__(self, outcomes: list[QueryOutcome]) -> None:
+        self._outcomes = outcomes
+        self.calls: list[str] = []
+
+    def query(self, proof_text: str) -> QueryOutcome:
+        self.calls.append(proof_text)
+        idx = len(self.calls) - 1
+        if idx >= len(self._outcomes):
+            raise AssertionError(
+                "fake querier: more query() calls than scripted outcomes"
+            )
+        return self._outcomes[idx]
+
+
+def _query_call(proof: str, *, id_: str = "qcall_1") -> FakeToolCall:
+    return FakeToolCall(
+        id=id_,
+        function=FakeFunction(
+            name="query_goal",
+            arguments=json.dumps({"proof_text": proof}),
+        ),
+    )
+
+
+def _response_with_query(proof: str, *, id_: str = "qcall_1") -> FakeResponse:
+    return FakeResponse(
+        choices=[
+            FakeChoice(
+                message=FakeMessage(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[_query_call(proof, id_=id_)],
+                ),
+                finish_reason="tool_calls",
+            )
+        ]
+    )
 
 
 def _tool_call(proof: str, *, id_: str = "call_1") -> FakeToolCall:
@@ -230,7 +270,7 @@ def test_no_tool_call_returns_failure_immediately():
         max_attempts=5,
     )
     assert result.ok is False
-    assert "no validate_proof" in (result.error or "")
+    assert "no tool call" in (result.error or "")
     assert validator.calls == []
 
 
@@ -312,9 +352,13 @@ def test_unknown_tool_call_is_recoverable():
         max_attempts=5,
     )
     assert result.ok is True
-    assert result.attempts == 2
-    # Validator only ran on the second attempt -- the first never
-    # got past the unknown-tool check.
+    # Under the new contract, unknown-tool calls do NOT count toward
+    # the validate_proof budget -- only the second turn's actual
+    # validate counts.  attempts is the number of validate_proof
+    # invocations (1), not the number of model turns (2).
+    assert result.attempts == 1
+    # Validator only ran on the second turn -- the first turn's
+    # unknown-tool call never reached it.
     assert validator.calls == ["reflexive"]
 
 
@@ -436,6 +480,108 @@ def test_works_with_dict_shaped_responses():
     )
     assert result.ok is True
     assert result.proof == "reflexive"
+
+
+# ---------------------------------------------------------------------------
+# query_goal tool tests.
+# ---------------------------------------------------------------------------
+
+
+def test_querier_exposes_both_tools_to_api():
+    """When a querier is passed, both tools appear in the request."""
+    client = FakeClient([_response_with_tool_call("reflexive")])
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    querier = FakeQuerier([])
+    _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=querier,
+    )
+    tool_names = [
+        t["function"]["name"]
+        for t in client.chat.completions.last_kwargs["tools"]
+    ]
+    assert tool_names == ["validate_proof", "query_goal"]
+
+
+def test_query_goal_call_does_not_burn_validate_attempt():
+    """query_goal first, then validate_proof; result.attempts counts
+    only the validate."""
+    client = FakeClient(
+        [
+            _response_with_query("?", id_="qcall_1"),
+            _response_with_tool_call("reflexive", id_="vcall_1"),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    querier = FakeQuerier(
+        [QueryOutcome(ok=True, goal="P = P", givens=())]
+    )
+    result = _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=querier,
+    )
+    assert result.ok is True
+    assert result.proof == "reflexive"
+    assert result.attempts == 1
+    assert client.chat.completions.calls == 2
+    assert querier.calls == ["?"]
+    assert validator.calls == ["reflexive"]
+
+
+def test_query_goal_failure_is_surfaced_to_model_not_loop():
+    """If the querier returns ok=False, the loop reports it via a
+    tool message and lets the model recover -- not a hard error."""
+    client = FakeClient(
+        [
+            _response_with_query("no_marker", id_="qcall_1"),
+            _response_with_tool_call("reflexive", id_="vcall_1"),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    querier = FakeQuerier(
+        [QueryOutcome(ok=False, error="proof_text contains no `?'")]
+    )
+    result = _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=querier,
+    )
+    assert result.ok is True
+    assert result.attempts == 1
+    assert querier.calls == ["no_marker"]
+
+
+def test_query_goal_unavailable_when_querier_is_none():
+    """No querier -> tools list contains only validate_proof; a
+    model that calls query_goal anyway gets unknown-tool back."""
+    client = FakeClient(
+        [
+            _response_with_query("?", id_="qcall_1"),
+            _response_with_tool_call("reflexive", id_="vcall_1"),
+        ]
+    )
+    validator = FakeValidator([ValidationOutcome(ok=True)])
+    result = _backend(client).run(
+        system_text=_SYSTEM_TEXT,
+        user_message="goal: P = P",
+        validator=validator,
+        max_attempts=5,
+        querier=None,
+    )
+    assert result.ok is True
+    tool_names = [
+        t["function"]["name"]
+        for t in client.chat.completions.last_kwargs["tools"]
+    ]
+    assert tool_names == ["validate_proof"]
 
 
 # ---------------------------------------------------------------------------
@@ -725,16 +871,19 @@ def test_non_recoverable_bad_request_still_returns_hard_error():
     assert raising.calls == 1
 
 
-def test_recoverable_bad_request_on_last_attempt_does_not_loop():
-    """If the malformed-args 400 lands on the final attempt of the
-    budget, there's no retry left -- return failure cleanly rather
-    than continuing past max_attempts."""
+def test_recoverable_bad_request_does_not_loop_indefinitely():
+    """A persistent malformed-args 400 (every call raises) eventually
+    bails -- it doesn't loop forever.  Under the new contract that
+    introduces query_goal, the loop runs up to max_attempts * 2
+    turns total, so a max_attempts=1 budget allows one recovery
+    retry before bailing.  The point is finite-loop, not exact
+    call-count."""
     exc = _FakeBadRequestError(
         "Error code: 400 - litellm.BadRequestError: "
         "Unterminated string at line 1 column 16"
     )
 
-    class _RaiseOnce:
+    class _AlwaysRaise:
         def __init__(self):
             self.calls = 0
 
@@ -742,7 +891,7 @@ def test_recoverable_bad_request_on_last_attempt_does_not_loop():
             self.calls += 1
             raise exc
 
-    raising = _RaiseOnce()
+    raising = _AlwaysRaise()
     client = type(
         "FakeClient3",
         (),
@@ -759,4 +908,6 @@ def test_recoverable_bad_request_on_last_attempt_does_not_loop():
     )
     assert result.ok is False
     assert "API call failed" in (result.error or "")
-    assert raising.calls == 1
+    # Bounded: with max_attempts=1, max_turns=2 -- so at most 2 calls
+    # before bailing.
+    assert raising.calls <= 2

--- a/test/claude_fill_hole/test_prompt.py
+++ b/test/claude_fill_hole/test_prompt.py
@@ -34,7 +34,9 @@ def test_build_system_prompt_does_not_raise_on_braces_in_scaffold():
 
 def test_build_system_prompt_substitutes_max_attempts():
     out = build_system_prompt(max_attempts=7)
-    assert "up to 7 times" in out
+    # The substitution lands; tolerate any whitespace between number
+    # and the next word (the SCAFFOLD wraps mid-sentence).
+    assert "up to 7" in out
     # The placeholder sentinel itself shouldn't survive into output.
     assert "__MAX_ATTEMPTS__" not in out
 

--- a/test/claude_fill_hole/test_prompt.py
+++ b/test/claude_fill_hole/test_prompt.py
@@ -39,14 +39,29 @@ def test_build_system_prompt_substitutes_max_attempts():
     assert "__MAX_ATTEMPTS__" not in out
 
 
-def test_build_system_prompt_embeds_cheatsheets_when_available():
-    """Both cheatsheets should be inlined under recognisable XML-ish
-    markers so a downstream consumer can find them."""
+def test_build_system_prompt_embeds_docs_when_available():
+    """The worked-examples doc and tactics cheatsheet should both be
+    inlined under recognisable XML-ish markers so a downstream
+    consumer can find them.  CheatSheet.md was deliberately dropped
+    -- its strategy-by-goal-shape content is subsumed by the
+    goal-shape-organised worked examples."""
     out = build_system_prompt(max_attempts=3)
+    assert "<worked_examples>" in out
+    assert "</worked_examples>" in out
     assert "<tactics_cheatsheet>" in out
     assert "</tactics_cheatsheet>" in out
-    assert "<cheatsheet>" in out
-    assert "</cheatsheet>" in out
+    # The standalone strategy cheatsheet is intentionally NOT embedded.
+    assert "<cheatsheet>" not in out
+
+
+def test_worked_examples_appear_before_tactics_cheatsheet():
+    """Worked examples lead because models pattern-match on concrete
+    code more reliably than they read strategy prose; the tactics
+    cheatsheet is the lookup-table fallback."""
+    out = build_system_prompt(max_attempts=3)
+    we_pos = out.index("<worked_examples>")
+    tc_pos = out.index("<tactics_cheatsheet>")
+    assert we_pos < tc_pos
 
 
 def test_build_user_message_shape():

--- a/test/claude_fill_hole/test_validator.py
+++ b/test/claude_fill_hole/test_validator.py
@@ -22,6 +22,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 from tools.claude_fill_hole.validator import (  # noqa: E402
+    HoleQuerier,
+    QueryOutcome,
     SubprocessValidator,
     ValidationOutcome,
 )
@@ -149,3 +151,118 @@ def test_missing_deduce_cmd_returns_structured_error(make_validator):
     outcome = v.validate("reflexive")
     assert outcome.ok is False
     assert outcome.error is not None
+
+
+# ---------------------------------------------------------------------------
+# HoleQuerier tests.
+#
+# A handful are pure-Python (rejecting bad input before invoking the
+# pipeline); the integration-shaped one bootstraps the deduce env and
+# exercises a real `lsp.query.hole_context_at' round-trip on a tiny
+# in-memory `.pf' source.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def make_querier(tmp_path):
+    def _build(source: str = SOURCE_WITH_HOLE, **overrides) -> HoleQuerier:
+        file_path = tmp_path / "proof.pf"
+        file_path.write_text(source)
+        start, end = _hole_offsets(source)
+        kwargs = {
+            "file_path": str(file_path),
+            "content": source,
+            "hole_start_offset": start,
+            "hole_end_offset": end,
+            "prelude": (),
+        }
+        kwargs.update(overrides)
+        return HoleQuerier(**kwargs)
+    return _build
+
+
+def test_query_rejects_proof_text_without_question_mark(make_querier):
+    """``query_goal`` is for inspecting partial proofs; a complete
+    proof_text with no ``?`` is a misuse and should be rejected
+    locally without invoking the pipeline."""
+    q = make_querier()
+    outcome = q.query("reflexive")
+    assert outcome.ok is False
+    assert outcome.error and "?" in outcome.error
+    # No goal/givens on failure.
+    assert outcome.goal is None
+    assert outcome.givens == ()
+
+
+def test_query_rejects_oversized_proof_text(make_querier):
+    """Same byte-cap as the validator; meant to bound runaway model output."""
+    q = make_querier(max_proof_text_bytes=128)
+    huge = "?" + "x " * 200  # has a `?' but is too long
+    outcome = q.query(huge)
+    assert outcome.ok is False
+    assert outcome.error and "exceeds" in outcome.error
+
+
+def _bootstrap_deduce_env_for_tests() -> None:
+    """Bootstrap the deduce env so HoleQuerier's in-process call to
+    ``lsp.query.hole_context_at`` can resolve imports.
+
+    Mirrors what __main__.py does at startup.  Idempotent.
+    """
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    sys.setrecursionlimit(10000)
+    # parser.py reads `Deduce.lark' relative to dirname(sys.argv[0]);
+    # under pytest, argv[0] is the pytest runner so the parser can't
+    # find the grammar.  Point it at deduce.py in REPO_ROOT.
+    sys.argv = [str(REPO_ROOT / "deduce.py")] + sys.argv[1:]
+    from abstract_syntax import (  # noqa: E402
+        add_import_directory,
+        init_import_directories,
+    )
+    from flags import set_quiet_mode  # noqa: E402
+
+    set_quiet_mode(True)
+    init_import_directories()
+    lib_dir = REPO_ROOT / "lib"
+    if lib_dir.is_dir():
+        add_import_directory(str(lib_dir))
+
+
+def test_query_returns_goal_at_hole_in_simple_proof(make_querier):
+    """Round-trip: feed a simple file with one ``?`` and ask the
+    querier to report the goal at that ``?``.
+
+    The fixture file has goal ``P = P`` after ``arbitrary P:bool``;
+    asking with ``proof_text = "?"`` should report exactly that goal.
+    """
+    _bootstrap_deduce_env_for_tests()
+    q = make_querier()  # default SOURCE_WITH_HOLE: P = P after arbitrary
+    outcome = q.query("?")
+    assert outcome.ok is True, f"expected ok, got error: {outcome.error}"
+    # The goal contains "P = P" (or some slight whitespace variant).
+    assert outcome.goal is not None
+    assert "P = P" in outcome.goal.replace(" ", "") or "P=P" in outcome.goal.replace(" ", "")
+
+
+def test_query_finds_first_question_mark_after_splice(make_querier):
+    """When proof_text contains multiple ``?``s, the querier reports
+    on the FIRST one located AT OR AFTER the hole's start offset.
+    """
+    _bootstrap_deduce_env_for_tests()
+    # Source has only one hole; we splice in a partial proof with
+    # the first `?' at the case-zero branch.
+    source = (
+        "union UN { z  s(UN) }\n"
+        "theorem t: all n:UN. n = n\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    q = make_querier(source=source)
+    outcome = q.query("induction UN\ncase z { ? }\ncase s(n') suppose IH: n' = n' { ? }\n")
+    assert outcome.ok is True, f"expected ok, got error: {outcome.error}"
+    # First `?' after the splice point is in the `case z' branch;
+    # its goal should mention z = z.
+    assert outcome.goal is not None
+    assert "z" in outcome.goal

--- a/tools/claude_fill_hole/__main__.py
+++ b/tools/claude_fill_hole/__main__.py
@@ -38,7 +38,67 @@ from .schema import (
     request_from_json,
     response_to_json,
 )
-from .validator import SubprocessValidator, ValidationOutcome
+from .validator import HoleQuerier, SubprocessValidator, ValidationOutcome
+
+
+def _default_prelude(deduce_root: Path) -> tuple:
+    """Return the standard-library prelude tuple for `hole_context_at'.
+
+    Matches what `lsp.lsp_server' does: every `.pf' file under `lib/'
+    is auto-prepended as a private import.  Returns an empty tuple
+    when `lib/' is missing.
+    """
+    lib_dir = deduce_root / "lib"
+    if not lib_dir.is_dir():
+        return ()
+    return tuple(sorted(p.stem for p in lib_dir.glob("*.pf")))
+
+
+def _bootstrap_deduce_env(deduce_root: Path) -> None:
+    """Configure module-level state in `abstract_syntax`/`flags' so the
+    in-process ``lsp.query.hole_context_at'' (used by HoleQuerier) can
+    resolve imports and produce sensible diagnostics.
+
+    Mirrors what `lsp.lsp_server' does at module-load time.  Running
+    this is harmless even if the sidecar never calls query_goal --
+    the validator's subprocess path is unaffected.
+
+    Idempotent: calling multiple times is OK (init_import_directories
+    resets the list each call).
+    """
+    if str(deduce_root) not in sys.path:
+        sys.path.insert(0, str(deduce_root))
+    sys.setrecursionlimit(10000)
+    # The deduce parser locates `Deduce.lark' via
+    # ``os.path.dirname(sys.argv[0])'' (see parser.py:get_deduce_directory).
+    # When the sidecar is launched as ``python -m tools.claude_fill_hole'',
+    # ``sys.argv[0]'' points at the runpy entry, not at deduce.py, so the
+    # in-process parser (used by query_goal) can't find the grammar.
+    # Repoint argv[0] at the deduce.py in our resolved root, mirroring
+    # what lsp.lsp_server does.
+    pseudo_entry = str(deduce_root / "deduce.py")
+    sys.argv = [pseudo_entry] + sys.argv[1:]
+    try:
+        from abstract_syntax import (  # noqa: E402
+            add_import_directory,
+            init_import_directories,
+        )
+        from flags import set_quiet_mode  # noqa: E402
+    except ImportError:
+        # Bootstrap is best-effort -- if the deduce repo isn't on
+        # sys.path (e.g. user invoked sidecar from outside a checkout
+        # with the wrong --deduce-root), validate_proof still works
+        # via subprocess; only query_goal will fail with a clear
+        # message.
+        return
+    set_quiet_mode(True)
+    init_import_directories()
+    lib_dir = deduce_root / "lib"
+    if lib_dir.is_dir():
+        add_import_directory(str(lib_dir))
+    test_imports = deduce_root / "test" / "test-imports"
+    if test_imports.is_dir():
+        add_import_directory(str(test_imports))
 
 
 _BACKEND_CHOICES = ("anthropic", "openai-compat")
@@ -134,6 +194,28 @@ def main(argv: Optional[list[str]] = None) -> int:
         timeout_seconds=float(args.timeout),
     )
 
+    # Bootstrap the deduce env so HoleQuerier's in-process
+    # `lsp.query.hole_context_at' call can resolve imports.  Best-
+    # effort: query_goal will fail with a clear message if the
+    # bootstrap couldn't load `abstract_syntax' (e.g. user pointed
+    # --deduce-root somewhere else than a real checkout).  Use the
+    # sidecar's own location as the deduce root when --deduce-root
+    # isn't given -- the sidecar lives at <root>/tools/claude_fill_hole/.
+    sidecar_root = (
+        Path(args.deduce_root)
+        if args.deduce_root
+        else Path(__file__).resolve().parents[2]
+    )
+    _bootstrap_deduce_env(sidecar_root)
+    prelude = () if args.no_stdlib else _default_prelude(sidecar_root)
+    querier = HoleQuerier(
+        file_path=request.file,
+        content=content,
+        hole_start_offset=hole_start_offset,
+        hole_end_offset=hole_end_offset,
+        prelude=prelude,
+    )
+
     if args.dry_run:
         return _run_dry_run(request, validator, args)
 
@@ -190,6 +272,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         user_message=user_message,
         validator=validator,
         max_attempts=args.max_attempts,
+        querier=querier,
         on_progress=_emit_progress,
     )
 

--- a/tools/claude_fill_hole/agent.py
+++ b/tools/claude_fill_hole/agent.py
@@ -19,19 +19,32 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-from .validator import Validator, ValidationOutcome
+from .validator import HoleQuerier, Validator, ValidationOutcome
 
 
-# What we tell the model the tool does.  Kept brief; the SCAFFOLD
-# in ``prompt.py`` already explains the iteration model.  The shape
-# below is the JSON-Schema spelling Anthropic uses; OpenAI wraps the
-# same dict in ``{"type": "function", "function": {...}}`` -- each
-# backend handles the wrapping at its own boundary.
+# What we tell the model the tools do.  Kept brief; the SCAFFOLD
+# in ``prompt.py`` already explains the iteration model.  Both
+# tools share the same input shape (a candidate proof_text); they
+# differ in semantics:
+#
+#   - ``validate_proof'' splices and runs the FULL checker.  Returns
+#     {ok, error}.  Counts toward the validate budget.
+#
+#   - ``query_goal'' splices a PARTIAL proof containing a `?', then
+#     reports the goal at that `?' without running the checker to
+#     completion.  Returns {goal, givens} (or {error}).  Does NOT
+#     count toward the validate budget -- use it freely to inspect
+#     the proof state mid-construction (e.g. inside an induction
+#     case before committing to the full proof).
+#
+# The shape below is the JSON-Schema spelling Anthropic uses; OpenAI
+# wraps the same dict in ``{"type": "function", "function": {...}}'' --
+# each backend handles the wrapping at its own boundary.
 VALIDATE_TOOL_NAME = "validate_proof"
 VALIDATE_TOOL_DESCRIPTION = (
     "Splice the given proof text into the file at the hole and run "
-    "the Deduce checker. Returns {ok, error}. Call repeatedly to "
-    "iterate; first valid proof wins."
+    "the Deduce checker. Returns {ok, error}. Counts toward your "
+    "attempt budget; first valid proof wins."
 )
 VALIDATE_TOOL_PARAMETERS = {
     "type": "object",
@@ -43,6 +56,33 @@ VALIDATE_TOOL_PARAMETERS = {
                 "The complete Deduce proof text to splice into the "
                 "hole. Multi-line allowed; do NOT wrap in code "
                 "fences; do NOT include English commentary."
+            ),
+        }
+    },
+    "additionalProperties": False,
+}
+
+
+QUERY_GOAL_TOOL_NAME = "query_goal"
+QUERY_GOAL_TOOL_DESCRIPTION = (
+    "Splice a partial proof_text (which itself MUST contain at least "
+    "one `?') into the file at the hole, then return the goal and "
+    "in-scope givens at the FIRST `?' in your spliced text. Use to "
+    "inspect intermediate goals -- e.g. after writing `induction T "
+    "case base { ? } case rec(n') suppose IH: ... { ? }' to see "
+    "what each case has to prove.  Does NOT count toward your "
+    "validate_proof budget; call it as often as helpful."
+)
+QUERY_GOAL_TOOL_PARAMETERS = {
+    "type": "object",
+    "required": ["proof_text"],
+    "properties": {
+        "proof_text": {
+            "type": "string",
+            "description": (
+                "Partial Deduce proof text containing at least one "
+                "`?' marking where to inspect the goal. Multi-line "
+                "allowed."
             ),
         }
     },
@@ -106,9 +146,10 @@ class Backend(ABC):
         user_message: str,
         validator: Validator,
         max_attempts: int,
+        querier: Optional[HoleQuerier] = None,
         on_progress: Optional[ProgressFn] = None,
     ) -> AgentResult:
-        """Drive the validate_proof tool-use loop until ok or budget exhausted.
+        """Drive the tool-use loop until ok or budget exhausted.
 
         ``system_text`` is the rendered system prompt as plain text;
         the backend wraps it in whatever shape its SDK expects (e.g.
@@ -119,7 +160,14 @@ class Backend(ABC):
         per-request bits (goal, givens, lemmas, surrounding source).
 
         ``validator`` runs each candidate proof.  The first call
-        that returns ``ok=True`` ends the loop.
+        that returns ``ok=True`` ends the loop.  Counts toward
+        ``max_attempts``.
+
+        ``querier``, when provided, is exposed to the model as the
+        ``query_goal'' tool.  It splices a partial proof containing a
+        `?'-marker and reports the goal at that point without
+        consuming a validate attempt.  When ``None``, only
+        ``validate_proof'' is exposed.
 
         ``on_progress`` is an optional NDJSON-shaped callback the
         protocol layer uses to stream status to emacs over stderr.

--- a/tools/claude_fill_hole/anthropic_backend.py
+++ b/tools/claude_fill_hole/anthropic_backend.py
@@ -1,14 +1,24 @@
-"""Anthropic SDK backend for the validate_proof tool-use loop.
+"""Anthropic SDK backend for the validate_proof + query_goal tool loop.
 
 Drives ``client.messages.create`` directly with adaptive thinking
-and the cheatsheet-cache prompt-control breakpoint.  This was the
-original sidecar implementation before the OpenAI-compat backend
-joined; the loop body is preserved verbatim, just lifted into a
-class with the shared types from ``agent.py``.
+and the cheatsheet-cache prompt-control breakpoint.
+
+Two tools are exposed (when ``querier`` is provided to ``run``):
+
+  - ``validate_proof'' -- splice and run the full checker.  Counts
+    toward ``max_attempts''.
+  - ``query_goal'' -- splice a partial proof containing a `?', report
+    the goal at that `?'.  Doesn't count toward attempts.
+
+The loop runs at most ``max_attempts * 2'' turns total: that's
+generous enough that a model can interleave queries and validates,
+but bounded so a confused model can't loop on free queries
+indefinitely.
 """
 
 from __future__ import annotations
 
+import json
 import time
 from typing import Any, Optional
 
@@ -17,33 +27,42 @@ from .agent import (
     AttemptRecord,
     Backend,
     ProgressFn,
+    QUERY_GOAL_TOOL_DESCRIPTION,
+    QUERY_GOAL_TOOL_NAME,
+    QUERY_GOAL_TOOL_PARAMETERS,
     VALIDATE_TOOL_DESCRIPTION,
     VALIDATE_TOOL_NAME,
     VALIDATE_TOOL_PARAMETERS,
     preview,
 )
-from .validator import Validator, ValidationOutcome
+from .validator import HoleQuerier, QueryOutcome, Validator, ValidationOutcome
 
 
 _DEFAULT_MODEL = "claude-opus-4-7"
 _DEFAULT_MAX_TOKENS = 16000
 
 
-# Anthropic's tool definition shape: name + description + input_schema
-# at the top level.
 _VALIDATE_TOOL = {
     "name": VALIDATE_TOOL_NAME,
     "description": VALIDATE_TOOL_DESCRIPTION,
     "input_schema": VALIDATE_TOOL_PARAMETERS,
 }
 
+_QUERY_GOAL_TOOL = {
+    "name": QUERY_GOAL_TOOL_NAME,
+    "description": QUERY_GOAL_TOOL_DESCRIPTION,
+    "input_schema": QUERY_GOAL_TOOL_PARAMETERS,
+}
+
 
 class AnthropicBackend(Backend):
-    """Drive Claude through the validate_proof loop via the Anthropic SDK.
+    """Drive Claude through the proof-completion tool loop via the
+    Anthropic SDK.
 
     ``client`` is duck-typed -- any object exposing
-    ``messages.create(...)`` returning a Claude-shaped response works,
-    which makes the class trivially testable with a fake client.
+    ``messages.create(...)`` returning a Claude-shaped response
+    works, which makes the class trivially testable with a fake
+    client.
     """
 
     name = "anthropic"
@@ -68,6 +87,7 @@ class AnthropicBackend(Backend):
         user_message: str,
         validator: Validator,
         max_attempts: int,
+        querier: Optional[HoleQuerier] = None,
         on_progress: Optional[ProgressFn] = None,
     ) -> AgentResult:
         started = time.monotonic()
@@ -76,10 +96,6 @@ class AnthropicBackend(Backend):
             if on_progress is not None:
                 on_progress(event, **fields)
 
-        # Wrap the system text in Anthropic's text-block shape with a
-        # cache breakpoint.  The cheatsheets dominate token count, so
-        # the cache hit on subsequent attempts is the load-bearing
-        # cost optimisation.
         system_blocks = [
             {
                 "type": "text",
@@ -88,13 +104,27 @@ class AnthropicBackend(Backend):
             }
         ]
 
+        tools = [_VALIDATE_TOOL]
+        if querier is not None:
+            tools = [_VALIDATE_TOOL, _QUERY_GOAL_TOOL]
+
         messages: list[dict] = [{"role": "user", "content": user_message}]
         history: list[AttemptRecord] = []
 
         _progress("start", maxAttempts=max_attempts)
 
-        for attempt in range(1, max_attempts + 1):
-            _progress("model_request", attempt=attempt)
+        validate_attempts = 0
+        # Bound the total loop so a model that only ever calls
+        # query_goal can't run forever.  2x the validate budget gives
+        # the model headroom to interleave queries with validates.
+        max_turns = max_attempts * 2
+
+        for turn in range(1, max_turns + 1):
+            _progress(
+                "model_request",
+                turn=turn,
+                attempt=validate_attempts,
+            )
 
             try:
                 response = self.client.messages.create(
@@ -103,22 +133,23 @@ class AnthropicBackend(Backend):
                     thinking={"type": "adaptive"},
                     output_config={"effort": self.effort},
                     system=system_blocks,
-                    tools=[_VALIDATE_TOOL],
+                    tools=tools,
                     messages=messages,
                 )
             except Exception as exc:
                 elapsed = int((time.monotonic() - started) * 1000)
                 _progress(
-                    "finish", ok=False, attempts=attempt - 1, error=str(exc)
+                    "finish", ok=False, attempts=validate_attempts,
+                    error=str(exc),
                 )
                 return AgentResult(
                     ok=False,
                     proof=None,
-                    attempts=attempt - 1,
+                    attempts=validate_attempts,
                     elapsed_ms=elapsed,
                     model=self.model,
                     history=tuple(history),
-                    error=f"API call failed on attempt {attempt}: {exc}",
+                    error=f"API call failed on turn {turn}: {exc}",
                 )
 
             tool_uses = [
@@ -126,121 +157,198 @@ class AnthropicBackend(Backend):
             ]
 
             if not tool_uses:
-                # Model emitted text-only response (or nothing).
-                # Treated as "model gave up" -- not a hard failure,
-                # but no proof to apply either.
                 elapsed = int((time.monotonic() - started) * 1000)
                 _progress(
-                    "finish", ok=False, attempts=attempt, reason="no_tool_call"
+                    "finish", ok=False, attempts=validate_attempts,
+                    reason="no_tool_call",
                 )
                 return AgentResult(
                     ok=False,
                     proof=None,
-                    attempts=attempt,
+                    attempts=validate_attempts,
                     elapsed_ms=elapsed,
                     model=self.model,
                     history=tuple(history),
-                    error="model returned no validate_proof call",
+                    error="model returned no tool call",
                 )
 
-            # Append the assistant message verbatim so the next turn
-            # sees its own tool_use blocks.
-            messages.append({"role": "assistant", "content": response.content})
+            messages.append(
+                {"role": "assistant", "content": response.content}
+            )
 
             tool_results: list[dict] = []
+            success_proof: Optional[str] = None
+
             for block in tool_uses:
+                tool_name = _tool_use_name(block)
                 proof_text = _extract_proof_text(block)
-                if proof_text is None:
+
+                if tool_name == VALIDATE_TOOL_NAME:
+                    if validate_attempts >= max_attempts:
+                        # Budget already used; tell the model and
+                        # don't increment further.
+                        tool_results.append(
+                            _tool_result_block(
+                                _block_id(block),
+                                ok=False,
+                                error=(
+                                    "validate_proof budget exhausted; "
+                                    "you must commit your best guess "
+                                    "but no further validates will run"
+                                ),
+                            )
+                        )
+                        continue
+                    validate_attempts += 1
+
+                    if proof_text is None:
+                        tool_results.append(
+                            _tool_result_block(
+                                _block_id(block),
+                                ok=False,
+                                error="tool input missing required `proof_text`",
+                            )
+                        )
+                        history.append(
+                            AttemptRecord(
+                                attempt=validate_attempts,
+                                proof_text="",
+                                outcome=ValidationOutcome(
+                                    ok=False, error="missing proof_text"
+                                ),
+                            )
+                        )
+                        _progress(
+                            "tool_call",
+                            tool=VALIDATE_TOOL_NAME,
+                            attempt=validate_attempts,
+                            proofPreview="",
+                        )
+                        _progress(
+                            "tool_result",
+                            tool=VALIDATE_TOOL_NAME,
+                            attempt=validate_attempts,
+                            ok=False,
+                            errorTail="missing proof_text",
+                        )
+                        continue
+
+                    _progress(
+                        "tool_call",
+                        tool=VALIDATE_TOOL_NAME,
+                        attempt=validate_attempts,
+                        proofPreview=preview(proof_text),
+                    )
+                    outcome = validator.validate(proof_text)
+                    history.append(
+                        AttemptRecord(
+                            attempt=validate_attempts,
+                            proof_text=proof_text,
+                            outcome=outcome,
+                        )
+                    )
+                    _progress(
+                        "tool_result",
+                        tool=VALIDATE_TOOL_NAME,
+                        attempt=validate_attempts,
+                        ok=outcome.ok,
+                        errorTail=preview(outcome.error or "", 200),
+                    )
+
+                    if outcome.ok and success_proof is None:
+                        success_proof = proof_text
+                        tool_results.append(
+                            _tool_result_block(
+                                _block_id(block), ok=True, error=None
+                            )
+                        )
+                    else:
+                        tool_results.append(
+                            _tool_result_block(
+                                _block_id(block),
+                                ok=False,
+                                error=outcome.error,
+                            )
+                        )
+
+                elif tool_name == QUERY_GOAL_TOOL_NAME and querier is not None:
+                    _progress(
+                        "tool_call",
+                        tool=QUERY_GOAL_TOOL_NAME,
+                        proofPreview=preview(proof_text or ""),
+                    )
+                    if proof_text is None:
+                        tool_results.append(
+                            _tool_result_block(
+                                _block_id(block),
+                                ok=False,
+                                error="tool input missing required `proof_text`",
+                            )
+                        )
+                        _progress(
+                            "tool_result",
+                            tool=QUERY_GOAL_TOOL_NAME,
+                            ok=False,
+                            errorTail="missing proof_text",
+                        )
+                        continue
+                    outcome = querier.query(proof_text)
+                    tool_results.append(
+                        _query_result_block(_block_id(block), outcome)
+                    )
+                    _progress(
+                        "tool_result",
+                        tool=QUERY_GOAL_TOOL_NAME,
+                        ok=outcome.ok,
+                        goal=preview(outcome.goal or "", 100),
+                        errorTail=preview(outcome.error or "", 200),
+                    )
+                else:
                     tool_results.append(
                         _tool_result_block(
                             _block_id(block),
                             ok=False,
-                            error="tool input missing required `proof_text`",
-                        )
-                    )
-                    history.append(
-                        AttemptRecord(
-                            attempt=attempt,
-                            proof_text="",
-                            outcome=ValidationOutcome(
-                                ok=False, error="missing proof_text"
+                            error=(
+                                f"unknown tool {tool_name!r}; available: "
+                                f"{VALIDATE_TOOL_NAME}"
+                                + (
+                                    f", {QUERY_GOAL_TOOL_NAME}"
+                                    if querier is not None
+                                    else ""
+                                )
                             ),
                         )
                     )
-                    _progress("tool_call", attempt=attempt, proofPreview="")
-                    _progress(
-                        "tool_result",
-                        attempt=attempt,
-                        ok=False,
-                        errorTail="missing proof_text",
-                    )
-                    continue
 
-                _progress(
-                    "tool_call",
-                    attempt=attempt,
-                    proofPreview=preview(proof_text),
-                )
-                outcome = validator.validate(proof_text)
-                history.append(
-                    AttemptRecord(
-                        attempt=attempt,
-                        proof_text=proof_text,
-                        outcome=outcome,
-                    )
-                )
-                _progress(
-                    "tool_result",
-                    attempt=attempt,
-                    ok=outcome.ok,
-                    errorTail=preview(outcome.error or "", 200),
-                )
-
-                if outcome.ok:
-                    tool_results.append(
-                        _tool_result_block(
-                            _block_id(block), ok=True, error=None
-                        )
-                    )
-                    for remaining in tool_uses[len(tool_results):]:
-                        tool_results.append(
-                            _tool_result_block(
-                                _block_id(remaining),
-                                ok=False,
-                                error="superseded by earlier valid proof",
-                            )
-                        )
-                    elapsed = int((time.monotonic() - started) * 1000)
-                    _progress("finish", ok=True, attempts=attempt)
-                    return AgentResult(
-                        ok=True,
-                        proof=proof_text,
-                        attempts=attempt,
-                        elapsed_ms=elapsed,
-                        model=self.model,
-                        history=tuple(history),
-                    )
-
-                tool_results.append(
-                    _tool_result_block(
-                        _block_id(block), ok=False, error=outcome.error
-                    )
+            if success_proof is not None:
+                elapsed = int((time.monotonic() - started) * 1000)
+                _progress("finish", ok=True, attempts=validate_attempts)
+                return AgentResult(
+                    ok=True,
+                    proof=success_proof,
+                    attempts=validate_attempts,
+                    elapsed_ms=elapsed,
+                    model=self.model,
+                    history=tuple(history),
                 )
 
             messages.append({"role": "user", "content": tool_results})
 
-        # Budget exhausted with no valid proof.
+            if validate_attempts >= max_attempts:
+                # Budget gone and last attempt didn't succeed.
+                break
+
         elapsed = int((time.monotonic() - started) * 1000)
         _progress(
             "finish",
             ok=False,
-            attempts=max_attempts,
+            attempts=validate_attempts,
             reason="budget_exhausted",
         )
         return AgentResult(
             ok=False,
             proof=None,
-            attempts=max_attempts,
+            attempts=validate_attempts,
             elapsed_ms=elapsed,
             model=self.model,
             history=tuple(history),
@@ -274,6 +382,12 @@ def _block_id(block) -> str:
     return getattr(block, "id", "")
 
 
+def _tool_use_name(block) -> str:
+    if isinstance(block, dict):
+        return block.get("name", "") or ""
+    return getattr(block, "name", "") or ""
+
+
 def _extract_proof_text(block) -> Optional[str]:
     if isinstance(block, dict):
         inp = block.get("input", {})
@@ -300,4 +414,32 @@ def _tool_result_block(
         "tool_use_id": tool_use_id,
         "content": content,
         "is_error": not ok,
+    }
+
+
+def _query_result_block(tool_use_id: str, outcome: QueryOutcome) -> dict:
+    """Format a tool_result carrying a structured query response.
+
+    JSON-encode the {goal, givens} (or {error}) payload so the model
+    sees it as a parseable structure rather than a free-form string.
+    """
+    if outcome.ok:
+        payload = {
+            "goal": outcome.goal,
+            "givens": [
+                {"label": g.label, "formula": g.formula}
+                for g in outcome.givens
+            ],
+        }
+        return {
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": json.dumps(payload),
+            "is_error": False,
+        }
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": json.dumps({"error": outcome.error or "unknown"}),
+        "is_error": True,
     }

--- a/tools/claude_fill_hole/examples/06_induction.pf
+++ b/tools/claude_fill_hole/examples/06_induction.pf
@@ -19,6 +19,5 @@ recursive add(UnaryNat, UnaryNat) -> UnaryNat {
 
 theorem t06_add_zero_right: all n:UnaryNat. add(n, zero) = n
 proof
-  arbitrary n:UnaryNat
   ?
 end

--- a/tools/claude_fill_hole/openai_backend.py
+++ b/tools/claude_fill_hole/openai_backend.py
@@ -38,12 +38,15 @@ from .agent import (
     AttemptRecord,
     Backend,
     ProgressFn,
+    QUERY_GOAL_TOOL_DESCRIPTION,
+    QUERY_GOAL_TOOL_NAME,
+    QUERY_GOAL_TOOL_PARAMETERS,
     VALIDATE_TOOL_DESCRIPTION,
     VALIDATE_TOOL_NAME,
     VALIDATE_TOOL_PARAMETERS,
     preview,
 )
-from .validator import Validator, ValidationOutcome
+from .validator import HoleQuerier, QueryOutcome, Validator, ValidationOutcome
 
 
 _DEFAULT_MAX_TOKENS = 16000
@@ -55,6 +58,15 @@ _VALIDATE_TOOL = {
         "name": VALIDATE_TOOL_NAME,
         "description": VALIDATE_TOOL_DESCRIPTION,
         "parameters": VALIDATE_TOOL_PARAMETERS,
+    },
+}
+
+_QUERY_GOAL_TOOL = {
+    "type": "function",
+    "function": {
+        "name": QUERY_GOAL_TOOL_NAME,
+        "description": QUERY_GOAL_TOOL_DESCRIPTION,
+        "parameters": QUERY_GOAL_TOOL_PARAMETERS,
     },
 }
 
@@ -108,6 +120,7 @@ class OpenAICompatBackend(Backend):
         user_message: str,
         validator: Validator,
         max_attempts: int,
+        querier: Optional[HoleQuerier] = None,
         on_progress: Optional[ProgressFn] = None,
     ) -> AgentResult:
         started = time.monotonic()
@@ -127,32 +140,42 @@ class OpenAICompatBackend(Backend):
         ]
         history: list[AttemptRecord] = []
 
+        tools = [_VALIDATE_TOOL]
+        if querier is not None:
+            tools = [_VALIDATE_TOOL, _QUERY_GOAL_TOOL]
+
         _progress("start", maxAttempts=max_attempts)
 
-        for attempt in range(1, max_attempts + 1):
-            _progress("model_request", attempt=attempt)
+        validate_attempts = 0
+        max_turns = max_attempts * 2
+
+        for turn in range(1, max_turns + 1):
+            _progress(
+                "model_request", turn=turn, attempt=validate_attempts
+            )
 
             try:
                 response = self.client.chat.completions.create(
                     model=self.model,
                     max_tokens=self.max_tokens,
-                    tools=[_VALIDATE_TOOL],
+                    tools=tools,
                     tool_choice="auto",
                     messages=messages,
                 )
             except Exception as exc:
                 if (
                     _is_recoverable_malformed_args_error(exc)
-                    and attempt < max_attempts
+                    and validate_attempts < max_attempts
+                    and turn < max_turns
                 ):
                     _progress(
                         "malformed_args_recovery",
-                        attempt=attempt,
+                        turn=turn,
                         error=preview(str(exc), 200),
                     )
                     history.append(
                         AttemptRecord(
-                            attempt=attempt,
+                            attempt=validate_attempts,
                             proof_text="",
                             outcome=ValidationOutcome(
                                 ok=False,
@@ -166,17 +189,17 @@ class OpenAICompatBackend(Backend):
                 _progress(
                     "finish",
                     ok=False,
-                    attempts=attempt - 1,
+                    attempts=validate_attempts,
                     error=str(exc),
                 )
                 return AgentResult(
                     ok=False,
                     proof=None,
-                    attempts=attempt - 1,
+                    attempts=validate_attempts,
                     elapsed_ms=elapsed,
                     model=self.model,
                     history=tuple(history),
-                    error=f"API call failed on attempt {attempt}: {exc}",
+                    error=f"API call failed on turn {turn}: {exc}",
                 )
 
             choice = _first_choice(response)
@@ -184,29 +207,23 @@ class OpenAICompatBackend(Backend):
             tool_calls = _tool_calls(assistant_msg)
 
             if not tool_calls:
-                # Model emitted a text-only response (or nothing).
-                # Treated as "gave up" -- mirror AnthropicBackend.
                 elapsed = int((time.monotonic() - started) * 1000)
                 _progress(
                     "finish",
                     ok=False,
-                    attempts=attempt,
+                    attempts=validate_attempts,
                     reason="no_tool_call",
                 )
                 return AgentResult(
                     ok=False,
                     proof=None,
-                    attempts=attempt,
+                    attempts=validate_attempts,
                     elapsed_ms=elapsed,
                     model=self.model,
                     history=tuple(history),
-                    error="model returned no validate_proof call",
+                    error="model returned no tool call",
                 )
 
-            # Append the assistant turn.  We have to re-serialise
-            # tool_calls into a JSON-safe shape because some clients
-            # return Pydantic models that don't round-trip through
-            # the request-side ``messages`` parameter.
             messages.append(
                 {
                     "role": "assistant",
@@ -215,124 +232,175 @@ class OpenAICompatBackend(Backend):
                 }
             )
 
-            valid_proof = None
+            valid_proof: Optional[str] = None
+
             for tc in tool_calls:
                 tc_id = _tool_call_id(tc)
                 tc_name = _tool_call_function_name(tc)
                 tc_args_raw = _tool_call_function_arguments(tc)
+                proof_text = _extract_proof_text(tc_args_raw)
 
-                if tc_name != VALIDATE_TOOL_NAME:
-                    # Model called something we don't expose.  Tell
-                    # it so via a tool message and let it retry.
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": tc_id,
-                            "content": json.dumps(
+                if tc_name == VALIDATE_TOOL_NAME:
+                    if validate_attempts >= max_attempts:
+                        messages.append(
+                            _tool_message(
+                                tc_id,
                                 {
                                     "ok": False,
                                     "error": (
-                                        f"unknown tool {tc_name!r}; "
-                                        f"only {VALIDATE_TOOL_NAME!r} is available"
+                                        "validate_proof budget exhausted; "
+                                        "no further validates will run"
                                     ),
-                                }
-                            ),
-                        }
-                    )
-                    continue
+                                },
+                            )
+                        )
+                        continue
+                    validate_attempts += 1
 
-                proof_text = _extract_proof_text(tc_args_raw)
-                if proof_text is None:
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": tc_id,
-                            "content": json.dumps(
+                    if proof_text is None:
+                        messages.append(
+                            _tool_message(
+                                tc_id,
                                 {
                                     "ok": False,
                                     "error": "tool input missing required `proof_text`",
-                                }
-                            ),
-                        }
+                                },
+                            )
+                        )
+                        history.append(
+                            AttemptRecord(
+                                attempt=validate_attempts,
+                                proof_text="",
+                                outcome=ValidationOutcome(
+                                    ok=False, error="missing proof_text"
+                                ),
+                            )
+                        )
+                        _progress(
+                            "tool_call",
+                            tool=VALIDATE_TOOL_NAME,
+                            attempt=validate_attempts,
+                            proofPreview="",
+                        )
+                        _progress(
+                            "tool_result",
+                            tool=VALIDATE_TOOL_NAME,
+                            attempt=validate_attempts,
+                            ok=False,
+                            errorTail="missing proof_text",
+                        )
+                        continue
+
+                    _progress(
+                        "tool_call",
+                        tool=VALIDATE_TOOL_NAME,
+                        attempt=validate_attempts,
+                        proofPreview=preview(proof_text),
                     )
+                    outcome = validator.validate(proof_text)
                     history.append(
                         AttemptRecord(
-                            attempt=attempt,
-                            proof_text="",
-                            outcome=ValidationOutcome(
-                                ok=False, error="missing proof_text"
-                            ),
+                            attempt=validate_attempts,
+                            proof_text=proof_text,
+                            outcome=outcome,
                         )
                     )
                     _progress(
-                        "tool_call", attempt=attempt, proofPreview=""
+                        "tool_result",
+                        tool=VALIDATE_TOOL_NAME,
+                        attempt=validate_attempts,
+                        ok=outcome.ok,
+                        errorTail=preview(outcome.error or "", 200),
+                    )
+                    messages.append(
+                        _tool_message(
+                            tc_id,
+                            {"ok": outcome.ok, "error": outcome.error},
+                        )
+                    )
+                    if outcome.ok and valid_proof is None:
+                        valid_proof = proof_text
+
+                elif tc_name == QUERY_GOAL_TOOL_NAME and querier is not None:
+                    _progress(
+                        "tool_call",
+                        tool=QUERY_GOAL_TOOL_NAME,
+                        proofPreview=preview(proof_text or ""),
+                    )
+                    if proof_text is None:
+                        messages.append(
+                            _tool_message(
+                                tc_id,
+                                {
+                                    "ok": False,
+                                    "error": "tool input missing required `proof_text`",
+                                },
+                            )
+                        )
+                        _progress(
+                            "tool_result",
+                            tool=QUERY_GOAL_TOOL_NAME,
+                            ok=False,
+                            errorTail="missing proof_text",
+                        )
+                        continue
+                    outcome = querier.query(proof_text)
+                    messages.append(
+                        _tool_message(tc_id, _query_payload(outcome))
                     )
                     _progress(
                         "tool_result",
-                        attempt=attempt,
-                        ok=False,
-                        errorTail="missing proof_text",
+                        tool=QUERY_GOAL_TOOL_NAME,
+                        ok=outcome.ok,
+                        goal=preview(outcome.goal or "", 100),
+                        errorTail=preview(outcome.error or "", 200),
                     )
-                    continue
 
-                _progress(
-                    "tool_call",
-                    attempt=attempt,
-                    proofPreview=preview(proof_text),
-                )
-                outcome = validator.validate(proof_text)
-                history.append(
-                    AttemptRecord(
-                        attempt=attempt,
-                        proof_text=proof_text,
-                        outcome=outcome,
+                else:
+                    messages.append(
+                        _tool_message(
+                            tc_id,
+                            {
+                                "ok": False,
+                                "error": (
+                                    f"unknown tool {tc_name!r}; available: "
+                                    f"{VALIDATE_TOOL_NAME}"
+                                    + (
+                                        f", {QUERY_GOAL_TOOL_NAME}"
+                                        if querier is not None
+                                        else ""
+                                    )
+                                ),
+                            },
+                        )
                     )
-                )
-                _progress(
-                    "tool_result",
-                    attempt=attempt,
-                    ok=outcome.ok,
-                    errorTail=preview(outcome.error or "", 200),
-                )
-
-                tool_payload = {
-                    "ok": outcome.ok,
-                    "error": outcome.error,
-                }
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc_id,
-                        "content": json.dumps(tool_payload),
-                    }
-                )
-                if outcome.ok and valid_proof is None:
-                    valid_proof = proof_text
 
             if valid_proof is not None:
                 elapsed = int((time.monotonic() - started) * 1000)
-                _progress("finish", ok=True, attempts=attempt)
+                _progress("finish", ok=True, attempts=validate_attempts)
                 return AgentResult(
                     ok=True,
                     proof=valid_proof,
-                    attempts=attempt,
+                    attempts=validate_attempts,
                     elapsed_ms=elapsed,
                     model=self.model,
                     history=tuple(history),
                 )
 
-        # Budget exhausted with no valid proof.
+            if validate_attempts >= max_attempts:
+                break
+
         elapsed = int((time.monotonic() - started) * 1000)
         _progress(
             "finish",
             ok=False,
-            attempts=max_attempts,
+            attempts=validate_attempts,
             reason="budget_exhausted",
         )
         return AgentResult(
             ok=False,
             proof=None,
-            attempts=max_attempts,
+            attempts=validate_attempts,
             elapsed_ms=elapsed,
             model=self.model,
             history=tuple(history),
@@ -344,6 +412,34 @@ class OpenAICompatBackend(Backend):
 # Response introspection -- duck-typed across openai's Pydantic models
 # and dict-shaped fakes used in tests.
 # ---------------------------------------------------------------------------
+
+
+def _tool_message(tool_call_id: str, payload: dict) -> dict:
+    """Format a `role: tool' message carrying a JSON-encoded payload.
+
+    Centralised here so the validate_proof and query_goal paths
+    serialise the same way -- the model sees a parseable structure
+    in either case."""
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": json.dumps(payload),
+    }
+
+
+def _query_payload(outcome: QueryOutcome) -> dict:
+    """Convert a QueryOutcome into the JSON shape the model sees in
+    the tool_result message: `{goal, givens}` on success, `{error}`
+    on failure."""
+    if outcome.ok:
+        return {
+            "goal": outcome.goal,
+            "givens": [
+                {"label": g.label, "formula": g.formula}
+                for g in outcome.givens
+            ],
+        }
+    return {"error": outcome.error or "unknown"}
 
 
 def _first_choice(response):

--- a/tools/claude_fill_hole/prompt.py
+++ b/tools/claude_fill_hole/prompt.py
@@ -1,10 +1,28 @@
 """System prompt + user message assembly for the hole-fill agent loop.
 
-Two cheatsheet files (``gh_pages/doc/TacticsCheatSheet.md`` and
-``gh_pages/doc/CheatSheet.md``) carry most of the model-facing
-context. They are embedded in the system prompt with prompt
-caching enabled, so the cost of sending them is paid once per
-5-minute window rather than once per attempt.
+Two model-facing reference docs are embedded in the system prompt:
+
+  - ``gh_pages/doc/WorkedExamples.md`` -- short proof snippets that
+    demonstrate each tactic concept (one per goal-shape and per
+    non-shape-keyed tactic). Models pattern-match on concrete
+    examples much more reliably than they parse strategy prose,
+    so this leads.
+
+  - ``gh_pages/doc/TacticsCheatSheet.md`` -- dense reference: every
+    tactic with a one-line meaning, plus a "Common pitfalls"
+    section. Used as the look-up table when the worked examples
+    don't cover a specific construct.
+
+The third doc, ``CheatSheet.md``, is intentionally NOT included --
+its strategy-by-goal-shape table is subsumed by the goal-shape-
+indexed worked examples, and including it adds noise without
+adding new information.
+
+The two embedded docs are wrapped in XML-ish tags
+(``<worked_examples>`` and ``<tactics_cheatsheet>``) so the model
+can refer to them in its reasoning. Prompt caching on the Anthropic
+backend amortises the cost across attempts; OpenAI-compat servers
+re-tokenise each attempt (no breakpoints).
 
 The user message carries the per-request bits: the goal, the
 givens, the lemmas in scope, and a small excerpt of the source
@@ -22,8 +40,8 @@ from .schema import Given, LemmaInfo
 # Repo root is two parents up from this file: tools/claude_fill_hole/prompt.py
 # -> tools/claude_fill_hole/ -> tools/ -> <repo>/.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKED_EXAMPLES = _REPO_ROOT / "gh_pages" / "doc" / "WorkedExamples.md"
 _TACTICS_CHEATSHEET = _REPO_ROOT / "gh_pages" / "doc" / "TacticsCheatSheet.md"
-_CHEATSHEET = _REPO_ROOT / "gh_pages" / "doc" / "CheatSheet.md"
 
 
 # Single literal placeholder, replaced via ``str.replace`` rather than
@@ -57,13 +75,13 @@ Rules:
 """
 
 
-def _read_cheatsheet(path: Path) -> str:
-    """Return the cheatsheet's contents, or an empty string if missing.
+def _read_doc(path: Path) -> str:
+    """Return the doc's contents, or an empty string if missing.
 
     The sidecar is expected to be invoked from a Deduce checkout
-    where the cheatsheets exist; missing-file is unusual but we
-    don't fail the whole run over it -- the model still has the
-    SCAFFOLD instructions.
+    where the docs exist; missing-file is unusual but we don't fail
+    the whole run over it -- the model still has the SCAFFOLD
+    instructions.
     """
     try:
         return path.read_text(encoding="utf-8")
@@ -78,23 +96,25 @@ def build_system_prompt(max_attempts: int) -> str:
     text-block list with ``cache_control``; the OpenAI-compat
     backend uses it as the content of a leading ``system`` message.
 
-    The prompt embeds two cheatsheets verbatim
-    (``gh_pages/doc/TacticsCheatSheet.md`` and ``CheatSheet.md``).
-    On Anthropic the caching breakpoint amortises that cost; on
-    OpenAI-compat servers, prefix caching is implicit (real OpenAI)
-    or absent (Ollama, some LiteLLM deployments) -- in either case
-    the same text is sent.
+    The prompt embeds two docs:
+
+    - ``gh_pages/doc/WorkedExamples.md`` (concrete proof snippets)
+    - ``gh_pages/doc/TacticsCheatSheet.md`` (dense tactic reference)
+
+    Worked examples come first because models pattern-match on
+    concrete code more reliably than they parse strategy prose.
+    The tactics cheatsheet follows as a look-up table.
     """
-    tactics = _read_cheatsheet(_TACTICS_CHEATSHEET)
-    cheats = _read_cheatsheet(_CHEATSHEET)
+    worked = _read_doc(_WORKED_EXAMPLES)
+    tactics = _read_doc(_TACTICS_CHEATSHEET)
 
     return (
         SCAFFOLD.replace(_MAX_ATTEMPTS_PLACEHOLDER, str(max_attempts))
-        + "\n\n<tactics_cheatsheet>\n"
+        + "\n\n<worked_examples>\n"
+        + worked
+        + "\n</worked_examples>\n\n<tactics_cheatsheet>\n"
         + tactics
-        + "\n</tactics_cheatsheet>\n\n<cheatsheet>\n"
-        + cheats
-        + "\n</cheatsheet>\n"
+        + "\n</tactics_cheatsheet>\n"
     )
 
 

--- a/tools/claude_fill_hole/prompt.py
+++ b/tools/claude_fill_hole/prompt.py
@@ -58,12 +58,27 @@ Deduce is a small functional language and proof checker for teaching
 logic. Source files have ``.pf`` extension; ``?`` marks an
 incomplete proof (a "hole"). Your job is to fill in one hole.
 
-You have one tool: ``validate_proof(proof_text)``. It splices
-``proof_text`` into the source at the hole's range, runs the
-checker, and returns ``{ok: bool, error?: str}``. You can call it
-up to __MAX_ATTEMPTS__ times; the first valid proof wins. After each
-failed attempt, the error message comes back to you and you can
-refine.
+You have two tools:
+
+  - ``validate_proof(proof_text)`` -- splice ``proof_text`` into the
+    source at the hole and run the checker.  Returns
+    ``{ok: bool, error?: str}``.  Call this when you're ready to
+    commit a complete proof.  You can call it up to __MAX_ATTEMPTS__
+    times; the first valid proof wins.  Counts toward your budget.
+
+  - ``query_goal(proof_text)`` -- splice a PARTIAL ``proof_text``
+    that itself contains a ``?'' marker, and return the goal +
+    in-scope givens at that ``?'' as a JSON object with ``{goal,
+    givens}'' (or ``{error}'' if the splice didn't reach the
+    marker).  Does NOT count toward your validate budget -- call it
+    freely to inspect intermediate goals.
+
+Use ``query_goal`` to plan multi-step proofs.  For an induction proof:
+write the skeleton ``induction T case ctor1 { ? } case ctor2(n')
+suppose IH: ... { ? }`` and call ``query_goal`` to see what each
+``?'' has to prove.  Refine each case with progressively-smaller
+holes until you can fill the whole thing, then ``validate_proof''
+the complete result.
 
 Rules:
 - Emit raw Deduce text in ``proof_text``. Do not wrap it in code

--- a/tools/claude_fill_hole/validator.py
+++ b/tools/claude_fill_hole/validator.py
@@ -168,6 +168,176 @@ class LspValidator(Validator):
         raise NotImplementedError
 
 
+# ---------------------------------------------------------------------------
+# Mid-proof goal queries: HoleQuerier
+# ---------------------------------------------------------------------------
+#
+# Sibling to Validator: instead of "splice this proof and run the
+# checker to completion", it answers "splice this partial proof
+# (which itself contains a `?') and tell me what the goal looks like
+# at that `?'".  Used by the agent loop's `query_goal' tool, which
+# does NOT count toward the validate budget -- it's a peek at the
+# proof state mid-construction so the model can see intermediate
+# goals (e.g. inside an induction case) before committing to a full
+# proof.
+#
+# Implementation: imports `lsp.query.hole_context_at' directly
+# (in-process), so the deduce environment must already be
+# bootstrapped (see __main__.py).
+
+
+@dataclass(frozen=True)
+class _Given:
+    """Local copy of the Given shape from `lsp.query`, included here
+    so test code that imports HoleQuerier doesn't have to also import
+    the deduce env."""
+
+    label: Optional[str]
+    formula: str
+
+
+@dataclass(frozen=True)
+class QueryOutcome:
+    """Result of one ``query_goal`` invocation.
+
+    On success: ``goal`` is the rendered formula at the queried
+    `?'; ``givens`` is the tuple of in-scope hypothesis labels and
+    formulas at that point.  On failure: ``error`` carries a
+    human-readable reason (no `?' in proof_text, splice didn't reach
+    the hole, parse error in the spliced source, etc.) and the other
+    fields are empty.
+    """
+
+    ok: bool
+    goal: Optional[str] = None
+    givens: tuple = ()
+    error: Optional[str] = None
+
+
+class HoleQuerier:
+    """Splice a partial proof and report the goal at the first `?' inside.
+
+    The model uses this to inspect intermediate goals during proof
+    construction without burning a `validate_proof' attempt.  Typical
+    flow: write a proof skeleton with `?' marking where you want to
+    see the goal, call query_goal, read the goal, refine the
+    skeleton, repeat.
+
+    Constructor takes the same splice anchors as SubprocessValidator
+    (file_path, content, hole offsets) plus the prelude tuple so
+    `hole_context_at' can resolve standard-library imports.
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        content: str,
+        hole_start_offset: int,
+        hole_end_offset: int,
+        prelude: tuple = (),
+        max_proof_text_bytes: int = 32 * 1024,
+    ) -> None:
+        self.file_path = file_path
+        self.content = content
+        self.hole_start_offset = hole_start_offset
+        self.hole_end_offset = hole_end_offset
+        self.prelude = prelude
+        self.max_proof_text_bytes = max_proof_text_bytes
+
+    def query(self, proof_text: str) -> QueryOutcome:
+        if len(proof_text.encode("utf-8")) > self.max_proof_text_bytes:
+            return QueryOutcome(
+                ok=False,
+                error=(
+                    f"proof text exceeds {self.max_proof_text_bytes} bytes; "
+                    "cap is meant to catch runaway model output"
+                ),
+            )
+        if "?" not in proof_text:
+            return QueryOutcome(
+                ok=False,
+                error=(
+                    "proof_text contains no `?'; query_goal needs at least "
+                    "one `?' marking where you want to inspect the goal"
+                ),
+            )
+
+        spliced = (
+            self.content[: self.hole_start_offset]
+            + proof_text
+            + self.content[self.hole_end_offset :]
+        )
+        # Find the first `?` AT OR AFTER the splice point -- earlier
+        # `?'s would belong to other (already-filled or unrelated) holes
+        # in the file, which we don't want to query.
+        new_q_offset = spliced.find("?", self.hole_start_offset)
+        if new_q_offset < 0:
+            return QueryOutcome(
+                ok=False,
+                error="splice produced no `?' to query (unexpected)",
+            )
+
+        line, col = _offset_to_line_col_1indexed(spliced, new_q_offset)
+
+        try:
+            from lsp.query import Position, hole_context_at
+        except ImportError as e:
+            return QueryOutcome(
+                ok=False,
+                error=(
+                    f"could not import lsp.query for goal lookup: {e} "
+                    "(sidecar must be invoked with deduce repo root on "
+                    "PYTHONPATH and the deduce env bootstrapped)"
+                ),
+            )
+
+        try:
+            ctx = hole_context_at(
+                self.file_path,
+                spliced,
+                Position(line=line, column=col),
+                prelude=self.prelude,
+                include_lemmas=False,
+            )
+        except Exception as e:  # pragma: no cover -- defensive
+            return QueryOutcome(
+                ok=False,
+                error=f"goal lookup raised: {e}",
+            )
+
+        if ctx is None:
+            return QueryOutcome(
+                ok=False,
+                error=(
+                    "couldn't reach the `?' to query -- check for parse "
+                    "or type errors before that point in your proof"
+                ),
+            )
+
+        givens = tuple(
+            _Given(label=g.label, formula=g.formula) for g in ctx.givens
+        )
+        return QueryOutcome(ok=True, goal=ctx.goal, givens=givens)
+
+
+def _offset_to_line_col_1indexed(text: str, offset: int) -> tuple:
+    """Convert a 0-indexed byte offset to a 1-indexed (line, column).
+
+    Mirrors lsp.query._offset_to_line_col but lives here so HoleQuerier
+    doesn't need to reach into lsp.query's private surface."""
+    line = 1
+    col = 1
+    for i, ch in enumerate(text):
+        if i == offset:
+            return line, col
+        if ch == "\n":
+            line += 1
+            col = 1
+        else:
+            col += 1
+    return line, col
+
+
 def _tail(text: str, max_bytes: int) -> str:
     """Return the last ``max_bytes`` of ``text``, byte-safe.
 


### PR DESCRIPTION
Adds [`gh_pages/doc/WorkedExamples.md`](gh_pages/doc/WorkedExamples.md) — short proof snippets demonstrating each construct in `TacticsCheatSheet.md` and `CheatSheet.md`, organized by goal shape. Updates `prompt.py` to embed `WorkedExamples.md + TacticsCheatSheet.md` (drops `CheatSheet.md` from the prompt — its content is subsumed). Adds a second tool, `query_goal`, that lets the model probe intermediate goals mid-proof without burning a `validate_proof` attempt.

## Coverage

**Goal shapes**: `true`, `false` (via `contradict`), `P and Q` (intro+destructure), `P or Q` (intro+`cases`), `if P then Q` (intro+`apply...to`), `not P`, `all` (`arbitrary`+brackets), `some` (`choose`+`obtain`), equality (`reflexive`/`equations`/`replace`/`symmetric`/`transitive`).

**Non-shape tactics**: induction over a custom union (multiple variants — see below), `switch` on a term, `have`, `suffices`, `apply lemma[t] to p`, `predicate` + `rule induction`.

**Induction-specific examples** (added in response to the level-6 benchmark failure mode):
- Pitfall callout: don't `arbitrary` before `induction` (induction consumes the leading `all`).
- Three-step `equations` chain.
- Induction whose goal involves an inductive predicate (uses `apply rule[t] to IH` and `expand fn` without trailing `.`).
- Induction over a parameterised list type.
- Induction with a quantified IH (instantiate via `IH[m]`; or `apply IH[m] to` for if-then IHs).

Each example checks under `deduce.py --no-stdlib`.

## query_goal tool

Beyond `validate_proof`, the model now has `query_goal(proof_text)`. It splices a partial proof_text containing `?` into the source, finds the first remaining `?`, and returns `{goal, givens}` at that point — without running the checker to completion. Doesn't count toward the validate budget; the loop bounds total turns at `max_attempts * 2` so a model that only ever queries can't loop forever.

The intended workflow:
1. Write a skeleton (`induction T case base { ? } case rec(n') suppose IH: ... { ? }`).
2. `query_goal` to see what each `?` has to prove.
3. Refine each branch.
4. `validate_proof` the complete proof once.

A walked-through example of this loop lives in WorkedExamples.md ("Using `query_goal` to plan a multi-step proof").

## Implementation

- `HoleQuerier` (in `validator.py`) wraps `lsp.query.hole_context_at` with the same splice anchors as `SubprocessValidator`.
- Both backends (Anthropic, OpenAI-compat) gain a `querier` argument on `run`; when provided, both tools are advertised.
- `__main__.py` bootstrap now sets `sys.argv[0]` to `<root>/deduce.py` so the in-process parser can find `Deduce.lark` (mirrors `lsp.lsp_server`'s init). Without this, query_goal would silently fail with a parse error.
- `gh_pages/scripts/convert.py`: registered `WorkedExamples` in all four name dictionaries (the missing entry was causing a CI `KeyError`).
- `06_induction.pf`: dropped `arbitrary n:UnaryNat` before the hole. The line stripped the leading `all`, which made the README's reference proof (`induction UnaryNat ...`) fail with "induction expected an all-formula". Fixture now matches its README spec.

## Benchmark

Re-ran [`tools/claude_fill_hole/examples/run_benchmark.py`](tools/claude_fill_hole/examples/run_benchmark.py) against the four REALLMs chat models. `llama-4-scout` never engages tool calls and is omitted from totals.

| Fixture | Pre (baseline) | Post |
|---|---|---|
| 01_trivial | 2/3 | 3/3 |
| 02_reflexive | 3/3 | 3/3 |
| 03_assumption | 3/3 | 3/3 |
| 04_conj_swap | 1/3 | 3/3 |
| 05_disj_swap | 2/3 | 2/3 (Qwen3 hit transport-level "bad json" — not a content issue) |
| 06_induction | 0/3 | 3/3 |
| **Total** | **11/18** | **17/18** |

Per-model: gpt-oss-120b 6/6, gemma-4-31B-it 6/6, Qwen3-Coder-Next 5/6 (lone failure was a transport-level JSON glitch on `cases` output).

The level-6 jump is the most meaningful — it came from two compounding fixes:
1. The fixture had `arbitrary n:UnaryNat` before the hole, which made the README's reference proof not actually compile. Removing the line lets `induction UnaryNat` work directly.
2. The new induction examples in WorkedExamples.md (5 variants + pitfall callout) give models a concrete `equations`/`expand`/`replace IH` template to copy.

## Test plan

- [x] All 28 code blocks in WorkedExamples.md verified by `deduce.py --no-stdlib`.
- [x] `pytest test/claude_fill_hole/` — 61 passing (14 new tests for HoleQuerier + query_goal agent loops in both backends).
- [x] Emacs ert tests — 25/25 passing.
- [x] `test-deduce.py --site` passes locally (CI fix verified).
- [x] Re-ran benchmark; level-6 now 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)