### PR TITLE
Fix #421: expose post-auto-normalized form on goal_at output

### DIFF
--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -176,8 +176,16 @@ def goal_at(path: str, line: int, column: int) -> Optional[dict]:
     Lines and columns are 1-indexed (matching the location text in
     Deduce error messages). Returns ``None`` when the cursor is
     outside any active proof or the file does not parse. The result
-    has ``formula`` (a rendered string), ``givens`` (a list of
-    ``{label, formula}`` pairs in scope), and ``range``.
+    has ``formula`` (a rendered string, source-shaped), ``givens``
+    (a list of ``{label, formula, formula_normalized?}`` pairs in
+    scope), ``range``, and ``formula_normalized``.
+
+    ``formula_normalized`` (on the goal and on each given) is the
+    post-auto-reduction form -- the shape the proof checker uses
+    when matching a candidate proof body. It is ``None`` (or absent
+    after serialization) when it would equal ``formula`` -- i.e. no
+    auto rule fired -- so callers can compare cheaply by presence
+    alone.
     """
     content = _read_file(path)
     pos = query.Position(line=line, column=column)

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -167,10 +167,16 @@ class Given:
     explicit label). ``formula`` is rendered text -- the same string
     Deduce's printer would produce -- not an AST node, so the type
     survives serialization across the MCP boundary.
+
+    ``formula_normalized`` is the post-auto-reduction form -- the shape
+    the proof checker actually compares against. ``None`` when it
+    coincides with ``formula`` (no auto rule fired), or when the
+    structured AST/env wasn't available to compute it.
     """
 
     label: Optional[str]
     formula: str
+    formula_normalized: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -181,11 +187,18 @@ class Goal:
     text. ``givens`` is a tuple (not list) so ``Goal`` stays hashable.
     ``range`` is the source range the goal corresponds to -- typically
     where the cursor or hole sits.
