### PR TITLE
editor/emacs: rewrite README around user-facing capabilities

### DIFF
--- a/docs/knowledge-base/emacs-lsp-protocol.md
+++ b/docs/knowledge-base/emacs-lsp-protocol.md
@@ -1,0 +1,88 @@
+# Emacs deduce-lsp ↔ LSP server wiring
+
+*Implementor notes. End users should read [`editor/emacs/README.md`](../../editor/emacs/README.md) instead.*
+
+This document records the protocol-level connection between the Emacs
+client (`editor/emacs/deduce-lsp.el`) and the LSP server
+(`lsp/lsp_server.py`). The user-facing README deliberately hides this
+information; this is where it lives so that anyone touching either
+side can reconcile them.
+
+## Client / server topology
+
+- `deduce-lsp.el` registers a major-mode hook on `deduce-mode` that
+  calls `eglot-ensure`. The launch command is
+  `python3 -m lsp.lsp_server` (override via
+  `deduce-lsp-server-command`).
+- The server is implemented with [pygls][pygls] (>= 2.1.0). Older
+  pygls (2.0.x) had a different API and will not work.
+- The Emacs side uses `eglot`, which ships in-tree from Emacs 29 and
+  exposes a stable `jsonrpc` API.
+
+[pygls]: https://github.com/openlawlibrary/pygls
+
+## Standard LSP requests used
+
+| Emacs entry point        | LSP method                       |
+| ------------------------ | -------------------------------- |
+| `M-.`                    | `textDocument/definition`        |
+| `M-x imenu`              | `textDocument/documentSymbol`    |
+| `C-c C-r` (refine hole)  | `textDocument/codeAction` (action title `Refine hole`) |
+| `C-c C-i` (induction)    | `textDocument/codeAction` (action title `Induction`)   |
+| Save                     | `textDocument/publishDiagnostics` (server-pushed) |
+
+The two `codeAction`-driven commands apply the named action directly
+(no picker). The action title is the contract — if the server renames
+either, the client breaks.
+
+## Custom (`deduce/*`) requests
+
+These are server-specific JSON-RPC methods. They are not part of LSP
+proper.
+
+| Emacs command          | Custom request(s)                              | Purpose                                               |
+| ---------------------- | ---------------------------------------------- | ----------------------------------------------------- |
+| `C-c C-g`              | `deduce/goalAt`                                | Goal + givens at point, rendered into a popup buffer |
+| `C-c C-c` (case split) | `deduce/splittableVarsAt`, `deduce/caseSplitAt` | Two-step: enumerate splittable vars, then split on chosen one |
+| `C-c C-e` (eliminate)  | `deduce/eliminableVarsAt`, `deduce/eliminateAt` | Two-step: enumerate eliminable hypotheses, then apply chosen one |
+| `C-c C-f` (fill-from-given) | `deduce/matchingGivensAt`, `deduce/fillFromGivenAt` | Two-step: enumerate givens whose formula matches the goal, then splice the chosen one |
+| `C-c C-a` (LLM fill)   | `deduce/holeContextAt`                         | Captures goal, givens, lemmas in scope, and a stable fingerprint for the `tools/claude_fill_hole` sidecar |
+
+The two-step pattern (`*VarsAt` + `*At`) exists so that Emacs can
+present a `completing-read` picker without the server having to
+generate every possible expansion eagerly. The `?` under the cursor
+is the unambiguous replacement target — the client never has to guess
+which hole the user meant.
+
+## Hole replacement targeting
+
+The cursor position pinpoints the `?` to be replaced. All hole-filling
+commands (refine, case-split, induction, eliminate, fill-from-given,
+LLM fill) use this convention. Tests that pin the request shape live
+in `editor/emacs/test/deduce-lsp-test.el`.
+
+## LLM hole-fill sidecar
+
+`C-c C-a` is structurally different: rather than a server round-trip,
+the Emacs client issues `deduce/holeContextAt` to gather context, then
+spawns `tools/claude_fill_hole` as a subprocess. The sidecar runs
+asynchronously, validating candidate proofs by re-invoking
+`deduce.py` (or, when wired up, the in-process incremental checker).
+On completion the client checks the stable fingerprint to confirm the
+buffer hasn't drifted, then splices in the validated proof.
+
+The sidecar entry point and validation contract are documented at
+[`tools/claude_fill_hole/README.md`](../../tools/claude_fill_hole/README.md).
+
+## What to keep in sync when changing the protocol
+
+If you rename a custom method, change the schema of a request /
+response, or rename a code-action title, all three of these need to
+move together:
+
+1. The server method registration in `lsp/lsp_server.py`.
+2. The Emacs command definition in `editor/emacs/deduce-lsp.el`.
+3. The corresponding pinning test in
+   `editor/emacs/test/deduce-lsp-test.el` (and the server-side test).
+
+Also update this document.

