### PR TITLE
MCP: add available_lemmas_at for goal-shape-driven lemma search

### DIFF
--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -412,6 +412,55 @@ def matching_givens_at(
 
 
 @mcp.tool()
+def available_lemmas_at(
+    path: str,
+    line: int,
+    column: int,
+    query: Optional[str] = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Search for theorems/lemmas/postulates relevant at a position.
+
+    The cursor at ``line``:``column`` is interpreted as follows:
+
+    - On a ``?`` token: the goal at that hole drives ranking. The
+      goal's head operator and operator/function tokens are matched
+      against each candidate lemma's conclusion.
+    - Off a ``?``: ``query`` is required. ``query`` is either a
+      substring (matched against the rendered signature) or a goal-
+      shape pattern containing ``_`` placeholders (each ``_`` matches
+      any run of characters, e.g. ``"_ ≤ _ + _"``).
+
+    Results are returned best-first, capped at ``limit`` entries
+    (default 50). Each entry has ``name``, ``kind`` (``"theorem"`` /
+    ``"lemma"`` / ``"postulate"``), ``signature``, ``module`` (the
+    source module's name; the file's stem for declarations in the
+    current file), and ``relevance`` -- a score in ``[0.0, 1.0]``
+    where ``1.0`` is the best match in the result set.
+
+    Visibility: lemmas declared ``private`` in the current file are
+    surfaced (they're in scope), but private lemmas in prelude
+    modules are not (matching what ``print_theorems`` exports).
+
+    Returns ``[]`` when the cursor isn't on a ``?`` and no ``query``
+    was given, or when nothing matches.
+    """
+    from lsp import query as _q
+
+    content = _read_file(path)
+    pos = _q.Position(line=line, column=column)
+    matches = _q.available_lemmas_at(
+        path,
+        content,
+        pos,
+        query=query,
+        prelude=_prelude_for(path),
+        limit=limit,
+    )
+    return [_to_serializable(m) for m in matches]
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -61,6 +61,7 @@ __all__ = [
     "SymbolInfo",
     "WorkspaceEdit",
     "LemmaInfo",
+    "LemmaMatch",
     "HoleContext",
     "ValidationResult",
     # Query functions
@@ -77,6 +78,7 @@ __all__ = [
     "fill_from_given_at",
     "matching_givens_at",
     "hole_context_at",
+    "available_lemmas_at",
     "validate_proof_at",
 ]
 
@@ -229,6 +231,26 @@ class LemmaInfo:
     name: str
     kind: SymbolKind
     signature: str
+
+
+@dataclass(frozen=True)
+class LemmaMatch:
+    """A lemma surfaced by :func:`available_lemmas_at`, with ranking.
+
+    Like :class:`LemmaInfo` but adds the ``module`` of origin (the
+    file's stem for the user file, the module name for prelude
+    lemmas) and a ``relevance`` score in ``[0.0, 1.0]`` -- ``1.0``
+    is the best match in the result set.
+
+    ``kind`` is restricted to ``THEOREM``, ``LEMMA``, or ``POSTULATE``;
+    other declaration kinds aren't returned.
+    """
+
+    name: str
+    kind: SymbolKind
+    signature: str
+    module: Optional[str]
+    relevance: float
 
 
 @dataclass(frozen=True)
@@ -2323,6 +2345,491 @@ def _lemma_info_for(stmt, public_only: bool = False) -> Optional[LemmaInfo]:
         kind=kind,
         signature=signature,
     )
+
+
+def available_lemmas_at(
+    path: str,
+    content: str,
+    pos: Position,
+    query: Optional[str] = None,
+    prelude: Sequence[str] = (),
+    limit: int = 50,
+) -> tuple:
+    """Return ranked lemmas visible at ``pos``, best matches first.
+
+    Driven by either (or both) of two signals:
+
+    - The cursor sits on a ``?`` token: the goal at that hole defines
+      the shape we're searching for.  ``available_lemmas_at`` extracts
+      the goal text and uses its head operator and operator/function
+      tokens for ranking.
+    - ``query`` is given: a substring (matched against the rendered
+      lemma signature) or a goal-shape pattern containing ``_``
+      placeholders (each ``_`` matches any run of characters).
+
+    When both are given they combine -- a lemma that matches the goal
+    *and* the query ranks above one that matches only one.
+
+    The result is a tuple of :class:`LemmaMatch` ordered by descending
+    ``relevance``; ties broken by name.  ``relevance`` is normalised
+    so the best match in the set is ``1.0`` and others scale linearly.
+    Only theorems, lemmas, and postulates are surfaced.
+
+    The lemma set is the same one :func:`hole_context_at` collects
+    (user-file declarations plus public declarations from each module
+    in ``prelude``), so this works without a hole as long as the file
+    parses.  Returns ``()`` when neither a hole nor a ``query`` is
+    available, or when no lemma matches even minimally.
+    """
+    from lsp.library import check_file
+
+    hole_range = _find_hole_at(content, pos)
+    goal_text: Optional[str] = None
+    if hole_range is not None:
+        target = (hole_range.start.line, hole_range.start.column)
+        with _target_hole(target):
+            result = check_file(path, content=content, prelude=prelude)
+        if not result.ok:
+            goal = _goal_from_exception(result.exception, hole_range)
+            if goal is not None:
+                goal_text = goal.formula
+        ast_nodes = result.ast
+    else:
+        result = check_file(path, content=content, prelude=prelude)
+        ast_nodes = result.ast
+
+    if goal_text is None and not query:
+        return ()
+
+    candidates = _collect_lemma_candidates(path, ast_nodes, prelude)
+    if not candidates:
+        return ()
+
+    ranked = _rank_lemmas(candidates, goal_text, query, _module_for_path(path))
+    if not ranked:
+        return ()
+
+    if limit > 0:
+        ranked = ranked[:limit]
+    return tuple(ranked)
+
+
+def _module_for_path(path: str) -> str:
+    """Module name for the file at ``path`` -- the path's stem."""
+    from pathlib import Path
+
+    return Path(path).stem
+
+
+def _collect_lemma_candidates(
+    path: str, ast_nodes, prelude: Sequence[str]
+) -> tuple:
+    """Build the ranking input: theorems/lemmas/postulates with their
+    formula AST and module of origin.
+
+    Returns a tuple of ``(LemmaInfo, formula_ast, module)`` triples,
+    drawn from the user file (one entry per ``Theorem``/``Postulate``
+    in source order, including private ones) and from each module
+    named in ``prelude`` (public theorems/postulates only, matching
+    ``print_theorems``' visibility filter).
+    """
+    from abstract_syntax import (
+        Import as _ImportNode,
+        Postulate,
+        Theorem,
+        get_uniquified_modules,
+    )
+
+    out = []
+    user_module = _module_for_path(path)
+
+    if ast_nodes is not None:
+        prelude_set = set(prelude)
+        for stmt in ast_nodes:
+            if isinstance(stmt, _ImportNode) and stmt.name in prelude_set:
+                continue
+            if not isinstance(stmt, (Theorem, Postulate)):
+                continue
+            info = _lemma_info_for(stmt, public_only=False)
+            if info is None:
+                continue
+            out.append((info, stmt.what, user_module))
+
+    if prelude:
+        modules = get_uniquified_modules()
+        for module_name in prelude:
+            module_ast = modules.get(module_name)
+            if module_ast is None:
+                continue
+            for stmt in module_ast:
+                if not isinstance(stmt, (Theorem, Postulate)):
+                    continue
+                info = _lemma_info_for(stmt, public_only=True)
+                if info is None:
+                    continue
+                out.append((info, stmt.what, module_name))
+
+    return tuple(out)
+
+
+# Operator-like rator names whose appearance in a goal we can extract
+# from rendered text.  Order is the precedence order used by Deduce's
+# pretty printer (coarsely): the lowest-precedence operator that
+# appears at depth 0 in a formula's text is its head.
+_GOAL_HEAD_OPERATORS = (
+    " iff ",
+    " or ",
+    " and ",
+    " = ",
+    " ≠ ",
+    " ≤ ",
+    " ≥ ",
+    " < ",
+    " > ",
+    " + ",
+    " - ",
+    " * ",
+    " ÷ ",
+    " / ",
+    " % ",
+)
+
+
+# Tokens that are language keywords / type names rather than the
+# function/operator names we want to count for symbol overlap.
+_GOAL_TOKEN_STOPWORDS = frozenset({
+    "all", "some", "if", "then", "else", "and", "or", "not",
+    "iff", "true", "false", "fun", "switch", "case", "where",
+    "obtain", "from", "by", "have", "suppose", "assume",
+    "lemma", "theorem", "proof", "end", "of", "in",
+})
+
+
+def _strip_outer_parens(text: str) -> str:
+    """Strip a single pair of outer parens iff they are balanced and
+    wrap the entire expression."""
+    s = text.strip()
+    while len(s) >= 2 and s[0] == "(" and s[-1] == ")":
+        depth = 0
+        inner_min = 1
+        for i, ch in enumerate(s):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0 and i < len(s) - 1:
+                    inner_min = 0
+                    break
+        if inner_min == 0:
+            break
+        s = s[1:-1].strip()
+    return s
+
+
+def _strip_outer_quantifiers(text: str) -> str:
+    """Repeatedly strip leading ``all <bindings>. `` and ``if <p> then ``
+    prefixes from rendered goal text, returning the conclusion body.
+
+    Stops as soon as neither prefix matches.  Paren-aware: an ``all``
+    or ``if`` inside parens at depth >0 is not a candidate."""
+    s = _strip_outer_parens(text)
+
+    while True:
+        prev = s
+        # all <bindings>. body
+        if s.startswith("all "):
+            dot = _find_top_level(s, ".")
+            if dot is not None:
+                s = s[dot + 1:].lstrip()
+                s = _strip_outer_parens(s)
+                continue
+        # if <prem> then <conc>
+        if s.startswith("if "):
+            then_pos = _find_top_level(s, " then ")
+            if then_pos is not None:
+                s = s[then_pos + len(" then "):].lstrip()
+                s = _strip_outer_parens(s)
+                continue
+        if s == prev:
+            break
+    return s
+
+
+def _find_top_level(s: str, needle: str) -> Optional[int]:
+    """Return the offset of ``needle`` at paren-depth 0 in ``s``, or
+    ``None``.  Used to strip top-level binders from rendered goals."""
+    depth = 0
+    n = len(needle)
+    for i, ch in enumerate(s):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and s.startswith(needle, i):
+            return i
+    return None
+
+
+def _goal_head_symbol(text: Optional[str]) -> Optional[str]:
+    """Best-effort extraction of the head operator from rendered goal
+    text.  Returns the operator with surrounding spaces stripped (e.g.
+    ``"="``, ``"≤"``, ``"and"``), or ``None`` when no recognised
+    operator appears at depth 0.
+
+    For function-call goals (e.g. ``less(x, y)``), returns the
+    function name."""
+    if not text:
+        return None
+    s = _strip_outer_quantifiers(text)
+    if not s:
+        return None
+
+    # Bare bool literal or identifier with nothing else: that's the head.
+    for op in _GOAL_HEAD_OPERATORS:
+        if _find_top_level(s, op) is not None:
+            return op.strip()
+
+    # Function call: ``name(...)`` at the top level.
+    m = re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(", s)
+    if m:
+        return m.group(1)
+
+    # Negation prefix.
+    if s.startswith("not "):
+        return "not"
+
+    return None
+
+
+_TOKEN_RE = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]*|[+\-*/%<>=≤≥≠÷]|and|or|iff|not"
+)
+
+
+def _goal_tokens(text: Optional[str]) -> frozenset:
+    """Operator and function-name tokens appearing in rendered goal
+    text, with stopwords (binders, language keywords) and short
+    identifiers (1 char) filtered out."""
+    if not text:
+        return frozenset()
+    tokens = set()
+    for raw in _TOKEN_RE.findall(text):
+        if raw in _GOAL_TOKEN_STOPWORDS:
+            continue
+        if raw.isalpha() and len(raw) == 1:
+            # Skip bare ``x``/``y``/``n``/``P``/``Q`` -- almost always
+            # bound variables or schematic placeholders, not symbols
+            # that distinguish lemmas.
+            continue
+        if raw.isdigit():
+            continue
+        tokens.add(raw)
+    return frozenset(tokens)
+
+
+def _formula_head_symbol(formula) -> Optional[str]:
+    """Head operator of a lemma's formula (peeling outer ``All`` and
+    ``IfThen``).  Returns the rator's base name for a ``Call``, or a
+    string token for non-Call shapes (``and``/``or``/``not``/etc.).
+    Returns ``None`` for unsupported shapes."""
+    from abstract_syntax import (
+        All, And, Bool, Call, IfThen, Or, TermInst, VarRef, base_name,
+    )
+
+    f = formula
+    while True:
+        if isinstance(f, All):
+            f = f.body
+        elif isinstance(f, IfThen):
+            f = f.conclusion
+        else:
+            break
+
+    if isinstance(f, Call):
+        rator = f.rator
+        if isinstance(rator, TermInst):
+            inner = getattr(rator, "subject", None)
+            if isinstance(inner, VarRef):
+                return base_name(inner.get_name())
+        if isinstance(rator, VarRef):
+            return base_name(rator.get_name())
+        return None
+    if isinstance(f, And):
+        return "and"
+    if isinstance(f, Or):
+        return "or"
+    if isinstance(f, Bool):
+        return "true" if f.value else "false"
+    return None
+
+
+def _formula_symbols(formula) -> frozenset:
+    """Set of all rator names appearing in ``formula`` (recursively).
+
+    Drives the symbol-overlap signal in lemma ranking.  Bound
+    variables introduced by ``All``/``Some`` are excluded -- only the
+    uniquified rator names of ``Call`` nodes count.  Names are
+    returned as their ``base_name`` so they line up with the
+    user-visible operator/function names used in goal text."""
+    from abstract_syntax import (
+        AST, And, Bool, Call, IfThen, Or, TermInst, VarRef, base_name,
+    )
+
+    out = set()
+
+    def visit(node):
+        if isinstance(node, Call):
+            rator = node.rator
+            if isinstance(rator, TermInst):
+                inner = getattr(rator, "subject", None)
+                if isinstance(inner, VarRef):
+                    out.add(base_name(inner.get_name()))
+            elif isinstance(rator, VarRef):
+                out.add(base_name(rator.get_name()))
+        elif isinstance(node, And):
+            out.add("and")
+        elif isinstance(node, Or):
+            out.add("or")
+        elif isinstance(node, IfThen):
+            # IfThen is logical implication; we don't add ``then`` or
+            # ``if`` to the symbol set -- the head match handles it.
+            pass
+        elif isinstance(node, Bool):
+            out.add("true" if node.value else "false")
+
+    _walk_ast(formula, visit, ast_class=AST)
+    return frozenset(out)
+
+
+def _query_pattern(query: Optional[str]):
+    """Return a compiled regex if ``query`` is a goal-shape pattern
+    (contains ``_``), else ``None``.  Each ``_`` becomes ``.+?`` and
+    other characters are matched literally with whitespace
+    flexibility (any run of whitespace matches any other run)."""
+    if not query or "_" not in query:
+        return None
+    parts = []
+    for chunk in query.split("_"):
+        if not chunk:
+            parts.append("")
+            continue
+        # Collapse runs of whitespace in the literal, then split on
+        # them so we can re-emit ``\s+`` between literal pieces.
+        words = chunk.split()
+        if not words:
+            parts.append(r"\s*")
+            continue
+        prefix = r"\s*" if chunk[:1].isspace() else ""
+        suffix = r"\s*" if chunk[-1:].isspace() else ""
+        parts.append(prefix + r"\s+".join(re.escape(w) for w in words) + suffix)
+    body = ".+?".join(parts)
+    try:
+        return re.compile(body)
+    except re.error:
+        return None
+
+
+def _rank_lemmas(
+    candidates: tuple,
+    goal_text: Optional[str],
+    query: Optional[str],
+    user_module: str,
+) -> list:
+    """Score and sort candidate lemmas.
+
+    ``candidates`` is the tuple from :func:`_collect_lemma_candidates`.
+    Returns a list of :class:`LemmaMatch` with normalised relevance
+    in ``[0.0, 1.0]``; only candidates with a strictly positive raw
+    score are included.
+
+    The four signals from issue #403:
+
+    1. Exact head-symbol match between conclusion and goal.
+    2. Goal symbols appearing in the lemma's full formula symbols.
+    3. Module proximity to the file under cursor.
+    4. Fuzzy substring of the query against the lemma name as
+       tiebreaker.
+
+    Plus one extra: a goal-shape pattern (a ``query`` containing ``_``
+    placeholders) matched against the rendered signature.
+    """
+    goal_head = _goal_head_symbol(goal_text)
+    goal_syms = _goal_tokens(goal_text)
+    pattern = _query_pattern(query)
+    query_substr = (query or "").strip().lower()
+    has_substring_query = bool(query_substr) and pattern is None
+
+    raw_scores: list = []
+    for info, formula, module in candidates:
+        head = _formula_head_symbol(formula)
+        symbols = _formula_symbols(formula)
+
+        head_score = 1.0 if (goal_head is not None and head == goal_head) else 0.0
+
+        if goal_syms:
+            overlap = len(goal_syms & symbols) / len(goal_syms)
+        else:
+            overlap = 0.0
+
+        proximity = 1.0 if module == user_module else 0.0
+
+        sig_lower = info.signature.lower()
+        name_lower = info.name.lower()
+
+        substring_score = 0.0
+        if has_substring_query:
+            if query_substr in name_lower:
+                substring_score = 1.0
+            elif query_substr in sig_lower:
+                substring_score = 0.5
+
+        pattern_score = 0.0
+        if pattern is not None and pattern.search(info.signature):
+            pattern_score = 1.0
+
+        raw = (
+            4.0 * head_score
+            + 2.0 * overlap
+            + 1.0 * proximity
+            + 2.0 * substring_score
+            + 3.0 * pattern_score
+        )
+
+        # When the user typed a goal-shape pattern or substring, only
+        # surface lemmas that match it -- other signals shouldn't
+        # promote unrelated lemmas above a query-only baseline.
+        if has_substring_query and substring_score == 0.0:
+            continue
+        if pattern is not None and pattern_score == 0.0:
+            continue
+
+        # No goal AND no query that this lemma matched -> nothing to
+        # score on.  Skip.
+        if raw <= 0.0:
+            continue
+
+        raw_scores.append((raw, info, module))
+
+    if not raw_scores:
+        return []
+
+    max_raw = max(r for r, _, _ in raw_scores)
+    if max_raw <= 0.0:
+        return []
+
+    raw_scores.sort(key=lambda t: (-t[0], t[1].name))
+    matches = []
+    for raw, info, module in raw_scores:
+        matches.append(
+            LemmaMatch(
+                name=info.name,
+                kind=info.kind,
+                signature=info.signature,
+                module=module,
+                relevance=raw / max_raw,
+            )
+        )
+    return matches
 
 
 def _hole_fingerprint(goal_formula: str, givens: tuple) -> str:

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -1,0 +1,310 @@
+"""Acceptance tests for ``lsp.query.available_lemmas_at`` (issue #403).
+
+The function is the goal-shape-driven lemma search behind the MCP
+``available_lemmas_at`` tool. It produces a ranked list of theorems
+/ lemmas / postulates relevant at a cursor: either driven by the
+goal at a ``?`` token or by an explicit ``query`` (substring or
+goal-shape pattern with ``_`` placeholders).
+
+Most tests stay inside ``bool`` territory so they don't depend on
+the standard library. The "prelude" cases use the small
+``HoleFillPrelude`` fixture from ``test/test-imports/`` -- the same
+one ``test_hole_context.py`` uses.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    LemmaMatch,
+    Position,
+    SymbolKind,
+    available_lemmas_at,
+)
+
+
+# ---------------------------------------------------------------------------
+# Goal-driven mode (cursor on a `?`)
+# ---------------------------------------------------------------------------
+
+
+def test_goal_drives_ranking_by_head_symbol() -> None:
+    """Cursor on a `?` whose goal has shape ``P and Q``: an ``and``-
+    headed user lemma outranks an unrelated equation lemma even
+    though both are in scope."""
+    source = (
+        "theorem and_helper: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem eq_helper: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=20, column=3),
+    )
+    assert isinstance(matches, tuple)
+    assert all(isinstance(m, LemmaMatch) for m in matches)
+
+    by_name = {m.name: m for m in matches}
+    assert "and_helper" in by_name
+    assert "eq_helper" in by_name
+
+    # Head match (``and``) plus symbol overlap pushes and_helper above
+    # eq_helper.
+    assert by_name["and_helper"].relevance > by_name["eq_helper"].relevance
+
+
+def test_no_hole_no_query_returns_empty() -> None:
+    """Cursor not on a `?` and no `query` -> nothing to match against."""
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    # Line 4 sits on `reflexive`, not a `?`.
+    assert available_lemmas_at(
+        "lemmas.pf", source, Position(line=4, column=3)
+    ) == ()
+
+
+def test_user_lemmas_get_module_set_to_file_stem() -> None:
+    """Lemmas declared in the user file have ``module`` set to the
+    path's stem (``"lemmas"`` for ``/tmp/lemmas.pf``)."""
+    source = (
+        "lemma helper: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "/tmp/lemmas.pf",
+        source,
+        Position(line=8, column=3),
+    )
+    by_name = {m.name: m for m in matches}
+    assert "helper" in by_name
+    assert by_name["helper"].module == "lemmas"
+    assert by_name["helper"].kind == SymbolKind.LEMMA
+
+
+# ---------------------------------------------------------------------------
+# Query-only mode (no hole)
+# ---------------------------------------------------------------------------
+
+
+def test_substring_query_matches_name() -> None:
+    """A bare-string ``query`` matches lemma names case-insensitively."""
+    source = (
+        "theorem foo_bar: true\n"
+        "proof\n  .\nend\n"
+        "\n"
+        "theorem qux: true\n"
+        "proof\n  .\nend\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=1, column=1),
+        query="foo",
+    )
+    names = {m.name for m in matches}
+    assert "foo_bar" in names
+    # qux doesn't contain "foo" -> filtered out by substring gate.
+    assert "qux" not in names
+
+
+def test_goal_shape_pattern_matches_signature() -> None:
+    """A ``query`` containing ``_`` placeholders matches structurally
+    against the rendered signature."""
+    source = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem unrelated: true\n"
+        "proof\n  .\nend\n"
+    )
+    # Pattern matches anything with ``_ and _``.
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=1, column=1),
+        query="_ and _",
+    )
+    names = {m.name for m in matches}
+    assert "and_intro" in names
+    assert "unrelated" not in names
+
+
+# ---------------------------------------------------------------------------
+# Visibility: prelude private lemmas are filtered, user-file private ones
+# are kept.
+# ---------------------------------------------------------------------------
+
+
+def test_user_file_private_lemma_is_visible() -> None:
+    """A ``lemma`` (i.e. private) declared in the user's file IS in
+    scope at a hole and so appears in the result list."""
+    source = (
+        "lemma local_priv: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=8, column=3),
+    )
+    names = {m.name for m in matches}
+    assert "local_priv" in names
+
+
+def test_prelude_postulate_is_surfaced() -> None:
+    """Postulates and theorems imported via the prelude appear in
+    results, with ``module`` set to the source module name."""
+    source = (
+        "theorem with_hole: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=4, column=3),
+        prelude=("HoleFillPrelude",),
+    )
+    by_name = {m.name: m for m in matches}
+    # ``hf_postulate`` is from HoleFillPrelude; ``hf_intro_and`` too.
+    assert "hf_postulate" in by_name
+    assert by_name["hf_postulate"].module == "HoleFillPrelude"
+    assert by_name["hf_postulate"].kind == SymbolKind.POSTULATE
+
+
+# ---------------------------------------------------------------------------
+# Ranking signals: relevance is normalised; user-module lemmas outrank
+# distant ones for the same head match.
+# ---------------------------------------------------------------------------
+
+
+def test_relevance_is_normalised_to_unit_interval() -> None:
+    """The top-ranked match has ``relevance == 1.0`` and all others
+    sit in ``[0.0, 1.0]``."""
+    source = (
+        "theorem foo_helper: true\n"
+        "proof\n  .\nend\n"
+        "\n"
+        "theorem foo_other: true\n"
+        "proof\n  .\nend\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=1, column=1),
+        query="foo",
+    )
+    assert matches
+    assert matches[0].relevance == pytest.approx(1.0)
+    for m in matches:
+        assert 0.0 <= m.relevance <= 1.0
+
+
+def test_module_proximity_breaks_tie_for_same_head() -> None:
+    """Two lemmas with identical head symbols: the one in the user's
+    own file (same module) outranks the one imported from a prelude
+    module."""
+    source = (
+        "theorem local_intro_and: all P:bool, Q:bool. "
+        "if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. "
+        "if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=14, column=3),
+        prelude=("HoleFillPrelude",),
+    )
+    by_name = {m.name: m for m in matches}
+    assert "local_intro_and" in by_name
+    # ``hf_intro_and`` from the prelude has the same head shape but
+    # is in a different module.
+    if "hf_intro_and" in by_name:
+        assert (
+            by_name["local_intro_and"].relevance
+            > by_name["hf_intro_and"].relevance
+        )
+
+
+def test_limit_caps_result_count() -> None:
+    """``limit`` caps how many entries come back."""
+    source = (
+        "theorem t1: true\nproof\n  .\nend\n"
+        "theorem t2: true\nproof\n  .\nend\n"
+        "theorem t3: true\nproof\n  .\nend\n"
+        "theorem t4: true\nproof\n  .\nend\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=1, column=1),
+        query="t",
+        limit=2,
+    )
+    assert len(matches) == 2

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -105,6 +105,7 @@ async def test_all_tools_are_registered(server):
             "eliminable_vars_at",
             "fill_from_given_at",
             "matching_givens_at",
