### PR TITLE
Add .mcp.json, fix incomplete_user_error typo, and clean up MCP setup docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "deduce": {
+      "command": "python3.13",
+      "args": ["-m", "lsp.mcp_server"]
+    }
+  }
+}

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -328,39 +328,62 @@ cd /path/to/deduce
 python3 -m pip install -r requirements-lsp.txt
 ```
 
-This pulls in the `mcp` Python package.
+This pulls in the `mcp` Python package. Note which interpreter
+`python3` resolves to here (`which python3`); step 2 must launch the
+**same** interpreter, or Claude Code will start a Python that doesn't
+have `mcp` installed.
 
 **2. Register the Deduce MCP server with your assistant.** For Claude
-Code, create (or edit) `.mcp.json` in the directory where you'll run
-`claude` — typically your Deduce checkout or the directory containing
-your `.pf` files:
+Code, create (or edit) `.mcp.json` in your Deduce checkout:
 
 ```json
 {
   "mcpServers": {
     "deduce": {
       "command": "python3",
-      "args": ["-m", "lsp.mcp_server"],
-      "env": {
-        "DEDUCE_ROOT": "/path/to/deduce"
-      }
+      "args": ["-m", "lsp.mcp_server"]
     }
   }
 }
 ```
 
-`DEDUCE_ROOT` tells the server where to find `lib/` (the standard
-library prelude) and `Deduce.lark` (the parser grammar). If you launch
-`claude` *from* the Deduce checkout, `DEDUCE_ROOT` is optional. To
-skip the prelude entirely, add `"DEDUCE_NO_STDLIB": "1"`. Alternative
-CLI registration:
+This form requires `claude` to be launched from the Deduce checkout
+(so Python can find the `lsp` package). To launch `claude` from a
+different directory — e.g. a separate proofs directory — give the
+absolute path to `mcp_server.py` instead. The server bootstraps
+itself from the file's location, so it works from any cwd:
 
-```sh
-claude mcp add deduce -- python3 -m lsp.mcp_server
+```json
+{
+  "mcpServers": {
+    "deduce": {
+      "command": "python3",
+      "args": ["/path/to/deduce/lsp/mcp_server.py"]
+    }
+  }
+}
 ```
 