--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -1,31 +1,77 @@
 # deduce-mode for Emacs
 
-A self-contained Emacs mode for the [Deduce][deduce] proof checker:
-syntax highlighting + indentation in `deduce-mode.el`, plus optional
-[eglot][eglot] integration in `deduce-lsp.el` that wires `.pf`
-buffers to the LSP server in `lsp/lsp_server.py`. An optional
-`deduce-fill-hole.el` adds Claude-powered hole filling on top.
+A self-contained Emacs mode for the [Deduce][deduce] proof checker.
+Three layers, each independently usable:
+
+- **`deduce-mode`** — syntax highlighting and indentation for `.pf`
+  files.
+- **`deduce-lsp`** *(optional)* — structured editing backed by a
+  language server: jump to definition, outline of top-level
+  declarations, show the proof goal at point, and a family of
+  hole-filling commands (refine, case split, induction skeleton,
+  eliminate hypothesis, fill from a matching given). Diagnostics
+  appear inline as you save.
+- **`deduce-fill-hole`** *(optional)* — ask an LLM to fill the hole at
+  point. Validated proofs only; the LLM's output is checked before
+  it is spliced into your buffer.
 
 [deduce]: https://github.com/jsiek/deduce
-[eglot]: https://www.gnu.org/software/emacs/manual/html_mono/eglot.html
 
 ## Prerequisites
 
-| Component                   | Required when                          | How to install                                  |
-| --------------------------- | -------------------------------------- | ----------------------------------------------- |
-| Emacs **29.1** or newer     | always                                 | `brew install emacs` / distro package           |
-| Python 3.11+ with `lark`    | always (deduce.py itself)              | `pip install lark==1.2.2`                       |
-| `pygls>=2.1.0`              | only if you load `deduce-lsp.el`       | `pip install -r requirements-lsp.txt`           |
-| `anthropic>=0.40.0`         | only if you load `deduce-fill-hole.el` | `pip install -r requirements-fill-hole.txt`     |
-| `openai>=1.50.0`            | only if you load `deduce-fill-hole.el` | `pip install -r requirements-fill-hole.txt`     |
-| API key env var             | only if you load `deduce-fill-hole.el` | one of: `ANTHROPIC_API_KEY` (real Claude), `OPENAI_API_KEY` (real OpenAI), `REALLMS_API_KEY` (IU REALLMs) |
+### Always
 
-Emacs 29 is the minimum because `eglot` ships in-tree from 29 onward
-and the `jsonrpc` library has a stable API there. Older Emacs would
-need `package-install eglot` and `compat`; that path is not
-supported.
+- **Emacs 29.1 or newer.** Install via `brew install emacs` or your
+  distro package. Emacs 29 is the minimum because eglot ships in
+  Emacs from version 29 onward; older Emacs is not supported.
+- **Python 3.11+ with `lark`.** Required to run `deduce.py` itself:
+  `pip install lark==1.2.2`.
+
+### For LSP capabilities (`deduce-lsp`)
+
+- **`pygls>=2.1.0`** — the language-server framework the Deduce LSP
+  is built on. Install with `pip install -r requirements-lsp.txt`
+  from the repo root. (pygls 2.0.x had a different API and will not
+  work.)
+
+### For LLM-powered hole filling (`deduce-fill-hole`)
+
+- **`anthropic>=0.40.0`** and **`openai>=1.50.0`** — install both
+  with `pip install -r requirements-fill-hole.txt` from the repo
+  root. Which one is used at runtime depends on your backend choice
+  (see `deduce-fill-hole-backend` under Customization).
+- **An API key in your environment.** Pick one based on your
+  provider:
+  - `ANTHROPIC_API_KEY` — direct Anthropic API (Claude).
+  - `OPENAI_API_KEY` — OpenAI or any OpenAI-compatible endpoint
+    (e.g. a local Ollama server).
+  - `REALLMS_API_KEY` — IU's REALLMs gateway.
+
+  Add a line like the following to your shell initialization script
+  (`~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`) so the
+  key is exported into every shell — Emacs picks it up from the
+  environment of whichever shell launched it:
+
+  ```sh
+  export ANTHROPIC_API_KEY='sk-ant-...'
+  ```
+
+  Reload the shell (or open a new terminal) and confirm with
+  `echo $ANTHROPIC_API_KEY`. On macOS, if you launch Emacs from the
+  Dock rather than from a terminal, you will likely also want
+  [exec-path-from-shell][epfs] so Emacs inherits the same
+  environment as your interactive shell.
+
+[epfs]: https://github.com/purcell/exec-path-from-shell
 
 ## Quick start
