### PR TITLE
Fix #420: add preview_conclude_at MCP tool

### DIFF
--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -419,6 +419,51 @@ def matching_givens_at(
 
 
 @mcp.tool()
+def preview_conclude_at(
+    path: str, line: int, column: int, label: str
+) -> Optional[dict]:
+    """Preview ``conclude <goal> by <label>`` modulo auto-rule
+    normalization at the hole at ``line``:``column``.
+
+    Like ``fill_from_given_at`` / ``matching_givens_at`` but reduces
+    both sides via ``.reduce(env)`` before checking implication --
+    mirroring what the proof checker does in the catch-all branch of
+    ``check_proof_of``. So a label this preview reports as
+    ``discharges`` would also validate when used as a proof body.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token.
+    ``label`` names an in-scope local proof binding.
+
+    Returns ``None`` when the cursor isn't on a ``?`` or the file has
+    no incomplete proof there. Otherwise returns a dict whose
+    ``outcome`` field discriminates:
+
+    - ``{"outcome": "discharges", "goal_normalized": "<formula>",
+       "given_normalized": "<formula>"}`` -- the (reduced) label
+      discharges the (reduced) goal.
+    - ``{"outcome": "no_match", "goal_normalized": "<formula>",
+       "given_normalized": "<formula>", "reason": "<message>"}`` --
+      the label is bound but its formula does not discharge the goal,
+      even modulo auto.
+    - ``{"outcome": "unbound", "label": "<name>"}`` -- ``label`` is
+      not bound at the hole.
+    - ``{"outcome": "not_local", "label": "<name>"}`` -- ``label``
+      refers to a non-local proof binding (theorem reference);
+      callers invoke those by name in proof position directly.
+
+    Companion to ``matching_givens_at`` / ``fill_from_given_at``: those
+    use bare ``check_implies`` (no reduce); this one matches what the
+    proof checker actually accepts. Use this to confirm a hypothesis
+    discharges the goal before committing an edit.
+    """
+    content = _read_file(path)
+    pos = query.Position(line=line, column=column)
+    return query.preview_conclude_at(
+        path, content, pos, label, prelude=_prelude_for(path)
+    )
+
+
+@mcp.tool()
 def apply_at(
     path: str, line: int, column: int,
     theorem: str,

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -81,6 +81,7 @@ __all__ = [
     "eliminable_vars_at",
     "fill_from_given_at",
     "matching_givens_at",
+    "preview_conclude_at",
     "apply_at",
     "hole_context_at",
     "available_lemmas_at",
@@ -2330,6 +2331,117 @@ def _fill_from_given_template(label: str, goal, env) -> Optional[str]:
     if binding.formula != goal and not _implies(binding.formula, goal):
         return None
     return f"conclude {goal} by {label}"
+
+
+# ---------------------------------------------------------------------------
+# preview_conclude_at -- issue #420: like ``fill_from_given_at`` but
+# matches modulo auto-rule normalization.
+# ---------------------------------------------------------------------------
+#
+# ``fill_from_given_at`` / ``matching_givens_at`` compare ``binding.formula``
+# against the goal under ``check_implies`` directly. The proof checker's
+# catch-all branch of ``check_proof_of`` (proof_checker.py, ~line 1870) does
+# more: it calls ``.reduce(env)`` on both sides first, which applies the
+# active ``auto`` rewrite rules. So the checker accepts a label whose
+# formula becomes the goal *after* auto fires, but ``matching_givens_at``
+# reports no match. Concrete example from PR #413: given
+# ``mult_le: 2^a * 1 ≤ 2^a * 2^(b - a)`` and goal ``2^a ≤ 2^a * 2^(b - a)``,
+# the goal and given differ by ``uint_mult_one: n * 1 = n`` (an auto rule),
+# so they are equal post-reduce but unequal pre-reduce.
+#
+# ``preview_conclude_at`` reproduces the checker's reduce-then-implies
+# step as a read-only preview, so an agent can confirm "this label
+# discharges the goal once auto fires" before committing the edit.
+
+
+def preview_conclude_at(
+    path: str, content: str, pos: Position,
+    label: str,
+    prelude: Sequence[str] = (),
+) -> Optional[dict]:
+    """Preview ``conclude <goal> by <label>`` modulo auto-rule
+    normalization.
+
+    The cursor must sit on (or immediately adjacent to) a ``?`` token.
+    ``label`` names an in-scope local proof binding. Both the binding's
+    formula and the goal are reduced via ``.reduce(env)`` -- which
+    applies any active ``auto`` rewrites -- and then
+    ``proof_checker.check_implies`` decides whether the (reduced)
+    binding discharges the (reduced) goal. This mirrors the catch-all
+    branch of the proof checker, so any label this preview reports as
+    ``discharges`` would also validate when used as the proof body of
+    a ``conclude ... by ...``.
+
+    Returns ``None`` when the cursor isn't on a ``?`` or the file has
+    no incomplete proof at that hole. Otherwise returns a dict whose
+    ``outcome`` field discriminates:
+
+    - ``{"outcome": "discharges", "goal_normalized": "<str>",
+       "given_normalized": "<str>"}`` -- the label's formula
+       (post-reduce) implies the goal (post-reduce).
+
+    - ``{"outcome": "no_match", "goal_normalized": "<str>",
+       "given_normalized": "<str>", "reason": "<msg>"}`` -- the label
+       is bound but its formula does not discharge the goal, even
+       modulo auto.
+
+    - ``{"outcome": "unbound", "label": "<name>"}`` -- ``label`` isn't
+       bound at the hole.
+
+    - ``{"outcome": "not_local", "label": "<name>"}`` -- ``label``
+       refers to a non-local proof binding (a theorem reference).
+       Theorem references are invoked by name in proof position
+       directly, not via ``conclude ... by ...`` -- matching the
+       filter already in :func:`fill_from_given_at`.
+    """
+    from abstract_syntax import ProofBinding, base_name
+
+    hole_range = _find_hole_at(content, pos)
+    if hole_range is None:
+        return None
+
+    from lsp.library import check_file
+
+    result = check_file(path, content=content, prelude=prelude)
+    if result.ok:
+        return None
+
+    exc = result.exception
+    env = getattr(exc, "env", None)
+    goal = getattr(exc, "formula", None)
+    if env is None or goal is None:
+        return None
+
+    matches = [k for k in env.dict if base_name(k) == label]
+    if not matches:
+        return {"outcome": "unbound", "label": label}
+    binding = env.dict[matches[0]]
+    if not isinstance(binding, ProofBinding):
+        return {"outcome": "unbound", "label": label}
+    if not binding.local:
+        return {"outcome": "not_local", "label": label}
+
+    from abstract_syntax import remove_mark
+
+    given_red = binding.formula.reduce(env)
+    goal_red = remove_mark(goal).reduce(env)
+
+    if given_red == goal_red or _implies(given_red, goal_red):
+        return {
+            "outcome": "discharges",
+            "goal_normalized": str(goal_red),
+            "given_normalized": str(given_red),
+        }
+
+    return {
+        "outcome": "no_match",
+        "goal_normalized": str(goal_red),
+        "given_normalized": str(given_red),
+        "reason": (
+            f"{label}: {given_red} does not imply {goal_red} "
+            "(checked modulo auto-rule normalization)"
+        ),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -105,6 +105,7 @@ async def test_all_tools_are_registered(server):
             "eliminable_vars_at",
             "fill_from_given_at",
             "matching_givens_at",
+            "preview_conclude_at",
             "apply_at",
             "preview_replace_at",
             "preview_expand_at",

--- a/test/lsp/test_preview_conclude.py
+++ b/test/lsp/test_preview_conclude.py
@@ -1,0 +1,224 @@
+"""Acceptance tests for ``lsp.query.preview_conclude_at`` (issue #420).
+
+UX shape: cursor on a ``?`` plus an explicit ``label`` argument
+naming the in-scope local hypothesis we want to check would
+discharge the goal. Differs from ``fill_from_given_at`` /
+``matching_givens_at`` by reducing both sides with ``.reduce(env)``
+before the implication check -- so it matches what the proof checker
+actually accepts in the catch-all branch of ``check_proof_of``.
+
+Coverage:
+
+(a) exact match (no auto needed)         -> ``discharges``
+(b) implies-only match (Or-intro)        -> ``discharges``
+(c) match via auto-rule normalization    -> ``discharges``
+(d) unrelated label                      -> ``no_match``
+(e) label not bound                      -> ``unbound``
+(f) label refers to a theorem            -> ``not_local``
+(g) cursor not on a ``?``                -> ``None``
+(h) file has no incomplete proof         -> ``None``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    preview_conclude_at,
+)
+
+
+def test_preview_conclude_at_exact_match() -> None:
+    """``H: P or Q`` exactly matches goal ``P or Q``."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P or Q then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P or Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert result is not None
+    assert result["outcome"] == "discharges"
+    # Renderer parenthesises top-level ``or`` expressions.
+    assert result["given_normalized"] == "(P or Q)"
+    assert result["goal_normalized"] == "(P or Q)"
+
+
+def test_preview_conclude_at_implies_only_match() -> None:
+    """``H: P`` strictly implies goal ``P or Q`` via Or introduction.
+    ``check_implies`` covers this; no auto-rule needed."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if P then P or Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert result is not None
+    assert result["outcome"] == "discharges"
+
+
+def test_preview_conclude_at_match_modulo_auto_rule() -> None:
+    """The motivating case from PR #413: ``H``'s formula reduces to
+    the goal under an active ``auto`` rewrite, so the goal and H
+    differ pre-reduce but equal post-reduce. ``matching_givens_at``
+    would report no match here; ``preview_conclude_at`` reports
+    ``discharges``, matching what ``conclude ... by H`` accepts.
+
+    Setup uses ``fadd_zero_right: all x. fadd(x, fzero) = x`` as the
+    auto rule -- a non-trivial theorem (needs induction on x), unlike
+    a function-definition rewrite which ``reduce`` would apply even
+    without the ``auto`` annotation. The goal ``z = fsucc(fzero)``
+    does not collapse to ``true`` even after the auto rule fires,
+    so we can assert on the post-reduce text without ambiguity."""
+    source = (
+        "union Foo {\n"                                                # 1
+        "  fzero\n"                                                    # 2
+        "  fsucc(Foo)\n"                                               # 3
+        "}\n"                                                          # 4
+        "recursive fadd(Foo, Foo) -> Foo {\n"                          # 5
+        "  fadd(fzero, y) = y\n"                                       # 6
+        "  fadd(fsucc(x), y) = fsucc(fadd(x, y))\n"                    # 7
+        "}\n"                                                          # 8
+        "postulate fadd_zero_right:\n"                                 # 9
+        "  all x:Foo. fadd(x, fzero) = x\n"                            # 10
+        "auto fadd_zero_right\n"                                       # 11
+        "\n"                                                           # 12
+        "theorem t: all z:Foo.\n"                                      # 13
+        "  if fadd(z, fzero) = fsucc(fzero) then z = fsucc(fzero)\n"   # 14
+        "proof\n"                                                      # 15
+        "  arbitrary z:Foo\n"                                          # 16
+        "  assume H: fadd(z, fzero) = fsucc(fzero)\n"                  # 17
+        "  ?\n"                                                        # 18
+        "end\n"                                                        # 19
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=18, column=3), "H"
+    )
+    assert result is not None, "preview_conclude_at returned None"
+    assert result["outcome"] == "discharges", result
+    # Both reduced sides equal ``z = fsucc(fzero)`` (the auto rule
+    # rewrites ``fadd(z, fzero) -> z`` on the LHS of the equation).
+    assert result["goal_normalized"] == "z = fsucc(fzero)"
+    assert result["given_normalized"] == "z = fsucc(fzero)"
+
+
+def test_preview_conclude_at_no_match_for_unrelated() -> None:
+    """Goal ``Q`` with an unrelated given ``H: P`` -- doesn't discharge
+    even modulo auto."""
+    source = (
+        "theorem t: all P:bool, Q:bool. if Q then if P then Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume HQ: Q\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=6, column=3), "H"
+    )
+    assert result is not None
+    assert result["outcome"] == "no_match"
+    assert result["goal_normalized"] == "Q"
+    assert result["given_normalized"] == "P"
+    assert "does not imply" in result["reason"]
+
+
+def test_preview_conclude_at_unbound_label() -> None:
+    """Label not bound at the hole."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=5, column=3), "nope"
+    )
+    assert result == {"outcome": "unbound", "label": "nope"}
+
+
+def test_preview_conclude_at_label_is_term_variable() -> None:
+    """Label refers to a term variable (``P:bool``), not a proof
+    binding -- reported as ``unbound`` (no proof binding by that
+    name)."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume pP: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=5, column=3), "P"
+    )
+    assert result == {"outcome": "unbound", "label": "P"}
+
+
+def test_preview_conclude_at_label_is_theorem_ref() -> None:
+    """A theorem in scope is a non-local proof binding. Theorem
+    references are invoked by name directly in proof position, not
+    via ``conclude ... by``, so this preview reports ``not_local``."""
+    source = (
+        "theorem h: true\n"
+        "proof . end\n"
+        "theorem t: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=5, column=3), "h"
+    )
+    assert result == {"outcome": "not_local", "label": "h"}
+
+
+def test_preview_conclude_at_returns_none_off_hole() -> None:
+    """Cursor not on a ``?`` -> ``None`` (this is a hole-driven tool)."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Cursor on `assume` keyword.
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=4, column=3), "H"
+    )
+    assert result is None
+
+
+def test_preview_conclude_at_returns_none_when_complete() -> None:
+    """File validates without ever raising IncompleteProof -- nothing
+    to preview against."""
+    source = (
+        "theorem t: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+    )
+    result = preview_conclude_at(
+        "test.pf", source, Position(line=5, column=3), "H"
+    )
+    assert result is None

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -93,6 +93,7 @@ EXPECTED_PUBLIC = {
     "eliminable_vars_at",
     "fill_from_given_at",
     "matching_givens_at",
+    "preview_conclude_at",
     "apply_at",
     "hole_context_at",
     "available_lemmas_at",


### PR DESCRIPTION
## Summary

Closes [#420](https://github.com/jsiek/deduce/issues/420). Adds a new MCP tool `preview_conclude_at(path, line, column, label)` that previews whether `conclude <goal> by <label>` would discharge the hole at the cursor — matching what the proof checker actually accepts.

`matching_givens_at` / `fill_from_given_at` (post-#428) call `proof_checker.check_implies` on raw formulas, but the catch-all branch of `check_proof_of` (`proof_checker.py:1870`) reduces both sides with `.reduce(env)` first — so the checker accepts label-discharges-goal pairs that differ only by an active `auto` rewrite, while `matching_givens_at` reports no match. PR [#413](https://github.com/jsiek/deduce/pull/413)'s motivating case (`mult_le: 2^a * 1 ≤ 2^a * 2^(b ∸ a)` vs goal `2^a ≤ 2^a * 2^(b ∸ a)`, gap closed by `uint_mult_one`) is exactly this shape.

`preview_conclude_at` reproduces the checker's reduce-then-implies step read-only.

## Outcomes

- `{outcome: "discharges", goal_normalized, given_normalized}` — the label's reduced formula implies the reduced goal.
- `{outcome: "no_match", goal_normalized, given_normalized, reason}` — bound but does not discharge even modulo auto.
- `{outcome: "unbound", label}` — not bound at the hole.
- `{outcome: "not_local", label}` — refers to a theorem (theorems are invoked by name in proof position directly; matches the existing `fill_from_given_at` filter).
- `null` — cursor not on a `?` or no incomplete proof there.

## Files

- `lsp/query.py` — new `preview_conclude_at` (factored next to `fill_from_given_at` / `matching_givens_at`); added to `__all__`.
- `lsp/mcp_server.py` — thin wrapper, registered next to `apply_at`.
- `test/lsp/test_preview_conclude.py` — 9 acceptance tests covering every outcome plus the motivating modulo-auto case (self-contained: uses a `postulate` + `auto` so no stdlib prelude needed).
- `test/lsp/test_query.py`, `test/lsp/test_mcp_server.py` — added `preview_conclude_at` to the public-API and registered-tool expected sets.

## Test plan

- [x] `python3.13 -m pytest test/lsp/test_preview_conclude.py` — 9 passed
- [x] `python3.13 -m pytest test/lsp/` — 826 passed (full LSP suite, no regression)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)