+            "available_lemmas_at",
         }
 
 
@@ -532,6 +533,60 @@ async def test_eliminable_vars_at_returns_candidates(server, tmp_path):
         {"path": str(fp), "line": 5, "column": 3},
     )
     assert "H" in payload
+
+
+# --------------------------------------------------------------------------
+# available_lemmas_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_available_lemmas_at_query_pattern(server, tmp_path):
+    """Goal-shape pattern with `_` placeholders surfaces matching lemmas."""
+    fp = tmp_path / "lemmas.pf"
+    fp.write_text(
+        "theorem helper_le_zero: all x:bool. x = x\n"
+        "proof\n"
+        "  arbitrary x:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    payload = await _call(
+        server,
+        "available_lemmas_at",
+        {
+            "path": str(fp),
+            "line": 1,
+            "column": 1,
+            "query": "helper_le",
+        },
+    )
+    assert isinstance(payload, list)
+    names = [m["name"] for m in payload]
+    assert "helper_le_zero" in names
+    entry = next(m for m in payload if m["name"] == "helper_le_zero")
+    assert entry["kind"] == "theorem"
+    assert entry["module"] == "lemmas"
+    assert 0.0 <= entry["relevance"] <= 1.0
+
+
+@pytest.mark.anyio
+async def test_available_lemmas_at_no_signal_returns_empty(server, tmp_path):
+    """No `?` and no `query` -> empty list."""
+    fp = tmp_path / "empty.pf"
+    fp.write_text(
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    payload = await _call(
+        server,
+        "available_lemmas_at",
+        {"path": str(fp), "line": 4, "column": 3},
+    )
+    assert payload == []
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -73,6 +73,7 @@ EXPECTED_PUBLIC = {
     "SymbolInfo",
     "WorkspaceEdit",
     "LemmaInfo",
+    "LemmaMatch",
     "HoleContext",
     "ValidationResult",
     "check",
@@ -88,6 +89,7 @@ EXPECTED_PUBLIC = {
     "fill_from_given_at",
     "matching_givens_at",
     "hole_context_at",
+    "available_lemmas_at",
     "validate_proof_at",
 }
 


### PR DESCRIPTION
## Summary
- New MCP tool `available_lemmas_at(path, line, column, query?, limit=50)` ranks visible theorems / lemmas / postulates by relevance to the cursor.
- Goal-driven mode: when the cursor sits on a `?`, the goal's head operator and operator/function tokens drive ranking. Off a `?`, an explicit `query` (substring or `_`-pattern goal shape) drives ranking instead.
- Returns `{name, kind, signature, module, relevance}` per match, normalised to `[0.0, 1.0]`. Surfaces user-file declarations (including private `lemma`s) and public declarations from each prelude module; private prelude lemmas (e.g. `mult_pos_nonneg`) are filtered, matching `print_theorems`.

Closes #403.

## Test plan
- [ ] `test/lsp/test_available_lemmas.py` (10 cases: goal-shape match, query substring, `_`-pattern, prelude module attribution, private-lemma visibility, normalisation, module proximity, limit)
- [ ] `test/lsp/test_mcp_server.py` extended for tool registration + the new tool
- [ ] `test/lsp/test_query.py` `__all__` lock updated to include `LemmaMatch` and `available_lemmas_at`
- [ ] CI on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)