### PR TITLE
Fix #266: auto rules with bare-variable LHS now fire

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -935,19 +935,19 @@ class OverloadedVar(VarRef):
         binding = env.dict[chosen]
         if binding.visibility == 'opaque' \
            and binding.module != env.get_current_module():
-            return self
+            return self if get_eval_all() else auto_rewrites(self, env)
 
       res = env.get_value_of_term_var(self)
       if res:
         if get_verbose():
           print('\t var ' + chosen + ' ===> ' + str(res))
         if isinstance(res, Union):
-          return self
+          return self if get_eval_all() else auto_rewrites(self, env)
         return res.reduce(env)
       else:
-        return self
+        return self if get_eval_all() else auto_rewrites(self, env)
     else:
-      return self
+      return self if get_eval_all() else auto_rewrites(self, env)
 
   def substitute(self, sub):
     chosen = self.resolved_names[0]
@@ -1029,19 +1029,19 @@ class ResolvedVar(VarRef):
         binding = env.dict[self.name]
         if binding.visibility == 'opaque' \
            and binding.module != env.get_current_module():
-            return self
+            return self if get_eval_all() else auto_rewrites(self, env)
 
       res = env.get_value_of_term_var(self)
       if res:
         if get_verbose():
           print('\t var ' + self.name + ' ===> ' + str(res))
         if isinstance(res, Union):
-          return self
+          return self if get_eval_all() else auto_rewrites(self, env)
         return res.reduce(env)
       else:
-        return self
+        return self if get_eval_all() else auto_rewrites(self, env)
     else:
-      return self
+      return self if get_eval_all() else auto_rewrites(self, env)
 
   def substitute(self, sub):
     if self.name in sub:

--- a/test/should-validate/auto_var_lhs.pf
+++ b/test/should-validate/auto_var_lhs.pf
@@ -1,0 +1,14 @@
+define my_true = true
+
+theorem my_true_is_true: my_true = true
+proof
+  expand my_true.
+end
+
+auto my_true_is_true
+
+theorem simplify_auto: if my_true then true else false
+proof
+  simplify
+  conclude true by .
+end


### PR DESCRIPTION
## Summary
- `auto my_true_is_true` (where the theorem is `my_true = true`) registered the rewrite rule but it never fired because `auto_rewrites` was only called from `Call.reduce`. A goal like `if my_true then true else false` reduces `my_true` through `ResolvedVar.reduce`, which returned `self` unchanged.
- Apply `auto_rewrites` on each return path of `OverloadedVar.reduce` and `ResolvedVar.reduce`, gated on `not get_eval_all()` to match the existing skip in `Call.reduce`.
- Adds [test/should-validate/auto_var_lhs.pf](test/should-validate/auto_var_lhs.pf) — the example from the issue, now validating.

Fixes #266

## Test plan
- [x] `python deduce.py test/should-validate/auto_var_lhs.pf` (recursive descent)
- [x] `python deduce.py --lalr test/should-validate/auto_var_lhs.pf`
- [ ] CI: full `make tests` + `make tests-lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)