### PR TITLE
Fix #430: add C-c C-x to show full diagnostic at point

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -203,6 +203,13 @@ auto-start hook:
   use. A narrower sibling of `C-c C-e`: eliminate picks by
   hypothesis shape; fill-from-given picks by formula equality with
   the goal.
+- `C-c C-x` — **show the full diagnostic at point** in a `*Deduce
+  Diagnostic*` popup buffer. Deduce error messages are multi-line
+  (headline + location + grammar / proof context); the echo area
+  clips them to the first line. This command preserves the newlines
+  and tab-indented continuations so the whole message is readable.
+  When point sits between diagnostics, every diagnostic on the
+  current line is shown.
 
 `deduce-dap` (when loaded, also requires the third-party
 `dap-mode` package from MELPA):
@@ -297,6 +304,7 @@ OpenAI, or IU REALLMs depending on backend choice):
 | `C-c C-i` | Replace `?` with `induction T` skeleton at a forall goal           | `deduce-lsp-induction`           | `deduce-lsp`   |
 | `C-c C-e` | Prompt for hypothesis, replace `?` with use-fact tactic            | `deduce-lsp-eliminate`           | `deduce-lsp`   |
 | `C-c C-f` | Replace `?` with `conclude ... by H` for a given matching the goal | `deduce-lsp-fill-from-given`     | `deduce-lsp`   |
+| `C-c C-x` | Show the full diagnostic at point in a popup buffer                | `deduce-show-diagnostic-at-point`| `deduce-lsp`   |
 | `C-c C-a` | Ask an LLM to fill the `?` at point. Async, non-blocking.          | `deduce-fill-hole`               | `deduce-fill-hole` |
 | `C-c C-d` | Launch a debug session on the current `.pf` file                   | `deduce-dap-debug-current-buffer`| `deduce-dap`   |
 | `F5`      | Continue execution (inside an active debug session)                | `dap-continue`                   | `deduce-dap`   |

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -76,6 +76,15 @@
 (declare-function eglot-current-server "eglot")
 (declare-function eglot--signal-textDocument/didChange "eglot")
 
