### PR TITLE
Hole-fill: isolate sidecar stdout to prevent JSON corruption (#383)

### DIFF
--- a/test/claude_fill_hole/test_main.py
+++ b/test/claude_fill_hole/test_main.py
@@ -180,6 +180,59 @@ def test_default_deduce_cmd_uses_sys_executable(monkeypatch, tmp_path):
     assert "No module named 'lark'" not in error_text
 
 
+def test_stray_print_does_not_corrupt_response(monkeypatch, tmp_path):
+    """Regression for #383: a stray ``print()`` from anywhere in the
+    sidecar's working code (deduce checker, third-party SDK, ...) must
+    not pollute the JSON response on stdout.
+
+    Before the fix, a ``/``-leading line printed to stdout produced
+    ``JSON readtable error: 47`` in emacs -- the editor saw the
+    pollution before the response and tried to parse the leading
+    ``/`` as the start of a JSON value.
+
+    Here we simulate the failure by patching ``_resolve_content`` to
+    print to stdout while still returning a valid string; the sidecar
+    must still emit a single, parseable JSON object on its
+    response stream."""
+    source = "theorem t: bool = true\n"
+    file_path = tmp_path / "proof.pf"
+    file_path.write_text(source)
+    request = _build_request(str(file_path), "?")  # placeholder; we use --dry-run
+
+    request_json = json.dumps(
+        {
+            "file": str(file_path),
+            "holeRange": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 1},
+            },
+            "goal": "x",
+            "givens": [],
+            "lemmasInScope": [],
+            "fingerprint": "fp",
+            "content": source,
+        }
+    )
+
+    real_resolve = sidecar_main._resolve_content
+
+    def leaky_resolve(req):
+        # The kind of accidental stdout write that triggered #383 --
+        # a path-shaped string ending up on fd 1.
+        print("/Users/someone/leaked/stdout.log: stray write")
+        return real_resolve(req)
+
+    monkeypatch.setattr(sidecar_main, "_resolve_content", leaky_resolve)
+    rc, stdout, stderr = _run_main(["--dry-run"], request_json, monkeypatch)
+
+    # The response on stdout must be a single parseable JSON object,
+    # regardless of what leaky_resolve scribbled.
+    decoded = json.loads(stdout.strip())
+    assert decoded["fingerprint"] == "fp"
+    # The leaked line must have ended up on stderr, where it's harmless.
+    assert "stray write" in stderr
+
+
 def test_hole_range_out_of_bounds_returns_failure(monkeypatch, tmp_path):
     """A holeRange past EOF is rejected before hitting the validator."""
     source = "theorem t: bool = true\n"

