### PR TITLE
Fix broken code-block rendering on gh-pages site

### DIFF
--- a/gh_pages/js/codeKeywords.js
+++ b/gh_pages/js/codeKeywords.js
@@ -1,17 +1,17 @@
-const idents = ["(?:[A-Z]|[a-z]|_)(?:(?:[₀₁₂₃₄₅₆₇₈₉!?']|[A-Z]|[a-z]|[0-9]|_))*"]
-
-const types = ['fn', 'bool', 'type']
-
-const prims = ['(?:[0-9])+', '∘', '\\.o\\.', 'true', 'false', '─', '\\.\\.\\.']
-
-const operators = ['iff', '&lt;&equals;&gt;', '⇔', ':', '&equals;', '≠', '&sol;&equals;', '&lt;', '&gt;', '≤', '&lt;&equals;', '≥', '&gt;&equals;', '⊆', '\\(&equals;', '∈', '≲', '≈', '\\+', '∪', '\\|', '∩', '\\&amp;', '⨄', '\\.\\+\\.', '\\+\\+', '\\-', '∸', '\\.\\-\\.', '&sol;', '%', '\\*', '\\^', '\\{', '\\}', 'operator', '∅', '\\.0\\.', '@', 'array', '\\(', '\\)', '\\[', '\\]', 'λ', '\\.', '&semi;', '\\?', '__', '\\#', ',', '\\$', '\\-&gt;', '0']
-
-const keywords = ['[ℕ](?:[0-9])+', '[\\-\\+∸*%&equals;≠&lt;&gt;≤≥&amp;∘∪∩⊆∈⨄⊝\\^≲≈]', 'and', 'or', 'in', '⊝', 'case', 'not', 'fun', 'generic', 'switch', 'all', 'some', 'define', 'if', 'then', 'else', 'suppose', 'assume', 'by', 'proof', 'end', 'conclude', 'apply', 'to', 'contradict', 'conjunct', 'of', 'cases', 'induction', 'expand', 'replace', 'evaluate', 'for', 'equations', 'recall', 'reflexive', 'symmetric', 'transitive', 'help', 'sorry', 'arbitrary', 'choose', 'show', 'extensionality', 'have', 'injective', 'obtain', 'where', 'from', 'stop', 'suffices', 'theorem', 'lemma', 'postulate', 'public', 'private', 'opaque', 'union', 'recursive', 'recfun', 'measure', 'terminates', 'import', 'using', 'hiding', 'export', 'assert', 'print', 'associative', 'auto', 'module']
+const prims = ['(?:[0-9])+', 'true', 'false', '∅', '\\.0\\.', '0']
 
 const whitespaces = ['(?:[ \t\x0c\r\n])+']
 
+const types = ['fn', 'bool', 'type']
+
+const keywords = ['[ℕ](?:[0-9])+', '[\\-\\+∸*%&equals;≠&lt;&gt;≤≥&amp;∘∪∩⊆∈⨄⊝\\^≲≈]', 'and', 'or', 'in', 'case', 'not', 'fun', 'generic', 'switch', 'all', 'some', 'define', 'if', 'then', 'else', 'suppose', 'assume', 'by', 'proof', 'end', 'conclude', 'apply', 'to', 'contradict', 'conjunct', 'of', 'cases', 'induction', 'rule', 'inversion', 'expand', 'replace', 'evaluate', 'simplify', 'for', 'equations', 'recall', 'reflexive', 'symmetric', 'transitive', 'help', 'sorry', 'with', 'arbitrary', 'choose', 'show', 'extensionality', 'have', 'injective', 'obtain', 'where', 'from', 'stop', 'suffices', 'theorem', 'lemma', 'postulate', 'public', 'private', 'opaque', 'union', 'predicate', 'relation', 'recursive', 'recfun', 'measure', 'terminates', 'import', 'using', 'hiding', 'export', 'assert', 'print', 'associative', 'auto', 'module', 'trace', 'inductive']
+
+const idents = ["(?:[A-Z]|[a-z]|_)(?:(?:[₀₁₂₃₄₅₆₇₈₉!?']|[A-Z]|[a-z]|[0-9]|_))*"]
+
+const operators = ['\\-&gt;', 'iff', '&lt;&equals;&gt;', '⇔', ':', '&equals;', '≠', '&sol;&equals;', '&lt;', '&gt;', '≤', '&lt;&equals;', '≥', '&gt;&equals;', '⊆', '\\(&equals;', '∈', '≲', '≈', '\\+', '∪', '\\|', '∩', '\\&amp;', '⨄', '\\.\\+\\.', '\\+\\+', '\\-', '∸', '\\.\\-\\.', '⊝', '&sol;', '%', '\\*', '∘', '\\.o\\.', '\\^', '\\{', '\\}', 'operator', '@', 'array', '\\(', '\\)', '\\[', '\\]', 'λ', '\\.', '&semi;', '\\?', '─', '__', '\\#', ',', '\\.\\.\\.', '\\$']
+
 const comments = ['&sol;&sol;[^\n]*', '\\&sol;\\*(\\*(?!\\&sol;)|[^*])*\\*\\&sol;']
 
