### PR TITLE
Run keywords.py token check in regular regression tests

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -22,6 +22,8 @@ jobs:
             python -m pip install --upgrade pip
             if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
             if [ -f ./gh_pages/requirements.txt ]; then pip install -r ./gh_pages/requirements.txt; fi
+      - name: Check known tokens
+        run: python ./gh_pages/scripts/keywords.py
       - name: execute py script # run file
         run: |
           python test-deduce.py --site

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ TEST_PASS_DIR = ./test/should-validate
 TEST_ERROR_DIR = ./test/should-error
 TEST_IMPORT_DIR = ./test/test-imports
 
-default: tests tests-lib
+default: tests-tokens tests tests-lib
+
+tests-tokens:
+	$(PYTHON) ./gh_pages/scripts/keywords.py
 
 tests-should-validate:
 	$(PYTHON) ./deduce.py --recursive-descent $(TEST_PASS_DIR) --dir $(LIB_DIR) --dir $(TEST_IMPORT_DIR)


### PR DESCRIPTION
## Summary

The known-tokens check (`gh_pages/scripts/keywords.py`) compares Lark's auto-numbered `__ANON_N` terminals against the table in `keywords.py`. Until now it only ran in the **Deploy to GitHub Pages** workflow, which fires *on push to `main`* — i.e. after merge. So when [#384](https://github.com/jsiek/deduce/pull/384) shifted the anonymous-token numbering, nothing flagged it at PR time, and the post-merge deploy failed (fixed in [#394](https://github.com/jsiek/deduce/pull/394)).

This PR runs the same check earlier:

- `.github/workflows/test_deduce.yml`: add a `Check known tokens` step ahead of the `test-deduce.py` runs, so PR builds catch token drift before merge.
- `Makefile`: add a `tests-tokens` target and pull it into the default goal, so `make` catches it locally too.

## Test plan

- [x] `make tests-tokens` exits 0 locally
- [ ] CI's new `Check known tokens` step passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)