### PR TITLE
Fix go-to-definition matching imported library nodes (#398)

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -724,7 +724,7 @@ def definition_of(
     if result.ast is None:
         return None
 
-    target_name = _find_reference_at(result.ast, pos)
+    target_name = _find_reference_at(result.ast, pos, path)
     if target_name is None:
         return None
 
@@ -797,7 +797,7 @@ def _meta_contains(meta, pos: Position) -> bool:
     return after_start and before_end
 
 
-def _find_reference_at(ast_nodes, pos: Position) -> Optional[str]:
+def _find_reference_at(ast_nodes, pos: Position, path: str) -> Optional[str]:
     """Locate the smallest reference node whose range contains ``pos``.
 
     Recognises term references (``Var``, with overload resolution via
@@ -805,6 +805,13 @@ def _find_reference_at(ast_nodes, pos: Position) -> Optional[str]:
     ``name`` is already the chosen uniquified name post-uniquify).
     "Smallest" means the deepest match in the AST -- inner refs take
     precedence over enclosing constructs that happen to share a range.
+
+    Only considers nodes whose ``location.filename`` matches ``path``.
+    The post-typecheck AST is threaded with references back into
+    imported library files (constructors, types, overload candidates),
+    and those nodes carry the *library* file's line/column. Without
+    this filter, a cursor in the user's file can spuriously match a
+    library node whose range happens to overlap the same coordinates.
 
     Returns the resolved (uniquified) name, or ``None`` when no
     reference node contains ``pos``. The ``base_name`` of the return
@@ -828,6 +835,8 @@ def _find_reference_at(ast_nodes, pos: Position) -> Optional[str]:
         meta = getattr(node, "location", None)
         if meta is None or not _meta_contains(meta, pos):
             return
+        if not _meta_in_file(meta, path):
+            return
         span = _meta_span(meta)
         if best_span[0] is None or span < best_span[0]:
             best_span[0] = span
@@ -837,6 +846,33 @@ def _find_reference_at(ast_nodes, pos: Position) -> Optional[str]:
         _walk_ast(top, visit, ast_class=AST)
 
     return best[0]
+
+
+def _meta_in_file(meta, path: str) -> bool:
+    """True iff ``meta``'s source file is ``path``.
+
+    Compares the ``filename`` attribute the parsers stash on each
+    ``Meta`` against ``path``. We accept a match when either the raw
+    strings are equal or the resolved absolute paths agree, so a
+    relative ``path`` from the caller still matches an absolute
+    ``meta.filename`` from the parser (and vice versa). When neither
+    side has a filename, fall back to permissive behaviour -- the
+    pre-prelude code path didn't filter at all.
+    """
+    import os
+
+    fname = getattr(meta, "filename", None)
+    if fname is None or fname == "???":
+        # No reliable file info on this node. Don't reject -- some
+        # synthetic nodes never get a filename, and rejecting them
+        # outright would regress same-file lookups.
+        return True
+    if fname == path:
+        return True
+    try:
+        return os.path.realpath(fname) == os.path.realpath(path)
+    except (OSError, ValueError):
+        return False
 
 
 def _meta_span(meta) -> int:

--- a/test/lsp/test_symbols.py
+++ b/test/lsp/test_symbols.py
@@ -222,3 +222,30 @@ def test_definition_of_returns_none_when_target_is_imported() -> None:
     # The 'true' literal is a Bool node, not a Var, so it has no
     # definition to find.
     assert definition_of("test.pf", source, Position(line=1, column=13)) is None
+
+
+def test_definition_of_ignores_imported_node_locations() -> None:
+    """Issue #398: with the prelude active, post-typecheck nodes copied
+    in from library files share Meta line/column with the user's file
+    by coincidence. The lookup must filter those out by ``filename``,
+    or the cursor in a postulate / equation lands on a library node
+    instead of the user's reference."""
+    # Prelude entries get auto-imported by the harness and contribute
+    # the noisy library-file Var nodes. ``List`` is enough to give
+    # ``app`` a return type of ``List<E>`` and pull in the library
+    # locations whose line numbers overlap the user file.
+    prelude = ("List",)
+    source = (
+        "recursive app <E>(List<E>, List<E>) -> List<E> {\n"  # 1
+        "  app([], ys) = ys\n"                                 # 2
+        "  app(node(n, xs), ys) = node(n, app(xs, ys))\n"      # 3
+        "}\n"                                                  # 4
+        "\n"                                                   # 5
+        "postulate p: all T:type. all x:T, y:T.\n"             # 6
+        "  app([x], [y]) = [x,y]\n"                            # 7 — the postulate body
+    )
+    # Cursor on the `app` reference inside the postulate body.
+    loc = definition_of("test.pf", source, Position(line=7, column=3),
+                        prelude=prelude)
+    assert loc is not None, "postulate body: definition_of returned None"
+    assert loc.range.start.line == 1


### PR DESCRIPTION
## Summary

Fixes #398. With the standard-library prelude active, `M-.` (go-to-definition) failed in postulates and the equation block of `equations` proofs while working in the theorem statement just above.

`definition_of` walks the post-typecheck AST looking for `VarRef`/`PVar` nodes whose `Meta` contains the cursor. The post-typecheck AST is threaded with references back into imported library files (constructors, types, overload candidates), and those nodes carry the *library* file's line/column. When the cursor in the user's file landed on coordinates that overlapped a library node — likely for postulate/equation lines because of how prelude line numbers happen to fall — the spurious match won and either returned the wrong name or silently failed in `_find_declaration`.

The fix filters `_find_reference_at` by the queried file's path: only nodes whose `Meta.filename` matches the file under the cursor are considered. A small `_meta_in_file` helper compares raw strings and falls back to `os.path.realpath` so a relative caller path matches the parser's absolute filename.

## Test plan

- [x] Added `test_definition_of_ignores_imported_node_locations` reproducing the postulate case with a `List` prelude — fails before the fix, passes after.
- [x] All existing tests in `test/lsp/test_symbols.py` still pass.
- [x] Full `test/lsp/` baseline (55 fail, 657 pass) is unchanged by this PR; no new regressions.
- [x] Manual smoke test using the issue's exact example: `app` references in the postulate body, theorem statement, equation lhs, equation rhs, and `expand app` clauses all resolve to the `recursive app` declaration.