### PR TITLE
fill-from-given: always pick first match (#385)

### DIFF
--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -341,12 +341,10 @@ is running in the current buffer."
 ;;
 ;;   `C-c C-f'  deduce-lsp-fill-from-given  (issue #353)
 ;;     Cursor on a `?'.  Issues `deduce/matchingGivensAt' to fetch
-;;     labels of in-scope givens whose formula equals the goal.
-;;     With a single match, applies it directly (no prompt -- the
-;;     prompt would just be a confirmation since there's only one
-;;     answer).  With multiple matches, prompts via `completing-
-;;     read'.  Issues `deduce/fillFromGivenAt' with the chosen
-;;     label and replaces the `?' with `conclude <goal> by <label>'.
+;;     labels of in-scope givens whose formula equals the goal, then
+;;     picks the first match without prompting (issue #385).  Issues
+;;     `deduce/fillFromGivenAt' with that label and replaces the `?'
+;;     with `conclude <goal> by <label>'.
 ;;
 ;; Refine and induction use `textDocument/codeAction' because they
 ;; take no extra user input.  Case-split and eliminate take a
@@ -612,14 +610,10 @@ that `?' is the replacement target.  LABEL names an in-scope local
 proof binding whose formula equals the goal at the hole.
 
 Interactively, queries the server for the matching given labels in
-scope at the hole (custom request `deduce/matchingGivensAt') and:
-
-  - errors with `No matching given at point.' when the candidate
-    list is empty;
-  - applies the single match directly when exactly one given
-    matches (the prompt would just be a confirmation);
-  - prompts via `completing-read' with TAB completion when multiple
-    givens match.
+scope at the hole (custom request `deduce/matchingGivensAt'),
+errors with `No matching given at point.' when the candidate list
+is empty, and otherwise picks the first candidate without prompting
+\(issue #385\).
 
 The chosen label is then sent in a `deduce/fillFromGivenAt'
 request; the returned WorkspaceEdit is applied directly.  Errors
@@ -637,10 +631,7 @@ out without applying when the server returns null."
                               candidates)))
        (unless candidate-list
          (user-error "No matching given at point"))
-       (list (if (= (length candidate-list) 1)
-                 (car candidate-list)
-               (completing-read "Fill from given: " candidate-list
-                                nil t))))))
+       (list (car candidate-list)))))
   (let ((server (eglot-current-server)))
     (unless server
       (user-error

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -916,11 +916,10 @@ interactive entry user-errors with `No elimination available'."
 ;; deduce-lsp-fill-from-given (issue #353, fronted by `C-c C-f')
 ;; ---------------------------------------------------------------------
 ;;
-;; Same wire shape as eliminate (Step 18): cursor on `?', the
-;; interactive form fetches candidate labels via
-;; `deduce/matchingGivensAt'; on a single match it skips
-;; completing-read and applies directly; on multiple it prompts.
-;; The chosen label drives a `deduce/fillFromGivenAt' request.
+;; Cursor on `?', the interactive form fetches candidate labels via
+;; `deduce/matchingGivensAt' and picks the first one without prompting
+;; (issue #385).  The chosen label drives a `deduce/fillFromGivenAt'
+;; request.
 
 (ert-deftest deduce-lsp/fill-from-given-bound-to-c-c-c-f ()
   "`C-c C-f' in deduce-mode-map runs `deduce-lsp-fill-from-given'."
@@ -1004,8 +1003,8 @@ user-errors instead of silently no-op-ing."
 
 
 (ert-deftest deduce-lsp/fill-from-given-interactive-single-match-autoselects ()
-  "With exactly one matching given, the interactive entry skips
-`completing-read' and uses the single candidate directly."
+  "With exactly one matching given, the interactive entry uses the
+single candidate without prompting via `completing-read'."
   (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf"))
         completing-read-called)
     (unwind-protect
@@ -1032,12 +1031,12 @@ user-errors instead of silently no-op-ing."
       (delete-file tmp))))
 
 
-(ert-deftest deduce-lsp/fill-from-given-interactive-multi-uses-completing-read ()
-  "With multiple matches, the interactive entry hits
-`deduce/matchingGivensAt' and feeds them to `completing-read'."
+(ert-deftest deduce-lsp/fill-from-given-interactive-multi-picks-first ()
+  "With multiple matches, the interactive entry picks the first
+candidate without prompting via `completing-read' (issue #385)."
   (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf"))
-        captured-prompt
-        captured-collection)
+        completing-read-called
+        captured-label)
     (unwind-protect
         (with-temp-buffer
           (insert "x")
@@ -1048,20 +1047,20 @@ user-errors instead of silently no-op-ing."
                     ((symbol-function 'eglot--signal-textDocument/didChange)
                      (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
-                     (lambda (_server method _params)
+                     (lambda (_server method params)
                        (cond
                         ((eq method :deduce/matchingGivensAt) ["H1" "H2"])
-                        ((eq method :deduce/fillFromGivenAt) nil))))
+                        ((eq method :deduce/fillFromGivenAt)
+                         (setq captured-label (plist-get params :label))
+                         nil))))
                     ((symbol-function 'completing-read)
-                     (lambda (prompt collection &rest _rest)
-                       (setq captured-prompt prompt)
-                       (setq captured-collection collection)
-                       "H1")))
+                     (lambda (&rest _args)
+                       (setq completing-read-called t)
+                       "H2")))
             (ignore-errors
               (call-interactively #'deduce-lsp-fill-from-given)))
-          (should (string-match-p "Fill from given:" captured-prompt))
-          (should (member "H1" captured-collection))
-          (should (member "H2" captured-collection)))
+          (should-not completing-read-called)
+          (should (equal captured-label "H1")))
       (delete-file tmp))))
 
 


### PR DESCRIPTION
## Summary
- `C-c C-f` (`deduce-lsp-fill-from-given`) no longer prompts via `completing-read` when multiple in-scope givens match the goal at the hole.
- The first candidate returned by `deduce/matchingGivensAt` is used directly, matching the existing single-match shortcut.

Closes #385.

## Test plan
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 51/51 pass, including the new `fill-from-given-interactive-multi-picks-first` test that asserts no prompt and verifies the first candidate is the one sent to `deduce/fillFromGivenAt`.
- [x] `deduce-mode-test` (28/28) and `deduce-fill-hole-test` (25/25) suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)