+
+Pick one of the two install styles below: `use-package` is more
+declarative and is the standard choice in modern Emacs configs, but
+it adds a layer that not everyone wants. **If you don't have a
+preference, use `use-package`** — it is built into Emacs 29 and
+keeps the configuration tidy. Otherwise, use the plain `require`
+form.
 
 ### Without `use-package`
 
@@ -34,16 +80,16 @@ supported.
 (add-to-list 'load-path "/path/to/deduce/editor/emacs")
 (require 'deduce-mode)
 (require 'deduce-lsp)         ; optional: omit for major mode only
-(require 'deduce-fill-hole)   ; optional: Claude hole filling, depends on deduce-lsp
+(require 'deduce-fill-hole)   ; optional: LLM hole filling, depends on deduce-lsp
 
 ;; If your .pf files live OUTSIDE the deduce repo, point the LSP
-;; server at your checkout so `python3 -m lsp.lsp_server' resolves:
+;; server at your checkout so the language server can be found:
 ;; (setq deduce-lsp-deduce-root "~/src/deduce")
 ```
 
 Opening any `.pf` file will then enter `deduce-mode` (registered via
-`auto-mode-alist`) and, with `deduce-lsp` loaded, eglot will auto-
-connect on first save.
+`auto-mode-alist`) and, with `deduce-lsp` loaded, the language server
+will auto-connect on first save.
 
 ### With `use-package`
 
@@ -61,7 +107,7 @@ connect on first save.
 
 ### Major mode only (no LSP)
 
-If you don't want eglot to auto-start, just skip
+If you don't want the language server to auto-start, just skip
 `(require 'deduce-lsp)`. You still get syntax highlighting and
 indentation. You can also keep `deduce-lsp` loaded but disable the
 auto-start hook:
@@ -85,86 +131,82 @@ auto-start hook:
 
 `deduce-lsp` (when loaded):
 
-- Diagnostics on save (flymake-style underlines).
-- `M-.` -- go to definition (`textDocument/definition`).
-- `M-x imenu` -- outline of top-level declarations
-  (`textDocument/documentSymbol`).
-- `C-c C-g` -- show the proof goal at point in a popup buffer
-  (custom `deduce/goalAt` request -- see below).
-- `C-c C-r` -- refine the hole at point. Issues
-  `textDocument/codeAction` and applies the action titled `Refine
-  hole` directly (no picker). Templates by goal shape: `?, ?` for `P
-  and Q`, `assume H: P\n?` for `if P then Q`, `arbitrary x:T\n?` for
-  `all`, `choose ?\n?` for `some`, `reflexive` when both sides of an
+- **Diagnostics on save.** When you save a `.pf` buffer, the language
+  server re-checks the file and reports any errors back to Emacs.
+  Each error is rendered as a *flymake-style underline* — a colored
+  squiggle drawn under the offending text directly in the buffer
+  (flymake is Emacs's built-in inline-diagnostics framework, which
+  eglot reuses). Hover the cursor on an underlined region to see the
+  error message in the echo area, or run `M-x flymake-show-buffer-diagnostics`
+  for a list view of every error in the file.
+- `M-.` — **go to definition.** Jump from a name to where it is
+  declared. `M-,` pops back.
+- `M-x imenu` — **outline of top-level declarations.** Browse the
+  theorems, definitions, unions, etc. in the current file.
+- `C-c C-g` — **show the proof goal at point** in a popup buffer,
+  along with the givens (named hypotheses) currently in scope.
+- `C-c C-r` — **refine the hole at point.** Replaces a `?` with a
+  template chosen by the goal's shape: `?, ?` for `P and Q`,
+  `assume H: P\n?` for `if P then Q`, `arbitrary x:T\n?` for `all`,
+  `choose ?\n?` for `some`, `reflexive` when both sides of an
   equation reduce to the same term.
-- `C-c C-c` -- case split. Cursor must sit on a `?`. Issues
-  `deduce/splittableVarsAt` to fetch the in-scope variables that
-  case-split can target, prompts via `completing-read` (TAB
-  completion) for which one to split on, then issues
-  `deduce/caseSplitAt` with the chosen variable. Replaces the `?`
-  with a `switch x { case Cons1(...) { ? } ... }` skeleton (for
-  term variables of `Union` type) or `cases H\n  case h1: P { ? }
-  ...` (for proof variables of `P or Q` shape). The `?` under the
-  cursor is unambiguously the replacement target -- no surprise
-  inserts at the wrong hole.
-- `C-c C-i` -- induction skeleton. Cursor on a `?` whose goal is
+- `C-c C-c` — **case split.** Cursor must sit on a `?`. Emacs prompts
+  (with TAB completion) for which in-scope variable to split on,
+  then replaces the `?` with a `switch` skeleton (one branch per
+  constructor) for term variables, or a `cases H` skeleton for proof
+  variables of `P or Q` shape. The `?` under the cursor is the
+  unambiguous replacement target — no surprise inserts at the wrong
+  hole.
+- `C-c C-i` — **induction skeleton.** Cursor on a `?` whose goal is
   `all x:T. P(x)` (T a `Union` with at least two constructors).
-  Issues `textDocument/codeAction` and applies the action titled
-  `Induction` directly (no picker). Replaces the `?` with
-  `induction T\n  case Cons1(...) { ? }\n  case Cons2(...) assume
-  IH<N>: ... { ? }\n...` -- one case per constructor in declaration
-  order; recursive parameters get `IH<N>` bindings whose formula is
-  the body with the inducted variable substituted.
-- `C-c C-e` -- eliminate / use-fact. Cursor on a `?`. Issues
-  `deduce/eliminableVarsAt` to fetch the in-scope hypothesis labels
-  whose formula has a supported template, prompts via
-  `completing-read` (TAB completion) for which label to use, then
-  issues `deduce/eliminateAt` with the chosen label. The template
-  depends on the hypothesis's shape: destructure for `and`, `cases`
-  for `or`, `apply ... to ?` for `if then`, `H[?]` for `all`,
-  `obtain ... from H` for `some`, `replace H` for equality, the
-  bare label for `false`. Dual to `C-c C-r` (refine): refine picks
-  by goal shape, eliminate picks by named-hypothesis shape.
-- `C-c C-f` -- fill hole with a given. Cursor on a `?`. Issues
-  `deduce/matchingGivensAt` to fetch the in-scope hypothesis labels
-  whose formula equals the goal, then issues
-  `deduce/fillFromGivenAt` with a chosen label and replaces the `?`
-  with `conclude <goal> by <label>`. With a single match, applies
-  it directly (no prompt). With multiple matches, prompts via
-  `completing-read` (TAB completion). A narrower sibling of `C-c
-  C-e`: eliminate picks by hypothesis shape; fill-from-given picks
-  by formula equality with the goal.
+  Replaces the `?` with `induction T` followed by one case per
+  constructor in declaration order; recursive parameters get `IH<N>`
+  bindings whose formula is the body with the inducted variable
+  substituted.
+- `C-c C-e` — **eliminate / use-fact.** Cursor on a `?`. Emacs prompts
+  for a hypothesis label (TAB completion against the in-scope
+  hypotheses whose shape matches a supported template). The
+  template depends on the hypothesis's shape: destructure for `and`,
+  `cases` for `or`, `apply ... to ?` for `if then`, `H[?]` for
+  `all`, `obtain ... from H` for `some`, `replace H` for equality,
+  the bare label for `false`. Dual to `C-c C-r` (refine): refine
+  picks by goal shape, eliminate picks by named-hypothesis shape.
+- `C-c C-f` — **fill hole with a matching given.** Cursor on a `?`.
+  If exactly one in-scope given's formula equals the goal, the `?`
+  is replaced directly with `conclude <goal> by <label>`. With
+  multiple matches, Emacs prompts (TAB completion) for which one to
+  use. A narrower sibling of `C-c C-e`: eliminate picks by
+  hypothesis shape; fill-from-given picks by formula equality with
+  the goal.
 
 `deduce-fill-hole` (additional, requires an LLM API key — Anthropic,
 OpenAI, or IU REALLMs depending on backend choice):
 
-- `C-c C-a` -- ask an LLM to fill the `?` at point ("ask AI"). Issues
-  `deduce/holeContextAt` to capture the goal, givens, lemmas in
-  scope, and a stable fingerprint, then spawns the
-  `tools/claude_fill_hole` sidecar asynchronously. Emacs stays
-  interactive while the model iterates (up to
-  `deduce-fill-hole-max-attempts` `validate_proof` calls; first valid
-  proof wins). On completion, if the markers around the hole are
-  still live and the fingerprint hasn't changed, the validated
-  proof is spliced in; otherwise the command errors and leaves the
-  buffer untouched. One fill-hole per buffer at a time; multiple
-  buffers can fill in parallel.
+- `C-c C-a` — **ask an LLM to fill the `?` at point** ("ask AI"). The
+  command captures the goal, in-scope givens, and lemmas, then runs
+  the chosen model asynchronously. Emacs stays interactive while
+  the model iterates (up to `deduce-fill-hole-max-attempts`
+  validation attempts; first valid proof wins). On completion, if
+  the buffer around the hole hasn't drifted in the meantime, the
+  validated proof is spliced in; otherwise the command errors and
+  leaves the buffer untouched. One fill-hole per buffer at a time;
+  multiple buffers can fill in parallel.
 
 ## Keybindings
 
-| Binding   | Command                          | Provided by    | Notes                                     |
-| --------- | -------------------------------- | -------------- | ----------------------------------------- |
-| `TAB`     | `deduce-mode-indent-line`        | `deduce-mode`  | Indent the current line                   |
-| `M-.`     | `xref-find-definitions`          | eglot          | Jump to symbol's definition               |
-| `M-,`     | `xref-go-back`                   | eglot          | Pop the xref stack                        |
-| `M-x imenu` | `imenu`                        | eglot          | Outline of top-level declarations         |
-| `C-c C-g` | `deduce-show-goal-at-point`      | `deduce-lsp`   | Goal + givens at cursor                   |
-| `C-c C-r` | `deduce-lsp-refine-hole`         | `deduce-lsp`   | Apply LSP-suggested template at hole      |
-| `C-c C-c` | `deduce-lsp-case-split`          | `deduce-lsp`   | Prompt for variable, replace `?` with case skeleton |
-| `C-c C-i` | `deduce-lsp-induction`           | `deduce-lsp`   | Replace `?` with `induction T` skeleton at a forall goal |
-| `C-c C-e` | `deduce-lsp-eliminate`           | `deduce-lsp`   | Prompt for hypothesis, replace `?` with use-fact tactic |
-| `C-c C-f` | `deduce-lsp-fill-from-given`     | `deduce-lsp`   | Replace `?` with `conclude ... by H` for a given matching the goal |
-| `C-c C-a` | `deduce-fill-hole`               | `deduce-fill-hole` | Ask an LLM to fill the `?` at point. Async, non-blocking. |
+| Binding   | Notes                                                              | Command                          | Provided by    |
+| --------- | ------------------------------------------------------------------ | -------------------------------- | -------------- |
+| `TAB`     | Indent the current line                                            | `deduce-mode-indent-line`        | `deduce-mode`  |
+| `M-.`     | Jump to symbol's definition                                        | `xref-find-definitions`          | eglot          |
+| `M-,`     | Pop the xref stack                                                 | `xref-go-back`                   | eglot          |
+| `M-x imenu` | Outline of top-level declarations                                | `imenu`                          | eglot          |
+| `C-c C-g` | Goal + givens at cursor                                            | `deduce-show-goal-at-point`      | `deduce-lsp`   |
+| `C-c C-r` | Apply the suggested template at hole                               | `deduce-lsp-refine-hole`         | `deduce-lsp`   |
+| `C-c C-c` | Prompt for variable, replace `?` with case skeleton                | `deduce-lsp-case-split`          | `deduce-lsp`   |
+| `C-c C-i` | Replace `?` with `induction T` skeleton at a forall goal           | `deduce-lsp-induction`           | `deduce-lsp`   |
+| `C-c C-e` | Prompt for hypothesis, replace `?` with use-fact tactic            | `deduce-lsp-eliminate`           | `deduce-lsp`   |
+| `C-c C-f` | Replace `?` with `conclude ... by H` for a given matching the goal | `deduce-lsp-fill-from-given`     | `deduce-lsp`   |
+| `C-c C-a` | Ask an LLM to fill the `?` at point. Async, non-blocking.          | `deduce-fill-hole`               | `deduce-fill-hole` |
 
 ## Customization
 
@@ -182,7 +224,7 @@ RET deduce RET` or `M-x customize-group RET deduce-lsp RET`.
 | Variable                       | Default     | Effect                                                                 |
 | ------------------------------ | ----------- | ---------------------------------------------------------------------- |
 | `deduce-lsp-auto-start`        | `t`         | If non-nil, `eglot-ensure` runs on `deduce-mode` entry                 |
-| `deduce-lsp-python-program`    | `"python3"` | Python interpreter used to launch `lsp.lsp_server`                     |
+| `deduce-lsp-python-program`    | `"python3"` | Python interpreter used to launch the language server                  |
 | `deduce-lsp-deduce-root`       | `nil`       | Path to a Deduce checkout; sets `PYTHONPATH` for the spawned server    |
 | `deduce-lsp-prelude-disabled`  | `nil`       | If non-nil, sets `DEDUCE_NO_STDLIB=1` so the server skips the prelude  |
 
@@ -199,9 +241,9 @@ in your `init.el` returning whatever list eglot should spawn.
 | `deduce-fill-hole-api-key-env`        | `nil` (backend default)       | Env var name; backend default is `"ANTHROPIC_API_KEY"` or `"OPENAI_API_KEY"`. IU REALLMs users override to `"REALLMS_API_KEY"`. |
 | `deduce-fill-hole-python-program`     | `"python3"`                   | Python interpreter used to launch the sidecar               |
 | `deduce-fill-hole-deduce-root`        | `nil`                         | Path to a Deduce checkout; falls back to `deduce-lsp-deduce-root`, then `project-root`, then cwd |
-| `deduce-fill-hole-max-attempts`       | `5`                           | Maximum number of `validate_proof` calls per invocation     |
+| `deduce-fill-hole-max-attempts`       | `5`                           | Maximum number of validation attempts per invocation        |
 | `deduce-fill-hole-prelude-disabled`   | `nil`                         | If non-nil, sidecar invokes `deduce.py --no-stdlib`         |
-| `deduce-fill-hole-timeout`            | `60`                          | Per-validate-proof timeout passed to the sidecar (seconds)  |
+| `deduce-fill-hole-timeout`            | `60`                          | Per-attempt timeout passed to the sidecar (seconds)         |
 
 **IU REALLMs preset** — drop this in your `init.el` to point at REALLMs:
 
@@ -215,7 +257,7 @@ in your `init.el` returning whatever list eglot should spawn.
 
 ## Troubleshooting
 
-### "Server died" / `AttributeError` immediately after eglot starts
+### "Server died" immediately after the language server starts
 
 Check the Python side first:
 
@@ -226,25 +268,25 @@ python3 -m lsp.lsp_server </dev/null
 The server should exit cleanly (it reads JSON-RPC from stdin; with
 no input it terminates). If you get an `ImportError`, install the
 LSP requirements: `pip install -r requirements-lsp.txt` from the
-deduce repo root. Verify `pygls>=2.1.0` is what got installed --
+deduce repo root. Verify `pygls>=2.1.0` is what got installed —
 2.0 had a different API and won't work.
 
 ### Server starts but `M-.` / `C-c C-g` always returns nothing
 
 Most likely the server is launched outside the deduce repo and
-can't import `lsp.lsp_server`. The fix is either:
+can't find the deduce sources. The fix is either:
 
 1. Set `deduce-lsp-deduce-root` to your deduce checkout, or
 2. Make sure `default-directory` is the repo root when you open
    the `.pf` file.
 
-You can confirm by inspecting `M-x eglot-events-buffer` -- the
+You can confirm by inspecting `M-x eglot-events-buffer` — the
 `initialize` reply should show the server's `serverInfo`. If the
 buffer says "process exited abnormally," see the previous step.
 
 ### First `C-c C-g` is slow
 
-Yes -- the first request bootstraps the prelude (~1s with the
+Yes — the first request bootstraps the prelude (~1s with the
 `.thm` cache, ~13s without). Subsequent requests are warm. You can
 disable the prelude entirely with `deduce-lsp-prelude-disabled = t`
 if you don't need the standard library.
@@ -254,7 +296,7 @@ if you don't need the standard library.
 `deduce-mode-indent-line` uses a balanced-bracket / `proof`/`end`
 matcher; it doesn't currently handle multi-line type signatures or
 `case` placement perfectly. If `TAB` insists on a column you don't
-want, just type the spaces yourself -- the indenter only fires when
+want, just type the spaces yourself — the indenter only fires when
 you ask. SMIE-grade alignment is a future enhancement.
 
 ## Manual smoke test
@@ -269,9 +311,9 @@ After installing, verify the major mode:
 
 Then verify the LSP integration:
 
-4. Wait for the eglot bootstrap to complete (watch the mode line
+4. Wait for the language server to bootstrap (watch the mode line
    for `[eglot:Deduce]`).
-5. Place point on `equal` (any reference) and press `M-.` -- it
+5. Place point on `equal` (any reference) and press `M-.` — it
    should jump to the definition.
 6. Press `M-x imenu RET` and confirm the top-level theorem names
    show up.
@@ -363,44 +405,22 @@ Then verify the LSP integration:
 
     Place point on the `?` and press `C-c C-f`. There is exactly
     one matching given (`H: P` matches the goal `P`), so the `?` is
-    replaced directly -- no prompt -- with `conclude P by H`. With
+    replaced directly — no prompt — with `conclude P by H`. With
     two matching givens in scope (e.g. `assume H1: P` and `assume
     H2: P`), Emacs prompts `Fill from:` with TAB completion against
     the matching labels.
 
-If you have `deduce-fill-hole` loaded and `ANTHROPIC_API_KEY`
-exported, also verify the Claude path:
+If you have `deduce-fill-hole` loaded and an API key exported, also
+verify the LLM path:
 
-12. Smoke-test the sidecar standalone first (no API key needed):
-
-    ```sh
-    pip install -r requirements-fill-hole.txt
-    cat > /tmp/req.json <<'EOF'
-    {"file": "/tmp/smoke.pf",
-     "holeRange": {"start": {"line": 3, "character": 2},
-                   "end":   {"line": 3, "character": 3}},
-     "goal": "P = P", "givens": [], "lemmasInScope": [],
-     "fingerprint": "fp",
-     "content": "theorem t: all P:bool. P = P\nproof\n  arbitrary P:bool\n  ?\nend\n"}
-    EOF
-    python3 -m tools.claude_fill_hole --dry-run --no-stdlib \
-      --deduce-root . < /tmp/req.json
-    ```
-
-    The dry-run reports `ok: false` with a structured `incomplete
-    proof` error (the stub it sends is `?`, which never validates).
-    What you're checking is that the splice + subprocess pipeline
-    works -- if you see the goal text in `errorTail`, the sidecar
-    is wired correctly.
-
-13. In a scratch `.pf` buffer with the same `theorem t: all P:bool.
-    P = P` shape, place point on the `?` and press `C-c C-a`
-    ("ask AI"). Emacs reports `deduce-fill-hole: asking...`. Within a
-    few seconds (depending on `effort` and how many attempts it
-    takes), the `?` is replaced with the validated proof and you
-    get a `filled in N attempts` message. If the API key is
-    missing, the sidecar surfaces a structured error and the buffer
-    is untouched.
+13. In a scratch `.pf` buffer with a `theorem t: all P:bool. P = P`
+    (or similar simple) shape, place point on the `?` and press
+    `C-c C-a` ("ask AI"). Emacs reports `deduce-fill-hole:
+    asking...`. Within a few seconds (depending on the model and how
+    many attempts it takes), the `?` is replaced with the validated
+    proof and you get a `filled in N attempts` message. If the API
+    key is missing, the buffer is left untouched and an error
+    message is reported.
 
 ## Development
 
@@ -415,7 +435,7 @@ emacs --batch -L editor/emacs -L editor/emacs/test \
       -l deduce-fill-hole-test -f ert-run-tests-batch-and-exit
 ```
 
-The end-to-end loop (subprocess server + real LSP traffic) is
+The end-to-end loop (subprocess server + real protocol traffic) is
 impractical to drive from a batch process; the tests pin the
 in-Emacs pieces (eglot registration, command construction,
 keybindings, request shape) but the actual server interaction
@@ -436,3 +456,8 @@ the byte-compiled artifacts entirely:
 ```sh
 rm editor/emacs/*.elc editor/emacs/test/*.elc
 ```
+
+For the protocol-level wiring between the Emacs client and the
+Python LSP server (request method names, server module path, what
+to keep in sync when adding a new command), see
+[`docs/knowledge-base/emacs-lsp-protocol.md`](../../docs/knowledge-base/emacs-lsp-protocol.md).


### PR DESCRIPTION
## Summary

Rewrite `editor/emacs/README.md` to describe what users get, not how the layers are wired internally. Move the protocol-level details to a new implementor doc.

## What changed

- **Intro** now lists the three layers (`deduce-mode`, `deduce-lsp`, `deduce-fill-hole`) by capability — jump to definition, structured editing, hole-filling commands, validated LLM proofs — instead of pointing at `.el` files and `lsp/lsp_server.py`.
- **Prerequisites** is split into three subsections (*Always*, *For LSP capabilities*, *For LLM-powered hole filling*). The API key bullet now tells the reader what to add to their shell init script (`~/.bashrc` / `~/.zshrc` / fish), how to verify with `echo`, and points macOS Dock users at `exec-path-from-shell`.
- **Quick start** opens with a sentence steering undecided users to `use-package`.
- **Features → Diagnostics** explains flymake-style underlines for readers who haven't met flymake (Emacs's built-in inline-diagnostics framework, colored squiggles, hover for the message, `M-x flymake-show-buffer-diagnostics` for a list view).
- All `(textDocument/definition)`, `deduce/goalAt`, `deduce/splittableVarsAt`, `Issues … codeAction` etc. removed from user-facing text and replaced with capability descriptions.
- **Keybindings** table column order is now `Binding | Notes | Command | Provided by`.

## New file

`docs/knowledge-base/emacs-lsp-protocol.md` — implementor doc capturing the protocol-level wiring: client/server topology, the standard LSP requests each Emacs entry point uses, the custom `deduce/*` requests and their two-step (`*VarsAt` + `*At`) pattern, the LLM sidecar's structural difference from the LSP commands, and a "what to keep in sync when changing the protocol" checklist. The README's Development section links to it.

## Why

Walking up to the README cold, a user wants to know what they can do with the mode and how to install it — not which RPC method gets sent on `M-.`. The protocol details still need to live somewhere for whoever's editing `deduce-lsp.el` or `lsp/lsp_server.py`, hence the separate `knowledge-base/` doc.

## Test plan

- [ ] Render `editor/emacs/README.md` and confirm tables/lists look right.
- [ ] Confirm the relative link from the README footer to `docs/knowledge-base/emacs-lsp-protocol.md` resolves.
- [ ] Confirm the relative link from `emacs-lsp-protocol.md` back to the README resolves, and the link to `tools/claude_fill_hole/README.md` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)