### PR TITLE
Suppress prelude entry when user import filters same module (#365)

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -224,8 +224,23 @@ def _check_file_impl(
                 )
 
             if len(prelude) > 0:
+                # Suppress the prelude entry for any module the user explicitly
+                # imports with `using`/`hiding`. Both imports run during
+                # ``uniquify_deduce`` and additively populate the env, so an
+                # unfiltered prelude entry races ahead of a filtered user
+                # entry and pollutes the env with names the user wanted to
+                # exclude. Skipping the prelude entry leaves the user's
+                # filtered import as the only one for that module. See #365.
+                user_filtered_modules = {
+                    s.name
+                    for s in ast
+                    if isinstance(s, Import)
+                    and (s.using is not None or s.hiding is not None)
+                }
                 imports = [
-                    Import(Meta(), name, visibility="private") for name in prelude
+                    Import(Meta(), name, visibility="private")
+                    for name in prelude
+                    if name not in user_filtered_modules
                 ]
                 ast = imports + ast
 

--- a/test/lsp/test_prelude_filter.py
+++ b/test/lsp/test_prelude_filter.py
@@ -1,0 +1,137 @@
+"""Issue #365: ``import M using ...`` / ``hiding ...`` must still
+filter even when ``M`` is also in the auto-prelude.
+
+Before the fix, the prelude entry for ``M`` ran first and populated
+``env`` with all of ``M``'s exports, so the user's filter was silently
+a no-op. The fix in ``lsp/library.py`` skips the prelude entry for any
+module the user explicitly imports with a filter.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.library import check_file  # noqa: E402
+
+
+# Full lib/ prelude, mirroring what ``deduce.py`` builds when run without
+# ``--no-stdlib``. ``BigO`` is the leaf module the tests filter against —
+# it has no other lib module that publicly re-imports it, so suppressing
+# the prelude entry for ``BigO`` is enough to make the user's filter
+# observable. Modules that ARE transitively re-imported (e.g. ``Nat``)
+# would still leak through other prelude entries; that's a known
+# limitation noted in #365.
+LIB_DIR = REPO_ROOT / "lib"
+PRELUDE = tuple(
+    sorted(p.stem for p in LIB_DIR.glob("*.pf"))
+)
+
+
+def _check(tmp_path: Path, source: str):
+    pf = tmp_path / "test_prelude_filter.pf"
+    pf.write_text(textwrap.dedent(source))
+    return check_file(str(pf), prelude=PRELUDE)
+
+
+def test_using_admits_listed_name(tmp_path: Path) -> None:
+    result = _check(
+        tmp_path,
+        """
+        import BigO using bigo_refl | operator≲
+
+        theorem t: all f : fn UInt -> UInt. f ≲ f
+        proof
+          bigo_refl
+        end
+        """,
+    )
+    assert result.ok, (
+        "expected the file to validate; got: " + (result.error_message or "")
+    )
+
+
+def test_using_excludes_unlisted_name(tmp_path: Path) -> None:
+    result = _check(
+        tmp_path,
+        """
+        import BigO using bigo_refl | operator≲
+
+        theorem t: all f : fn UInt -> UInt, g : fn UInt -> UInt, h : fn UInt -> UInt.
+          if f ≲ g and g ≲ h then f ≲ h
+        proof
+          bigo_trans
+        end
+        """,
+    )
+    assert not result.ok, (
+        "expected an error because bigo_trans is filtered out by `using`, "
+        "but the file validated"
+    )
+    assert "bigo_trans" in (result.error_message or "")
+
+
+def test_hiding_admits_unlisted_name(tmp_path: Path) -> None:
+    result = _check(
+        tmp_path,
+        """
+        import BigO hiding bigo_trans
+
+        theorem t: all f : fn UInt -> UInt. f ≲ f
+        proof
+          bigo_refl
+        end
+        """,
+    )
+    assert result.ok, (
+        "expected the file to validate; got: " + (result.error_message or "")
+    )
+
+
+def test_hiding_excludes_listed_name(tmp_path: Path) -> None:
+    result = _check(
+        tmp_path,
+        """
+        import BigO hiding bigo_trans
+
+        theorem t: all f : fn UInt -> UInt, g : fn UInt -> UInt, h : fn UInt -> UInt.
+          if f ≲ g and g ≲ h then f ≲ h
+        proof
+          bigo_trans
+        end
+        """,
+    )
+    assert not result.ok, (
+        "expected an error because bigo_trans is hidden, "
+        "but the file validated"
+    )
+    assert "bigo_trans" in (result.error_message or "")
+
+
+def test_unfiltered_user_import_keeps_prelude_entry(tmp_path: Path) -> None:
+    """An unfiltered user `import M` must NOT suppress the prelude entry.
+
+    The prelude wins (and the user's import is dropped as a duplicate),
+    matching the long-standing behaviour. Only ``using``/``hiding``
+    triggers the suppression.
+    """
+    result = _check(
+        tmp_path,
+        """
+        import BigO
+
+        theorem t: all f : fn UInt -> UInt, g : fn UInt -> UInt, h : fn UInt -> UInt.
+          if f ≲ g and g ≲ h then f ≲ h
+        proof
+          bigo_trans
+        end
+        """,
+    )
+    assert result.ok, (
+        "expected the file to validate (full BigO is in scope via prelude); got: "
+        + (result.error_message or "")
+    )

--- a/test/prelude/import_hiding_prelude.pf
+++ b/test/prelude/import_hiding_prelude.pf
@@ -1,0 +1,9 @@
+// Issue #365 companion: `hiding` against a prelude (lib/) module also
+// has to take effect — names other than the hidden one stay in scope.
+
+import BigO hiding bigo_trans
+
+theorem prelude_filter_hiding_admits: all f : fn UInt -> UInt. f ≲ f
+proof
+  bigo_refl
+end

--- a/test/prelude/import_using_prelude.pf
+++ b/test/prelude/import_using_prelude.pf
@@ -1,0 +1,11 @@
+// Issue #365: `import M using ...` from a prelude (lib/) module must
+// behave the same as for non-prelude modules. The prelude's unfiltered
+// auto-import used to race ahead and pollute the env; we now skip the
+// prelude entry whenever the user has an explicit `using`/`hiding`.
+
+import BigO using bigo_refl | operator≲
+
+theorem prelude_filter_using_admits: all f : fn UInt -> UInt. f ≲ f
+proof
+  bigo_refl
+end


### PR DESCRIPTION
## Summary

Fixes #365. `import M using ...` / `hiding ...` was a silent no-op
whenever M was also in the auto-prelude (anything in `lib/`). Both
imports ran during `uniquify_deduce` and additively populated `env`,
so the unfiltered prelude entry raced ahead of the filtered user
entry and pulled in every name the user wanted excluded.

The fix is at the prelude-injection site in `lsp/library.py`: skip
the prelude entry for any module the user explicitly imports with
`using` or `hiding`. The user's import then becomes the only one for
that module and the filter takes effect. Unfiltered user imports
keep the long-standing "prelude wins, user duplicate dropped"
behaviour, so existing tests like `ImportTests.pf` (which use plain
`import List` / `import Nat`) are unaffected.

## Tests

- **`test/prelude/import_using_prelude.pf`** /
  **`import_hiding_prelude.pf`** — positive cases under the full
  `lib/` prelude: filter still admits the listed (or non-hidden)
  names.
- **`test/lsp/test_prelude_filter.py`** — five cases covering both
  filters in both directions, plus a regression that an *unfiltered*
  user `import M` still inherits everything from the prelude entry
  (no behaviour change for existing files).

Verified locally: `pytest test/lsp/` (808 passed), `test-deduce.py
--passable`, `--errors`, `--lib` all green on both parsers.

## Known limitation (noted in the commit + an issue follow-up)

The suppression acts on the *direct* prelude entry only. If M is
also reachable through another prelude module's public import
(e.g. `UIntDefs` publicly imports `Nat`), those names still leak
through that other path. Filtering a leaf module like `BigO` works
fully; filtering a transitively re-exported module like `Nat` does
not. Doing better would require chasing the dependency graph at
prelude-injection time, which is bigger than the scope of this
issue — but the simple fix already closes the
`import M using foo` / `hiding bar` no-op for the modules where it
matters most (the leaves people actually filter).

## Test plan

- [x] `pytest test/lsp/`
- [x] `python test-deduce.py --passable`
- [x] `python test-deduce.py --errors`
- [x] `python test-deduce.py --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)