### PR TITLE
Sync keywords.py token numbering with Deduce.lark

### DIFF
--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -132,24 +132,25 @@ known_tokens = {
     '__ANON_0': 'operator',  # <=>
     '__ANON_1': 'operator',  # ⇔
     '__ANON_10': 'operator', # ∈
-    '__ANON_11': 'operator', # ∪
-    '__ANON_12': 'operator', # ∩
-    '__ANON_13': 'operator', # ⨄
-    '__ANON_14': 'operator', # \\.\\+\\.
-    '__ANON_15': 'operator', # \\+\\+
-    '__ANON_16': 'operator', # ⊝
-    '__ANON_17': 'operator', # ∘
-    '__ANON_18': 'operator', # \\.o\\.
-    '__ANON_19': 'keyword',  # operator
+    '__ANON_11': 'operator', # ≲
+    '__ANON_12': 'operator', # ≈
+    '__ANON_13': 'operator', # ∪
+    '__ANON_14': 'operator', # ∩
+    '__ANON_15': 'operator', # ⨄
+    '__ANON_16': 'operator', # \\.\\+\\.
+    '__ANON_17': 'operator', # \\+\\+
+    '__ANON_18': 'operator', # ∸
+    '__ANON_19': 'operator', # \\.\\-\\.
     '__ANON_2': 'operator',  # ≠
-    '__ANON_20': 'prim',     # ∅
-    '__ANON_21': 'prim',     # \\.0\\.
-    '__ANON_22': 'operator', # ─
-    '__ANON_23': 'operator', # \\.\\.\\.
-    '__ANON_24': 'prim',     # 0
-    '__ANON_25': 'prim',     # \.-
-    '__ANON_26': 'operator', # ≲
-    '__ANON_27': 'operator', # ≈
+    '__ANON_20': 'operator', # ⊝
+    '__ANON_21': 'operator', # ∘
+    '__ANON_22': 'operator', # \\.o\\.
+    '__ANON_23': 'keyword',  # operator
+    '__ANON_24': 'prim',     # ∅
+    '__ANON_25': 'prim',     # \\.0\\.
+    '__ANON_26': 'operator', # ─
+    '__ANON_27': 'operator', # \\.\\.\\.
+    '__ANON_28': 'prim',     # 0
     '__ANON_3': 'operator',  # /=
     '__ANON_4': 'operator',  # ≤
     '__ANON_5': 'operator',  # <=


### PR DESCRIPTION
## Summary

The **Deploy to GitHub Pages** workflow has been failing on `main` since PR #384. The `Check known tokens` step compares Lark's auto-numbered `__ANON_N` terminals against `gh_pages/scripts/keywords.py` and was off by one (and re-ordered).

Two grammar shifts caused the drift:
- `≲` and `≈` moved earlier in the grammar (now `__ANON_11`/`__ANON_12`)
- `∸` (`__ANON_18`) and `.-.` (`__ANON_19`) were added by [#384](https://github.com/jsiek/deduce/pull/384)
- Everything that was `__ANON_18..24` shifted up to `__ANON_22..28`
- The old `__ANON_25` (`\.-`) was replaced by `__ANON_19` (`\.\-\.`)

This PR updates the comments and category assignments in `keywords.py` so they match what Lark currently produces. Verified locally with `python3.13 ./gh_pages/scripts/keywords.py`.

## Test plan

- [x] `python ./gh_pages/scripts/keywords.py` exits 0 locally
- [ ] `Deploy to GitHub Pages` workflow succeeds on this branch / after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)