### PR TITLE
Fix #406: case_split_at unfolds function-body hypotheses to Or

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -1651,6 +1651,10 @@ def _splittable_vars(env) -> tuple:
         if isinstance(binding, ProofBinding):
             if isinstance(binding.formula, Or):
                 seen.add(bname)
+            elif _unfold_call_to_or(binding.formula, env) is not None:
+                # Hypothesis whose definition unfolds to Or, e.g.
+                # UInt's ``a ≤ b`` (issue #406).
+                seen.add(bname)
         elif isinstance(binding, TermBinding):
             ty = binding.typ
             try:
@@ -1682,6 +1686,10 @@ def _case_split_template(name: str, env) -> Optional[str]:
     name ``foo``). Dispatches on the binding's kind:
 
     - ``ProofBinding`` whose formula is ``Or(...)`` -> ``cases``
+    - ``ProofBinding`` whose formula is ``f(a, b)`` where ``f``'s
+      definition unfolds to an ``Or`` (e.g. UInt's ``a ≤ b``, defined
+      as ``a < b or a = b``) -> ``have ... by expand f in <var>`` +
+      ``cases``. Issue #406.
     - ``TermBinding`` whose type resolves to a ``Union`` -> ``switch``
 
     Returns ``None`` for any other shape (built-in atom, function,
@@ -1700,6 +1708,10 @@ def _case_split_template(name: str, env) -> Optional[str]:
     if isinstance(binding, ProofBinding):
         if isinstance(binding.formula, Or):
             return _cases_template(name, binding.formula, env)
+        unfolded = _unfold_call_to_or(binding.formula, env)
+        if unfolded is not None:
+            or_formula, op_name = unfolded
+            return _expand_cases_template(name, op_name, or_formula, env)
         return None
 
     if isinstance(binding, TermBinding):
@@ -1748,6 +1760,98 @@ def _cases_template(var_name: str, formula, env) -> str:
         f"  case {fresh()}: {arg} {{ ? }}" for arg in args
     ]
     return f"cases {var_name}\n" + "\n".join(case_lines)
+
+
+def _unfold_call_to_or(formula, env):
+    """Return ``(or_formula, op_source_name)`` when ``formula`` is a
+    ``Call`` to a user-defined function whose body is an ``Or``, with
+    the call's arguments substituted in.  ``None`` otherwise.
+
+    ``op_source_name`` is the rendered name suitable for an ``expand``
+    clause: bare for regular functions (``le``), ``operator <symbol>``
+    for symbolic operators (``operator ≤``) — the rec-desc parser's
+    ``parse_identifier`` requires the ``operator`` prefix to consume
+    the following symbol.
+
+    Drives the issue-#406 case-split path for hypotheses whose type is
+    syntactically a function application (e.g. UInt's ``a ≤ b``,
+    defined as ``a < b or a = b``) but whose unfolded form is a
+    disjunction.  Skips ``opaque`` definitions and any rator whose
+    body isn't a literal ``Or`` -- Nat's recursive ``≤`` (switch-based)
+    and Int's ``opaque`` ``≤`` both fall through, by design: a
+    generated ``expand operator ≤`` would fail there.
+    """
+    from abstract_syntax import (
+        Call, Lambda, Or, TermBinding, VarRef, base_name, is_operator_name,
+    )
+    if not isinstance(formula, Call):
+        return None
+    rator = formula.rator
+    if not isinstance(rator, VarRef):
+        return None
+    op_binding = env.dict.get(rator.get_name())
+    if not isinstance(op_binding, TermBinding):
+        return None
+    if getattr(op_binding, "visibility", None) == "opaque":
+        return None
+    defn = getattr(op_binding, "defn", None)
+    if not isinstance(defn, Lambda):
+        return None
+    if not isinstance(defn.body, Or):
+        return None
+    if len(defn.vars) != len(formula.args):
+        return None
+    sub = {
+        param_name: arg
+        for (param_name, _ty), arg in zip(defn.vars, formula.args)
+    }
+    try:
+        instantiated = defn.body.substitute(sub)
+    except Exception:
+        return None
+    if not isinstance(instantiated, Or):
+        return None
+    op_full = rator.get_name()
+    op_base = base_name(op_full)
+    if is_operator_name(op_full):
+        op_source = f"operator {op_base}"
+    else:
+        op_source = op_base
+    return instantiated, op_source
+
+
+def _expand_cases_template(
+    var_name: str, op_name: str, or_formula, env
+) -> str:
+    """Render the issue-#406 ``expand <op> + cases`` skeleton.
+
+    The first line introduces the unfolded disjunction with a fresh
+    ``or_eq<N>`` label so the subsequent ``cases`` has a proper ``Or``
+    proof variable to destructure.  Each branch gets a fresh ``h<N>``
+    label; both label sets share the env's used-name set so they
+    don't collide with each other.
+    """
+    from abstract_syntax import base_name
+    used = {base_name(k) for k in env.dict.keys()}
+
+    def fresh(stem: str) -> str:
+        n = 1
+        while f"{stem}{n}" in used:
+            n += 1
+        used.add(f"{stem}{n}")
+        return f"{stem}{n}"
+
+    or_label = fresh("or_eq")
+    case_lines = [
+        f"  case {fresh('h')}: {arg} {{ ? }}"
+        for arg in or_formula.args
+    ]
+    return (
+        f"have {or_label}: {or_formula}"
+        f" by expand {op_name} in {var_name}\n"
+        f"cases {or_label}\n"
+        + "\n".join(case_lines)
+    )
 
 
 def _switch_template(var_name: str, union_def, env) -> str:

--- a/test/lsp/test_case_split.py
+++ b/test/lsp/test_case_split.py
@@ -470,3 +470,226 @@ def test_case_split_at_picks_second_of_two_holes() -> None:
     # Template covers both disjuncts of `P or Q`.
     assert "case" in edit.new_text
     assert edit.range.start == Position(line=7, column=3)
+
+
+# --------------------------------------------------------------------------
+# Unfold-to-Or proof hypotheses (issue #406)
+# --------------------------------------------------------------------------
+#
+# UInt's ``≤`` is defined as ``a < b or a = b``, so a hypothesis ``H:
+# a ≤ b`` isn't *literally* an ``Or`` but unfolds to one. The standalone
+# UInt test would need the prelude; these fixtures stay in bool-land
+# by defining a one-line wrapper ``fun le(x:bool, y:bool) { x or y }``,
+# which has the same shape.
+
+
+def test_case_split_at_unfolds_function_body_to_or() -> None:
+    """``H: le(P, Q)`` where ``le`` unfolds to ``or`` -> ``expand le
+    in H`` + ``cases``. Mirrors the UInt ``a ≤ b`` shape from #406."""
+    source = (
+        "fun le(x:bool, y:bool) {\n"
+        "  x or y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if le(P, Q) then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: le(P, Q)\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at(
+        "test.pf", source, Position(line=9, column=3), "H"
+    )
+    assert edit is not None
+    assert isinstance(edit, WorkspaceEdit)
+    # 2-space indent continuation lines (issue #333).
+    assert edit.new_text == (
+        "have or_eq1: (P or Q) by expand le in H\n"
+        "  cases or_eq1\n"
+        "    case h1: P { ? }\n"
+        "    case h2: Q { ? }"
+    )
+    assert edit.range.start == Position(line=9, column=3)
+
+
+def test_case_split_at_unfolds_then_post_check_holes_inside_cases() -> None:
+    """Plan acceptance: applying the unfold-cases edit and re-checking
+    must produce holes inside the new case bodies, not at the ``have``
+    line. Pins the template against the actual Deduce parser/typechecker."""
+    source = (
+        "fun le(x:bool, y:bool) {\n"
+        "  x or y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if le(P, Q) then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: le(P, Q)\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at(
+        "test.pf", source, Position(line=9, column=3), "H"
+    )
+    assert edit is not None
+
+    lines = source.splitlines(keepends=True)
+    line_idx = edit.range.start.line - 1
+    start_col = edit.range.start.column - 1
+    end_col = edit.range.end.column - 1
+    new_line = (
+        lines[line_idx][:start_col]
+        + edit.new_text
+        + lines[line_idx][end_col:]
+    )
+    post = "".join(lines[:line_idx] + [new_line] + lines[line_idx + 1:])
+
+    diags = check("test.pf", post, prelude=())
+    # Expect one diagnostic per remaining ``?``, both for the same
+    # post-cases goal ``Q or P``. The ``have ... by expand`` line and
+    # the ``cases`` step must succeed, otherwise we'd see a goal-level
+    # error too.
+    assert len(diags) >= 1
+    for diag in diags:
+        assert diag.severity == Severity.ERROR
+        assert "incomplete proof" in diag.message
+    # Each remaining hole's goal must be the original post-implication
+    # one (``Q or P``), not the post-have intermediate.
+    for diag in diags:
+        assert "(Q or P)" in diag.message, (
+            f"unexpected goal in {diag.message!r}"
+        )
+
+
+def test_case_split_at_unfolds_operator_with_operator_prefix() -> None:
+    """For a symbolic operator (``fun operator ≲``), the template's
+    ``expand`` clause needs the ``operator`` keyword prefix -- the
+    parser doesn't accept a bare symbol as an identifier. Matches the
+    UInt ``operator ≤`` shape this issue is named for."""
+    source = (
+        "fun operator ≲(x:bool, y:bool) {\n"
+        "  x or y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if P ≲ Q then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P ≲ Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at(
+        "test.pf", source, Position(line=9, column=3), "H"
+    )
+    assert edit is not None
+    assert edit.new_text == (
+        "have or_eq1: (P or Q) by expand operator ≲ in H\n"
+        "  cases or_eq1\n"
+        "    case h1: P { ? }\n"
+        "    case h2: Q { ? }"
+    )
+
+    # Pin the post-edit type-check: the ``expand operator ≲`` step
+    # must succeed and the only remaining diagnostics are the two
+    # case-body holes.
+    lines = source.splitlines(keepends=True)
+    line_idx = edit.range.start.line - 1
+    start_col = edit.range.start.column - 1
+    end_col = edit.range.end.column - 1
+    new_line = (
+        lines[line_idx][:start_col]
+        + edit.new_text
+        + lines[line_idx][end_col:]
+    )
+    post = "".join(lines[:line_idx] + [new_line] + lines[line_idx + 1:])
+    diags = check("test.pf", post, prelude=())
+    for diag in diags:
+        assert diag.severity == Severity.ERROR
+        assert "incomplete proof" in diag.message
+        assert "(Q or P)" in diag.message
+
+
+def test_case_split_at_does_not_unfold_opaque_definition() -> None:
+    """``opaque fun le ...`` -> ``expand le`` would fail, so no
+    template is generated. Mirrors Int's opaque ``≤``."""
+    source = (
+        "opaque fun le(x:bool, y:bool) {\n"
+        "  x or y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if le(P, Q) then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: le(P, Q)\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at(
+        "test.pf", source, Position(line=9, column=3), "H"
+    )
+    assert edit is None
+
+
+def test_case_split_at_does_not_unfold_non_or_body() -> None:
+    """A function whose body is *not* an ``Or`` produces no template
+    -- ``H: conj(P, Q)`` unfolding to ``P and Q`` isn't case-splittable."""
+    source = (
+        "fun conj(x:bool, y:bool) {\n"
+        "  x and y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if conj(P, Q) then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: conj(P, Q)\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = case_split_at(
+        "test.pf", source, Position(line=9, column=3), "H"
+    )
+    assert edit is None
+
+
+def test_splittable_vars_includes_unfold_to_or_proof_variable() -> None:
+    """A proof variable whose formula unfolds to ``or`` must surface
+    in ``splittable_vars_at`` so the editor can offer it as a completion
+    candidate."""
+    source = (
+        "fun le(x:bool, y:bool) {\n"
+        "  x or y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if le(P, Q) then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: le(P, Q)\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=9, column=3)
+    )
+    assert "H" in candidates
+
+
+def test_splittable_vars_excludes_opaque_unfold_to_or() -> None:
+    """``opaque`` definitions don't expand, so the hypothesis must
+    not be surfaced as splittable."""
+    source = (
+        "opaque fun le(x:bool, y:bool) {\n"
+        "  x or y\n"
+        "}\n"
+        "\n"
+        "theorem t: all P:bool, Q:bool. if le(P, Q) then Q or P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: le(P, Q)\n"
+        "  ?\n"
+        "end\n"
+    )
+    candidates = splittable_vars_at(
+        "test.pf", source, Position(line=9, column=3)
+    )
+    assert "H" not in candidates


