### PR TITLE
MCP: refine_at returns reason when no template applies (#405)

### DIFF
--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -430,7 +430,7 @@ def on_code_action(
     actions: list[lsp_types.CodeAction] = []
 
     refine_edit = _query.refine_at(path, content, pos, prelude=prelude)
-    if refine_edit is not None:
+    if isinstance(refine_edit, _query.WorkspaceEdit):
         actions.append(
             _code_action_from_edit(uri, "Refine hole", refine_edit)
         )

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -204,10 +204,17 @@ def refine_at(path: str, line: int, column: int) -> Optional[dict]:
     """Propose a refinement template for the hole at ``line``:``column``.
 
     The cursor must sit on (or immediately adjacent to) a ``?`` token.
-    Returns ``None`` when the cursor isn't on a hole, the file has no
-    incomplete proof at that hole, or the goal shape isn't supported.
-    Otherwise returns a ``{path, range, new_text}`` dict describing
-    the edit to apply.
+
+    Returns ``None`` when the cursor isn't on a ``?`` or the file has
+    no incomplete proof at that hole.
+
+    Returns ``{path, range, new_text}`` (a workspace edit) when a
+    template applies.
+
+    Returns ``{outcome: "unsupported_shape", goal, supported_shapes}``
+    when the cursor *is* on a real hole but the goal's shape isn't in
+    the table below -- so the caller can pick another tactic without
+    guessing why ``refine_at`` declined.
 
     Templates by goal shape:
     - ``true`` -> ``.``

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -44,7 +44,7 @@ import re
 import traceback as _traceback
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 
 __all__ = [
@@ -60,6 +60,7 @@ __all__ = [
     "Goal",
     "SymbolInfo",
     "WorkspaceEdit",
+    "UnsupportedRefineShape",
     "LemmaInfo",
     "LemmaMatch",
     "HoleContext",
@@ -207,6 +208,37 @@ class WorkspaceEdit:
     path: str
     range: Range
     new_text: str
+
+
+# Stable list of goal shapes that ``refine_at`` knows a template for.
+# Surfaced on ``UnsupportedRefineShape`` so callers don't have to
+# re-read the docstring to find out which shapes are covered.
+REFINE_SUPPORTED_SHAPES: tuple = (
+    "true",
+    "_ and _",
+    "if _ then _",
+    "all _. _",
+    "some _. _",
+    "reducible _ = _",
+)
+
+
+@dataclass(frozen=True)
+class UnsupportedRefineShape:
+    """Reason returned by :func:`refine_at` when the cursor sits on a
+    real hole but no template matches the goal's shape.
+
+    Distinguishes "there's nothing to refine" (``refine_at`` returns
+    ``None``) from "there's a goal but no template applies"
+    (``refine_at`` returns this). ``goal`` is the rendered goal text;
+    ``supported_shapes`` enumerates the shapes ``refine_at`` does
+    cover, so the caller can decide what to try next without
+    re-reading the docstring.
+    """
+
+    outcome: str
+    goal: str
+    supported_shapes: tuple
 
 
 @dataclass(frozen=True)
@@ -1125,7 +1157,7 @@ def _symbol_info_for(stmt, path: str) -> Optional[SymbolInfo]:
 
 def refine_at(
     path: str, content: str, pos: Position, prelude: Sequence[str] = ()
-) -> Optional[WorkspaceEdit]:
+) -> Union[WorkspaceEdit, UnsupportedRefineShape, None]:
     """Propose a refinement template for the hole at ``pos``.
 
     The cursor must sit on (or immediately adjacent to) a ``?`` token
@@ -1139,9 +1171,15 @@ def refine_at(
     - ``some x:T. body`` -> ``choose ?\\n?``
     - reducible ``e1 = e2`` -> ``reflexive``
 
-    Returns ``None`` when the cursor is not on a ``?``, when the file
-    does not raise at a hole, or when the goal shape is not in the
-    list above.
+    Returns:
+
+    - :class:`WorkspaceEdit` when a template applies.
+    - :class:`UnsupportedRefineShape` when the cursor is on a real
+      hole with a goal but the goal's shape isn't in the table above.
+      The shape list is surfaced so the caller can decide what to try
+      next without re-reading the docstring.
+    - ``None`` when the cursor isn't on a ``?`` or the file has no
+      incomplete proof at that hole.
 
     ``prelude`` matches the meaning in :func:`check`.
     """
@@ -1165,7 +1203,11 @@ def refine_at(
 
     template = _refine_template(formula, env)
     if template is None:
-        return None
+        return UnsupportedRefineShape(
+            outcome="unsupported_shape",
+            goal=str(formula),
+            supported_shapes=REFINE_SUPPORTED_SHAPES,
+        )
 
     template = _indent_continuation(
         template, _line_indent_at(content, hole_range.start)

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -314,6 +314,34 @@ async def test_refine_at_returns_null_when_cursor_not_on_hole(
     assert payload is None
 
 
+@pytest.mark.anyio
+async def test_refine_at_returns_unsupported_shape_dict(server, tmp_path):
+    """Cursor on a real `?` whose goal is a bare bool atom: no
+    template applies, so the tool returns an explanatory dict
+    (``outcome``/``goal``/``supported_shapes``) rather than ``None``.
+    Distinguishes "no template" from "no hole here" for callers."""
+    src = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  suppose pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "unsupported.pf"
+    fp.write_text(src)
+    payload = await _call(
+        server,
+        "refine_at",
+        {"path": str(fp), "line": 5, "column": 3},
+    )
+    assert payload is not None
+    assert payload["outcome"] == "unsupported_shape"
+    assert payload["goal"] == "P"
+    assert "if _ then _" in payload["supported_shapes"]
+    assert "all _. _" in payload["supported_shapes"]
+
+
 # --------------------------------------------------------------------------
 # case_split_at and splittable_vars_at
 # --------------------------------------------------------------------------

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -19,7 +19,7 @@ broken adapter contract. It checks:
 import inspect
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import pytest
 
@@ -39,6 +39,7 @@ from lsp.query import (  # noqa: E402
     Severity,
     SymbolInfo,
     SymbolKind,
+    UnsupportedRefineShape,
     ValidationResult,
     WorkspaceEdit,
     case_split_at,
@@ -72,6 +73,7 @@ EXPECTED_PUBLIC = {
     "Goal",
     "SymbolInfo",
     "WorkspaceEdit",
+    "UnsupportedRefineShape",
     "LemmaInfo",
     "LemmaMatch",
     "HoleContext",
@@ -128,7 +130,8 @@ def test_no_protocol_imports():
 @pytest.mark.parametrize(
     "cls",
     [Position, Range, Location, Diagnostic, Given, Goal, SymbolInfo,
-     WorkspaceEdit, LemmaInfo, HoleContext, ValidationResult],
+     WorkspaceEdit, UnsupportedRefineShape, LemmaInfo, HoleContext,
+     ValidationResult],
 )
 def test_dataclasses_are_frozen(cls):
     """All public data types must be frozen so callers can't mutate
@@ -217,7 +220,7 @@ def test_refine_at_signature():
     _check_sig(
         refine_at,
         ["path", "content", "pos", "prelude"],
-        Optional[WorkspaceEdit],
+        Union[WorkspaceEdit, UnsupportedRefineShape, None],
     )
 
 

--- a/test/lsp/test_refine.py
+++ b/test/lsp/test_refine.py
@@ -27,6 +27,8 @@ sys.path.insert(0, str(REPO_ROOT))
 from lsp.query import (  # noqa: E402
     Position,
     Range,
+    REFINE_SUPPORTED_SHAPES,
+    UnsupportedRefineShape,
     WorkspaceEdit,
     refine_at,
 )
@@ -214,10 +216,16 @@ def test_refine_at_returns_none_when_cursor_not_on_hole() -> None:
     assert refine_at("test.pf", source, Position(line=4, column=3)) is None
 
 
-def test_refine_at_returns_none_for_unsupported_goal_shape() -> None:
-    """A bare bool atom (no logical structure) has no template here."""
+def test_refine_at_returns_unsupported_shape_for_bare_atom() -> None:
+    """A bare bool atom (no logical structure) -> UnsupportedRefineShape.
+
+    Distinguishes "no template applies" (this case) from "no hole
+    here" (returns ``None``). The caller gets the rendered goal and
+    the list of shapes ``refine_at`` does cover, so it can pick
+    another tactic without re-reading the docstring.
+    """
     # Goal at hole: ``P`` (a bool literal-shape variable). Not in the
-    # template table, so refine_at returns None rather than guess.
+    # template table.
     source = (
         "theorem t: all P:bool. if P then P\n"
         "proof\n"
@@ -226,8 +234,11 @@ def test_refine_at_returns_none_for_unsupported_goal_shape() -> None:
         "  ?\n"
         "end\n"
     )
-    edit = refine_at("test.pf", source, Position(line=5, column=3))
-    assert edit is None
+    result = refine_at("test.pf", source, Position(line=5, column=3))
+    assert isinstance(result, UnsupportedRefineShape)
+    assert result.outcome == "unsupported_shape"
+    assert result.goal == "P"
+    assert result.supported_shapes == REFINE_SUPPORTED_SHAPES
 
 
 def test_refine_at_returns_none_when_file_is_complete() -> None:


### PR DESCRIPTION
## Summary

- `refine_at` now distinguishes "no hole at the cursor" (still `null`) from "hole exists but its goal shape isn't covered by any template" (returns `{outcome: \"unsupported_shape\", goal, supported_shapes}`).
- `supported_shapes` is the stable list documented in the tool's docstring (`true`, `_ and _`, `if _ then _`, `all _. _`, `some _. _`, `reducible _ = _`), so callers don't have to re-read the docstring after a `null`.
- LSP code-action handler still only offers \"Refine hole\" when an actual edit is available, so editor UX is unchanged.

Closes #405.

## Test plan

- [x] `python3.13 -m pytest test/lsp/` (803 passed)
- [x] New test in `test/lsp/test_refine.py` covers the unsupported-shape return path (bare bool atom goal)
- [x] New test in `test/lsp/test_mcp_server.py` verifies the wire-format dict has `outcome`/`goal`/`supported_shapes`
- [x] Existing `test_refine_at_returns_null_when_cursor_not_on_hole` still asserts `null` for the genuine \"no hole\" case

🤖 Generated with [Claude Code](https://claude.com/claude-code)