### PR TITLE
Fix #368: snapshot proof_checker.name_id between check_file calls

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -27,9 +27,15 @@ checks produce reproducible names *and* never collide with
 prelude-cached names.
 
 ``proof_checker.name_id`` (its own counter, used post-uniquify
-for synthesis paths) is still a process-monotonic global; Steps 13
-and 14 may give it the same treatment if cache keys end up
-depending on those names.
+for synthesis paths -- predicate desugaring, induction/switch
+fresh labels) is captured the same way as the tracked containers
+and restored between calls.  Without this, two checks of the same
+source would produce different suffixes for ``EvenDeriv.<id>`` /
+``D_<rule>.<id>`` / etc. -- which would survive the per-statement
+cache only because ``_hash_ast`` is memoised on the pre-decl AST
+node, and any future change that recomputes the hash post-decl
+would silently invalidate the cache for every predicate-using
+module.  Issue #368.
 """
 
 from __future__ import annotations
@@ -379,9 +385,8 @@ def _check_file_impl(
 # state we capture once and restore between calls. The uniquify
 # counter is *not* in this list -- it's now an explicit
 # ``UniquifyContext`` (Step 12) managed via ``_post_prelude_ctx``
-# below.  ``proof_checker.name_id`` is still a process-monotonic
-# global; if a future change adds a new container that contributes
-# to per-call results, it goes here.
+# below.  ``proof_checker.name_id`` is *also* not in this list --
+# it's a scalar and lives in ``_TRACKED_SCALARS`` below.
 _TRACKED_CONTAINERS: tuple[tuple[Any, str], ...] = (
     (_abstract_syntax, "uniquified_modules"),
     (_abstract_syntax, "_predicate_decls_by_unique_name"),
@@ -394,6 +399,18 @@ _TRACKED_CONTAINERS: tuple[tuple[Any, str], ...] = (
     (_proof_checker, "dirty_files"),
 )
 
+# Module-level scalar counters in the pipeline whose post-prelude
+# value we capture and restore between calls.  Scalars are handled
+# separately from containers because they aren't ``.clear()``-able
+# -- restore is a plain ``setattr``.  ``proof_checker.name_id`` is
+# the fresh-name counter consumed during predicate desugaring,
+# induction / switch fresh-label generation, and the rest of the
+# post-uniquify synthesis paths.  Snapshotting it keeps the
+# post-decl AST reproducible across calls (issue #368).
+_TRACKED_SCALARS: tuple[tuple[Any, str], ...] = (
+    (_proof_checker, "name_id"),
+)
+
 # The prelude key (tuple of module names) that the snapshot below was
 # captured for. ``None`` until the first ``check_file`` call.
 _prelude_key: Optional[tuple[str, ...]] = None
@@ -401,6 +418,11 @@ _prelude_key: Optional[tuple[str, ...]] = None
 # Snapshot of ``_TRACKED_CONTAINERS`` taken right after the prelude
 # load. Each entry is a fresh shallow copy of the live container.
 _prelude_snapshot: Optional[dict[tuple[str, str], Any]] = None
+
+# Snapshot of ``_TRACKED_SCALARS`` taken right after the prelude
+# load.  Each entry is the captured scalar value (an int for the
+# fresh-name counter).
+_prelude_scalars: Optional[dict[tuple[str, str], Any]] = None
 
 # Post-prelude ``UniquifyContext`` baseline. After the prelude has
 # been uniquified, its counter records the highest id allocated.
@@ -423,10 +445,11 @@ def _prepare_state(prelude_key: tuple[str, ...]) -> None:
     snapshot. The prelude reload is the expensive part (~3s for the
     full stdlib); restore is a handful of dict/set copies.
     """
-    global _prelude_key, _prelude_snapshot, _post_prelude_ctx
+    global _prelude_key, _prelude_snapshot, _prelude_scalars, _post_prelude_ctx
 
     if _prelude_snapshot is not None and _prelude_key == prelude_key:
         _restore_containers(_prelude_snapshot)
+        _restore_scalars(_prelude_scalars)
         return
 
     _clear_containers()
