### PR TITLE
Fix #419: show pre-auto-reduce form in `replace` mismatch errors

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -554,7 +554,8 @@ def check_proof(proof, env):
       eqns = [check_proof(proof, env) for proof in equation_proofs]
       red_formula = formula.reduce(env)
       current_formula = red_formula
-      current_formula = apply_rewrites(loc, current_formula, eqns, env)
+      current_formula = apply_rewrites(loc, current_formula, eqns, env,
+                                       display_formula=formula)
       ret = current_formula
 
     case SimplifyFact(loc, subject, givens):
@@ -1849,7 +1850,8 @@ def check_proof_of(proof, formula, env):
       equations = [check_proof(proof, env) for proof in equation_proofs]
       eqns = [equation.reduce(env) for equation in equations]
       new_formula = formula.reduce(env)
-      new_formula = apply_rewrites(loc, new_formula, eqns, env)
+      new_formula = apply_rewrites(loc, new_formula, eqns, env,
+                                   display_formula=formula)
       _try_check_proof_of(body, new_formula, env)
 
     case SimplifyGoal(loc, body, givens):
@@ -1966,7 +1968,10 @@ def expand_definitions(loc, formula, defs, env):
   else:
       return check_formula(replace_mark(formula, new_formula).reduce(env), env)
 
-def apply_rewrites(loc, formula, eqns, env):#
+def apply_rewrites(loc, formula, eqns, env, *, display_formula=None):
+  # `formula` is the value rewrites operate over (may be auto-normalized).
+  # `display_formula`, if provided, is the pre-normalized form shown in
+  # error messages so users see the goal they actually wrote.
   num_marks = count_marks(formula)
   if num_marks == 0:
       new_formula = formula
@@ -1990,10 +1995,15 @@ def apply_rewrites(loc, formula, eqns, env):#
     new_formula = rewrite_aux(loc, new_formula, eq, env)
     if get_num_rewrites() == 0:
         (lhs, rhs) = split_equation(loc, eq, env)
-        user_error(loc, '\ncould not find any matches for\n\t' + str(lhs) \
-                   + '\nin\n\t' + str(new_formula) \
-                   + '\nwhile trying to replace using the below equation, left to right\n\t' + str(eq) \
-                   + auto_simplified_hint(new_formula))
+        shown_formula = display_formula if display_formula is not None else new_formula
+        msg = '\ncould not find any matches for\n\t' + str(lhs) \
+              + '\nin\n\t' + str(shown_formula)
+        if display_formula is not None and str(shown_formula) != str(new_formula):
+            msg += '\n(which auto-rule normalization reduced to:\n\t' \
+                   + str(new_formula) + ')'
+        msg += '\nwhile trying to replace using the below equation, left to right\n\t' + str(eq) \
+               + auto_simplified_hint(new_formula)
+        user_error(loc, msg)
     new_formula = new_formula.reduce(env)
       
   if num_marks == 0:          

--- a/test/should-error/replace_shows_preauto_form.pf
+++ b/test/should-error/replace_shows_preauto_form.pf
@@ -1,0 +1,23 @@
+import UInt
+
+// Regression test for issue #419: when an auto rewrite rule (here,
+// uint_less_refl_false: (x < x) = false) normalizes the current goal,
+// a failing `replace` should still show the goal the user wrote,
+// not just the auto-normalized form.
+
+postulate fact: all a:UInt, b:UInt. a < a
+
+theorem test419: all a:UInt, b:UInt. if a < b or a = b then false
+proof
+  arbitrary a:UInt, b:UInt
+  assume disj: a < b or a = b
+  have step: a < a by {
+    cases disj
+    case lt: a < b { fact[a, b] }
+    case eq: a = b {
+      replace symmetric eq
+      fact[a, b]
+    }
+  }
+  apply uint_less_irreflexive to step
+end

--- a/test/should-error/replace_shows_preauto_form.pf.err
+++ b/test/should-error/replace_shows_preauto_form.pf.err
@@ -1,0 +1,9 @@
+./test/should-error/replace_shows_preauto_form.pf:18.7-18.27:
+could not find any matches for
+	b
+in
+	a < a
+(which auto-rule normalization reduced to:
+	false)
+while trying to replace using the below equation, left to right
+	b = a


### PR DESCRIPTION
## Summary

Fixes [#419](https://github.com/jsiek/deduce/issues/419).

When `replace` fails to find a match in the current goal, the error message used to show the *post-auto-normalized* form of the goal. Inside a nested `have ... by { cases ... case eq { replace ... } }`, if the inner have-goal happens to auto-reduce (e.g. `2^a < 2^a` collapses to `false` via the auto rule `uint_less_refl_false`), the error read "in `false`" — which looks like the outer `false` goal of the surrounding contradiction proof.

This change carries the unreduced formula through `apply_rewrites` as a `display_formula`. The error now shows the goal as the user wrote it and adds a note when auto-rule normalization changed the form. For the reproducer in the issue, the message now reads:

```
could not find any matches for
	b
in
	a < a
(which auto-rule normalization reduced to:
	false)
while trying to replace using the below equation, left to right
	b = a
```

## Test plan

- [x] Added regression fixture `test/should-error/replace_shows_preauto_form.pf` reproducing the nested-`cases` shape from the issue.
- [x] Existing `should-error` fixtures continue to pass (`replace_match_failure`, `replace_after_auto_simplify`).
- [ ] CI: full `should-validate` + lib sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)