-const libs = ['UInt', 'Pair', 'NatLess', 'NatMonus', 'UIntAdd', 'Option', 'IntDefs', 'NatMult', 'MultiSet', 'Set', 'List', 'Int', 'NatPowLog', 'Base', 'NatSum', 'UIntToFrom', 'NatDefs', 'UIntLess', 'IntMult', 'UIntDefs', 'IntAddSub', 'UIntDiv', 'UIntEvenOdd', 'Nat', 'NatAdd', 'UIntMult', 'UIntMonus', 'UIntPowLog', 'BigO', 'NatEvenOdd', 'Maps', 'NatDiv']
+const libs = ['UIntDefs', 'NatPowLog', 'UIntMult', 'UIntMonus', 'MultiSet', 'UIntToFrom', 'Set', 'NatAdd', 'UInt', 'NatDefs', 'Int', 'UIntPowLog', 'Base', 'Pair', 'NatDiv', 'NatMult', 'NatEvenOdd', 'NatSum', 'Maps', 'UIntEvenOdd', 'NatMonus', 'IntMult', 'IntAddSub', 'List', 'BigO', 'Option', 'NatLess', 'IntDefs', 'UIntLess', 'UIntDiv', 'Nat', 'UIntAdd']
 
-export { idents, types, prims, operators, keywords, whitespaces, comments, libs }
+export { prims, whitespaces, types, keywords, idents, operators, comments, libs }

--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -145,7 +145,7 @@ known_tokens = {
     '__ANON_20': 'operator', # ⊝
     '__ANON_21': 'operator', # ∘
     '__ANON_22': 'operator', # \\.o\\.
-    '__ANON_23': 'keyword',  # operator
+    '__ANON_23': 'operator', # the literal keyword `operator`; categorised here, not in 'keyword', because the CSS class name `operator` in codeUtils.js collides with `\boperator\b` when applied after the operator-span pass and corrupts the rendered HTML
     '__ANON_24': 'prim',     # ∅
     '__ANON_25': 'prim',     # \\.0\\.
     '__ANON_26': 'operator', # ─


### PR DESCRIPTION
## Summary

- The deployed site at https://jsiek.github.io/deduce/ shows mangled code samples like `searchoperator">(Listoperator"><UIntoperator">>…`. Root cause: the keyword-highlight regex re-matches the literal text `operator` inside the `class="operator"` attribute of previously-emitted operator spans, corrupting the HTML.
- Restored the pre-regression classification of the literal `operator` token (Lark `__ANON_23`) to the **operator** category instead of **keyword**, and regenerated `gh_pages/js/codeKeywords.js` so local devs see the same output CI will produce.

## Why this regressed

The autogenerated keyword list was introduced in 8289170. Before that, the hand-maintained `codeKeywords.js` had `'operator'` in the operators list precisely to dodge the collision with the `class="operator"` CSS class name. The same defensive workaround still survives one layer down: `defs.filter(e => e !== "operator")` in `codeUtils.js:37`. Putting `__ANON_23` in `'keyword'` accidentally undid that hack and `\boperator\b` started matching inside `class="operator"` — turning `<span class="operator">(</span>` into `<span class="<span class="keyword">operator</span>">(</span>`, which the browser parses as a span with two malformed attributes followed by leftover text `operator">(`.

## Verification

Reproduced the broken text content byte-for-byte through JSDOM by running `codeToHTML` against the live `codeKeywords.js`, then re-ran the same parse with the fixed file:

- Before: `"recursive searchoperator\">(Listoperator\"><UIntoperator\">>…"`
- After: `"recursive search(List<UInt>, UInt) -> UInt { … }"`

Also verified that source code using the `operator` keyword in declarations (`define operator + : fn (UInt, UInt) -> UInt = foo`) still renders correctly — `operator` is now highlighted in the operator color rather than keyword color, matching pre-regression appearance.

## Test plan

- [ ] After merge, confirm code blocks on https://jsiek.github.io/deduce/ render correctly (no `operator">` artifacts on the linear-search example).
- [ ] Spot-check a few other code examples on the docs/programming pages.
- [ ] Confirm `gh_pages/scripts/keywords.py` self-check still passes (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)