### PR TITLE
Closes #267: expand simplify tutorial section

### DIFF
--- a/gh_pages/doc/ProofIntro.md
+++ b/gh_pages/doc/ProofIntro.md
@@ -1462,11 +1462,50 @@ proof
 end
 ```  
 
+When `simplify` reduces the goal all the way to `true`, you can close
+the proof by ending the statement with a period. In the next proof,
+the auto theorem `uint_zero_add` from the standard library lets
+`simplify` rewrite `0 + x` to `x`, and `simplify` then reduces `x = x`
+to `true`.
+
+```{.deduce^#simplify_zero_plus}
+theorem zero_plus_eq: all x:UInt. 0 + x = x
+proof
+  arbitrary x:UInt
+  simplify.
+end
+```
+
+If there is a fact you would like `simplify` to use, write `simplify
+with` followed by the label of that fact. If the fact has the form
+`not P`, then `simplify` replaces occurrences of `P` with `false`;
+otherwise it replaces occurrences of the fact `P` with `true`.
+Multiple facts are separated by `|`.
+
+```{.deduce^#simplify_with_if}
+theorem simplify_with_if: all P:bool, Q:bool.
+  if P and not Q then (if Q then false else P or Q)
+proof
+  arbitrary P:bool, Q:bool
+  assume prem
+  have p: P by prem
+  have nq: not Q by prem
+  simplify with p | nq.
+end
+```
+
+In the proof above, `simplify with p | nq` tells `simplify` to
+substitute `P` with `true` (using `p: P`) and `Q` with `false` (using
+`nq: not Q`). The goal becomes `if false then false else true or
+false`, which the built-in rules then reduce to `true`.
+
 <!--
 ```{.deduce^file=ProofIntro.pf}
 <<import_uint_and_list>>
 
 <<simplify_or_true>>
+<<simplify_zero_plus>>
+<<simplify_with_if>>
 <<length_uint_empty>>
 <<length_node42>>
 


### PR DESCRIPTION
## Summary
- Expand the "Simplify the Goal" section in `gh_pages/doc/ProofIntro.md` (the *Writing Proofs in Deduce* tutorial) with two additional worked examples that complement the existing arithmetic example
- New example `simplify_zero_plus` shows closing a goal with `simplify.` when the goal reduces all the way to `true` (illustrates the `auto`-theorem path via `uint_zero_add`)
- New example `simplify_with_if` shows `simplify with p | nq`, demonstrating how a positive given becomes a `true` substitution and a `not P` given becomes a `false` substitution

The Reference manual already documents these uses (`Reference.md` § "Simplify (Proof)"), but the tutorial only covered basic literal-arithmetic simplification, which is what the issue flagged.

## Test plan
- [x] `python3.13 test-deduce.py --site` passes — the regenerated `test/should-validate/doc_proof.pf` validates under both parsers
- [x] Manually checked each new example as a standalone `.pf` file
- [x] Both new code blocks are wired into the literate-programming inclusion list at the bottom of `ProofIntro.md` so they round-trip through the doc-extract → validate pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)