### PR TITLE
emacs fill-hole: show resolved model name in "asking..." message

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -414,8 +414,9 @@ verify the LLM path:
 
 13. In a scratch `.pf` buffer with a `theorem t: all P:bool. P = P`
     (or similar simple) shape, place point on the `?` and press
-    `C-c C-a` ("ask AI"). Emacs reports `deduce-fill-hole:
-    asking...`. Within a few seconds (depending on the model and how
+    `C-c C-a` ("ask AI"). Emacs reports `deduce-fill-hole: asking
+    <model>...` (e.g. `asking claude-opus-4-7...`). Within a few
+    seconds (depending on the model and how
     many attempts it takes), the `?` is replaced with the validated
     proof and you get a `filled in N attempts` message. If the API
     key is missing, the buffer is left untouched and an error

--- a/editor/emacs/deduce-fill-hole.el
+++ b/editor/emacs/deduce-fill-hole.el
@@ -652,6 +652,13 @@ in the success message."
     (_ "claude-opus-4-7")))
 
 
+(defun deduce-fill-hole--effective-model ()
+  "Return the model id that will be passed to the sidecar, honoring the
+user's `deduce-fill-hole-model' override before falling back to the
+backend default."
+  (or deduce-fill-hole-model (deduce-fill-hole--default-model)))
+
+
 (defun deduce-fill-hole--default-api-key-env ()
   "Return the env-var name appropriate for the current backend, when
 `deduce-fill-hole-api-key-env' is nil."
@@ -674,8 +681,7 @@ for nicer customize UI; the sidecar takes hyphenated string flags."
 
 (defun deduce-fill-hole--build-cli-args ()
   "Return the CLI flag list for the current customization values."
-  (let ((model (or deduce-fill-hole-model
-                   (deduce-fill-hole--default-model)))
+  (let ((model (deduce-fill-hole--effective-model))
         (api-key-env (or deduce-fill-hole-api-key-env
                          (deduce-fill-hole--default-api-key-env))))
     (append (list "--backend" (deduce-fill-hole--backend-flag)
@@ -760,7 +766,8 @@ have their own session in parallel."
     (process-send-string process
                          (deduce-fill-hole--build-request context))
     (process-send-eof process)
-    (message "deduce-fill-hole: asking the model...")))
+    (message "deduce-fill-hole: asking %s..."
+             (deduce-fill-hole--effective-model))))
 
 
 ;; Bind `C-c C-a' (ask AI) in `deduce-mode-map'.  Same rationale as

--- a/editor/emacs/test/deduce-fill-hole-test.el
+++ b/editor/emacs/test/deduce-fill-hole-test.el
@@ -175,6 +175,26 @@ defaults; setting base-url adds --base-url."
       (should-not (member "--base-url" args)))))
 
 
+(ert-deftest deduce-fill-hole/effective-model-uses-override ()
+  "An explicit `deduce-fill-hole-model' wins over the backend default."
+  (let ((deduce-fill-hole-backend 'anthropic)
+        (deduce-fill-hole-model "claude-sonnet-4-6"))
+    (should (equal (deduce-fill-hole--effective-model)
+                   "claude-sonnet-4-6"))))
+
+
+(ert-deftest deduce-fill-hole/effective-model-falls-back-to-backend-default ()
+  "With `deduce-fill-hole-model' nil the helper picks the backend default."
+  (let ((deduce-fill-hole-backend 'openai-compat)
+        (deduce-fill-hole-model nil))
+    (should (equal (deduce-fill-hole--effective-model)
+                   "gemma-4-31B-it")))
+  (let ((deduce-fill-hole-backend 'anthropic)
+        (deduce-fill-hole-model nil))
+    (should (equal (deduce-fill-hole--effective-model)
+                   "claude-opus-4-7"))))
+
+
 (ert-deftest deduce-fill-hole/build-cli-args-with-prelude-disabled ()
   "`deduce-fill-hole-prelude-disabled' adds --no-stdlib."
   (let ((deduce-fill-hole-backend 'anthropic)


### PR DESCRIPTION
## Summary

Closes [#392](https://github.com/jsiek/deduce/issues/392).

The Emacs fill-hole command currently reports `deduce-fill-hole: asking the model...` while the sidecar runs.  As the issue requests, this PR replaces that with the resolved model id, e.g.

- `deduce-fill-hole: asking claude-opus-4-7...`
- `deduce-fill-hole: asking gemma-4-31B-it...`

The model resolution (custom override → backend default) is factored into a small helper `deduce-fill-hole--effective-model` so the progress message and the `--model` CLI flag stay in lockstep.  Two ert tests pin the helper's behavior — explicit override wins, otherwise the per-backend default is returned.

## Test plan

- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l ert -l deduce-fill-hole-test.el -f ert-run-tests-batch-and-exit` — 33/33 pass (31 prior + 2 new).
- [x] Byte-compiles cleanly via `emacs --batch -L editor/emacs --eval "(byte-compile-file \"editor/emacs/deduce-fill-hole.el\")"`.
- [ ] Manual: in a `.pf` buffer with `deduce-fill-hole` loaded, place point on a `?`, press `C-c C-a`, and confirm the echo area shows e.g. `deduce-fill-hole: asking claude-opus-4-7...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)