-**3. Try it out.** Start `claude` in the directory with your `.pf`
-file and ask something concrete:
+To skip the standard library prelude, add
+`"env": {"DEDUCE_NO_STDLIB": "1"}`.
+
+Alternative CLI registration. The default scope is `local` (per-user,
+per-project — won't be picked up by other contributors); pass
+`--scope project` to write to `.mcp.json` in the current directory
+instead:
+
+```sh
+claude mcp add --scope project deduce -- python3 -m lsp.mcp_server
+```
+
+After creating `.mcp.json`, **restart `claude`** so it discovers
+the new server. On first start in a project with `.mcp.json`, Claude
+Code prompts you to trust the server before invoking its tools.
+
+**3. Try it out.** Start `claude` from the directory matching the
+`.mcp.json` form you picked in step 2 — the Deduce checkout for the
+`-m lsp.mcp_server` form, or anywhere for the absolute-path form —
+and ask something concrete:
 
 ```
 $ cd /path/to/your/proofs

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -41,6 +41,7 @@ in user-visible error messages.
 
 import contextlib
 import re
+import traceback as _traceback
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Sequence
@@ -341,9 +342,12 @@ def _diagnostic_from_exception(
 
     Reads ``exc.location`` and ``exc.message_body`` if present
     (attached by ``error.py`` for all error/incomplete/static/match/
-    parse errors). Falls back to ``str_fallback`` plus a sentinel
-    range when the exception is unstructured -- which only happens
-    for unexpected internal exceptions.
+    parse errors). When the exception is unstructured -- a Python
+    exception that escaped the checker without being wrapped as a
+    Deduce error, almost always a bug in Deduce itself -- the
+    diagnostic message includes the formatted traceback so the user
+    reporting the bug knows which frame raised, instead of seeing a
+    bare ``name 'X' is not defined`` at the sentinel position.
 
     For ``IncompleteProof``, the message is replaced with a clean
     ``Goal: ... \\n Givens: ...`` block formatted to match
@@ -375,9 +379,29 @@ def _diagnostic_from_exception(
     else:
         body = getattr(exc, "message_body", None)
         if body is None:
-            body = str_fallback if str_fallback is not None else str(exc)
+            body = _format_unstructured_exception(exc, str_fallback)
 
     return Diagnostic(severity=Severity.ERROR, range=rng, message=body)
+
+
+def _format_unstructured_exception(
+    exc: BaseException, str_fallback: Optional[str]
+) -> str:
+    """Format an unstructured exception with its traceback.
+
+    The pipeline catches ``Diagnostic`` subclasses (``UserError``,
+    ``IncompleteProof``, ``StaticError``) and decorates them with
+    ``location`` / ``message_body``. Anything else -- ``NameError``,
+    ``AttributeError``, an unexpected ``KeyError``, etc. -- is a bug
+    in Deduce. Without the traceback the user only sees ``str(exc)``
+    pinned to line 1, column 1, which is useless for filing a report.
+    """
+    msg = str_fallback if str_fallback is not None else str(exc)
+    tb = exc.__traceback__
+    if tb is not None:
+        formatted = "".join(_traceback.format_exception(type(exc), exc, tb))
+        return f"internal error in Deduce: {msg}\n\n{formatted}"
+    return f"internal error in Deduce: {msg}"
 
 
 def _format_incomplete_proof_message(formula) -> str:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1562,7 +1562,7 @@ def check_proof_of(proof, formula, env):
             for (frm,pf) in zip(frms, pfs):
               _try_check_proof_of(pf, frm, env)
             if len(pfs) < len(frms):
-              incomplete_user_error(loc, 'expected ' + str(len(frms)) + ' proofs but only got '\
+              incomplete_error(loc, 'expected ' + str(len(frms)) + ' proofs but only got '\
                                + str(len(pfs)))
           case _:
             user_error(loc, 'comma proves logical-and, not ' + str(red_formula))

--- a/test/lsp/test_check.py
+++ b/test/lsp/test_check.py
@@ -295,3 +295,53 @@ def test_check_reports_proof_error_plus_hole_independently() -> None:
         f"expected a diagnostic on line 8 (the hole), got "
         f"{[(d.range.start.line, d.message[:40]) for d in diags]}"
     )
+
+
+# --------------------------------------------------------------------------
+# Unstructured-exception fallback
+# --------------------------------------------------------------------------
+#
+# A Python exception that escapes the checker without being wrapped as
+# a Deduce error (NameError, AttributeError, an unexpected KeyError) is
+# almost always a Deduce bug -- the kind of thing the user needs a
+# traceback for to file a useful report. Without this hook, a typo
+# like ``incomplete_user_error`` (issue surfaced during MCP smoke
+# testing of #390) shows up as a single-line ``name 'X' is not
+# defined`` at line 1, column 1 with no indication of which checker
+# frame raised. The diagnostic must include the formatted traceback.
+
+
+def test_check_includes_traceback_for_unstructured_exception(
+    monkeypatch,
+) -> None:
+    """When the checker raises a plain Python exception (not a Deduce
+    error type), the resulting diagnostic carries the traceback so
+    the user can file a bug report with a real frame."""
+    from lsp import library, query
+
+    sentinel_msg = "deliberate test failure: synthetic NameError"
+
+    def _boom(*args, **kwargs):
+        raise NameError(sentinel_msg)
+
+    # ``check_deduce`` runs inside ``_check_file_impl``'s catch-all
+    # try/except. A NameError here bypasses the sink (which only
+    # catches ``Diagnostic`` subclasses) and lands in
+    # ``CheckResult.exception`` -- the single-diagnostic fallback in
+    # ``query.check``.
+    monkeypatch.setattr(library, "check_deduce", _boom)
+
+    # Use a goal that needs no prelude (UInt et al. aren't loaded for a
+    # default ``query.check``), so we reach ``check_deduce`` before any
+    # uniquify diagnostic short-circuits the test.
+    diags = query.check("synthetic.pf", "theorem t: true proof . end\n")
+    assert len(diags) == 1
+    msg = diags[0].message
+    assert "internal error in Deduce" in msg, msg
+    assert sentinel_msg in msg, msg
+    # The formatted traceback must include the file that raised --
+    # the user filing a report needs to know which frame failed.
+    assert "Traceback" in msg, f"expected traceback in message, got: {msg!r}"
+    assert "_boom" in msg, (
+        f"expected the offending frame name in the traceback, got: {msg!r}"
+    )

--- a/test/should-error/ptuple_too_few.pf
+++ b/test/should-error/ptuple_too_few.pf
@@ -1,0 +1,11 @@
+theorem T: all x:bool. x or not x
+proof
+  arbitrary x:bool
+  switch x { case true { . } case false { . } }
+end
+
+theorem U: all x:bool. (x or not x) and (x or not x) and (x or not x)
+proof
+  arbitrary x:bool
+  T[x], T[x]
+end

--- a/test/should-error/ptuple_too_few.pf.err
+++ b/test/should-error/ptuple_too_few.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/ptuple_too_few.pf:10.3-10.13: expected 3 proofs but only got 2


### PR DESCRIPTION
## Summary

- Add `.mcp.json` so the Deduce MCP server auto-registers with Claude Code in this checkout (uses `python3.13`, matching the Makefile pin).
- Fix a latent typo from #390: `proof_checker.py` called `incomplete_user_error`, which doesn't exist anywhere — it conflated `incomplete_error` and `user_error`. The branch fires when proving a conjunction with too few comma-separated proofs *and* the synthesis-mode fallback also fails to recover. `lib/UIntPowLog.pf` exercised it under the MCP server's `collect_errors=True` continuation, surfacing it as a `NameError` diagnostic. Regression test added at `test/should-error/ptuple_too_few.pf`.
- Fix five issues in the MCP setup section of `GettingStarted.md` that would trip a new user:
  - The doc's `DEDUCE_ROOT`-makes-it-portable claim is wrong — `python3 -m lsp.mcp_server` needs the `lsp` package on the cwd / `PYTHONPATH`, and `DEDUCE_ROOT` doesn't fix that. Now documents two correct `.mcp.json` shapes: the simple `-m lsp.mcp_server` form (cwd-bound) and an absolute-path form that works from any cwd.
  - `claude mcp add` example was missing `--scope project`; default is `local`.
  - Added the restart-after-config-change requirement.
  - Added a one-liner about Claude Code's trust prompt for project-scoped MCP servers.
  - Added a one-liner about Python interpreter consistency between step 1's pip install and step 2's launcher.

## Test plan

- [x] `python3.13 test-deduce.py --errors` passes (new fixture included)
- [x] `python3.13 test-deduce.py --passable` passes
- [x] `python3.13 test-deduce.py --lib` passes
- [x] `make quick-lsp` passes
- [x] Smoke-tested: MCP server starts, exposes 12 tools, `check_file` on `lib/UIntPowLog.pf` returns 0 diagnostics
- [x] Verified the documented absolute-path `.mcp.json` form works from `cwd=/tmp`
- [x] Verified the documented `-m lsp.mcp_server` form fails from `cwd=/tmp` (justifying the doc rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)