### PR TITLE
Fill-hole: indent multi-line model proofs to the hole's column (#391)

### DIFF
--- a/editor/emacs/deduce-fill-hole.el
+++ b/editor/emacs/deduce-fill-hole.el
@@ -524,6 +524,67 @@ doesn't have to special-case parse failures."
                :attempts 0)))))))
 
 
+(defun deduce-fill-hole--reindent-proof (proof column)
+  "Return PROOF with each line after the first prefixed by COLUMN spaces.
+
+The model emits proof text without knowing the column the `?'
+sits at, so a multi-line response lands with the first line at
+the hole's column (correct) and every following line at column 0
+(wrong).  We re-indent to match the hole's column so the splice
+lines up with the surrounding source.  If the model already
+prefixed lines with whitespace (mirroring the excerpt's
+indentation), strip a common leading-whitespace prefix from the
+follow-on lines first so we don't double-indent."
+  (let* ((lines (split-string proof "\n"))
+         (first (car lines))
+         (rest (cdr lines)))
+    (if (null rest)
+        proof
+      (let* ((non-blank (seq-filter
+                         (lambda (l) (not (string-match-p "\\`[ \t]*\\'" l)))
+                         rest))
+             (common (deduce-fill-hole--common-leading-whitespace non-blank))
+             (strip (length common))
+             (pad (make-string column ?\s))
+             (rest-fixed
+              (mapcar (lambda (l)
+                        (cond
+                         ;; Blank lines stay blank -- don't pad trailing
+                         ;; whitespace onto an otherwise-empty line.
+                         ((string-match-p "\\`[ \t]*\\'" l) "")
+                         ((and (> strip 0)
+                               (>= (length l) strip)
+                               (string= (substring l 0 strip) common))
+                          (concat pad (substring l strip)))
+                         (t (concat pad l))))
+                      rest)))
+        (mapconcat #'identity (cons first rest-fixed) "\n")))))
+
+
+(defun deduce-fill-hole--common-leading-whitespace (lines)
+  "Return the longest leading-whitespace prefix shared by LINES.
+
+Used by `deduce-fill-hole--reindent-proof' to detect the model's
+own indentation so it can be stripped before re-indenting to the
+hole's column.  Returns the empty string when LINES is empty or
+no shared prefix exists."
+  (if (null lines)
+      ""
+    (let ((prefix (progn
+                    (string-match "\\`\\([ \t]*\\)" (car lines))
+                    (match-string 1 (car lines)))))
+      (dolist (line (cdr lines))
+        (string-match "\\`\\([ \t]*\\)" line)
+        (let ((this (match-string 1 line))
+              (i 0)
+              (lim (min (length prefix)
+                        (length (match-string 1 line)))))
+          (while (and (< i lim) (eq (aref prefix i) (aref this i)))
+            (setq i (1+ i)))
+          (setq prefix (substring prefix 0 i))))
+      prefix)))
+
+
 (defun deduce-fill-hole--splice-proof (start-marker end-marker proof
                                                     orig-fingerprint attempts)
   "Replace the marker range with PROOF after the marker + fingerprint check.
@@ -567,8 +628,9 @@ in the success message."
            "deduce-fill-hole: hole context changed while the model was thinking")))))
   (save-excursion
     (goto-char start-marker)
-    (delete-region start-marker end-marker)
-    (insert proof))
+    (let ((column (current-column)))
+      (delete-region start-marker end-marker)
+      (insert (deduce-fill-hole--reindent-proof proof column))))
   (message "deduce-fill-hole: filled in %d attempt%s"
            attempts (if (= attempts 1) "" "s")))
 

--- a/editor/emacs/test/deduce-fill-hole-test.el
+++ b/editor/emacs/test/deduce-fill-hole-test.el
@@ -548,5 +548,67 @@ thinking, the sentinel must not raise -- just message the user."
                        msgs)))))
 
 
