### PR TITLE
Fix #361: widen fill-from-given to use check_implies

### DIFF
--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -1084,6 +1084,37 @@ interactive entry user-errors with `No matching given'."
       (delete-file tmp))))
 
 
+(ert-deftest deduce-lsp/fill-from-given-implies-candidate-flows-through ()
+  "When `deduce/matchingGivensAt' returns an implies-only candidate
+\(issue #361 widens the filter to `check_implies'\), the interactive
+entry sends `deduce/fillFromGivenAt' with that label just like an
+exact-match candidate -- no special-casing at the transport layer."
+  (let ((tmp (make-temp-file "deduce-lsp-fill" nil ".pf"))
+        captured-label)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method params)
+                       (cond
+                        ;; H: P implies goal P or Q -- single candidate,
+                        ;; returned by the widened filter.
+                        ((eq method :deduce/matchingGivensAt) ["H"])
+                        ((eq method :deduce/fillFromGivenAt)
+                         (setq captured-label (plist-get params :label))
+                         nil)))))
+            (ignore-errors
+              (call-interactively #'deduce-lsp-fill-from-given)))
+          (should (equal captured-label "H")))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -2252,29 +2252,70 @@ def matching_givens_at(
     return _matching_given_names(goal, env)
 
 
+def _implies(frm1, frm2) -> bool:
+    """Side-effect-free wrapper around ``proof_checker.check_implies``.
+
+    ``check_implies`` raises ``UserError`` (or ``MatchFailed``) on failure
+    and prints when ``--verbose`` is set. Here we silence verbose
+    temporarily and treat any exception as a negative answer, so this
+    function can be used as a predicate inside candidate filters.
+    """
+    import flags
+    from proof_checker import check_implies
+
+    saved = flags.verbose
+    flags.verbose = False
+    try:
+        check_implies(frm1.location, frm1, frm2)
+        return True
+    except Exception:
+        return False
+    finally:
+        flags.verbose = saved
+
+
 def _matching_given_names(goal, env) -> tuple:
-    """Names of local proof bindings whose formula equals ``goal``."""
+    """Names of local proof bindings that discharge ``goal``.
+
+    Exact equality matches come first (alphabetical), followed by
+    implies-only matches (alphabetical) -- the latter where the given's
+    formula strictly implies the goal via ``proof_checker.check_implies``
+    (handles ``Or`` introduction, ``And`` elimination, ``IfThen``
+    covariance, ``All`` instantiation; see issue #361).
+    """
     from abstract_syntax import ProofBinding, base_name
 
-    seen = set()
+    exact: set = set()
+    implies: set = set()
     for unique, binding in env.dict.items():
         if not isinstance(binding, ProofBinding):
             continue
         if not binding.local:
             continue
-        if binding.formula != goal:
+        name = base_name(unique)
+        if binding.formula == goal:
+            exact.add(name)
+            implies.discard(name)
             continue
-        seen.add(base_name(unique))
-    return tuple(sorted(seen))
+        if name in exact:
+            continue
+        if _implies(binding.formula, goal):
+            implies.add(name)
+    return tuple(sorted(exact)) + tuple(sorted(implies))
 
 
 def _fill_from_given_template(label: str, goal, env) -> Optional[str]:
     """Return ``conclude <goal> by <label>`` when ``label`` names a
-    local proof binding in ``env`` whose formula equals ``goal``.
+    local proof binding in ``env`` whose formula equals or implies
+    ``goal``.
 
     Returns ``None`` when the label isn't bound, isn't a local proof
-    binding, or its formula doesn't match the goal.  The base-name
-    match (rather than unique-name) mirrors :func:`_eliminate_template`.
+    binding, or its formula neither equals nor implies the goal. The
+    base-name match (rather than unique-name) mirrors
+    :func:`_eliminate_template`. Implication checks use
+    ``proof_checker.check_implies`` -- the same routine ``conclude ... by
+    ...`` runs at proof-check time -- so any accepted label produces a
+    template the proof checker will validate.
     """
     from abstract_syntax import ProofBinding, base_name
 
@@ -2286,7 +2327,7 @@ def _fill_from_given_template(label: str, goal, env) -> Optional[str]:
         return None
     if not binding.local:
         return None
-    if binding.formula != goal:
+    if binding.formula != goal and not _implies(binding.formula, goal):
         return None
     return f"conclude {goal} by {label}"
 

--- a/test/lsp/test_fill_from_given.py
+++ b/test/lsp/test_fill_from_given.py
@@ -104,8 +104,9 @@ def test_fill_from_given_at_picks_either_match() -> None:
         assert edit.new_text == f"conclude P by {label}"
 
 
-def test_fill_from_given_at_returns_none_when_no_match() -> None:
-    """Goal ``P or Q`` with given ``H: P`` (different formula)."""
+def test_fill_from_given_at_implies_or_intro() -> None:
+    """Goal ``P or Q`` with given ``H: P`` -- the given strictly
+    implies the goal via ``Or`` introduction (issue #361)."""
     source = (
         "theorem t: all P:bool, Q:bool. if P then P or Q\n"
         "proof\n"
@@ -116,6 +117,26 @@ def test_fill_from_given_at_returns_none_when_no_match() -> None:
     )
     edit = fill_from_given_at(
         "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert edit is not None
+    assert edit.new_text == "conclude (P or Q) by H"
+
+
+def test_fill_from_given_at_returns_none_when_unrelated() -> None:
+    """Goal ``Q`` with an unrelated given ``H: P`` -- neither equals
+    nor implies the goal."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if Q then if P then Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume HQ: Q\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Goal at the hole is `Q`; `H: P` does not imply it.
+    edit = fill_from_given_at(
+        "test.pf", source, Position(line=6, column=3), "H"
     )
     assert edit is None
 
@@ -227,22 +248,75 @@ def test_matching_givens_lists_all_matches() -> None:
     assert candidates == ("H1", "H2")
 
 
-def test_matching_givens_excludes_non_matching() -> None:
-    """Givens whose formulas differ from the goal aren't listed."""
+def test_matching_givens_excludes_unrelated() -> None:
+    """Givens that neither equal nor imply the goal aren't listed."""
     source = (
-        "theorem t: all P:bool, Q:bool. if P then if Q then P or Q\n"
+        "theorem t: all P:bool, Q:bool. if Q then if P then Q\n"
         "proof\n"
         "  arbitrary P:bool, Q:bool\n"
-        "  assume H1: P\n"
-        "  assume H2: Q\n"
+        "  assume HQ: Q\n"
+        "  assume H: P\n"
         "  ?\n"
         "end\n"
     )
-    # Goal here is `P or Q`; neither H1 nor H2 matches it.
+    # Goal is `Q`; only HQ matches (exactly). H is unrelated.
     candidates = matching_givens_at(
         "test.pf", source, Position(line=6, column=3)
     )
-    assert candidates == ()
+    assert candidates == ("HQ",)
+
+
+def test_matching_givens_includes_implies_or_intro() -> None:
+    """Given strictly implies the goal via ``Or`` introduction
+    (issue #361): ``H: P`` should match goal ``P or Q``."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert candidates == ("H",)
+
+
+def test_matching_givens_includes_implies_and_elim() -> None:
+    """Given strictly implies the goal via ``And`` elimination
+    (issue #361): ``H: P and Q`` should match goal ``P``."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P and Q then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P and Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=5, column=3)
+    )
+    assert candidates == ("H",)
+
+
+def test_matching_givens_orders_exact_before_implies() -> None:
+    """When both an exact match and an implies-only match are
+    available, the exact match comes first (issue #361)."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then if P then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H1: P or Q\n"
+        "  assume H2: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    # H1: P or Q is exact; H2: P implies (P or Q) but isn't exact.
+    candidates = matching_givens_at(
+        "test.pf", source, Position(line=6, column=3)
+    )
+    assert candidates == ("H1", "H2")
 
 
 def test_matching_givens_excludes_term_variables() -> None:


### PR DESCRIPTION
## Summary

Closes [#361](https://github.com/jsiek/deduce/issues/361). The candidate filter in `lsp/query.py` for `fill_from_given_at` / `matching_givens_at` is now goal *implication* rather than bare AST equality.

- New helper `_implies(frm1, frm2) -> bool` wraps `proof_checker.check_implies`: silences verbose output during the call and treats any exception as a negative answer.
- `_matching_given_names` returns exact-equality matches first (alphabetical), then implies-only matches (alphabetical).
- `_fill_from_given_template` accepts either an exact or an implies match; the replacement is unchanged (`conclude <goal> by <label>`), which already validates because `PAnnot` calls `check_implies` internally.

The motivating fixture from PR [#358](https://github.com/jsiek/deduce/pull/358) (`H: P`, goal `P or Q`) now produces `conclude (P or Q) by H` instead of `No matching given`.

## Test plan

- [x] `python3.13 -m pytest test/lsp/test_fill_from_given.py` — 18 passed
- [x] `python3.13 -m pytest test/lsp/` — 815 passed (full LSP suite, no regression)
- [x] `emacs -batch ... ert-run-tests-batch-and-exit` on `deduce-lsp-test.el` — 52/52 passed
- [x] `python3.13 test-deduce.py --passable` and `--errors` (see CI / local run)

### New / changed tests

- `test_fill_from_given_at_implies_or_intro` — `H: P` ⇒ goal `P or Q` produces the expected edit (was `test_..._returns_none_when_no_match`).
- `test_fill_from_given_at_returns_none_when_unrelated` — `H: P` does **not** match goal `Q`.
- `test_matching_givens_includes_implies_or_intro` — `H: P` listed for goal `P or Q`.
- `test_matching_givens_includes_implies_and_elim` — `H: P and Q` listed for goal `P`.
- `test_matching_givens_orders_exact_before_implies` — exact match (`H1: P or Q`) comes before implies-only (`H2: P`) for goal `P or Q`.
- `test_matching_givens_excludes_unrelated` — renamed from `..._excludes_non_matching`; now uses a truly unrelated given since the original "different formula" case is now a valid implies match.
- New `deduce-lsp/fill-from-given-implies-candidate-flows-through` ert test confirms an implies-only candidate flows through the existing transport path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)