### PR TITLE
Fix assert with /= on non-reducible values (#202)

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -4711,6 +4711,20 @@ def check_proofs(stmt, env: Env):
           else:
               error(loc, 'assertion failed:\n' +
                     '\t' + str(L) + ' ≠ ' + str(R) + '\n')
+        case IfThen(loc2, tyof2,
+                    Call(_, _, rator, [lhs, rhs]),
+                    Bool(_, _, False)) if isinstance(rator, VarRef) and rator.get_name() == '=':
+          set_reduce_all(True)
+          set_eval_all(True)
+          L = lhs.reduce(env)
+          R = rhs.reduce(env)
+          set_eval_all(False)
+          set_reduce_all(False)
+          if L != R:
+            pass
+          else:
+              error(loc, 'assertion failed:\n' +
+                    '\t' + str(L) + ' = ' + str(R) + '\n')
         case _:
           set_reduce_all(True)
           set_eval_all(True)

--- a/test/should-error/assert_neq_fail.pf
+++ b/test/should-error/assert_neq_fail.pf
@@ -1,0 +1,8 @@
+union Blah {
+  zero
+  suc(Blah)
+}
+
+define id_blah : fn Blah -> Blah = λx{x}
+
+assert id_blah /= id_blah

--- a/test/should-error/assert_neq_fail.pf.err
+++ b/test/should-error/assert_neq_fail.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/assert_neq_fail.pf:8.1-8.26: assertion failed:
+	fun x { x } = fun x { x }
+

--- a/test/should-validate/not_equal.pf
+++ b/test/should-validate/not_equal.pf
@@ -1,1 +1,13 @@
 assert true ≠ false
+assert true /= false
+
+union Blah {
+  zero
+  suc(Blah)
+}
+
+define id_blah : fn Blah -> Blah = λx{x}
+define other_blah : fn Blah -> Blah = fun x { zero }
+
+assert id_blah ≠ other_blah
+assert id_blah /= other_blah


### PR DESCRIPTION
## Summary
- `assert a /= b` is parsed to `IfThen(a = b, false)`. When neither side reduced to a literal (e.g. comparing two `fun` values), the IfThen result was not a `Bool`, and assert reported `assertion expected Boolean result, not not (...)`.
- Mirror the existing `=` fast path in `Assert` for the `IfThen(Call(=, [lhs, rhs]), Bool(False))` shape: reduce both sides and compare directly.
- Closes #202.

## Test plan
- [x] Added passing cases (function values, bools) to `test/should-validate/not_equal.pf`.
- [x] Added a should-error fixture `test/should-error/assert_neq_fail.pf` for `id_blah /= id_blah`.
- [x] `python3.13 test-deduce.py --passable` passes (recursive-descent + LALR).
- [x] `python3.13 test-deduce.py --errors` passes (recursive-descent + LALR).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)