+;; Flymake is built into Emacs 29+; declare the diagnostic accessors so
+;; the byte-compiler doesn't warn before `flymake' is loaded.
+(declare-function flymake-diagnostics "flymake")
+(declare-function flymake-diagnostic-type "flymake")
+(declare-function flymake-diagnostic-beg "flymake")
+(declare-function flymake-diagnostic-end "flymake")
+(declare-function flymake-diagnostic-text "flymake")
+(declare-function flymake-diagnostic-buffer "flymake")
+
 
 (defgroup deduce-lsp nil
   "Eglot integration for `deduce-mode'."
@@ -654,6 +663,115 @@ out without applying when the server returns null."
 (define-key deduce-mode-map (kbd "C-c C-i") #'deduce-lsp-induction)
 (define-key deduce-mode-map (kbd "C-c C-e") #'deduce-lsp-eliminate)
 (define-key deduce-mode-map (kbd "C-c C-f") #'deduce-lsp-fill-from-given)
+
+
+;; ---------------------------------------------------------------------
+;; Show diagnostic at point (issue #430)
+;; ---------------------------------------------------------------------
+;;
+;; Deduce error messages are multi-line by design: a one-line headline
+;; followed by a location line and one or more tab-indented grammar
+;; rules (parse errors) or a goal/givens block (proof errors).  The
+;; echo area, where flymake/eglot surface the diagnostic at point,
+;; shows only the first line on most Emacs configurations -- the body
+;; gets clipped and the user can't see why their proof failed.
+;;
+;; `deduce-show-diagnostic-at-point' pulls every flymake diagnostic
+;; overlapping point and renders the full text into a `*Deduce
+;; Diagnostic*' popup buffer.  Same display strategy as the goal-at
+;; popup (read-only `view-mode', `display-buffer'), so the keybinding
+;; is symmetric: `C-c C-g' for the proof goal, `C-c C-x' for the
+;; error explanation.
+
+(defconst deduce-lsp-diagnostic-buffer-name "*Deduce Diagnostic*"
+  "Buffer name used to display the full diagnostic message at point.")
+
+
+(defun deduce-lsp--diagnostics-at-point ()
+  "Return the list of flymake diagnostics overlapping point.
+
+When point sits between diagnostics, this returns nil; the caller
+widens the search to the current line."
+  (require 'flymake)
+  (when (fboundp 'flymake-diagnostics)
+    (flymake-diagnostics (point) (point))))
+
+
+(defun deduce-lsp--diagnostics-on-line ()
+  "Return the list of flymake diagnostics overlapping the current line."
+  (require 'flymake)
+  (when (fboundp 'flymake-diagnostics)
+    (flymake-diagnostics (line-beginning-position) (line-end-position))))
+
+
+(defun deduce-lsp--render-diagnostic (diag)
+  "Insert a flymake DIAG into the current buffer.
+
+Renders a one-line header (severity + 1-indexed line:col range) so
+the user can correlate the popup with the underline in the source
+buffer, then the full diagnostic text on subsequent lines -- newlines
+and tab-indented continuations preserved."
+  (let* ((type   (flymake-diagnostic-type diag))
+         (beg    (flymake-diagnostic-beg diag))
+         (end    (flymake-diagnostic-end diag))
+         (text   (or (flymake-diagnostic-text diag) ""))
+         (buffer (flymake-diagnostic-buffer diag))
+         (sev    (cond ((eq type :error)   "error")
+                       ((eq type :warning) "warning")
+                       ((eq type :note)    "note")
+                       (t                  (format "%s" type)))))
+    (insert (format "[%s]" sev))
+    (when (and buffer (buffer-live-p buffer) beg end)
+      (let (line col-start col-end)
+        (with-current-buffer buffer
+          (save-excursion
+            (goto-char beg)
+            (setq line (line-number-at-pos)
+                  col-start (1+ (current-column)))
+            (goto-char end)
+            (setq col-end (1+ (current-column)))))
+        (insert (format " %d:%d-%d" line col-start col-end))))
+    (insert "\n")
+    (insert text)
+    (unless (string-suffix-p "\n" text)
+      (insert "\n"))))
+
+
+(defun deduce-lsp--show-diagnostics (diags)
+  "Display the list of DIAGS in the `*Deduce Diagnostic*' buffer."
+  (let ((buf (get-buffer-create deduce-lsp-diagnostic-buffer-name)))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (read-only-mode 0)
+        (erase-buffer)
+        (if (null diags)
+            (insert "No diagnostic at point.\n")
+          (let ((first t))
+            (dolist (d diags)
+              (unless first (insert "\n"))
+              (setq first nil)
+              (deduce-lsp--render-diagnostic d))))
+        (goto-char (point-min)))
+      (view-mode 1))
+    (display-buffer buf)))
+
+
+(defun deduce-show-diagnostic-at-point ()
+  "Show the full text of the diagnostic(s) at point in a popup buffer.
+
+Deduce error messages span several lines (a headline, a location,
+and a grammar / proof context).  Flymake clips that to the first
+line in the echo area, so this command opens a `*Deduce
+Diagnostic*' buffer with every diagnostic that overlaps point --
+or, if point is between diagnostics, every diagnostic on the
+current line."
+  (interactive)
+  (let ((diags (or (deduce-lsp--diagnostics-at-point)
+                   (deduce-lsp--diagnostics-on-line))))
+    (deduce-lsp--show-diagnostics diags)))
+
+
+(define-key deduce-mode-map (kbd "C-c C-x") #'deduce-show-diagnostic-at-point)
 
 
 (provide 'deduce-lsp)

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -1115,6 +1115,158 @@ exact-match candidate -- no special-casing at the transport layer."
       (delete-file tmp))))
 
 
+;; ---------------------------------------------------------------------
+;; deduce-show-diagnostic-at-point (issue #430)
+;; ---------------------------------------------------------------------
+;;
+;; The popup-buffer command for full multi-line diagnostics.  We don't
+;; run a live flymake-eglot loop in these tests; instead we stub
+;; `flymake-diagnostics' to return a hand-built diagnostic and check
+;; that the render routine preserves the newlines / tabs that the echo
+;; area would otherwise clip.
+
+(require 'flymake)
+
+(defun deduce-lsp-test--make-diag (buffer beg end type text)
+  "Build a flymake diagnostic for the tests.
+
+The flymake constructor (`flymake-make-diagnostic') accepts the
+five-positional form `(buffer beg end type text)' across every
+Emacs version we support; using it keeps the diagnostic structurally
+identical to one flymake itself would emit."
+  (flymake-make-diagnostic buffer beg end type text))
+
+
+(ert-deftest deduce-lsp/show-diagnostic-bound-to-c-c-c-x ()
+  "`C-c C-x' in deduce-mode-map runs `deduce-show-diagnostic-at-point'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-x"))
+              #'deduce-show-diagnostic-at-point)))
+
+
+(ert-deftest deduce-lsp/show-diagnostic-renders-multiline-text ()
+  "The popup buffer preserves newlines and tab-indented continuations
+from the diagnostic text -- the whole point of the command."
+  (let ((tmp (make-temp-file "deduce-diag" nil ".pf"))
+        (multi (concat "Missing type annotation. Expected ':' followed by a type.\n"
+                       "/tmp/x.pf:1.18-1.20: while parsing\n"
+                       "\ttype_annot_list ::= identifier \":\" type")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem foo: all P. P = P\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (goto-char (point-min))
+          (forward-char 18)
+          (let* ((src-buffer (current-buffer))
+                 (diag (deduce-lsp-test--make-diag
+                        src-buffer (point) (1+ (point)) :error multi)))
+            (cl-letf (((symbol-function 'flymake-diagnostics)
+                       (lambda (&rest _) (list diag))))
+              (deduce-show-diagnostic-at-point)))
+          (let ((rendered
+                 (with-current-buffer
+                     (get-buffer deduce-lsp-diagnostic-buffer-name)
+                   (buffer-substring-no-properties (point-min) (point-max)))))
+            (should (string-match-p "\\[error\\]" rendered))
+            (should (string-match-p "Missing type annotation" rendered))
+            (should (string-match-p "while parsing" rendered))
+            ;; The tab-indented continuation must survive intact --
+            ;; without this the echo-area version (which clips at
+            ;; the first newline) is exactly what the user already
+            ;; sees, and the command is pointless.
+            (should (string-match-p "\ttype_annot_list" rendered))))
+      (when (get-buffer deduce-lsp-diagnostic-buffer-name)
+        (kill-buffer deduce-lsp-diagnostic-buffer-name))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/show-diagnostic-falls-back-to-line ()
+  "When point sits between diagnostics, the command widens its
+search to the current line and still finds the diagnostic."
+  (let ((tmp (make-temp-file "deduce-diag" nil ".pf"))
+        (calls nil))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem foo: all P. P = P\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (goto-char (point-min))
+          (let* ((src-buffer (current-buffer))
+                 (diag (deduce-lsp-test--make-diag
+                        src-buffer 19 20 :error
+                        "Missing type annotation.")))
+            (cl-letf (((symbol-function 'flymake-diagnostics)
+                       (lambda (beg end)
+                         (push (cons beg end) calls)
+                         ;; First call (point .. point) returns nil;
+                         ;; second call (line bounds) returns the diag.
+                         (if (= beg end) nil (list diag)))))
+              (deduce-show-diagnostic-at-point)))
+          ;; Two queries: point-level, then line-level.
+          (should (= (length calls) 2))
+          (let ((rendered
+                 (with-current-buffer
+                     (get-buffer deduce-lsp-diagnostic-buffer-name)
+                   (buffer-substring-no-properties (point-min) (point-max)))))
+            (should (string-match-p "Missing type annotation" rendered))))
+      (when (get-buffer deduce-lsp-diagnostic-buffer-name)
+        (kill-buffer deduce-lsp-diagnostic-buffer-name))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/show-diagnostic-empty-reports-none ()
+  "With no diagnostics at point or on the line, the popup buffer
+states `No diagnostic at point.' rather than displaying stale text."
+  (let ((tmp (make-temp-file "deduce-diag" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: bool\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'flymake-diagnostics)
+                     (lambda (&rest _) nil)))
+            (deduce-show-diagnostic-at-point))
+          (let ((rendered
+                 (with-current-buffer
+                     (get-buffer deduce-lsp-diagnostic-buffer-name)
+                   (buffer-substring-no-properties (point-min) (point-max)))))
+            (should (string-match-p "No diagnostic at point" rendered))))
+      (when (get-buffer deduce-lsp-diagnostic-buffer-name)
+        (kill-buffer deduce-lsp-diagnostic-buffer-name))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/show-diagnostic-multiple-diagnostics ()
+  "When several diagnostics overlap point, each is rendered with its
+own [severity] header so the user can tell them apart."
+  (let ((tmp (make-temp-file "deduce-diag" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (let* ((src-buffer (current-buffer))
+                 (d1 (deduce-lsp-test--make-diag
+                      src-buffer 1 2 :error "first error\nwith body"))
+                 (d2 (deduce-lsp-test--make-diag
+                      src-buffer 1 2 :warning "second warning")))
+            (cl-letf (((symbol-function 'flymake-diagnostics)
+                       (lambda (&rest _) (list d1 d2))))
+              (deduce-show-diagnostic-at-point)))
+          (let ((rendered
+                 (with-current-buffer
+                     (get-buffer deduce-lsp-diagnostic-buffer-name)
+                   (buffer-substring-no-properties (point-min) (point-max)))))
+            (should (string-match-p "\\[error\\]" rendered))
+            (should (string-match-p "\\[warning\\]" rendered))
+            (should (string-match-p "first error" rendered))
+            (should (string-match-p "with body" rendered))
+            (should (string-match-p "second warning" rendered))))
+      (when (get-buffer deduce-lsp-diagnostic-buffer-name)
+        (kill-buffer deduce-lsp-diagnostic-buffer-name))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here


### PR DESCRIPTION
## Summary

- Adds `deduce-show-diagnostic-at-point` (`C-c C-x`), which opens a `*Deduce Diagnostic*` popup buffer with the full multi-line text of every flymake diagnostic overlapping point.
- When point sits between diagnostics, the search widens to the current line, so the command "just works" even when the cursor isn't sitting precisely on the underlined span.
- Same display strategy as the existing `C-c C-g` goal popup (read-only `view-mode`, `display-buffer`); the popup preserves newlines and tab-indented continuations that the echo area would otherwise clip.

The motivating case from the issue — `"Unexpected error while parsing:\n\t<details>"` — now renders fully in the popup. Same fix covers every other multi-line Deduce diagnostic (missing-annotation parse errors, IncompleteProof messages, etc.).

Closes #430.

## Test plan

- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 57/57 pass, including 5 new tests covering the keybinding, multi-line rendering, line-level fallback, the empty-popup case, and multi-diagnostic rendering.
- [x] `emacs --batch -L editor/emacs -f batch-byte-compile editor/emacs/deduce-lsp.el` — no warnings.
- [ ] Manual smoke test: in a real Emacs, open a `.pf` with a parse error, hit `C-c C-x`, confirm the popup shows the full multi-line message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)