### PR TITLE
Fix #417: available_lemmas_at finds lemmas from explicit imports

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -2834,11 +2834,12 @@ def available_lemmas_at(
     so the best match in the set is ``1.0`` and others scale linearly.
     Only theorems, lemmas, and postulates are surfaced.
 
-    The lemma set is the same one :func:`hole_context_at` collects
-    (user-file declarations plus public declarations from each module
-    in ``prelude``), so this works without a hole as long as the file
-    parses.  Returns ``()`` when neither a hole nor a ``query`` is
-    available, or when no lemma matches even minimally.
+    The lemma set covers everything in scope at the cursor: the
+    user-file's own declarations, the modules it explicitly
+    ``import``s (transitively, through public imports), and any
+    module named in ``prelude``.  This works without a hole as long
+    as the file parses.  Returns ``()`` when neither a hole nor a
+    ``query`` is available, or when no lemma matches even minimally.
     """
     from lsp.library import check_file
 
@@ -2887,10 +2888,18 @@ def _collect_lemma_candidates(
     formula AST and module of origin.
 
     Returns a tuple of ``(LemmaInfo, formula_ast, module)`` triples,
-    drawn from the user file (one entry per ``Theorem``/``Postulate``
-    in source order, including private ones) and from each module
-    named in ``prelude`` (public theorems/postulates only, matching
-    ``print_theorems``' visibility filter).
+    drawn from:
+
+    - The user file: one entry per ``Theorem``/``Postulate`` in source
+      order, including private ones (everything in the file is in
+      scope at a hole there).
+    - Each module the user file explicitly ``import``s, and the
+      transitive closure of those modules' public imports (matching
+      what ``Import.collect_exports`` propagates): public theorems
+      and postulates only, filtered through the import's
+      ``using``/``hiding`` clause.
+    - Each module named in ``prelude`` (public theorems/postulates
+      only, matching ``print_theorems``' visibility filter).
     """
     from abstract_syntax import (
         Import as _ImportNode,
@@ -2901,11 +2910,39 @@ def _collect_lemma_candidates(
 
     out = []
     user_module = _module_for_path(path)
+    prelude_set = set(prelude)
+    seen_modules: set = set()
+
+    def _collect_from_module(
+        module_ast, module_name: str, importer
+    ) -> None:
+        if module_ast is None:
+            return
+        for stmt in module_ast:
+            if importer is not None and not importer._filter_admits(stmt):
+                continue
+            if isinstance(stmt, (Theorem, Postulate)):
+                info = _lemma_info_for(stmt, public_only=True)
+                if info is not None:
+                    out.append((info, stmt.what, module_name))
+            elif isinstance(stmt, _ImportNode) and stmt.visibility == "public":
+                if stmt.name in seen_modules or stmt.name == user_module:
+                    continue
+                if stmt.name in prelude_set:
+                    # Prelude is walked separately below.
+                    continue
+                seen_modules.add(stmt.name)
+                _collect_from_module(stmt.ast, stmt.name, stmt)
 
     if ast_nodes is not None:
-        prelude_set = set(prelude)
         for stmt in ast_nodes:
-            if isinstance(stmt, _ImportNode) and stmt.name in prelude_set:
+            if isinstance(stmt, _ImportNode):
+                if stmt.name in prelude_set or stmt.name == user_module:
+                    continue
+                if stmt.name in seen_modules:
+                    continue
+                seen_modules.add(stmt.name)
+                _collect_from_module(stmt.ast, stmt.name, stmt)
                 continue
             if not isinstance(stmt, (Theorem, Postulate)):
                 continue
@@ -2917,16 +2954,13 @@ def _collect_lemma_candidates(
     if prelude:
         modules = get_uniquified_modules()
         for module_name in prelude:
+            if module_name in seen_modules:
+                continue
             module_ast = modules.get(module_name)
             if module_ast is None:
                 continue
-            for stmt in module_ast:
-                if not isinstance(stmt, (Theorem, Postulate)):
-                    continue
-                info = _lemma_info_for(stmt, public_only=True)
-                if info is None:
-                    continue
-                out.append((info, stmt.what, module_name))
+            seen_modules.add(module_name)
+            _collect_from_module(module_ast, module_name, None)
 
     return tuple(out)
 

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -201,6 +201,56 @@ def test_user_file_private_lemma_is_visible() -> None:
     assert "local_priv" in names
 
 
+def test_explicit_import_substring_query_finds_lemma() -> None:
+    """Issue #417: a substring ``query`` should match theorems that
+    live in modules the user explicitly ``import``s, not just the
+    user's file and the prelude.
+
+    Mirrors the ``lib/`` reproducer: a file in ``lib/`` has an empty
+    prelude (``_prelude_for`` returns ``()``) but still pulls in
+    cross-module lemmas via ``import``. Without the fix the candidate
+    set is empty, so the substring query returns nothing.
+    """
+    source = (
+        "import HoleFillPrelude\n"
+        "\n"
+        "theorem t: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=3, column=1),
+        query="hf_intro_and",
+    )
+    by_name = {m.name: m for m in matches}
+    assert "hf_intro_and" in by_name
+    assert by_name["hf_intro_and"].module == "HoleFillPrelude"
+
+
+def test_explicit_import_goal_shape_query_finds_lemma() -> None:
+    """Issue #417: goal-shape patterns must also match lemmas from
+    explicitly-imported modules, not just the user's file."""
+    source = (
+        "import HoleFillPrelude\n"
+        "\n"
+        "theorem t: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=3, column=1),
+        query="if _ then _ and _",
+    )
+    names = {m.name for m in matches}
+    assert "hf_intro_and" in names
+
+
 def test_prelude_postulate_is_surfaced() -> None:
     """Postulates and theorems imported via the prelude appear in
     results, with ``module`` set to the source module name."""


### PR DESCRIPTION
## Summary

Fixes [#417](https://github.com/jsiek/deduce/issues/417). `available_lemmas_at` was missing theorems that live in modules the user file explicitly `import`s.

The candidate set in `_collect_lemma_candidates` only walked the user file's local declarations plus modules named in the caller's `prelude`. For files in `lib/` the MCP passes an empty prelude (to avoid double-importing the prelude itself), which meant explicit `import UIntMult` style statements contributed nothing — so substring queries for real cross-module names came back empty.

This change walks `Import` nodes in the user file too, recursing into their public re-exports (matching what `Import.collect_exports` propagates) and respecting each import's `using`/`hiding` filter.

## Test plan
- [x] New unit tests in `test/lsp/test_available_lemmas.py` covering substring + goal-shape queries against an explicitly-imported module
- [x] Existing 12 `test_available_lemmas.py` cases still pass
- [x] Full `test/lsp/` suite (806 tests) passes
- [ ] Issue #417 reproducer (substring `uint_pos_mult_both_sides_of_less` at end of `lib/UIntPowLog.pf`) verified by hand: now returns the lemma, previously returned `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)