+;; ---------------------------------------------------------------------
+;; Multi-line proof re-indentation (issue #391)
+;; ---------------------------------------------------------------------
+
+
+(ert-deftest deduce-fill-hole/reindent-leaves-single-line-proofs-alone ()
+  "A proof with no newline has no follow-on lines to indent."
+  (should (equal (deduce-fill-hole--reindent-proof "reflexive" 2)
+                 "reflexive")))
+
+
+(ert-deftest deduce-fill-hole/reindent-pads-followon-lines-to-column ()
+  "Lines after the first get prefixed by COLUMN spaces so the splice
+lines up under the hole's indent."
+  (should (equal (deduce-fill-hole--reindent-proof
+                  "arbitrary x:Nat\nassume p: P x\np" 2)
+                 "arbitrary x:Nat\n  assume p: P x\n  p")))
+
+
+(ert-deftest deduce-fill-hole/reindent-strips-common-prefix-then-pads ()
+  "When the model already indented its follow-on lines (mirroring the
+excerpt), strip a common leading-whitespace prefix before padding."
+  (should (equal (deduce-fill-hole--reindent-proof
+                  "arbitrary x:Nat\n  assume p: P x\n  p" 4)
+                 "arbitrary x:Nat\n    assume p: P x\n    p")))
+
+
+(ert-deftest deduce-fill-hole/reindent-blank-lines-stay-blank ()
+  "Blank follow-on lines must not collect trailing whitespace."
+  (should (equal (deduce-fill-hole--reindent-proof
+                  "arbitrary x:Nat\n\nassume p: P x" 2)
+                 "arbitrary x:Nat\n\n  assume p: P x")))
+
+
+(ert-deftest deduce-fill-hole/reindent-zero-column-is-noop ()
+  "A hole at column 0 (theorems start there) needs no padding."
+  (should (equal (deduce-fill-hole--reindent-proof
+                  "arbitrary x:Nat\nassume p: P x" 0)
+                 "arbitrary x:Nat\nassume p: P x")))
+
+
+(ert-deftest deduce-fill-hole/sentinel-success-indents-multiline-proof ()
+  "End-to-end: a multi-line proof from the sidecar gets each follow-on
+line padded to the `?''s column when spliced into the buffer."
+  (with-temp-buffer
+    (insert "theorem t: bool = true\nproof\n  ?\nend\n")
+    (let* ((source (current-buffer))
+           (session (deduce-fill-hole-test--make-session
+                     source
+                     (concat "{\"ok\": true,"
+                             " \"proof\": \"arbitrary x:Nat\\nassume p: P x\\np\","
+                             " \"attempts\": 1, \"fingerprint\": \"test-fp\","
+                             " \"elapsedMs\": 100, \"model\": \"test\","
+                             " \"validations\": []}")
+                     nil)))
+      (deduce-fill-hole-test--with-captured-messages
+        (deduce-fill-hole--apply-result session))
+      (should (string-match-p
+               "  arbitrary x:Nat\n  assume p: P x\n  p"
+               (buffer-string))))))
+
+
 (provide 'deduce-fill-hole-test)
 ;;; deduce-fill-hole-test.el ends here


### PR DESCRIPTION
## Summary

Fixes #391 -- when the model returned a multi-line proof, the first
line landed at the `?`'s column (correct) but every follow-on line
started at column 0, so the spliced result looked like:

```
proof
  arbitrary x:Nat
assume p: P x
p
end
```

After this PR the same response splices as:

```
proof
  arbitrary x:Nat
  assume p: P x
  p
end
```

Implementation lives entirely on the emacs side
(`deduce-fill-hole--splice-proof`):

- New `deduce-fill-hole--reindent-proof` strips a common leading-
  whitespace prefix the model may have already added (so we don't
  double-indent when the model mirrors the excerpt's indentation),
  then pads each follow-on line to the hole's column.
- Blank follow-on lines stay blank instead of collecting trailing
  whitespace.
- The hole's column is read at splice time via `current-column` after
  navigating to `start-marker`.

The sidecar protocol is unchanged -- this is a pure post-processing
fix on the editor side.

## Test plan

- [x] Six new ert tests in `deduce-fill-hole-test.el` cover the
      reindent helper directly (single-line no-op, basic padding,
      common-prefix stripping, blank-line preservation, column-0 no-op)
      and an end-to-end sentinel splice.
- [x] `editor/emacs/test/deduce-fill-hole-test.el`: 31/31 pass.
- [x] `editor/emacs/test/deduce-lsp-test.el`: 51/51 pass.
- [x] `editor/emacs/test/deduce-mode-test.el`: 28/28 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)