### PR TITLE
Fix #365: import using/hiding now applies to prelude (lib/) modules

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -224,8 +224,19 @@ def _check_file_impl(
                 )
 
             if len(prelude) > 0:
+                # If the user file explicitly imports a prelude module
+                # with `using` or `hiding`, suppress the prelude's
+                # unfiltered auto-import for that module so the user's
+                # filter actually takes effect (issue #365).
+                user_filtered = {
+                    s.name for s in ast
+                    if isinstance(s, Import)
+                    and (s.using is not None or s.hiding is not None)
+                }
                 imports = [
-                    Import(Meta(), name, visibility="private") for name in prelude
+                    Import(Meta(), name, visibility="private")
+                    for name in prelude
+                    if name not in user_filtered
                 ]
                 ast = imports + ast
 

--- a/test/lsp/test_prelude_filter.py
+++ b/test/lsp/test_prelude_filter.py
@@ -1,0 +1,55 @@
+"""Acceptance test for issue #365.
+
+When the user file imports a prelude module with `using` or `hiding`,
+the prelude's auto-injected unfiltered import for that same module is
+suppressed so the user's filter actually narrows the visible names.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.library import check_file  # noqa: E402
+
+
+PRELUDE = ("Base", "Option", "NatDefs", "NatAdd", "NatMonus", "NatMult",
+           "NatLess", "NatEvenOdd", "NatDiv", "NatPowLog", "NatSum",
+           "Pair", "Nat")
+
+
+def _check(content: str):
+    return check_file(
+        "__test__.pf", prelude=PRELUDE, content=content,
+    )
+
+
+def test_unfiltered_prelude_import_brings_all_names():
+    result = _check("define _ : Nat = gcd(suc(zero), suc(suc(zero)))\n")
+    assert result.ok, f"baseline (no user filter) should validate: {result.error_message}"
+
+
+def test_user_using_excludes_other_prelude_names():
+    """`import Nat using equal_refl` should make `gcd` undefined."""
+    src = "import Nat using equal_refl\n\ndefine _ : Nat = gcd(suc(zero), suc(suc(zero)))\n"
+    result = _check(src)
+    assert not result.ok, "expected gcd to be undefined under filtered prelude"
+    assert "gcd" in (result.error_message or "")
+
+
+def test_user_using_admits_named_prelude_name():
+    """`import Nat using gcd` should still allow gcd."""
+    src = "import Nat using gcd\n\ndefine _ : Nat = gcd(suc(zero), suc(suc(zero)))\n"
+    result = _check(src)
+    assert result.ok, f"expected gcd to be available: {result.error_message}"
+
+
+def test_user_hiding_excludes_named_prelude_name():
+    """`import Nat hiding gcd` should make gcd undefined."""
+    src = "import Nat hiding gcd\n\ndefine _ : Nat = gcd(suc(zero), suc(suc(zero)))\n"
+    result = _check(src)
+    assert not result.ok, "expected gcd to be hidden"
+    assert "gcd" in (result.error_message or "")


### PR DESCRIPTION
## Summary

Closes #365.

When a user file explicitly imports a prelude module with `using` or `hiding`, suppress the prelude's auto-injected unfiltered import of that module so the user's filter actually narrows the visible names.

Before this change, e.g. `import Nat using gcd` was a silent no-op: the prelude brought all of `Nat`'s exports into scope first, and the user's filtered import only contributed names that weren't already there.

## What changed

- [lsp/library.py](lsp/library.py): in `_check_file_impl`, scan the user AST for `Import` nodes with `using` or `hiding` set, and skip the corresponding prelude entries. Untouched modules (and unfiltered user imports) keep the existing behavior.
- New unit test [test/lsp/test_prelude_filter.py](test/lsp/test_prelude_filter.py) exercising four cases against an explicit `Nat`-prelude:
  1. baseline (no user filter): `gcd` is reachable;
  2. `import Nat using equal_refl`: `gcd` is now undefined;
  3. `import Nat using gcd`: `gcd` is reachable;
  4. `import Nat hiding gcd`: `gcd` is undefined.

A `should-error` / `should-validate` fixture would be the more natural test, but the Makefile's `tests-should-validate` target and `test-deduce.py`'s default both run those directories with `--no-stdlib --dir lib`, which disables the auto-prelude — so the bug being fixed can't be exercised through the .pf-fixture harness. The unit test above calls `check_file` directly with an explicit prelude so the filter behaviour is directly observable.

## Test plan

- [x] `python deduce.py tmp/repro.pf` (recursive descent + LALR) errors as expected
- [x] `make tests` (both parsers) green
- [x] `make tests-lib` green
- [x] `python test-deduce.py` (full default suite) green
- [x] `pytest test/lsp/` (808 tests, including the new ones) green
- [x] Verified the new tests fail without the lsp/library.py fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)