### PR DESCRIPTION
## Summary

- Extends `case_split_at(variable=H)` to handle proof hypotheses whose formula is a `Call` to a non-opaque function whose body is a literal `Or` (e.g. UInt's `a ≤ b`, defined as `a < b or a = b`).
- The generated skeleton matches the one in the issue:
  ```
  have or_eq1: (a < b or a = b) by expand operator ≤ in H
    cases or_eq1
      case h1: a < b { ? }
      case h2: a = b { ? }
  ```
- `splittable_vars_at` surfaces those hypotheses too, so the editor's completion candidates include them.

## Design note (vs. issue text)

The issue's title says \"extend `refine_at` templates\", but the body proposal — *an optional hypothesis argument, moving closer to the `case_split_at(variable)` shape* — is what `case_split_at` already is. Lives there rather than as a new `refine_at` arg to avoid a second dual-purpose tool.

## What falls through

- Nat's recursive switch-based `≤` — body isn't a literal `Or`.
- Int's `opaque` `≤` — opaque definitions can't be `expand`ed.

Both produce `None` from `case_split_at`, by design.

## Test plan

- [x] `pytest test/lsp/test_case_split.py test/lsp/test_refine.py test/lsp/test_query.py test/lsp/test_goal_at.py test/lsp/test_mcp_server.py test/lsp/test_lsp_server.py` — 162 passed locally
- [x] Integration probe against the actual UInt prelude: post-edit `check_file` raises only at the two new case-body holes, with goal `a ≤ b`
- [ ] CI: `make tests` (both parsers) + `make tests-lib`

Closes #406