### PR TITLE
Fix #418: available_lemmas_at off-hole, no-query browse mode

### DIFF
--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -559,10 +559,14 @@ def available_lemmas_at(
     - On a ``?`` token: the goal at that hole drives ranking. The
       goal's head operator and operator/function tokens are matched
       against each candidate lemma's conclusion.
-    - Off a ``?``: ``query`` is required. ``query`` is either a
-      substring (matched against the rendered signature) or a goal-
-      shape pattern containing ``_`` placeholders (each ``_`` matches
-      any run of characters, e.g. ``"_ ≤ _ + _"``).
+    - Off a ``?`` with ``query`` given: ``query`` is a substring
+      (matched against the rendered signature) or a goal-shape
+      pattern containing ``_`` placeholders (each ``_`` matches any
+      run of characters, e.g. ``"_ ≤ _ + _"``).
+    - Off a ``?`` with no ``query``: browse mode -- every lemma in
+      scope at ``line``:``column`` is returned, ranked by module
+      proximity (user-file first) then alphabetically. Lets agents
+      explore "what's available here?" without inserting a ``?``.
 
     Results are returned best-first, capped at ``limit`` entries
     (default 50). Each entry has ``name``, ``kind`` (``"theorem"`` /
@@ -575,8 +579,8 @@ def available_lemmas_at(
     surfaced (they're in scope), but private lemmas in prelude
     modules are not (matching what ``print_theorems`` exports).
 
-    Returns ``[]`` when the cursor isn't on a ``?`` and no ``query``
-    was given, or when nothing matches.
+    Returns ``[]`` only when nothing is in scope at the position or
+    a given ``query`` matches nothing.
     """
     from lsp import query as _q
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -2857,7 +2857,7 @@ def available_lemmas_at(
 ) -> tuple:
     """Return ranked lemmas visible at ``pos``, best matches first.
 
-    Driven by either (or both) of two signals:
+    Driven by zero, one, or both of two signals:
 
     - The cursor sits on a ``?`` token: the goal at that hole defines
       the shape we're searching for.  ``available_lemmas_at`` extracts
@@ -2868,7 +2868,11 @@ def available_lemmas_at(
       placeholders (each ``_`` matches any run of characters).
 
     When both are given they combine -- a lemma that matches the goal
-    *and* the query ranks above one that matches only one.
+    *and* the query ranks above one that matches only one.  When
+    neither is given (off-hole exploration), every in-scope lemma is
+    surfaced, ranked by module proximity (user-file first) then by
+    name -- useful for "what's available here?" browsing without
+    inserting a synthetic ``?``.
 
     The result is a tuple of :class:`LemmaMatch` ordered by descending
     ``relevance``; ties broken by name.  ``relevance`` is normalised
@@ -2878,9 +2882,9 @@ def available_lemmas_at(
     The lemma set covers everything in scope at the cursor: the
     user-file's own declarations, the modules it explicitly
     ``import``s (transitively, through public imports), and any
-    module named in ``prelude``.  This works without a hole as long
-    as the file parses.  Returns ``()`` when neither a hole nor a
-    ``query`` is available, or when no lemma matches even minimally.
+    module named in ``prelude``.  Returns ``()`` only when the file
+    produces no candidates at all, or when a given ``query`` matches
+    nothing.
     """
     from lsp.library import check_file
 
@@ -2898,9 +2902,6 @@ def available_lemmas_at(
     else:
         result = check_file(path, content=content, prelude=prelude)
         ast_nodes = result.ast
-
-    if goal_text is None and not query:
-        return ()
 
     candidates = _collect_lemma_candidates(path, ast_nodes, prelude)
     if not candidates:
@@ -3286,12 +3287,19 @@ def _rank_lemmas(
 
     Plus one extra: a goal-shape pattern (a ``query`` containing ``_``
     placeholders) matched against the rendered signature.
+
+    When neither a goal nor a query is given, runs in *browse mode*:
+    every candidate is surfaced, ranked only by module proximity
+    (user-file lemmas first) then alphabetically. This is what makes
+    off-hole exploration usable -- an agent can ask "what's in scope
+    here?" without inserting a synthetic hole.
     """
     goal_head = _goal_head_symbol(goal_text)
     goal_syms = _goal_tokens(goal_text)
     pattern = _query_pattern(query)
     query_substr = (query or "").strip().lower()
     has_substring_query = bool(query_substr) and pattern is None
+    browse_mode = goal_text is None and not query
 
     raw_scores: list = []
     for info, formula, module in candidates:
@@ -3335,6 +3343,13 @@ def _rank_lemmas(
         if has_substring_query and substring_score == 0.0:
             continue
         if pattern is not None and pattern_score == 0.0:
+            continue
+
+        if browse_mode:
+            # Surface every candidate; ranking is proximity then name.
+            # Use a fixed baseline so out-of-module candidates aren't
+            # dropped by the ``raw <= 0`` filter below.
+            raw_scores.append((1.0 + proximity, info, module))
             continue
 
         # No goal AND no query that this lemma matched -> nothing to

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -79,19 +79,30 @@ def test_goal_drives_ranking_by_head_symbol() -> None:
     assert by_name["and_helper"].relevance > by_name["eq_helper"].relevance
 
 
-def test_no_hole_no_query_returns_empty() -> None:
-    """Cursor not on a `?` and no `query` -> nothing to match against."""
+def test_no_hole_no_query_returns_browse_results() -> None:
+    """Cursor not on a `?` and no `query`: browse mode surfaces every
+    in-scope lemma so off-hole exploration works without inserting a
+    synthetic `?` (issue #418)."""
     source = (
-        "theorem t: all P:bool. P = P\n"
+        "theorem alpha: true\n"
+        "proof\n  .\nend\n"
+        "\n"
+        "theorem beta: true\n"
+        "proof\n  .\nend\n"
+        "\n"
+        "theorem gamma: all P:bool. P = P\n"
         "proof\n"
         "  arbitrary P:bool\n"
         "  reflexive\n"
         "end\n"
     )
-    # Line 4 sits on `reflexive`, not a `?`.
-    assert available_lemmas_at(
-        "lemmas.pf", source, Position(line=4, column=3)
-    ) == ()
+    # Cursor on `reflexive` (line 12), not a `?`. Browse mode returns
+    # every user-file lemma in scope at that point.
+    matches = available_lemmas_at(
+        "lemmas.pf", source, Position(line=12, column=3)
+    )
+    names = {m.name for m in matches}
+    assert {"alpha", "beta", "gamma"} <= names
 
 
 def test_user_lemmas_get_module_set_to_file_stem() -> None:
@@ -355,6 +366,69 @@ def test_limit_caps_result_count() -> None:
         source,
         Position(line=1, column=1),
         query="t",
+        limit=2,
+    )
+    assert len(matches) == 2
+
+
+# ---------------------------------------------------------------------------
+# Browse mode (no hole, no query): issue #418
+# ---------------------------------------------------------------------------
+
+
+def test_browse_mode_includes_prelude_lemmas() -> None:
+    """Browse mode (no `?`, no `query`) also surfaces lemmas reached
+    through ``prelude``, not just user-file declarations."""
+    source = (
+        "theorem local: true\n"
+        "proof\n  .\nend\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=1, column=1),
+        prelude=("HoleFillPrelude",),
+    )
+    by_name = {m.name: m for m in matches}
+    # User-file lemma is present.
+    assert "local" in by_name
+    # Prelude lemma is also surfaced.
+    assert "hf_intro_and" in by_name
+    assert by_name["hf_intro_and"].module == "HoleFillPrelude"
+
+
+def test_browse_mode_user_module_outranks_prelude() -> None:
+    """Browse-mode ordering: same-file lemmas come before prelude
+    lemmas, so the most-relevant scope shows up first."""
+    source = (
+        "theorem local: true\n"
+        "proof\n  .\nend\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=1, column=1),
+        prelude=("HoleFillPrelude",),
+    )
+    by_name = {m.name: m for m in matches}
+    if "local" in by_name and "hf_intro_and" in by_name:
+        assert (
+            by_name["local"].relevance > by_name["hf_intro_and"].relevance
+        )
+
+
+def test_browse_mode_respects_limit() -> None:
+    """``limit`` caps browse-mode results too."""
+    source = (
+        "theorem t1: true\nproof\n  .\nend\n"
+        "theorem t2: true\nproof\n  .\nend\n"
+        "theorem t3: true\nproof\n  .\nend\n"
+        "theorem t4: true\nproof\n  .\nend\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf",
+        source,
+        Position(line=1, column=1),
         limit=2,
     )
     assert len(matches) == 2

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -792,11 +792,16 @@ async def test_available_lemmas_at_query_pattern(server, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_available_lemmas_at_no_signal_returns_empty(server, tmp_path):
-    """No `?` and no `query` -> empty list."""
-    fp = tmp_path / "empty.pf"
+async def test_available_lemmas_at_no_signal_browses(server, tmp_path):
+    """No `?` and no `query`: browse mode surfaces every in-scope
+    lemma so off-hole exploration works (issue #418)."""
+    fp = tmp_path / "browse.pf"
     fp.write_text(
-        "theorem t: all P:bool. P = P\n"
+        "theorem alpha: true\nproof\n  .\nend\n"
+        "\n"
+        "theorem beta: true\nproof\n  .\nend\n"
+        "\n"
+        "theorem gamma: all P:bool. P = P\n"
         "proof\n"
         "  arbitrary P:bool\n"
         "  reflexive\n"
@@ -805,9 +810,11 @@ async def test_available_lemmas_at_no_signal_returns_empty(server, tmp_path):
     payload = await _call(
         server,
         "available_lemmas_at",
-        {"path": str(fp), "line": 4, "column": 3},
+        {"path": str(fp), "line": 9, "column": 3},
     )
-    assert payload == []
+    assert isinstance(payload, list)
+    names = {m["name"] for m in payload}
+    assert {"alpha", "beta", "gamma"} <= names
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #418. Off-hole calls to `available_lemmas_at` with no `query` used to return `[]`, forcing the "insert a `?`, save, run query, undo" dance the issue describes just to ask "what lemmas are in scope here?".

Now treats (no hole + no query) as **browse mode**: every in-scope lemma is surfaced, ranked by module proximity (user-file first) then alphabetically. The goal-driven and query-driven paths are unchanged — they still gate-filter to matches only.

## Changes

- `lsp/query.py`: drop the early `return ()` when neither a hole nor a query is given; add a `browse_mode` branch in `_rank_lemmas` that gives every candidate a baseline score (1.0 + proximity) so out-of-module lemmas survive the `raw <= 0` filter. Docstring updated.
- `lsp/mcp_server.py`: tool description rewritten to document the three modes (hole-driven / query / browse).
- `test/lsp/test_available_lemmas.py`: replaced the old `test_no_hole_no_query_returns_empty` with `test_no_hole_no_query_returns_browse_results`; added three browse-mode tests covering prelude inclusion, module proximity, and `limit`.
- `test/lsp/test_mcp_server.py`: updated the matching MCP-level test.

## Test plan

- [x] `python3.13 -m pytest test/lsp/` — 820 passed
- [ ] CI green