--- a/tools/claude_fill_hole/__main__.py
+++ b/tools/claude_fill_hole/__main__.py
@@ -115,63 +115,92 @@ _DEFAULT_API_KEY_ENVS = {
 def main(argv: Optional[list[str]] = None) -> int:
     args = _parse_args(argv)
 
+    # Claim stdout for the JSON response and redirect ``sys.stdout`` to
+    # ``sys.stderr`` so any stray ``print()`` from the in-process deduce
+    # checker pipeline (or a third-party SDK that logs to stdout) lands
+    # in the progress buffer instead of corrupting the response.  Without
+    # this, a single leaked path-shaped line is enough to make emacs
+    # fail with ``JSON readtable error: 47`` (47 == ``/``).  See #383.
+    response_stream = sys.stdout
+    sys.stdout = sys.stderr
+    try:
+        return _main_with_response_stream(args, response_stream)
+    except BaseException as exc:
+        # Last-ditch: an uncaught exception (deduce internal_error,
+        # SDK fault, OOM, ...) still produces a parseable response so
+        # the editor doesn't fall back to the generic "could not parse"
+        # path with no diagnostic.  Re-raise SystemExit so test runners
+        # and ``sys.exit`` calls behave normally.
+        _emit_response(
+            response_stream,
+            HoleFillResponse(
+                ok=False,
+                fingerprint="",
+                attempts=0,
+                elapsed_ms=0,
+                model=getattr(args, "model", "") or "",
+                proof=None,
+                error=f"sidecar crashed: {type(exc).__name__}: {exc}",
+                validations=(),
+            ),
+        )
+        if isinstance(exc, SystemExit):
+            raise
+        return 1
+    finally:
+        sys.stdout = response_stream
+
+
+def _main_with_response_stream(args: argparse.Namespace, response_stream) -> int:
     raw = sys.stdin.read()
     if not raw.strip():
         _emit_progress("error", message="empty stdin")
-        sys.stdout.write(
-            response_to_json(
-                _failure_response(
-                    fingerprint="",
-                    error="empty stdin -- expected a JSON request",
-                    model="",
-                )
-            )
+        _emit_response(
+            response_stream,
+            _failure_response(
+                fingerprint="",
+                error="empty stdin -- expected a JSON request",
+                model="",
+            ),
         )
-        sys.stdout.write("\n")
         return 2
 
     try:
         request = request_from_json(raw)
     except (ValueError, KeyError) as e:
         _emit_progress("error", message=f"bad request: {e}")
-        sys.stdout.write(
-            response_to_json(
-                _failure_response(
-                    fingerprint="",
-                    error=f"could not parse stdin as a HoleFillRequest: {e}",
-                    model="",
-                )
-            )
+        _emit_response(
+            response_stream,
+            _failure_response(
+                fingerprint="",
+                error=f"could not parse stdin as a HoleFillRequest: {e}",
+                model="",
+            ),
         )
-        sys.stdout.write("\n")
         return 2
 
     content = _resolve_content(request)
     if content is None:
-        sys.stdout.write(
-            response_to_json(
-                _failure_response(
-                    fingerprint=request.fingerprint,
-                    error=f"could not read content for {request.file}",
-                    model="",
-                )
-            )
+        _emit_response(
+            response_stream,
+            _failure_response(
+                fingerprint=request.fingerprint,
+                error=f"could not read content for {request.file}",
+                model="",
+            ),
         )
-        sys.stdout.write("\n")
         return 2
 
     hole_start_offset, hole_end_offset = _hole_offsets(content, request)
     if hole_start_offset is None or hole_end_offset is None:
-        sys.stdout.write(
-            response_to_json(
-                _failure_response(
-                    fingerprint=request.fingerprint,
-                    error="hole range out of bounds",
-                    model="",
-                )
-            )
+        _emit_response(
+            response_stream,
+            _failure_response(
+                fingerprint=request.fingerprint,
+                error="hole range out of bounds",
+                model="",
+            ),
         )
-        sys.stdout.write("\n")
         return 2
 
     # Default `--deduce-cmd` to `<this Python> deduce.py` so the
@@ -217,35 +246,31 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
 
     if args.dry_run:
-        return _run_dry_run(request, validator, args)
+        return _run_dry_run(request, validator, args, response_stream)
 
     api_key = os.environ.get(args.api_key_env)
     if not api_key:
-        sys.stdout.write(
-            response_to_json(
-                _failure_response(
-                    fingerprint=request.fingerprint,
-                    error=f"{args.api_key_env} not set",
-                    model=args.model,
-                )
-            )
+        _emit_response(
+            response_stream,
+            _failure_response(
+                fingerprint=request.fingerprint,
+                error=f"{args.api_key_env} not set",
+                model=args.model,
+            ),
         )
-        sys.stdout.write("\n")
         return 2
 
     try:
         backend = _build_backend(args, api_key)
     except _BackendBuildError as e:
-        sys.stdout.write(
-            response_to_json(
-                _failure_response(
-                    fingerprint=request.fingerprint,
-                    error=str(e),
-                    model=args.model,
-                )
-            )
+        _emit_response(
+            response_stream,
+            _failure_response(
+                fingerprint=request.fingerprint,
+                error=str(e),
+                model=args.model,
+            ),
         )
-        sys.stdout.write("\n")
         return 2
 
     system_text = build_system_prompt(max_attempts=args.max_attempts)
@@ -277,8 +302,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
 
     response = _agent_result_to_response(request, result, backend.model)
-    sys.stdout.write(response_to_json(response))
-    sys.stdout.write("\n")
+    _emit_response(response_stream, response)
     return 0 if result.ok else 1
 
 
@@ -504,7 +528,10 @@ def _failure_response(
 
 
 def _run_dry_run(
-    request: HoleFillRequest, validator: SubprocessValidator, args: argparse.Namespace
+    request: HoleFillRequest,
+    validator: SubprocessValidator,
+    args: argparse.Namespace,
+    response_stream,
 ) -> int:
     """Validate a known-trivial stub proof and report the outcome.
 
@@ -540,9 +567,20 @@ def _run_dry_run(
             ),
         ),
     )
-    sys.stdout.write(response_to_json(response))
-    sys.stdout.write("\n")
+    _emit_response(response_stream, response)
     return 0 if outcome.ok else 1
+
+
+def _emit_response(stream, response: HoleFillResponse) -> None:
+    """Write the JSON response and a trailing newline to ``stream``.
+
+    All response writes go through this helper so the response channel
+    stays a single, well-defined object -- ``main()`` captures the
+    real stdout into ``stream`` once at startup and points
+    ``sys.stdout`` at stderr; nothing else writes to ``stream``."""
+    stream.write(response_to_json(response))
+    stream.write("\n")
+    stream.flush()
 
 
 def _emit_progress(event: str, **fields):


### PR DESCRIPTION
## Summary

Fixes #383 (`deduce-fill-hole error: JSON readtable error: 47`).

The sidecar wrote its JSON response to stdout but had no protection against accidental writes from the in-process deduce checker (called via `lsp.query.hole_context_at` for the `query_goal` tool) or any other library it imports. A single stray path-shaped `print` (starting with `/`) is enough to make Emacs's JSON parser blow up with `JSON readtable error: 47` (47 == `/`) before the user sees any model attempts.

## What changed

**`tools/claude_fill_hole/__main__.py`** — defense-in-depth at the sidecar entry:

- At the top of `main()`, capture `sys.stdout` as a dedicated response channel and redirect `sys.stdout` to `sys.stderr` so any stray output goes to the progress buffer instead of corrupting the response.
- Funnel every response write through a single `_emit_response(stream, response)` helper.
- Wrap the body in `try/except` so even an uncaught exception still produces a parseable JSON response (with a `sidecar crashed: ...` error) instead of dropping into Emacs's generic "could not parse" path with no diagnostic.
- Restore `sys.stdout` in `finally` for clean test isolation.

**`test/claude_fill_hole/test_main.py`** — `test_stray_print_does_not_corrupt_response` patches `_resolve_content` to leak a `/`-leading line to stdout and asserts (a) the response stream still parses as JSON and (b) the leaked line ended up on stderr.

## Notes for the reviewer

- I did **not** pin down the exact source of the original leak. The most plausible candidates I never confirmed: an unguarded `print()` in `proof_checker.py` that only fires on certain proof shapes the model exercised via `query_goal`, or the OpenAI/httpx stack logging under specific REALLMs response conditions. I tested `hole_context_at` against the user's exact file with the full prelude and captured zero stdout output, so the obvious in-process suspect didn't reproduce.
- This change makes the sidecar robust to **any** future leak rather than fixing one specific bug, which I think is the right move regardless. A follow-up to identify and silence the actual print is still useful.

## Test plan

- [x] `python3.13 -m pytest test/claude_fill_hole/` — 62 passed (61 existing + 1 new regression test)
- [x] Manual `--dry-run` invocation produces clean JSON on stdout, progress events on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)