+
+    ``formula_normalized`` is the post-auto-reduction form of the goal
+    -- the shape the proof checker compares against when matching a
+    candidate proof body. ``None`` when it coincides with ``formula``
+    (no auto rule fired), or when the structured AST/env wasn't
+    available to compute it. See issue #421.
     """
 
     formula: str
     givens: tuple
     range: Range
+    formula_normalized: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -768,8 +781,88 @@ def _goal_from_exception(
     if formula is None:
         return None
 
+    formula_ast = getattr(exc, "formula", None)
+    env = getattr(exc, "env", None)
+    formula_normalized = _normalize_formula(formula_ast, env, formula)
+
     givens = _parse_givens_section(body)
-    return Goal(formula=formula, givens=givens, range=goal_range)
+    givens = _attach_normalized_givens(givens, env)
+
+    return Goal(
+        formula=formula,
+        givens=givens,
+        range=goal_range,
+        formula_normalized=formula_normalized,
+    )
+
+
+def _normalize_formula(formula_ast, env, rendered: str) -> Optional[str]:
+    """Render the auto-reduced form of ``formula_ast`` under ``env``.
+
+    Returns ``None`` when reduction is unavailable (missing AST or env)
+    or when the result matches the source-shaped ``rendered`` string,
+    so callers don't have to compare to know "no auto rule fired".
+    """
+    if formula_ast is None or env is None:
+        return None
+    try:
+        reduced = formula_ast.reduce(env)
+    except Exception:
+        return None
+    text = str(reduced)
+    if text == rendered:
+        return None
+    return text
+
+
+def _attach_normalized_givens(givens: tuple, env) -> tuple:
+    """Add ``formula_normalized`` to each given when env exposes its AST.
+
+    Walks ``env``'s ``ProofBinding`` entries to map each printed label
+    back to its formula AST, reduces under ``env``, and attaches the
+    string form when it differs from what the given carries. Givens
+    that we can't match (anonymous, env unavailable, label collisions)
+    pass through unchanged.
+    """
+    if env is None or not givens:
+        return givens
+    try:
+        from abstract_syntax import ProofBinding, name2str
+    except Exception:
+        return givens
+
+    by_label: dict = {}
+    for unique, binding in env.dict.items():
+        if not isinstance(binding, ProofBinding):
+            continue
+        label = name2str(unique)
+        # A label could appear more than once across nested scopes;
+        # keep the most recent (later-inserted) binding to match what
+        # the proof checker resolves to at the hole.
+        by_label[label] = binding.formula
+
+    result = []
+    for given in givens:
+        if given.label is None or given.label not in by_label:
+            result.append(given)
+            continue
+        try:
+            reduced = by_label[given.label].reduce(env)
+        except Exception:
+            result.append(given)
+            continue
+        text = str(reduced)
+        if text == given.formula:
+            result.append(given)
+            continue
+        result.append(
+            Given(
+                label=given.label,
+                formula=given.formula,
+                formula_normalized=text,
+            )
+        )
+    return tuple(result)
 
 
 def _extract_goal_formula(body: str) -> Optional[str]:

--- a/test/lsp/test_goal_at.py
+++ b/test/lsp/test_goal_at.py
@@ -329,6 +329,110 @@ def test_goal_at_picks_hole_in_second_theorem() -> None:
     assert g.formula == "Q = Q"
 
 
+# ---------------------------------------------------------------------------
+# Post-auto-rule normalization (issue #421)
+# ---------------------------------------------------------------------------
+#
+# When the goal or a given differs from the post-auto-reduction form
+# that the proof checker compares against, ``goal_at`` surfaces the
+# normalized form via ``formula_normalized``. When they coincide --
+# the common case -- the field is ``None`` so callers can detect "no
+# auto rule fired" by presence alone.
+
+
+def test_goal_at_normalized_is_none_when_no_auto_rule_fires() -> None:
+    """No auto rule in scope: ``formula_normalized`` stays ``None``
+    on the goal and on each given, so callers don't have to compare
+    strings to know the proof checker sees the same shape."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P then if Q then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    g = goal_at("test.pf", source, Position(line=6, column=3))
+    assert g is not None
+    assert g.formula == "P"
+    assert g.formula_normalized is None, (
+        "expected no normalized form when no auto rule fires; "
+        f"got {g.formula_normalized!r}"
+    )
+    for given in g.givens:
+        assert given.formula_normalized is None, (
+            f"given {given.label!r} unexpectedly normalized "
+            f"from {given.formula!r} to {given.formula_normalized!r}"
+        )
+
+
+def test_goal_at_exposes_normalized_goal_under_auto_rule() -> None:
+    """An ``auto`` rewrite turns ``id_bool(Q)`` into ``Q``. The
+    pre-auto form stays in ``formula`` (matching the rendered
+    ``Goal:`` text in the error message), and the post-auto form
+    appears in ``formula_normalized`` -- the shape ``check_implies``
+    actually sees."""
+    source = (
+        "fun id_bool(x : bool) { x }\n"
+        "\n"
+        "theorem id_bool_id: all x:bool. id_bool(x) = x\n"
+        "proof\n"
+        "  arbitrary x:bool\n"
+        "  expand id_bool.\n"
+        "end\n"
+        "\n"
+        "auto id_bool_id\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if id_bool(P) then id_bool(Q)\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose hp: id_bool(P)\n"
+        "  ?\n"
+        "end\n"
+    )
+    g = goal_at("test.pf", source, Position(line=15, column=3))
+    assert g is not None
+    assert g.formula == "id_bool(Q)"
+    assert g.formula_normalized == "Q", (
+        f"expected normalized goal 'Q'; got {g.formula_normalized!r}"
+    )
+
+
+def test_goal_at_exposes_normalized_given_under_auto_rule() -> None:
+    """Same auto rule as the goal test, but cursor is on a hole where
+    the given ``hp: id_bool(P)`` should expose ``formula_normalized
+    = 'P'`` -- so an agent can match the given against a goal of
+    shape ``P`` without writing a probe edit."""
+    source = (
+        "fun id_bool(x : bool) { x }\n"
+        "\n"
+        "theorem id_bool_id: all x:bool. id_bool(x) = x\n"
+        "proof\n"
+        "  arbitrary x:bool\n"
+        "  expand id_bool.\n"
+        "end\n"
+        "\n"
+        "auto id_bool_id\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if id_bool(P) then id_bool(Q)\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose hp: id_bool(P)\n"
+        "  ?\n"
+        "end\n"
+    )
+    g = goal_at("test.pf", source, Position(line=15, column=3))
+    assert g is not None
+    by_label = {given.label: given for given in g.givens}
+    assert "hp" in by_label, f"expected hp in givens; got {g.givens}"
+    assert by_label["hp"].formula == "id_bool(P)"
+    assert by_label["hp"].formula_normalized == "P", (
+        f"expected normalized given 'P'; got "
+        f"{by_label['hp'].formula_normalized!r}"
+    )
+
+
 def test_goal_at_synthetic_hole_skips_earlier_existing_hole() -> None:
     """A `?` already exists earlier in the proof; cursor sits on a
     blank line later. The synthetic `?` inserted at the cursor must


### PR DESCRIPTION
## Summary
- Adds `formula_normalized` to the `Goal` payload returned by the `goal_at` MCP/LSP tool — the post-auto-reduction shape the proof checker compares against.
- Adds the same field to each `Given`, so an agent can match a hypothesis against a goal without writing a probe edit when an auto rule is what's preventing the match.
- Field stays `None` when reduction would equal the source-shaped `formula`, so callers can detect "no auto rule fired" by presence alone — no string compares needed.

Computed via `exc.formula.reduce(env)` using the structured AST/env attached by `incomplete_error`. Givens are walked from `env.dict`'s `ProofBinding` entries and matched back to the parsed labels via `name2str`.

Closes [#421](https://github.com/jsiek/deduce/issues/421).

## Test plan
- [x] `python3.13 -m pytest test/lsp/test_goal_at.py` — 16 passed, including three new cases: a no-auto sanity check that `formula_normalized` stays `None`, an `id_bool`-based auto-rule test that pins the goal-side normalization, and a sibling test that pins the given-side normalization.
- [x] `python3.13 -m pytest test/lsp/` — 820 passed; no regressions from the dataclass field additions (defaults keep older constructions working).
- [x] `python3.13 -m pytest test/lsp/test_mcp_server.py` — existing `goal_at` payload assertions still pass (they don't compare full dicts, so the additional `formula_normalized: None` field doesn't affect them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)