@@ -446,6 +469,7 @@ def _prepare_state(prelude_key: tuple[str, ...]) -> None:
         )
     _prelude_key = prelude_key
     _prelude_snapshot = _capture_containers()
+    _prelude_scalars = _capture_scalars()
     _post_prelude_ctx = bootstrap_ctx.snapshot()
 
 
@@ -479,6 +503,22 @@ def _restore_containers(snapshot: dict[tuple[str, str], Any]) -> None:
                 f"unexpected container type for {module.__name__}.{attr}: "
                 f"{type(live).__name__}"
             )
+
+
+def _capture_scalars() -> dict[tuple[str, str], Any]:
+    """Capture the current value of each tracked scalar."""
+    snap: dict[tuple[str, str], Any] = {}
+    for module, attr in _TRACKED_SCALARS:
+        snap[(module.__name__, attr)] = getattr(module, attr)
+    return snap
+
+
+def _restore_scalars(snapshot: Optional[dict[tuple[str, str], Any]]) -> None:
+    """Re-bind each tracked scalar to its captured value."""
+    if snapshot is None:
+        return
+    for module, attr in _TRACKED_SCALARS:
+        setattr(module, attr, snapshot[(module.__name__, attr)])
 
 
 def _clear_containers() -> None:
@@ -518,8 +558,9 @@ def reset_prelude_cache() -> None:
     scratch. Used by the test suite to test the bootstrap path and by
     long-running daemons that want to pick up changes to ``lib/``.
     """
-    global _prelude_key, _prelude_snapshot, _post_prelude_ctx
+    global _prelude_key, _prelude_snapshot, _prelude_scalars, _post_prelude_ctx
     _prelude_key = None
     _prelude_snapshot = None
+    _prelude_scalars = None
     _post_prelude_ctx = None
     _clear_containers()

--- a/test/lsp/test_check_proofs_cache.py
+++ b/test/lsp/test_check_proofs_cache.py
@@ -400,3 +400,96 @@ def test_cache_skips_check_proofs_for_unchanged_stmt() -> None:
         f"check_proofs was invoked despite cache hits; "
         f"called {len(calls)} times: {calls}"
     )
+
+
+# Predicate desugaring (``process_declaration`` for the ``Predicate``
+# case) consumes ``proof_checker.name_id`` to mint synthesised names
+# for the derivation union (``<Pred>Deriv.<id>``), its constructors
+# (``D_<rule>.<id>``), the validator, and the auto-generated
+# rule-induction / rule-inversion theorems.  Two consecutive
+# ``check_file`` calls on the same source must produce the same
+# suffixes -- the post-decl AST has to be reproducible across calls,
+# so the per-statement cache keys (and any other state that walks the
+# post-decl AST) stay stable.  Issue #368.
+
+_PREDICATE_SRC = (
+    "predicate Even : fn Nat -> bool {\n"
+    "  even_zero: Even(zero)\n"
+    "  even_ss: all n:Nat. if Even(n) then Even(suc(suc(n)))\n"
+    "}\n"
+    "\n"
+    "theorem t1: Even(zero)\n"
+    "proof\n"
+    "  even_zero\n"
+    "end\n"
+)
+
+
+def test_predicate_fresh_names_are_stable_across_calls() -> None:
+    """A predicate exercises ``proof_checker.generate_name`` during
+    process_declaration.  Two checks of the same source must leave
+    ``proof_checker.name_id`` at the same value -- otherwise the
+    synthesised names drift between calls, the post-decl AST drifts
+    with them, and any post-decl hashing path silently invalidates
+    its cache."""
+    from lsp.library import reset_prelude_cache
+    reset_prelude_cache()
+    check("test.pf", _PREDICATE_SRC, prelude=("Nat",))
+    name_id_after_first = proof_checker.name_id
+
+    check("test.pf", _PREDICATE_SRC, prelude=("Nat",))
+    name_id_after_second = proof_checker.name_id
+
+    assert name_id_after_first == name_id_after_second, (
+        f"proof_checker.name_id drifted between identical checks: "
+        f"first={name_id_after_first}, second={name_id_after_second}. "
+        f"Predicate desugaring uses generate_name, so a drifting "
+        f"counter makes the post-decl AST non-reproducible."
+    )
+
+
+def test_predicate_re_check_is_all_hits() -> None:
+    """End-to-end: a fixture that triggers predicate desugaring on
+    the first run hits the per-statement cache on every user-file
+    statement on the second run.  Pins the plan acceptance for
+    issue #368 -- the test the issue asks to land alongside the
+    name_id snapshot."""
+    from lsp.library import reset_prelude_cache
+    reset_prelude_cache()
+    check("test.pf", _PREDICATE_SRC, prelude=("Nat",))
+    proof_checker._cache_stats["hits"].clear()
+    proof_checker._cache_stats["misses"].clear()
+
+    calls: list = []
+    real_check_proofs = proof_checker.check_proofs
+
+    def stub(s, env):
+        calls.append(s)
+        return real_check_proofs(s, env)
+
+    proof_checker.check_proofs = stub
+    try:
+        check("test.pf", _PREDICATE_SRC, prelude=("Nat",))
+    finally:
+        proof_checker.check_proofs = real_check_proofs
+
+    # All four user-file statements (one ``Import`` for the prelude
+    # module, the ``Predicate``, and the ``Theorem``) should hit the
+    # cache.  The prelude module itself is checked once during
+    # bootstrap; on the second call ``_prepare_state`` restores the
+    # post-prelude snapshot so the prelude isn't re-checked.
+    assert _hits() >= 3, (
+        f"expected the predicate + theorem + import to hit the "
+        f"cache on re-run; got hits={_hits()}, misses={_misses()}, "
+        f"check_proofs invocations={len(calls)}"
+    )
+    assert _misses() == 0, (
+        f"unexpected misses on re-run of identical source; "
+        f"misses={_misses()}, check_proofs invocations={len(calls)}"
+    )
+    assert calls == [], (
+        f"check_proofs ran on a cache hit -- name_id drift would "
+        f"cause this by changing the synthesised names in the "
+        f"post-decl AST; called {len(calls)} times: "
+        f"{[type(c).__name__ for c in calls]}"
+    )


### PR DESCRIPTION
## Summary
- Snapshot `proof_checker.name_id` alongside the existing `_TRACKED_CONTAINERS` machinery in `lsp/library.py`, so the post-prelude counter value is captured once and restored before each user-file check.
- Add a parallel `_TRACKED_SCALARS` tuple — scalars aren't `.clear()`-able, so they get their own `_capture_scalars` / `_restore_scalars` pair.
- Add two acceptance tests in `test/lsp/test_check_proofs_cache.py`.

## Why

`proof_checker.name_id` is the post-uniquify fresh-name counter consumed by predicate desugaring (`<Pred>Deriv.<id>`, `D_<rule>.<id>`, validator + rule-induction/rule-inversion bodies) and by induction / switch fresh-label generation. It was process-monotonic across `check_file` calls, so two consecutive checks of the same source produced different synthesised-name suffixes and a non-reproducible post-decl AST.

The per-statement cache (Steps 13 / 14) survives this today only because `_hash_ast` is memoised on the pre-decl AST node — the hashed snapshot predates `process_declaration`'s name minting. That invariant is fragile: any future change that recomputes the hash post-decl, or that hashes the post-decl AST for a cache key, would silently invalidate the cache for every predicate-using module. This is option 2 from the issue.

## Test plan

- [x] `python3.13 -m pytest test/lsp/test_check_proofs_cache.py` — 11 passed (9 existing + 2 new).
- [x] `python3.13 -m pytest test/lsp/` — 899 passed.
- [x] `make` — tokens + tests-should-validate + tests-should-error + tests-lib (recursive-descent AND LALR), all pass.
- [x] Reverted the fix locally to confirm `test_predicate_fresh_names_are_stable_across_calls` fails without it (`name_id` drifts 60 → 113 across two identical checks).
- [ ] CI green.

Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)