### PR TITLE
Fix gh-pages key-bindings table: keep chords on one line

### DIFF
--- a/gh_pages/css/style-dev.css
+++ b/gh_pages/css/style-dev.css
@@ -821,6 +821,11 @@ table {
             padding: 10px 15px;
             border: solid var(--light-gray) 1px;
         }
+
+        th code.inline,
+        td code.inline {
+            white-space: nowrap;
+        }
     }
 
     tr:nth-child(even) {

--- a/gh_pages/css/style.css
+++ b/gh_pages/css/style.css
@@ -537,6 +537,9 @@ table {
     margin: 0;
     padding: 10px 15px;
     border: solid var(--light-gray) 1px; }
+  table tr th code.inline,
+  table tr td code.inline {
+    white-space: nowrap; }
   table tr:nth-child(even) {
     background-color: var(--very-lighter-gray); }
 


### PR DESCRIPTION
## Summary

- On the [Getting Started](https://jsiek.github.io/deduce/pages/getting-started.html) page, the key-bindings table was rendering chords like `C-c C-g` broken across two lines (`C-c C-` then `g`) because the browser allocated a narrow first column and wrapped at the hyphen inside the inline `<code>`.
- Fix: in `code.inline` inside `<th>`/`<td>`, set `white-space: nowrap`. Each chord stays a single semantic unit and the column widens to fit instead of breaking mid-token.
- Mirrored in both `gh_pages/css/style.css` (the file actually served — `convert.py` links it) and `gh_pages/css/style-dev.css` (the nested SCSS-style source kept in sync alongside it).

## Test plan

- [ ] After gh-pages rebuild, open https://jsiek.github.io/deduce/pages/getting-started.html and confirm the Emacs key-bindings table renders `C-c C-g`, `C-c C-r`, etc. on a single line.
- [ ] Check at a few viewport widths (narrow window / mobile) that the table still scrolls/reflows gracefully rather than overflowing horizontally.
- [ ] Spot-check other pages with tables containing inline code (e.g. the MCP tool table on the same page) for regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)