### PR TITLE
MCP: add auto_rules_at (#404)

### DIFF
--- a/docs/lsp-plan.md
+++ b/docs/lsp-plan.md
@@ -179,6 +179,12 @@ Steps 15 and 18 are duals: Step 15 is **introduction** (template chosen by the *
 
   - *Implementation:* `lsp/query.py:matching_givens_at` walks `IncompleteProof`'s stashed env for `ProofBinding`s whose formula equals the goal and returns the labels in declaration order; `fill_from_given_at` validates that `label` is among them and emits `WorkspaceEdit(... new_text="conclude <goal> by <label>")` covering the `?` token.  Filters out `Theorem`-typed bindings -- those are referred to by name directly, no `conclude … by` wrapping needed.  14-case acceptance test in `test/lsp/test_fill_from_given.py` covering single-match, multi-match completion list, no-match (returns `None`), label-not-in-scope, and the auto-apply / completing-read editor flow.
 
+- [x] **Step 20: List in-scope `auto` rewrite rules (issue #404).**  Pure read-only query, no edit.  When Deduce silently rewrites a goal via an `auto` rule (or rejects a `replace` with *no need for replace because this equation is handled automatically*), the user wants to know which rule fired.  Today the recovery is `grep '^auto ' lib/*.pf`; the post-uniquify state already has the answer.
+
+  New query API: `auto_rules_at(path, content, pos, prelude=()) -> tuple[AutoRule, ...]` plus a new frozen `AutoRule(name, equation, module)` dataclass added to `lsp/query.py` and `__all__`.  Order matches declaration order — the same order ``abstract_syntax.auto_rewrites`` tries equations when several share a head constructor.  MCP-only for v1: the issue notes the editor side is less load-bearing (the diagnostic surface that *needs* the answer is "no need for replace" and the agent can call the tool itself); skip the LSP custom request unless an editor consumer asks.
+
+  - *Implementation:* `lsp/query.py:auto_rules_at` runs `check` once, then walks every module cached in `get_uniquified_modules()` for top-level `Auto` statements (always in scope — they were imported into the env before the user's file ran) and the user file's AST for the same nodes filtered to `location <= pos`.  Each rule's `equation` is resolved by looking up the referenced theorem's `what` in the same walk's `Theorem`/`Postulate` map.  MCP wrapper `auto_rules_at(path, line, column)` in `mcp_server.py`.  7-case acceptance test in `test/lsp/test_auto_rules.py` covering declaration order, position filtering, the empty case, and the dataclass shape; matching MCP wrapper test in `test/lsp/test_mcp_server.py`.
+
 ## Cross-cutting notes
 
 - Add `lsp/` to the `make tests` target as a separate phase, otherwise it'll bitrot.

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -587,6 +587,29 @@ def available_lemmas_at(
 
 
 @mcp.tool()
+def auto_rules_at(path: str, line: int, column: int) -> list[dict]:
+    """Return ``auto`` rewrite rules in scope at ``line``:``column``.
+
+    Lines and columns are 1-indexed.  Each entry has ``name`` (the
+    user-visible identifier of the source theorem), ``equation`` (the
+    rendered formula the rule rewrites with), and ``module`` (the
+    module that declared the ``auto`` statement).  Order matches
+    declaration order, which is also the order the auto-rewriter
+    tries equations when multiple share a head constructor -- so the
+    first hit in the list is the one that fires first.
+
+    Useful when Deduce reports *no need for replace because this
+    equation is handled automatically* or a goal silently simplifies
+    before a tactic runs: scan the list for the rewrite rule whose
+    equation matches the surprise.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    rules = query.auto_rules_at(path, content, pos, prelude=_prelude_for(path))
+    return _to_serializable(rules)
+
+
+@mcp.tool()
 def list_symbols(path: str) -> list[dict]:
     """Return all top-level declarations in ``path``.
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -66,6 +66,7 @@ __all__ = [
     "ValidationResult",
     "RewritePreview",
     "ExpandPreview",
+    "AutoRule",
     # Query functions
     "check",
     "goal_at",
@@ -85,6 +86,7 @@ __all__ = [
     "validate_proof_at",
     "preview_replace_at",
     "preview_expand_at",
+    "auto_rules_at",
 ]
 
 
@@ -356,6 +358,26 @@ class ValidationResult:
 
     ok: bool
     error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AutoRule:
+    """An ``auto`` rewrite rule visible at a source position.
+
+    Returned (in tuples) by :func:`auto_rules_at`. ``name`` is the
+    user-visible identifier of the theorem the rule was declared from
+    (i.e. ``base_name`` of the uniquified name). ``equation`` is the
+    rendered formula -- the same string Deduce's printer would
+    produce for the theorem's body -- so callers can see what shape
+    the auto-rewriter will rewrite. ``module`` is the module that
+    declared the ``auto`` statement (the file stem for prelude
+    modules and for the user file itself), useful to disambiguate
+    rules with the same base name from different modules.
+    """
+
+    name: str
+    equation: str
+    module: str
 
 
 # ---------------------------------------------------------------------------
@@ -3558,4 +3580,139 @@ def _preview_expand(
         outcome="ok",
         before=str(formula),
         after=str(after),
+    )
+
+
+# ---------------------------------------------------------------------------
+# auto_rules_at -- list `auto` rewrite rules in scope at a position
+# ---------------------------------------------------------------------------
+#
+# Issue #404: when Deduce reports "no need for replace because this
+# equation is handled automatically" or a goal silently simplifies
+# before a tactic can fire, the user wants to know which `auto`
+# declaration is responsible without grepping the prelude.  This
+# function returns every `auto` rule visible at the cursor in
+# declaration order -- the same order ``auto_rewrites`` (in
+# ``abstract_syntax.py``) tries them when several heads match.
+
+
+def auto_rules_at(
+    path: str,
+    content: str,
+    pos: Position,
+    prelude: Sequence[str] = (),
+) -> tuple:
+    """Return the ``auto`` rewrite rules in scope at ``pos``.
+
+    The returned tuple lists rules in *declaration order* -- the same
+    order the auto-rewriter applies them when multiple equations
+    share a head constructor.  Sources are walked in this order:
+
+    1. Every module currently cached in ``get_uniquified_modules()``
+       (the prelude transitively, plus any module the user file
+       imports), each module's ``Auto`` statements in source order.
+       Modules are visited in the alphabetical iteration order of
+       the cache, which is stable for a given prelude key.
+    2. The user's file itself, ``Auto`` statements in source order,
+       restricted to those whose location is at or before ``pos``.
+
+    Each entry's ``equation`` is the rendered formula of the theorem
+    the rule references; if the theorem can't be located in any
+    walked AST (rare -- e.g. a private lemma in a module we can
+    only see through a filtered import), ``equation`` is ``""``.
+
+    ``prelude`` matches the meaning in :func:`check`.  Returns ``()``
+    when the file fails to parse before any prelude is loaded.
+    """
+    from abstract_syntax import (
+        Auto,
+        Postulate,
+        Theorem,
+        get_uniquified_modules,
+    )
+    from lsp.library import check_file
+    from pathlib import Path as _Path
+
+    # Run the pipeline once. We don't bail on errors -- partial
+    # results are still useful (and the prelude state is loaded by
+    # ``_prepare_state`` before the user file is even parsed).
+    result = check_file(path, content=content, prelude=prelude)
+
+    user_module = _Path(path).stem
+    cached_modules = get_uniquified_modules()
+
+    # Build a lookup ``unique_name -> formula_text`` so each Auto
+    # can resolve its referenced theorem.  Walk every module we
+    # know about, then the user file's own AST (which overrides any
+    # cached entry that happens to share a unique name -- shouldn't
+    # happen in practice, but the cache could be slightly stale).
+    formula_by_name: dict[str, str] = {}
+    for module_name, module_ast in cached_modules.items():
+        if module_name == user_module:
+            continue
+        for stmt in module_ast or ():
+            if isinstance(stmt, (Theorem, Postulate)):
+                formula_by_name[stmt.name] = str(stmt.what)
+    if result.ast is not None:
+        for stmt in result.ast:
+            if isinstance(stmt, (Theorem, Postulate)):
+                formula_by_name[stmt.name] = str(stmt.what)
+
+    rules: list[AutoRule] = []
+
+    for module_name in sorted(cached_modules.keys()):
+        if module_name == user_module:
+            continue
+        module_ast = cached_modules.get(module_name)
+        if module_ast is None:
+            continue
+        for stmt in module_ast:
+            if isinstance(stmt, Auto):
+                rules.append(_auto_rule_from_stmt(stmt, module_name, formula_by_name))
+
+    if result.ast is not None:
+        for stmt in result.ast:
+            if isinstance(stmt, Auto) and _meta_at_or_before(stmt.location, pos):
+                rules.append(_auto_rule_from_stmt(stmt, user_module, formula_by_name))
+
+    return tuple(rules)
+
+
+def _meta_at_or_before(meta, pos: Position) -> bool:
+    """True iff ``meta`` starts at or before 1-indexed ``pos``.
+
+    Empty/missing meta counts as "before" so we don't drop a rule
+    just because the parser elided its location info.
+    """
+    if getattr(meta, "empty", True):
+        return True
+    if meta.line < pos.line:
+        return True
+    if meta.line == pos.line and meta.column <= pos.column:
+        return True
+    return False
+
+
+def _auto_rule_from_stmt(stmt, module_name: str, formula_by_name) -> "AutoRule":
+    """Render an ``Auto`` AST node into an :class:`AutoRule`.
+
+    ``Auto.name`` is a ``PVar`` (or compatible proof reference) whose
+    ``.name`` field holds the uniquified identifier after
+    ``uniquify``.  ``base_name`` strips the suffix to recover what
+    the user wrote.  ``formula_by_name`` is the lookup built in
+    :func:`auto_rules_at`.
+    """
+    from abstract_syntax import base_name
+
+    unique = getattr(stmt.name, "name", None)
+    if unique is None:
+        # Best effort: render whatever Term is here (shouldn't happen
+        # in practice -- the parsers always emit a PVar).
+        return AutoRule(
+            name=str(stmt.name), equation="", module=module_name
+        )
+    return AutoRule(
+        name=base_name(unique),
+        equation=formula_by_name.get(unique, ""),
+        module=module_name,
     )

--- a/test/lsp/test_auto_rules.py
+++ b/test/lsp/test_auto_rules.py
@@ -1,0 +1,111 @@
+"""Acceptance tests for ``lsp.query.auto_rules_at`` (issue #404).
+
+The fixtures stay self-contained -- the prelude is intentionally
+empty so test ordering doesn't affect the rule list returned. The
+prelude path is exercised separately via the cached
+``get_uniquified_modules()`` map.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    AutoRule,
+    Position,
+    auto_rules_at,
+)
+
+
+# Self-contained mini-arithmetic: a unary-Nat-shaped union with a
+# recursive ``add`` whose two equations make non-trivial auto rules
+# (lhs differs from rhs, so the rewriter terminates).
+SRC = (
+    "union Foo {\n"                                                   # 1
+    "  fzero\n"                                                       # 2
+    "  fsucc(Foo)\n"                                                  # 3
+    "}\n"                                                             # 4
+    "\n"                                                              # 5
+    "recursive fadd(Foo, Foo) -> Foo {\n"                             # 6
+    "  fadd(fzero, y) = y\n"                                          # 7
+    "  fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"                       # 8
+    "}\n"                                                             # 9
+    "\n"                                                              # 10
+    "theorem fadd_zero_left: all y:Foo. fadd(fzero, y) = y\n"         # 11
+    "proof\n"                                                         # 12
+    "  arbitrary y:Foo\n"                                             # 13
+    "  conclude fadd(fzero, y) = y by expand fadd.\n"                 # 14
+    "end\n"                                                           # 15
+    "auto fadd_zero_left\n"                                           # 16
+    "\n"                                                              # 17
+    "theorem fadd_succ:\n"                                            # 18
+    "  all x:Foo, y:Foo. fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"     # 19
+    "proof\n"                                                         # 20
+    "  arbitrary x:Foo, y:Foo\n"                                      # 21
+    "  conclude fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"              # 22
+    "    by expand fadd.\n"                                           # 23
+    "end\n"                                                           # 24
+    "auto fadd_succ\n"                                                # 25
+    "\n"                                                              # 26
+    "theorem use_them: all z:Foo. z = z\n"                            # 27
+    "proof\n"                                                         # 28
+    "  arbitrary z:Foo\n"                                             # 29
+    "  ?\n"                                                           # 30
+    "end\n"                                                           # 31
+)
+
+
+def test_auto_rules_at_lists_both_in_declaration_order() -> None:
+    rules = auto_rules_at("auto_test.pf", SRC, Position(line=30, column=3))
+    assert [r.name for r in rules] == ["fadd_zero_left", "fadd_succ"]
+    # Equation text echoes the theorem's body (parentheses around the
+    # quantifier are how the printer renders ``all``).
+    assert "fadd(fzero, y) = y" in rules[0].equation
+    assert "fadd(fsucc(x), y) = fsucc(fadd(x, y))" in rules[1].equation
+
+
+def test_auto_rules_at_attributes_module_to_user_file_stem() -> None:
+    rules = auto_rules_at("my_module.pf", SRC, Position(line=30, column=3))
+    assert all(r.module == "my_module" for r in rules)
+
+
+def test_auto_rules_at_filters_to_those_declared_before_cursor() -> None:
+    # Cursor on line 17 -- only the first auto declaration (line 16)
+    # is in scope; the second (line 25) is later in the file.
+    rules = auto_rules_at("test.pf", SRC, Position(line=17, column=1))
+    assert [r.name for r in rules] == ["fadd_zero_left"]
+
+
+def test_auto_rules_at_includes_rule_on_cursor_line() -> None:
+    # Cursor at the start of the line where ``auto fadd_zero_left`` is
+    # declared: still in scope (location.column <= cursor.column).
+    rules = auto_rules_at("test.pf", SRC, Position(line=16, column=20))
+    assert [r.name for r in rules] == ["fadd_zero_left"]
+
+
+def test_auto_rules_at_returns_empty_when_no_rules_yet() -> None:
+    rules = auto_rules_at("test.pf", SRC, Position(line=1, column=1))
+    assert rules == ()
+
+
+def test_auto_rules_at_returns_AutoRule_dataclass() -> None:
+    rules = auto_rules_at("test.pf", SRC, Position(line=30, column=3))
+    assert all(isinstance(r, AutoRule) for r in rules)
+    assert all(isinstance(r.name, str) for r in rules)
+    assert all(isinstance(r.equation, str) for r in rules)
+    assert all(isinstance(r.module, str) for r in rules)
+
+
+def test_auto_rules_at_handles_file_with_no_auto_decls() -> None:
+    src = (
+        "theorem t: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    rules = auto_rules_at("test.pf", src, Position(line=4, column=1))
+    assert rules == ()

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -109,6 +109,7 @@ async def test_all_tools_are_registered(server):
             "preview_replace_at",
             "preview_expand_at",
             "available_lemmas_at",
+            "auto_rules_at",
         }
 
 
@@ -777,6 +778,83 @@ async def test_available_lemmas_at_no_signal_returns_empty(server, tmp_path):
         server,
         "available_lemmas_at",
         {"path": str(fp), "line": 4, "column": 3},
+    )
+    assert payload == []
+
+
+# --------------------------------------------------------------------------
+# auto_rules_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_auto_rules_at_returns_each_in_scope_rule(server, tmp_path):
+    """Two ``auto`` declarations, cursor past both -> both surfaced
+    in declaration order with their rendered equations."""
+    src = (
+        "union Foo {\n"
+        "  fzero\n"
+        "  fsucc(Foo)\n"
+        "}\n"
+        "\n"
+        "recursive fadd(Foo, Foo) -> Foo {\n"
+        "  fadd(fzero, y) = y\n"
+        "  fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"
+        "}\n"
+        "\n"
+        "theorem fadd_zero_left: all y:Foo. fadd(fzero, y) = y\n"
+        "proof\n"
+        "  arbitrary y:Foo\n"
+        "  conclude fadd(fzero, y) = y by expand fadd.\n"
+        "end\n"
+        "auto fadd_zero_left\n"
+        "\n"
+        "theorem fadd_succ:\n"
+        "  all x:Foo, y:Foo. fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"
+        "proof\n"
+        "  arbitrary x:Foo, y:Foo\n"
+        "  conclude fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"
+        "    by expand fadd.\n"
+        "end\n"
+        "auto fadd_succ\n"
+        "\n"
+        "theorem use_them: all z:Foo. z = z\n"
+        "proof\n"
+        "  arbitrary z:Foo\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "auto.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "auto_rules_at",
+        {"path": str(fp), "line": 30, "column": 3},
+    )
+    assert isinstance(payload, list)
+    names = [r["name"] for r in payload]
+    assert names == ["fadd_zero_left", "fadd_succ"]
+    assert all(r["module"] == "auto" for r in payload)
+    assert "fadd(fzero, y) = y" in payload[0]["equation"]
+    assert "fadd(fsucc(x), y)" in payload[1]["equation"]
+
+
+@pytest.mark.anyio
+async def test_auto_rules_at_returns_empty_when_no_rules_in_scope(
+    server, tmp_path
+):
+    src = (
+        "theorem t: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    fp = tmp_path / "empty.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "auto_rules_at",
+        {"path": str(fp), "line": 3, "column": 3},
     )
     assert payload == []
 

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -78,6 +78,7 @@ EXPECTED_PUBLIC = {
     "ValidationResult",
     "RewritePreview",
     "ExpandPreview",
+    "AutoRule",
     "check",
     "goal_at",
     "definition_of",
@@ -96,6 +97,7 @@ EXPECTED_PUBLIC = {
     "validate_proof_at",
     "preview_replace_at",
     "preview_expand_at",
+    "auto_rules_at",
 }
 
 


### PR DESCRIPTION
## Summary

- Adds an `auto_rules_at(path, line, column)` MCP tool that lists every `auto` rewrite rule in scope at the cursor — name, rendered equation, and declaring module — in the same declaration order the auto-rewriter applies them.
- Closes the loop the issue describes: when Deduce reports *no need for replace because this equation is handled automatically*, or a goal silently simplifies before a tactic runs, the user can now query the tool instead of running `grep '^auto ' lib/*.pf`.
- New `AutoRule` frozen dataclass and `auto_rules_at` query function in `lsp/query.py`; thin MCP wrapper in `lsp/mcp_server.py`.

## Test plan

- [x] `pytest test/lsp/test_auto_rules.py` — 7 cases covering declaration order, position filtering (rule at-or-before cursor), the rule-on-cursor-line edge case, the empty case, the dataclass shape, and a file with no `auto` decls.
- [x] `pytest test/lsp/test_mcp_server.py::test_auto_rules_at_*` — 2 cases through the SDK's in-memory MCP client (registered tool list updated to include `auto_rules_at`).
- [x] `pytest test/lsp/test_query.py::test_all_matches_expected` — `__all__` plan matches reality.
- [x] Manual smoke test against the real prelude: `auto_rules_at(...)` on a file with the `0 = 0` goal returns 109 rules including `[UIntMult] uint_zero_mult: 0 * n = 0` — the exact rule cited in the original issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)