### PR TITLE
MCP: add apply_at preview tool for forward `apply` checks (#402)

### DIFF
--- a/error.py
+++ b/error.py
@@ -211,7 +211,7 @@ def add_incomplete(location, msg, formula=None, env=None):
   """
   global _active_sink
   if _active_sink is None:
-    incomplete_error(location, msg)
+    incomplete_error(location, msg, formula=formula, env=env)
   exc = IncompleteProof(error_header(location) + msg)
   exc.depth = 0
   exc.location = location

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -412,6 +412,56 @@ def matching_givens_at(
 
 
 @mcp.tool()
+def apply_at(
+    path: str, line: int, column: int,
+    theorem: str,
+    args: Optional[list[str]] = None,
+) -> Optional[dict]:
+    """Preview ``apply <theorem>[<args>] to ?`` at the hole at
+    ``line``:``column``.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token.
+    ``theorem`` is the name of an in-scope hypothesis, theorem, lemma,
+    or postulate. ``args`` is the optional ordered list of explicit
+    term arguments instantiating ``theorem``'s outermost ``all``
+    quantifiers, matching the ``theorem[arg, arg, ...]`` syntax. Each
+    entry is the rendered text of a term (parsed in the scope at the
+    hole, so ``arbitrary``-bound variables are visible).
+
+    Returns ``None`` when the cursor isn't on a ``?``, the
+    surrounding file fails to parse, or the targeted hole isn't
+    reached. Otherwise returns a dict whose ``outcome`` field
+    discriminates the shape:
+
+    - ``{"outcome": "ok", "conclusion": "<formula>",
+       "remaining_premises": ["<formula>", ...]}`` -- the apply would
+      succeed; ``remaining_premises`` is the ordered list of
+      obligations the user still has to prove (split on top-level
+      ``and`` so it maps to what would go after ``to``).
+    - ``{"outcome": "unifies_against", "goal": "<formula>",
+       "reason": "<message>"}`` -- the conclusion didn't match the
+      goal, or all-bound variables couldn't be deduced.
+    - ``{"outcome": "unbound", "theorem": "<name>"}`` -- the theorem
+      isn't in scope at the hole.
+    - ``{"outcome": "arity_mismatch", "expected": N, "got": M}``
+      (or ``{"outcome": "arity_mismatch", "reason": "..."}``) --
+      too many ``[args]`` for the theorem's outer quantifiers, or
+      ``theorem`` is not an implication.
+
+    Companion to ``eliminate_at`` (which generates an ``apply`` /
+    ``cases`` / ... template from a hypothesis): ``eliminate_at`` says
+    *what tactic to write*; ``apply_at`` says *whether the apply will
+    actually unify with the current goal*.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    return query.apply_at(
+        path, content, pos, theorem,
+        args=args, prelude=_prelude_for(path),
+    )
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -76,6 +76,7 @@ __all__ = [
     "eliminable_vars_at",
     "fill_from_given_at",
     "matching_givens_at",
+    "apply_at",
     "hole_context_at",
     "validate_proof_at",
 ]
@@ -2109,6 +2110,307 @@ def _fill_from_given_template(label: str, goal, env) -> Optional[str]:
     if binding.formula != goal:
         return None
     return f"conclude {goal} by {label}"
+
+
+# ---------------------------------------------------------------------------
+# apply_at -- issue #402: forward `apply` preview tool
+# ---------------------------------------------------------------------------
+#
+# Sibling to ``eliminate_at`` / ``fill_from_given_at``: simulates
+# ``apply <theorem>[<args>] to ?`` against the goal at the cursor's
+# hole and reports whether the apply would succeed, what conclusion it
+# produces, and what premises the user would still have to discharge.
+#
+# Strategy: do the matching manually rather than splicing ``apply ...
+# to ?`` and reading the result. Splicing looked simpler but suffers
+# from a short-circuit in ``proof_checker.ModusPonens``: the inner
+# ``?`` raises ``IncompleteProof`` *before* the apply's conclusion is
+# compared with the outer goal, so a mismatched conclusion looks like
+# success. Manual matching reproduces what the checker would do
+# (``collect_all_if_then`` + ``formula_match``) and gives us full
+# visibility into both the conclusion match and the premise.
+#
+# When ``args`` is non-empty, we splice ``define`` statements at the
+# hole so the proof checker parses and type-checks the user-supplied
+# arg expressions in the right scope (the variables ``arbitrary``-
+# bound by the surrounding proof have to be visible). We then read the
+# resulting term ASTs out of ``env`` and feed them to ``instantiate``.
+
+
+def apply_at(
+    path: str, content: str, pos: Position,
+    theorem: str,
+    args: Optional[Sequence[str]] = None,
+    prelude: Sequence[str] = (),
+) -> Optional[dict]:
+    """Preview ``apply <theorem>[<args>] to ?`` at the cursor's hole.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token.
+    ``theorem`` names an in-scope hypothesis, theorem, lemma, or
+    postulate. ``args`` is the optional list of explicit term arguments
+    instantiating the theorem's outermost ``all`` quantifiers --
+    matching the ``theorem[arg, arg, ...]`` syntax. Each entry is the
+    rendered text of a term (parsed in the scope at the hole, so
+    ``arbitrary``-bound variables are visible).
+
+    Returns ``None`` when the cursor isn't on a ``?`` or when the
+    surrounding file fails to reach an ``IncompleteProof`` at the
+    targeted hole (e.g. earlier parse / type errors). Otherwise returns
+    a dict whose ``outcome`` field discriminates the shape:
+
+    - ``{"outcome": "ok", "conclusion": "<rendered formula>",
+       "remaining_premises": ["<formula>", ...]}``
+       The apply would succeed; ``conclusion`` is the goal at the hole
+       (which the apply matched), and ``remaining_premises`` is the
+       ordered list of obligations the user still has to prove. A
+       conjunctive premise is split on top-level ``and`` so the list
+       maps to what the user would put after ``to``.
+
+    - ``{"outcome": "unifies_against", "goal": "<rendered formula>",
+       "reason": "<message>"}``
+       The conclusion did not match the goal, or instantiation could
+       not deduce the all-bound variables.
+
+    - ``{"outcome": "unbound", "theorem": "<name>"}``
+       ``theorem`` is not in scope at the hole.
+
+    - ``{"outcome": "arity_mismatch", "expected": N, "got": M}``
+       Too many ``[args]`` were supplied for the theorem's outer
+       quantifiers (``expected`` is the maximum acceptable count;
+       ``got`` is ``len(args)``). Also returned without ``expected`` /
+       ``got`` when ``theorem`` is not an implication at all.
+    """
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return None
+
+    from error import IncompleteProof
+    from lsp.library import check_file
+
+    # Splice ``define`` statements at the hole so user-supplied arg
+    # expressions are parsed and type-checked in the surrounding
+    # proof's scope. Without args we just check the file as-is.
+    if args:
+        run_path, run_content, target = _splice_apply_args(
+            path, content, hole_range, args
+        )
+    else:
+        run_path = path
+        run_content = content
+        target = (hole_range.start.line, hole_range.start.column)
+
+    with _target_hole(target):
+        result = check_file(run_path, content=run_content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    if not isinstance(exc, IncompleteProof):
+        # Splicing a malformed arg expression can produce a UserError
+        # at the synthetic ``define`` line. Surface it as a parse-of-
+        # arg error rather than pretending the apply itself failed.
+        if args:
+            msg = getattr(exc, "message_body", None) or str(exc) or ""
+            return {
+                "outcome": "unifies_against",
+                "goal": "",
+                "reason": "could not parse args: " + msg.strip(),
+            }
+        return None
+    goal = getattr(exc, "formula", None)
+    env = getattr(exc, "env", None)
+    if goal is None or env is None:
+        return None
+
+    # When ``args`` were spliced via ``define _apply_at_arg_N = <arg>``,
+    # the goal printed by the checker is in terms of the synthetic
+    # alias instead of the user's original term (e.g. ``_apply_at_arg_0``
+    # in place of ``Q``). Render the goal with full reduction so the
+    # user-visible string is unaffected by the splice.
+    from abstract_syntax import set_reduce_all
+    if args:
+        set_reduce_all(True)
+        try:
+            goal_for_display = goal.reduce(env)
+        finally:
+            set_reduce_all(False)
+        goal_str = str(goal_for_display)
+    else:
+        goal_str = str(goal)
+
+    from abstract_syntax import ProofBinding, TermBinding, base_name
+    matches = [k for k in env.dict if base_name(k) == theorem]
+    if not matches or not isinstance(env.dict[matches[0]], ProofBinding):
+        return {"outcome": "unbound", "theorem": theorem}
+    formula = env.dict[matches[0]].formula
+
+    # Resolve and apply each user-supplied arg by instantiating the
+    # outermost ``All``-quantifier on the theorem formula.
+    if args:
+        from proof_checker import instantiate
+        from abstract_syntax import All
+        for i, raw_arg in enumerate(args):
+            arg_key = _APPLY_AT_ARG_PREFIX + str(i)
+            arg_matches = [k for k in env.dict if base_name(k) == arg_key]
+            if not arg_matches:
+                return {
+                    "outcome": "unifies_against",
+                    "goal": goal_str,
+                    "reason": "could not parse arg #" + str(i + 1)
+                              + ": " + raw_arg,
+                }
+            binding = env.dict[arg_matches[0]]
+            if not isinstance(binding, TermBinding) or binding.defn is None:
+                return {
+                    "outcome": "unifies_against",
+                    "goal": goal_str,
+                    "reason": "arg #" + str(i + 1) + " is not a term: "
+                              + raw_arg,
+                }
+            if not isinstance(formula, All):
+                already_consumed = i
+                return {
+                    "outcome": "arity_mismatch",
+                    "expected": already_consumed,
+                    "got": len(args),
+                }
+            formula = instantiate(formula.location, formula, binding.defn)
+
+    return _apply_match_manual(formula, goal, env, goal_str)
+
+
+_APPLY_AT_ARG_PREFIX = "_apply_at_arg_"
+
+
+def _splice_apply_args(
+    path: str, content: str, hole_range: Range, args: Sequence[str]
+) -> tuple:
+    """Splice ``define _apply_at_arg_N = <arg_N>`` statements before
+    the hole and return ``(path, modified_content, target_pos)``.
+
+    The new ``?`` ends up on the line after the last define so the
+    surrounding proof body's indentation isn't disturbed.
+    """
+    start_off = _line_col_to_offset(content, hole_range.start)
+    end_off = _line_col_to_offset(content, hole_range.end)
+    indent = _line_indent_at(content, hole_range.start)
+
+    define_lines = "".join(
+        f"define {_APPLY_AT_ARG_PREFIX}{i} = {raw}\n{indent}"
+        for i, raw in enumerate(args)
+    )
+    splice_text = define_lines + "?"
+    spliced = content[:start_off] + splice_text + content[end_off:]
+
+    new_offset = start_off + len(splice_text) - 1
+    new_line, new_col = _offset_to_line_col(spliced, new_offset)
+    return path, spliced, (new_line, new_col)
+
+
+def _apply_match_manual(formula, goal, env, goal_str: str) -> dict:
+    """Compute the result of ``apply <formula> to ?`` against ``goal``.
+
+    Mirrors what ``ModusPonens`` does in ``proof_checker``:
+
+    - ``if P then C``: ``C`` must reduce to the goal; ``P`` is the
+      premise the user still has to prove.
+    - ``all xs. <body>``: collect outer ``all``-quantifiers and the
+      ``(prem, conc)`` pairs of the body via ``collect_all_if_then``,
+      then ``formula_match`` each conclusion against the goal to
+      deduce the all-bound variables; substitute those back into the
+      premise.
+    - anything else: ``arity_mismatch`` -- the theorem isn't an
+      implication.
+
+    Reductions happen with ``reduce_all`` enabled so the synthetic
+    ``define _apply_at_arg_N = <arg>`` bindings the splice introduces
+    fold back to their definitions before the comparison.
+    """
+    from abstract_syntax import All, IfThen, formula_match, set_reduce_all
+    from error import MatchFailed
+    from proof_checker import collect_all_if_then
+
+    location = formula.location
+
+    set_reduce_all(True)
+    try:
+        if isinstance(formula, IfThen):
+            if formula.conclusion.reduce(env) == goal.reduce(env):
+                premise = formula.premise.reduce(env)
+                return {
+                    "outcome": "ok",
+                    "conclusion": goal_str,
+                    "remaining_premises": _split_premise_on_and(premise),
+                }
+            return {
+                "outcome": "unifies_against",
+                "goal": goal_str,
+                "reason": (
+                    "the proved formula\n\t" + str(formula.conclusion)
+                    + "\ndoes not match the goal\n\t" + goal_str
+                ),
+            }
+
+        if isinstance(formula, All):
+            try:
+                vars, imps = collect_all_if_then(location, formula, env)
+            except Exception as e:
+                msg = getattr(e, "message_body", None) or str(e) or ""
+                return {
+                    "outcome": "arity_mismatch",
+                    "reason": msg.strip() if msg else (
+                        "expected an if-then formula under "
+                        "the all-quantifiers, not " + str(formula)
+                    ),
+                }
+            reasons = []
+            for prem, conc in imps:
+                matching = {}
+                try:
+                    formula_match(location, vars, conc, goal, matching, env)
+                except MatchFailed as e:
+                    reasons.append(str(e))
+                    continue
+                unmatched = [v for v in vars if v.name not in matching]
+                if unmatched:
+                    reasons.append(
+                        "could not deduce instantiations for "
+                        + ", ".join(str(v) for v in unmatched)
+                    )
+                    continue
+                premise = prem.substitute(matching).reduce(env)
+                return {
+                    "outcome": "ok",
+                    "conclusion": goal_str,
+                    "remaining_premises": _split_premise_on_and(premise),
+                }
+            return {
+                "outcome": "unifies_against",
+                "goal": goal_str,
+                "reason": (
+                    "\n".join(reasons) if reasons
+                    else "no quantified implication conclusion matched the goal"
+                ),
+            }
+
+        return {
+            "outcome": "arity_mismatch",
+            "reason": "expected an if-then formula, not " + str(formula),
+        }
+    finally:
+        set_reduce_all(False)
+
+
+def _split_premise_on_and(formula) -> list:
+    """If ``formula`` is a top-level conjunction, render each conjunct
+    separately so the result maps to what the user would put after
+    ``to`` (Deduce desugars ``to A, B`` into a tuple proof of an
+    ``And``). Otherwise return a singleton list."""
+    from abstract_syntax import And
+
+    if isinstance(formula, And):
+        return [str(arg) for arg in formula.args]
+    return [str(formula)]
 
 
 # ---------------------------------------------------------------------------

--- a/test/lsp/test_apply.py
+++ b/test/lsp/test_apply.py
@@ -1,0 +1,304 @@
+"""Acceptance tests for ``lsp.query.apply_at`` (issue #402).
+
+UX shape: cursor on a ``?`` plus the name of an in-scope theorem
+or hypothesis, plus an optional ordered list of explicit term
+arguments instantiating outer ``all``-quantifiers (matching the
+``theorem[arg, arg, ...]`` syntax).
+
+Coverage:
+
+(a) ``H: if P then C``, goal C ........... ok with [P]
+(b) ``H: if P and Q then C``, goal C ..... ok with [P, Q] (split)
+(c) ``T: all x. if P(x) then C(x)``, goal C(v) — no args, infer x ............... ok with [P(v)]
+(d) ``T: all x. if P(x) then C(x)``, args [v] (explicit) ............... ok with [P(v)]
+(e) Conclusion does not match goal ....... unifies_against
+(f) Theorem name not in scope ............ unbound
+(g) Theorem isn't an implication ......... arity_mismatch
+(h) Too many ``[args]`` for outer alls ... arity_mismatch w/ expected,got
+(i) Cursor not on ``?`` .................. None
+
+All fixtures stay inside ``bool``-only territory so the tests run
+without the standard library prelude.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    apply_at,
+)
+
+
+def test_apply_at_local_ifthen_hypothesis() -> None:
+    """``H: if P then Q`` against goal ``Q`` -> ``ok`` with premise
+    ``[P]``."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if (if P then Q) and P then Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: (if P then Q) and P\n"
+        "  have Hpq: if P then Q by conjunct 0 of H\n"
+        "  have Hp: P by conjunct 1 of H\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=7, column=3), "Hpq"
+    )
+    assert result == {
+        "outcome": "ok",
+        "conclusion": "Q",
+        "remaining_premises": ["P"],
+    }
+
+
+def test_apply_at_conjunctive_premise_splits_on_and() -> None:
+    """A premise of the shape ``P and Q`` is split into two entries
+    so it maps to what the user would write after ``to``."""
+    source = (
+        "theorem multi: all P:bool, Q:bool. if P and Q then Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P and Q\n"
+        "  conjunct 1 of H\n"
+        "end\n"
+        "\n"
+        "theorem t: all R:bool, S:bool. if R then if S then S\n"
+        "proof\n"
+        "  arbitrary R:bool, S:bool\n"
+        "  assume HR: R\n"
+        "  assume HS: S\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=13, column=3),
+        "multi", args=["R", "S"],
+    )
+    assert result == {
+        "outcome": "ok",
+        "conclusion": "S",
+        "remaining_premises": ["R", "S"],
+    }
+
+
+def test_apply_at_quantified_no_args_infers_from_goal() -> None:
+    """``identity: all P. if P then P`` against goal ``Q`` infers
+    ``P := Q`` from unifying the conclusion with the goal."""
+    source = (
+        "theorem identity: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+        "\n"
+        "theorem t: all Q:bool. if Q then Q\n"
+        "proof\n"
+        "  arbitrary Q:bool\n"
+        "  assume H: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=12, column=3), "identity"
+    )
+    assert result == {
+        "outcome": "ok",
+        "conclusion": "Q",
+        "remaining_premises": ["Q"],
+    }
+
+
+def test_apply_at_quantified_with_explicit_args() -> None:
+    """Explicit ``[Q]`` instantiates the outer ``all P`` directly."""
+    source = (
+        "theorem identity: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+        "\n"
+        "theorem t: all Q:bool. if Q then Q\n"
+        "proof\n"
+        "  arbitrary Q:bool\n"
+        "  assume H: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=12, column=3),
+        "identity", args=["Q"],
+    )
+    assert result == {
+        "outcome": "ok",
+        "conclusion": "Q",
+        "remaining_premises": ["Q"],
+    }
+
+
+def test_apply_at_conclusion_does_not_match_goal() -> None:
+    """``identity[Q]`` against goal ``R`` -> conclusion ``Q``
+    doesn't match ``R``."""
+    source = (
+        "theorem identity: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+        "\n"
+        "theorem t: all Q:bool, R:bool. if Q then R\n"
+        "proof\n"
+        "  arbitrary Q:bool, R:bool\n"
+        "  assume H: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=12, column=3),
+        "identity", args=["Q"],
+    )
+    assert result is not None
+    assert result["outcome"] == "unifies_against"
+    assert result["goal"] == "R"
+    assert "Q" in result["reason"] and "R" in result["reason"]
+
+
+def test_apply_at_unbound_theorem() -> None:
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=5, column=3), "no_such_thing"
+    )
+    assert result == {
+        "outcome": "unbound",
+        "theorem": "no_such_thing",
+    }
+
+
+def test_apply_at_not_an_implication() -> None:
+    """``H: P`` is a bare proposition, not an implication."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert result is not None
+    assert result["outcome"] == "arity_mismatch"
+    assert "if-then" in result["reason"]
+
+
+def test_apply_at_too_many_args() -> None:
+    """``identity`` has one outer ``all``; passing two args is over."""
+    source = (
+        "theorem identity: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+        "\n"
+        "theorem t: all Q:bool. if Q then Q\n"
+        "proof\n"
+        "  arbitrary Q:bool\n"
+        "  assume H: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=12, column=3),
+        "identity", args=["Q", "Q"],
+    )
+    assert result == {
+        "outcome": "arity_mismatch",
+        "expected": 1,
+        "got": 2,
+    }
+
+
+def test_apply_at_arg_does_not_parse() -> None:
+    """An arg referencing an undefined variable surfaces as
+    ``unifies_against`` with a ``could not parse args`` reason."""
+    source = (
+        "theorem identity: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+        "\n"
+        "theorem t: all Q:bool. if Q then Q\n"
+        "proof\n"
+        "  arbitrary Q:bool\n"
+        "  assume H: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=12, column=3),
+        "identity", args=["this_is_not_in_scope"],
+    )
+    assert result is not None
+    assert result["outcome"] == "unifies_against"
+    assert "could not parse args" in result["reason"]
+
+
+def test_apply_at_returns_none_when_cursor_not_on_hole() -> None:
+    """Cursor on the ``assume`` keyword, not on a ``?``."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = apply_at(
+        "test.pf", source, Position(line=4, column=3), "H"
+    )
+    assert result is None
+
+
+def test_apply_at_no_args_and_local_premise_unifies() -> None:
+    """Without ``args`` and a fully-instantiated implication, the
+    premise comes through directly."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if (if P then Q) and P then Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: (if P then Q) and P\n"
+        "  have Hpq: if P then Q by conjunct 0 of H\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Hpq has formula ``if P then Q`` with no Alls.
+    result = apply_at(
+        "test.pf", source, Position(line=6, column=3), "Hpq"
+    )
+    assert result == {
+        "outcome": "ok",
+        "conclusion": "Q",
+        "remaining_premises": ["P"],
+    }

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -105,6 +105,7 @@ async def test_all_tools_are_registered(server):
             "eliminable_vars_at",
             "fill_from_given_at",
             "matching_givens_at",
+            "apply_at",
         }
 
 
@@ -532,6 +533,99 @@ async def test_eliminable_vars_at_returns_candidates(server, tmp_path):
         {"path": str(fp), "line": 5, "column": 3},
     )
     assert "H" in payload
+
+
+# --------------------------------------------------------------------------
+# apply_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_apply_at_returns_ok_dict(server, tmp_path):
+    """Cursor on ``?`` + ``theorem='H'`` for an in-scope ``if P then Q``
+    -> ``ok`` outcome with the premise as a remaining obligation."""
+    src = (
+        "theorem t: all P:bool, Q:bool. if (if P then Q) and P then Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: (if P then Q) and P\n"
+        "  have Hpq: if P then Q by conjunct 0 of H\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "apply_ok.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "apply_at",
+        {"path": str(fp), "line": 6, "column": 3, "theorem": "Hpq"},
+    )
+    assert payload == {
+        "outcome": "ok",
+        "conclusion": "Q",
+        "remaining_premises": ["P"],
+    }
+
+
+@pytest.mark.anyio
+async def test_apply_at_unbound_returns_unbound_dict(server, tmp_path):
+    src = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "apply_unbound.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "apply_at",
+        {"path": str(fp), "line": 5, "column": 3, "theorem": "no_such"},
+    )
+    assert payload == {"outcome": "unbound", "theorem": "no_such"}
+
+
+@pytest.mark.anyio
+async def test_apply_at_with_args_instantiates_quantifier(
+    server, tmp_path
+):
+    """Explicit ``[Q]`` instantiates the outer ``all P`` so the
+    conclusion ``Q`` matches the goal."""
+    src = (
+        "theorem identity: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+        "\n"
+        "theorem t: all Q:bool. if Q then Q\n"
+        "proof\n"
+        "  arbitrary Q:bool\n"
+        "  assume H: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "apply_args.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "apply_at",
+        {
+            "path": str(fp),
+            "line": 12,
+            "column": 3,
+            "theorem": "identity",
+            "args": ["Q"],
+        },
+    )
+    assert payload == {
+        "outcome": "ok",
+        "conclusion": "Q",
+        "remaining_premises": ["Q"],
+    }
 
 
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -87,6 +87,7 @@ EXPECTED_PUBLIC = {
     "eliminable_vars_at",
     "fill_from_given_at",
     "matching_givens_at",
+    "apply_at",
     "hole_context_at",
     "validate_proof_at",
 }


### PR DESCRIPTION
## Summary

- Adds `apply_at(path, line, column, theorem, args?)` MCP tool — sibling to `eliminate_at` / `fill_from_given_at`, implements [#402](https://github.com/jsiek/deduce/issues/402).
- Simulates `apply <theorem>[<args>] to ?` against the goal at the cursor's hole and reports whether the apply would unify, what conclusion it produces, and what premises the user would still have to discharge.
- Drive-by: `error.add_incomplete` was dropping `formula`/`env` when no sink was active, breaking the four existing query tools that read those attributes (`eliminate_at`, `eliminable_vars_at`, `fill_from_given_at`, `matching_givens_at`). Forwarding kwargs through to `incomplete_error` fixes them.

Companion to the existing `eliminate_at`: `eliminate_at` says *what tactic to write*; `apply_at` says *whether the apply will actually unify with the current goal*.

## Outcome shapes

- `{outcome: "ok", conclusion, remaining_premises}` — conjunctive premises are split on top-level `and` so the list maps to what the user would put after `to`.
- `{outcome: "unifies_against", goal, reason}` — conclusion didn't match the goal, or quantifier instantiation could not be deduced.
- `{outcome: "unbound", theorem}`.
- `{outcome: "arity_mismatch", expected, got}` for over-arity, or `{outcome: "arity_mismatch", reason}` when the theorem isn't an implication.

## Implementation note

I went with manual matching (mirroring `proof_checker.ModusPonens`'s `collect_all_if_then` + `formula_match`) rather than splicing `apply ... to ?` and reading the inner `?`'s `IncompleteProof`. Splicing would short-circuit: the proof checker type-checks the apply's arg *before* comparing the conclusion against the outer goal, so a mismatched conclusion would falsely look like success. Manual matching gives full visibility into both the conclusion match and the substituted premise.

When `args` are supplied they're parsed by splicing `define _apply_at_arg_N = <arg>` statements at the hole — that way the surrounding proof's `arbitrary`-bound variables are visible to the arg expressions, matching how the user would write them inline.

## Test plan

- [x] `python3.13 -m pytest test/lsp/test_apply.py` — 11 acceptance tests pass (ok, conjunctive premise split, all-quantified inference, explicit args, conclusion mismatch, unbound, not-an-implication, too-many-args, arg parse error, off-hole, fully-instantiated implication).
- [x] `python3.13 -m pytest test/lsp/` — all 730 tests pass (the `add_incomplete` fix re-enables the previously-broken `eliminate_at` test cases).
- [x] `python3.13 test-deduce.py --passable` and `--errors` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)