### PR TITLE
Fix false-positive errors from speculative proof-check probes (#400)

### DIFF
--- a/error.py
+++ b/error.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import flags
 
 class Diagnostic(Exception):
@@ -180,6 +182,53 @@ def set_active_sink(sink):
 def get_active_sink():
   return _active_sink
 
+# Depth counter for nested speculative_probe blocks. While > 0,
+# ``add_diagnostic`` raises instead of silently recording — so the
+# surrounding ``except UserError`` at a backtracking site actually
+# fires. ``add_incomplete`` is intentionally unaffected so holes
+# from sibling subproofs (e.g. ``?, ?`` in a PTuple) still each
+# become their own diagnostic.
+_speculative_depth = 0
+
+
+@contextlib.contextmanager
+def speculative_probe():
+  """Make a speculative proof-checker probe well-behaved when an
+  error sink is active.
+
+  Use at sites that try one interpretation and have a recovery path
+  on failure (iff-application picking a direction, PTuple's
+  goal-directed-then-synthesis fallback, etc.). Inside the block:
+
+  * ``add_diagnostic`` raises (instead of silently recording into the
+    sink), so the surrounding ``except UserError`` fires and the
+    parent rule's recovery path runs.
+  * ``add_incomplete`` continues to record holes — multiple ``?``
+    siblings still each become their own diagnostic.
+
+  On exit, if a ``UserError`` escaped the block, any sink entries
+  that were added inside are discarded (apart from
+  ``IncompleteProof`` holes, which represent real user-visible
+  ``?``s that the recovery path can't conjure away). Without this,
+  failed probes used to surface as false-positive errors in
+  ``check_file(..., collect_errors=True)`` while ``deduce.py``
+  validated the same file cleanly (issue #400)."""
+  global _speculative_depth
+  sink = _active_sink
+  saved_len = len(sink.errors) if sink is not None else 0
+  _speculative_depth += 1
+  try:
+    yield
+  except UserError:
+    if sink is not None:
+      kept = [e for e in sink.errors[saved_len:]
+              if isinstance(e, IncompleteProof)]
+      del sink.errors[saved_len:]
+      sink.errors.extend(kept)
+    raise
+  finally:
+    _speculative_depth -= 1
+
 def add_diagnostic(location, msg):
   """Record a user-visible diagnostic in the active sink and *return
   normally*, unlike :func:`user_error` which raises. Use at sites whose
@@ -189,9 +238,14 @@ def add_diagnostic(location, msg):
   back to :func:`error` -- so a CLI run still raises and the
   existing ``goal_at`` / MCP paths see the same shape they always
   have.
+
+  Inside a :func:`speculative_probe` block (depth > 0), this also
+  raises -- the parent rule has a recovery path waiting on the
+  exception, and silently recording would leak the failed probe's
+  error into the user-visible list (issue #400).
   """
   global _active_sink
-  if _active_sink is None:
+  if _active_sink is None or _speculative_depth > 0:
     user_error(location, msg)
   exc = UserError(error_header(location) + msg)
   exc.depth = 0

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -23,7 +23,7 @@
 #    reduce some formulas and terms automatically.
 
 from abstract_syntax import *
-from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, ErrorSink, get_active_sink, set_active_sink, add_incomplete, add_diagnostic
+from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, ErrorSink, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe
 from flags import get_verbose, set_verbose, print_verbose, VerboseLevel, get_target_hole_location
 
 imported_modules = set()
@@ -722,7 +722,8 @@ def check_proof(proof, env):
           rets = []
           for prem, conc in imps:
             try:
-              _try_check_proof_of(arg, prem, env)
+              with speculative_probe():
+                check_proof_of(arg, prem, env)
               rets.append(conc)
             except UserError as e:
               pass
@@ -1556,24 +1557,26 @@ def check_proof_of(proof, formula, env):
 
     case PTuple(loc, pfs):
       try:
-        red_formula = formula.reduce(env)
-        match red_formula:
-          case And(loc2, tyof2, frms):
-            for (frm,pf) in zip(frms, pfs):
-              _try_check_proof_of(pf, frm, env)
-            if len(pfs) < len(frms):
-              incomplete_error(loc, 'expected ' + str(len(frms)) + ' proofs but only got '\
-                               + str(len(pfs)))
-          case _:
-            user_error(loc, 'comma proves logical-and, not ' + str(red_formula))
+        with speculative_probe():
+          red_formula = formula.reduce(env)
+          match red_formula:
+            case And(loc2, tyof2, frms):
+              for (frm,pf) in zip(frms, pfs):
+                check_proof_of(pf, frm, env)
+              if len(pfs) < len(frms):
+                incomplete_error(loc, 'expected ' + str(len(frms)) + ' proofs but only got '\
+                                 + str(len(pfs)))
+            case _:
+              user_error(loc, 'comma proves logical-and, not ' + str(red_formula))
       except IncompleteProof as ex:
         raise ex
       except UserError as ex1:
         try:
-          form = check_proof(proof, env)
-          form_red = form.reduce(env)
-          formula_red = formula.reduce(env)
-          check_implies(proof.location, form_red, remove_mark(formula_red))
+          with speculative_probe():
+            form = check_proof(proof, env)
+            form_red = form.reduce(env)
+            formula_red = formula.reduce(env)
+            check_implies(proof.location, form_red, remove_mark(formula_red))
         except UserError as ex2:
           add_diagnostic(loc, 'failed to prove: ' + str(formula) + '\n' \
                 + '\tfirst tried each subproof in goal-directed mode, but:\n' \

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -22,6 +22,7 @@ from lsp.library import CheckResult, check_file  # noqa: E402
 
 PASS_DIR = REPO_ROOT / "test" / "should-validate"
 ERROR_DIR = REPO_ROOT / "test" / "should-error"
+LIB_DIR = REPO_ROOT / "lib"
 
 
 def _pf_files(d: Path) -> list[Path]:
@@ -53,3 +54,18 @@ def test_should_error(path: Path) -> None:
     assert result.error_message != ""
     assert result.exception is not None
     assert result.module_name == path.stem
+
+
+@pytest.mark.parametrize("path", _pf_files(LIB_DIR), ids=lambda p: p.name)
+def test_lib_collect_errors_no_false_positives(path: Path) -> None:
+    """Regression test for issue #400: ``check_file(..., collect_errors=True)``
+    on a stdlib file must agree with ``deduce.py`` -- speculative
+    iff-application and PTuple goal-directed-then-synthesis attempts
+    used to leak failed-probe errors into the sink even when the
+    enclosing rule recovered."""
+    result = check_file(str(path), collect_errors=True, prelude=())
+    assert result.ok, (
+        f"{path.name} should validate but collect_errors mode reported "
+        f"{len(result.errors)} error(s); first:\n{result.error_message}"
+    )
+    assert result.errors == []


### PR DESCRIPTION
## Summary

Fixes [#400](https://github.com/jsiek/deduce/issues/400). `mcp__deduce__check_file` (and the LSP `check_file(..., collect_errors=True)` path it wraps) used to report phantom errors on stdlib files that `deduce.py` validated cleanly — 11 of the 18 `lib/*.pf` files were affected.

The leak came from speculative proof-check sites: when iff-application picks a direction of `P→Q ∧ Q→P` or PTuple's goal-directed mode falls back to synthesis, the failed probe's `add_diagnostic` calls were silently appended to the active error sink even though the enclosing rule had a recovery path. fail-fast mode was unaffected because the `except` block let the failed probe vanish.

## What changed

- New `speculative_probe` context manager in [error.py](error.py). Inside the block, `add_diagnostic` raises (so the parent's `except UserError` actually fires); `add_incomplete` keeps recording (so sibling `?` holes still each become their own diagnostic). On `UserError` exit, sink entries added during the probe are removed — `IncompleteProof` entries are preserved so a hole + sibling-error case keeps the hole.
- Two call sites in [proof_checker.py](proof_checker.py) wrapped: iff-apply's `And` direction-picker and PTuple's goal-directed-then-synthesis fallback. Both now use plain `check_proof_of` so the `UserError` actually escapes to the recovery path.
- Regression test [test/lsp/test_library.py:test_lib_collect_errors_no_false_positives](test/lsp/test_library.py) parametrized over every `lib/*.pf` file (32 cases) — asserts `check_file(..., collect_errors=True)` agrees with the CLI.

## Test plan

- [x] All 32 affected `lib/*.pf` files now check OK with `collect_errors=True`.
- [x] `python3.13 test-deduce.py --lib`, `--passable`, `--errors`, `--parser` all pass.
- [x] `python3.13 -m pytest test/lsp` at parity with `main`: 59 pre-existing failures, 689 passed (including the 32 new regression tests).
- [x] Original issue reproduction: `lib/NatLess.pf` returns ok=True / 0 errors in both fail-fast and collect-errors modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)