### PR TITLE
Fix #126: print givens on proof-checker errors

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1438,7 +1438,7 @@ def check_proof_of(proof, formula, env):
           body_env = env.declare_local_proof_var(loc, label, new_prem1)
           _try_check_proof_of(body, conc, body_env)
         case _:
-          add_diagnostic(proof.location, 'the assume statement is for if-then formula, not ' + repr(formula)
+          add_diagnostic(proof.location, 'the assume statement is for if-then formula, not ' + str(formula)
                 + givens_str(env))
 
     # define x = t

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1366,8 +1366,9 @@ def check_proof_of(proof, formula, env):
           _try_check_proof_of(body, frm2, body_env)
         case _:
           add_diagnostic(loc, 'arbitrary is proof of an all formula, not\n' \
-                + str(formula))
-                
+                + str(formula)
+                + givens_str(env))
+
     case SomeIntro(loc, witnesses, body):
       # room for improvement, if var has type annotation, could type_check the witness
       witnesses = [type_synth_term(trm, env, None, []) for trm in witnesses]
@@ -1381,7 +1382,8 @@ def check_proof_of(proof, formula, env):
           body_frm = formula2.substitute(sub)
           _try_check_proof_of(body, body_frm, env)
         case _:
-          add_diagnostic(loc, "choose expects the goal to start with 'some', not " + str(formula))
+          add_diagnostic(loc, "choose expects the goal to start with 'some', not " + str(formula)
+                + givens_str(env))
           
     case SomeElim(loc, witnesses, label, prop, some, body):
       someFormula = check_proof(some, env)
@@ -1404,7 +1406,8 @@ def check_proof_of(proof, formula, env):
           body_env = body_env.declare_local_proof_var(loc, label, prop)
           _try_check_proof_of(body, formula, body_env)
         case _:
-          add_diagnostic(loc, "obtain expects 'from' to be a proof of a 'some' formula, not " + str(someFormula))
+          add_diagnostic(loc, "obtain expects 'from' to be a proof of a 'some' formula, not " + str(someFormula)
+                + givens_str(env))
         
     case ImpIntro(loc, label, None, body):
 
@@ -1417,7 +1420,8 @@ def check_proof_of(proof, formula, env):
           _try_check_proof_of(body, conc, body_env)
         case _:
           add_diagnostic(proof.location, 'expected proof of ' + str(formula) + \
-                '\n\tnot a proof of if-then: ' + str(proof))
+                '\n\tnot a proof of if-then: ' + str(proof)
+                + givens_str(env))
           
     case ImpIntro(loc, label, prem1, body):
       new_prem1 = check_formula(prem1, env)
@@ -1429,11 +1433,13 @@ def check_proof_of(proof, formula, env):
             (small1, small2) = isolate_difference(prem1_red, prem2_red)
             msg = str(prem1_red) + ' ≠ ' + str(prem2_red) + '\n' \
                 + 'because\n' + str(small1) + ' ≠ ' + str(small2)
-            add_diagnostic(loc, 'mismatch in premise:\n' + msg)
+            add_diagnostic(loc, 'mismatch in premise:\n' + msg
+                + givens_str(env))
           body_env = env.declare_local_proof_var(loc, label, new_prem1)
           _try_check_proof_of(body, conc, body_env)
         case _:
-          add_diagnostic(proof.location, 'the assume statement is for if-then formula, not ' + repr(formula))
+          add_diagnostic(proof.location, 'the assume statement is for if-then formula, not ' + repr(formula)
+                + givens_str(env))
 
     # define x = t
     case PTLetNew(loc, var, rhs, rest):
@@ -1472,7 +1478,8 @@ def check_proof_of(proof, formula, env):
       match new_claim:
         case Hole(loc2, tyof):
           _try_check_proof_of(reason, formula, env)
-          add_diagnostic(loc, '\nneed to show:\n\t' + str(formula))
+          add_diagnostic(loc, '\nneed to show:\n\t' + str(formula)
+                + givens_str(env))
         case _:
           claim_red = new_claim.reduce(env)
           formula_red = formula.reduce(env)
@@ -1488,7 +1495,8 @@ def check_proof_of(proof, formula, env):
       set_dont_reduce_opaque(False)
       if red_formula != Bool(loc, None, True):
           add_diagnostic(loc, 'the goal did not evaluate to `true`, but instead:\n\t' \
-                + str(red_formula))
+                + str(red_formula)
+                + givens_str(env))
 
     #  goal is P
     #  suffices Q by r        r proves (if Q then P)
@@ -1542,7 +1550,8 @@ def check_proof_of(proof, formula, env):
                 warning(loc2, '\nsuffices to prove:\n\t' + str(prem))
                 _try_check_proof_of(rest, prem, env)
               case _:
-                add_diagnostic(loc, 'expected a proof of an "if"-"then" formula, not ' + str(proved_formula))
+                add_diagnostic(loc, 'expected a proof of an "if"-"then" formula, not ' + str(proved_formula)
+                      + givens_str(env))
           case Omitted(loc2, tyof):
             proved_formula = check_proof(reason, env)
             match proved_formula:
@@ -1550,7 +1559,8 @@ def check_proof_of(proof, formula, env):
                 check_implies(loc, conc, formula)
                 _try_check_proof_of(rest, prem, env)
               case _:
-                add_diagnostic(loc, 'expected a proof of an "if"-"then" formula, not ' + str(proved_formula))
+                add_diagnostic(loc, 'expected a proof of an "if"-"then" formula, not ' + str(proved_formula)
+                      + givens_str(env))
           case _:
             imp = IfThen(loc, BoolType(loc), claim_red, formula).reduce(env)
             _try_check_proof_of(reason, imp, env)
@@ -1583,7 +1593,8 @@ def check_proof_of(proof, formula, env):
                 + '\tfirst tried each subproof in goal-directed mode, but:\n' \
                 + str(ex1) + '\n' \
                 + '\tthen tried synthesis mode, but:\n'\
-                + str(ex2))
+                + str(ex2)
+                + givens_str(env))
             
     case Cases(loc, subject, cases):
       sub_frm = check_proof(subject, env)
@@ -1596,16 +1607,19 @@ def check_proof_of(proof, formula, env):
       match sub_red:
         case Or(loc1, tyof, frms):
           if len(cases) < len(frms):
-              add_diagnostic(loc, "expected " + str(len(frms)) + " cases, not " + str(len(cases)))
+              add_diagnostic(loc, "expected " + str(len(frms)) + " cases, not " + str(len(cases))
+                    + givens_str(env))
           for (frm, (label,frm2,the_case)) in zip(frms, cases):
             if frm2:
                 new_frm2 = check_formula(frm2, env)
             if frm2 and (frm != new_frm2): # was frm != red_frm2
-              add_diagnostic(loc, 'case ' + str(new_frm2) + '\ndoes not match alternative in goal: \n' + str(frm))
+              add_diagnostic(loc, 'case ' + str(new_frm2) + '\ndoes not match alternative in goal: \n' + str(frm)
+                    + givens_str(env))
             body_env = env.declare_local_proof_var(loc, label, frm)
             _try_check_proof_of(the_case, formula, body_env)
         case _:
-          add_diagnostic(proof.location, "expected 'or', not " + str(sub_red))
+          add_diagnostic(proof.location, "expected 'or', not " + str(sub_red)
+                + givens_str(env))
           
     case RuleInduction(loc, hyp_name, ri_cases):
       _check_rule_induction(proof, formula, env)
@@ -1622,9 +1636,11 @@ def check_proof_of(proof, formula, env):
         case All(loc2, tyof, (var,ty), _, frm):
           if typ != ty:
             add_diagnostic(loc, "type of induction: " + str(typ) \
-                  + "\ndoes not match the all-formula's type: " + str(ty))
+                  + "\ndoes not match the all-formula's type: " + str(ty)
+                  + givens_str(env))
         case _:
-          add_diagnostic(loc, 'induction expected an all-formula, not ' + str(formula))
+          add_diagnostic(loc, 'induction expected an all-formula, not ' + str(formula)
+                + givens_str(env))
       
       # TODO: Allow for specification of what type to use
       custom_ind = env.get_inductive(typ)
@@ -1679,7 +1695,8 @@ def check_proof_of(proof, formula, env):
           case Union(loc2, name, typarams, alts):
             if len(cases) != len(alts):
               add_diagnostic(loc, 'expected ' + str(len(alts)) + ' cases for induction' \
-                    + ', but only have ' + str(len(cases)))
+                    + ', but only have ' + str(len(cases))
+                    + givens_str(env))
             cases_present = {}
             for (constr,indcase) in zip(alts, cases):
               check_pattern(indcase.pattern, typ, env, cases_present)
@@ -1687,11 +1704,13 @@ def check_proof_of(proof, formula, env):
                   print('\nCase ' + str(indcase.pattern))
               if indcase.pattern.constructor.name != constr.name:
                 add_diagnostic(indcase.location, "expected a case for " + str(base_name(constr.name)) \
-                      + " not " + str(base_name(indcase.pattern.constructor.name)))
+                      + " not " + str(base_name(indcase.pattern.constructor.name))
+                      + givens_str(env))
               if len(indcase.pattern.parameters) != len(constr.parameters):
                 add_diagnostic(indcase.location, "expected " + str(len(constr.parameters)) \
                       + " arguments to " + base_name(constr.name) \
-                      + " not " + str(len(indcase.pattern.parameters)))
+                      + " not " + str(len(indcase.pattern.parameters))
+                      + givens_str(env))
               induction_hypotheses = [instantiate(loc, formula,
                                                   ResolvedVar(loc,None, param))
                                       for (param, ty) in 
@@ -1729,7 +1748,8 @@ def check_proof_of(proof, formula, env):
                     msg = 'incorrect induction hypothesis, expected\n' \
                         + str(frm2) + '\nbut got\n' + str(new_frm1) \
                         + '\nin particular\n' + str(small_frm1) + '\n≠\n' + str(small_frm2) 
-                    add_diagnostic(frm1.location, msg)
+                    add_diagnostic(frm1.location, msg
+                          + givens_str(body_env))
                 body_env = body_env.declare_local_proof_var(loc, x, frm2)
 
               _try_check_proof_of(indcase.body, goal, body_env)
@@ -1754,14 +1774,17 @@ def check_proof_of(proof, formula, env):
               case _:
                 internal_error(loc, 'unhandled case in switch proof')
           if not has_true_case:
-            add_diagnostic(loc, 'missing case for true')
+            add_diagnostic(loc, 'missing case for true'
+                + givens_str(env))
           if not has_false_case:
-            add_diagnostic(loc, 'missing case for false')
-            
+            add_diagnostic(loc, 'missing case for false'
+                + givens_str(env))
+
           # check each case
           for scase in cases:
             if not isinstance(scase.pattern, PatternBool):
-              add_diagnostic(scase.location, "expected pattern 'true' or 'false' in switch on bool")
+              add_diagnostic(scase.location, "expected pattern 'true' or 'false' in switch on bool"
+                    + givens_str(env))
               
             subject_case = Bool(scase.location, BoolType(scase.location), True) if scase.pattern.value \
                            else Bool(scase.location, BoolType(scase.location), False)
@@ -1781,33 +1804,39 @@ def check_proof_of(proof, formula, env):
                 msg = 'expected assumption\n' + str(predicate) \
                     + '\nnot\n' + str(assumptions[0][1]) \
                     + '\nbecause\n\t' + str(small_case_asm) + ' ≠ ' + str(small_eqn)
-                add_diagnostic(scase.location, msg)
+                add_diagnostic(scase.location, msg
+                      + givens_str(env))
               body_env = body_env.declare_local_proof_var(loc, assumptions[0][0], predicate)
 
             if len(assumptions) > 1:
-              add_diagnostic(scase.location, 'only one assumption is allowed in a switch case')
+              add_diagnostic(scase.location, 'only one assumption is allowed in a switch case'
+                    + givens_str(env))
             frm = rewrite(loc, formula.reduce(env), equation.reduce(env), env)
             new_frm = frm.reduce(env)
             _try_check_proof_of(scase.body, new_frm, body_env)
         case TypeType(_):
           # As far as I know, it is not possible to switch on a type
-          add_diagnostic(loc, "In 'switch' expected a term, got " + str(new_subject))
+          add_diagnostic(loc, "In 'switch' expected a term, got " + str(new_subject)
+                + givens_str(env))
         case _:
           tname = get_type_name(ty)
           match env.get_def_of_type_var(tname):
             case Union(loc2, name, typarams, alts):
               if len(cases) != len(alts):
-                add_diagnostic(loc, 'expected ' + str(len(alts)) + ' cases in switch, but only have ' + str(len(cases)))
+                add_diagnostic(loc, 'expected ' + str(len(alts)) + ' cases in switch, but only have ' + str(len(cases))
+                      + givens_str(env))
               cases_present = {}
               for (constr,scase) in zip(alts, cases):
                 check_pattern(scase.pattern, ty, env, cases_present)
                 if scase.pattern.constructor.name != constr.name:
                   add_diagnostic(scase.location, "expected a case for " + str(constr) \
-                        + " not " + str(scase.pattern.constructor))
+                        + " not " + str(scase.pattern.constructor)
+                        + givens_str(env))
                 if len(scase.pattern.parameters) != len(constr.parameters):
                   add_diagnostic(scase.location, "expected " + str(len(constr.parameters)) \
                         + " arguments to " + base_name(constr.name) \
-                        + " not " + str(len(scase.pattern.parameters)))
+                        + " not " + str(len(scase.pattern.parameters))
+                        + givens_str(env))
                 subject_case = pattern_to_term(scase.pattern)
                 body_env = env
 
@@ -1832,11 +1861,13 @@ def check_proof_of(proof, formula, env):
                       case_assumption = type_synth_term(assumptions[0][1], body_env, None, [])
                       if case_assumption != new_assumption:
                           add_diagnostic(scase.location, 'in case, expected assume of\n' + str(new_assumption) \
-                                + '\nnot\n' + str(case_assumption))
+                                + '\nnot\n' + str(case_assumption)
+                                + givens_str(body_env))
                   body_env = body_env.declare_local_proof_var(loc, assumptions[0][0], new_assumption)
                 if len(assumptions) > 1:
-                  add_diagnostic(scase.location, 'only one assumption is allowed in a switch case')
-                  
+                  add_diagnostic(scase.location, 'only one assumption is allowed in a switch case'
+                        + givens_str(body_env))
+
                 if isinstance(new_subject, VarRef):
                   frm = formula.substitute({new_subject.name: new_subject_case})
                 else:
@@ -1844,7 +1875,8 @@ def check_proof_of(proof, formula, env):
                 red_frm = frm.reduce(body_env)
                 _try_check_proof_of(scase.body, red_frm, body_env)
             case _:
-              add_diagnostic(loc, "switch expected union type or bool, not " + str(ty))
+              add_diagnostic(loc, "switch expected union type or bool, not " + str(ty)
+                    + givens_str(env))
           
     case RewriteGoal(loc, equation_proofs, body):
       equations = [check_proof(proof, env) for proof in equation_proofs]

--- a/test/should-error/cases_error2.pf.err
+++ b/test/should-error/cases_error2.pf.err
@@ -1,1 +1,3 @@
 ./test/should-error/cases_error2.pf:5.3-8.4: expected 2 cases, not 1
+Givens:
+	pq: (P or Q)

--- a/test/should-error/givens_arbitrary_not_all.pf
+++ b/test/should-error/givens_arbitrary_not_all.pf
@@ -1,0 +1,7 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  arbitrary x:bool
+  ?
+end

--- a/test/should-error/givens_arbitrary_not_all.pf.err
+++ b/test/should-error/givens_arbitrary_not_all.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/givens_arbitrary_not_all.pf:5.3-5.19: arbitrary is proof of an all formula, not
+P
+Givens:
+	p: P

--- a/test/should-error/givens_assume_no_prem_not_ifthen.pf
+++ b/test/should-error/givens_assume_no_prem_not_ifthen.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  assume q
+end

--- a/test/should-error/givens_assume_no_prem_not_ifthen.pf.err
+++ b/test/should-error/givens_assume_no_prem_not_ifthen.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/givens_assume_no_prem_not_ifthen.pf:5.3-5.11: expected proof of P
+	not a proof of if-then: assume q.s0_3{?}
+Givens:
+	p: P

--- a/test/should-error/givens_assume_prem_mismatch.pf
+++ b/test/should-error/givens_assume_prem_mismatch.pf
@@ -1,0 +1,7 @@
+theorem T: all P:bool, Q:bool. if P then (if Q then Q)
+proof
+  arbitrary P:bool, Q:bool
+  assume p: P
+  assume r: P
+  r
+end

--- a/test/should-error/givens_assume_prem_mismatch.pf.err
+++ b/test/should-error/givens_assume_prem_mismatch.pf.err
@@ -1,0 +1,6 @@
+./test/should-error/givens_assume_prem_mismatch.pf:5.3-5.14: mismatch in premise:
+P ≠ Q
+because
+P ≠ Q
+Givens:
+	p: P

--- a/test/should-error/givens_assume_prem_not_ifthen.pf
+++ b/test/should-error/givens_assume_prem_not_ifthen.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  assume q: P
+end

--- a/test/should-error/givens_assume_prem_not_ifthen.pf.err
+++ b/test/should-error/givens_assume_prem_not_ifthen.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_assume_prem_not_ifthen.pf:5.3-5.14: the assume statement is for if-then formula, not P
+Givens:
+	p: P

--- a/test/should-error/givens_cases_alt_mismatch.pf
+++ b/test/should-error/givens_cases_alt_mismatch.pf
@@ -1,0 +1,8 @@
+theorem T: all P:bool, Q:bool, R:bool. if P or Q then R
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  assume porq: P or Q
+  cases porq
+  case h1: R { ? }
+  case h2: Q { ? }
+end

--- a/test/should-error/givens_cases_alt_mismatch.pf.err
+++ b/test/should-error/givens_cases_alt_mismatch.pf.err
@@ -1,0 +1,5 @@
+./test/should-error/givens_cases_alt_mismatch.pf:5.3-7.19: case R
+does not match alternative in goal: 
+P
+Givens:
+	porq: (P or Q)

--- a/test/should-error/givens_cases_not_or.pf
+++ b/test/should-error/givens_cases_not_or.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  cases p
+end

--- a/test/should-error/givens_cases_not_or.pf.err
+++ b/test/should-error/givens_cases_not_or.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_cases_not_or.pf:5.3-5.10: expected 'or', not P
+Givens:
+	p: P

--- a/test/should-error/givens_choose_not_some.pf
+++ b/test/should-error/givens_choose_not_some.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  choose true
+end

--- a/test/should-error/givens_choose_not_some.pf.err
+++ b/test/should-error/givens_choose_not_some.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_choose_not_some.pf:5.3-5.14: choose expects the goal to start with 'some', not P
+Givens:
+	p: P

--- a/test/should-error/givens_conclude_hole.pf
+++ b/test/should-error/givens_conclude_hole.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  conclude ? by p
+end

--- a/test/should-error/givens_conclude_hole.pf.err
+++ b/test/should-error/givens_conclude_hole.pf.err
@@ -1,0 +1,5 @@
+./test/should-error/givens_conclude_hole.pf:5.3-5.18: 
+need to show:
+	P
+Givens:
+	p: P

--- a/test/should-error/givens_evaluate_not_true.pf
+++ b/test/should-error/givens_evaluate_not_true.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool, Q:bool. if P then P = Q
+proof
+  arbitrary P:bool, Q:bool
+  assume p: P
+  evaluate
+end

--- a/test/should-error/givens_evaluate_not_true.pf.err
+++ b/test/should-error/givens_evaluate_not_true.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/givens_evaluate_not_true.pf:5.3-5.11: the goal did not evaluate to `true`, but instead:
+	P = Q
+Givens:
+	p: P

--- a/test/should-error/givens_induction_case_count.pf
+++ b/test/should-error/givens_induction_case_count.pf
@@ -1,0 +1,10 @@
+union Color { Red Blue Green }
+
+theorem T: all P:bool. if P then (all c:Color. c = c)
+proof
+  arbitrary P:bool
+  assume p: P
+  induction Color
+  case Red { ? }
+  case Blue { ? }
+end

--- a/test/should-error/givens_induction_case_count.pf.err
+++ b/test/should-error/givens_induction_case_count.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_induction_case_count.pf:7.3-9.18: expected 3 cases for induction, but only have 2
+Givens:
+	p: P

--- a/test/should-error/givens_induction_not_all.pf
+++ b/test/should-error/givens_induction_not_all.pf
@@ -1,0 +1,8 @@
+union N { z s(N) }
+
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  induction N
+end

--- a/test/should-error/givens_induction_not_all.pf.err
+++ b/test/should-error/givens_induction_not_all.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_induction_not_all.pf:7.3-7.14: induction expected an all-formula, not P
+Givens:
+	p: P

--- a/test/should-error/givens_induction_type_mismatch.pf
+++ b/test/should-error/givens_induction_type_mismatch.pf
@@ -1,0 +1,11 @@
+union N { z s(N) }
+union Color { Red Blue }
+
+theorem T: all P:bool. if P then (all n:N. n = n)
+proof
+  arbitrary P:bool
+  assume p: P
+  induction Color
+  case Red { ? }
+  case Blue { ? }
+end

--- a/test/should-error/givens_induction_type_mismatch.pf.err
+++ b/test/should-error/givens_induction_type_mismatch.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/givens_induction_type_mismatch.pf:8.3-10.18: type of induction: Color
+does not match the all-formula's type: N
+Givens:
+	p: P

--- a/test/should-error/givens_induction_wrong_arg_count.pf
+++ b/test/should-error/givens_induction_wrong_arg_count.pf
@@ -1,0 +1,9 @@
+union Box { Pack(bool, bool) }
+
+theorem T: all P:bool. if P then (all b:Box. b = b)
+proof
+  arbitrary P:bool
+  assume p: P
+  induction Box
+  case Pack(x) { ? }
+end

--- a/test/should-error/givens_induction_wrong_arg_count.pf.err
+++ b/test/should-error/givens_induction_wrong_arg_count.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_induction_wrong_arg_count.pf:8.3-8.21: expected 2 arguments to Pack not 1
+Givens:
+	p: P

--- a/test/should-error/givens_induction_wrong_constructor.pf
+++ b/test/should-error/givens_induction_wrong_constructor.pf
@@ -1,0 +1,10 @@
+union Color { Red Blue }
+
+theorem T: all P:bool. if P then (all c:Color. c = c)
+proof
+  arbitrary P:bool
+  assume p: P
+  induction Color
+  case Blue { ? }
+  case Red { ? }
+end

--- a/test/should-error/givens_induction_wrong_constructor.pf.err
+++ b/test/should-error/givens_induction_wrong_constructor.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_induction_wrong_constructor.pf:8.3-8.18: expected a case for Red not Blue
+Givens:
+	p: P

--- a/test/should-error/givens_induction_wrong_ih.pf
+++ b/test/should-error/givens_induction_wrong_ih.pf
@@ -1,0 +1,12 @@
+union Tree { node(Tree, Tree) leaf }
+
+theorem T: all P:bool. if P then (all t:Tree. t = t)
+proof
+  arbitrary P:bool
+  assume p: P
+  induction Tree
+  case node(l, r) suppose IH1: P, IH2: P {
+    ?
+  }
+  case leaf { ? }
+end

--- a/test/should-error/givens_induction_wrong_ih.pf.err
+++ b/test/should-error/givens_induction_wrong_ih.pf.err
@@ -1,0 +1,10 @@
+./test/should-error/givens_induction_wrong_ih.pf:8.32-8.33: incorrect induction hypothesis, expected
+l = l
+but got
+P
+in particular
+P
+≠
+l = l
+Givens:
+	p: P

--- a/test/should-error/givens_obtain_not_some.pf
+++ b/test/should-error/givens_obtain_not_some.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  obtain x where _: x = x from p
+end

--- a/test/should-error/givens_obtain_not_some.pf.err
+++ b/test/should-error/givens_obtain_not_some.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_obtain_not_some.pf:5.3-5.33: obtain expects 'from' to be a proof of a 'some' formula, not P
+Givens:
+	p: P

--- a/test/should-error/givens_ptuple_synthesis_fail.pf
+++ b/test/should-error/givens_ptuple_synthesis_fail.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool, Q:bool. if P then (if Q then P)
+proof
+  arbitrary P:bool, Q:bool
+  assume p: P
+  p, p
+end

--- a/test/should-error/givens_ptuple_synthesis_fail.pf.err
+++ b/test/should-error/givens_ptuple_synthesis_fail.pf.err
@@ -1,0 +1,14 @@
+./test/should-error/givens_ptuple_synthesis_fail.pf:5.3-5.7: failed to prove: (if Q then P)
+	first tried each subproof in goal-directed mode, but:
+./test/should-error/givens_ptuple_synthesis_fail.pf:5.3-5.7: comma proves logical-and, not (if Q then P)
+	then tried synthesis mode, but:
+./test/should-error/givens_ptuple_synthesis_fail.pf:5.3-5.7: 
+Could not prove that
+	(P and P)
+implies
+	(if Q then P)
+because we could not prove at least one of
+	P   implies   (if Q then P)
+	P   implies   (if Q then P)
+Givens:
+	p: P

--- a/test/should-error/givens_suffices_hole_not_ifthen.pf
+++ b/test/should-error/givens_suffices_hole_not_ifthen.pf
@@ -1,0 +1,6 @@
+theorem T: all P:bool. if P then P
+proof
+  arbitrary P:bool
+  assume p: P
+  suffices ? by p
+end

--- a/test/should-error/givens_suffices_hole_not_ifthen.pf.err
+++ b/test/should-error/givens_suffices_hole_not_ifthen.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_suffices_hole_not_ifthen.pf:5.3-5.18: expected a proof of an "if"-"then" formula, not P
+Givens:
+	p: P

--- a/test/should-error/givens_switch_missing_false.pf
+++ b/test/should-error/givens_switch_missing_false.pf
@@ -1,0 +1,8 @@
+theorem T: all b:bool, P:bool. if P then b = b
+proof
+  arbitrary b:bool, P:bool
+  assume p: P
+  switch b {
+    case true { . }
+  }
+end

--- a/test/should-error/givens_switch_missing_false.pf.err
+++ b/test/should-error/givens_switch_missing_false.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_switch_missing_false.pf:5.3-7.4: missing case for false
+Givens:
+	p: P

--- a/test/should-error/givens_switch_missing_true.pf
+++ b/test/should-error/givens_switch_missing_true.pf
@@ -1,0 +1,8 @@
+theorem T: all b:bool, P:bool. if P then b = b
+proof
+  arbitrary b:bool, P:bool
+  assume p: P
+  switch b {
+    case false { . }
+  }
+end

--- a/test/should-error/givens_switch_missing_true.pf.err
+++ b/test/should-error/givens_switch_missing_true.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_switch_missing_true.pf:5.3-7.4: missing case for true
+Givens:
+	p: P

--- a/test/should-error/givens_switch_union_case_count.pf
+++ b/test/should-error/givens_switch_union_case_count.pf
@@ -1,0 +1,11 @@
+union Color { Red Blue Green }
+
+theorem T: all c:Color, P:bool. if P then c = c
+proof
+  arbitrary c:Color, P:bool
+  assume p: P
+  switch c {
+    case Red { . }
+    case Blue { . }
+  }
+end

--- a/test/should-error/givens_switch_union_case_count.pf.err
+++ b/test/should-error/givens_switch_union_case_count.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_switch_union_case_count.pf:7.3-10.4: expected 3 cases in switch, but only have 2
+Givens:
+	p: P

--- a/test/should-error/givens_switch_union_wrong_arg_count.pf
+++ b/test/should-error/givens_switch_union_wrong_arg_count.pf
@@ -1,0 +1,10 @@
+union Box { Pack(bool, bool) }
+
+theorem T: all b:Box, P:bool. if P then b = b
+proof
+  arbitrary b:Box, P:bool
+  assume p: P
+  switch b {
+    case Pack(x) { . }
+  }
+end

--- a/test/should-error/givens_switch_union_wrong_arg_count.pf.err
+++ b/test/should-error/givens_switch_union_wrong_arg_count.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_switch_union_wrong_arg_count.pf:8.5-8.23: expected 2 arguments to Pack not 1
+Givens:
+	p: P

--- a/test/should-error/givens_switch_union_wrong_assume.pf
+++ b/test/should-error/givens_switch_union_wrong_assume.pf
@@ -1,0 +1,11 @@
+union Color { Red Blue }
+
+theorem T: all c:Color, P:bool. if P then c = c
+proof
+  arbitrary c:Color, P:bool
+  assume p: P
+  switch c {
+    case Red assume eq: c = Blue { . }
+    case Blue { . }
+  }
+end

--- a/test/should-error/givens_switch_union_wrong_assume.pf.err
+++ b/test/should-error/givens_switch_union_wrong_assume.pf.err
@@ -1,0 +1,6 @@
+./test/should-error/givens_switch_union_wrong_assume.pf:8.5-8.39: in case, expected assume of
+c = Red
+not
+c = Blue
+Givens:
+	p: P

--- a/test/should-error/givens_switch_union_wrong_constructor.pf
+++ b/test/should-error/givens_switch_union_wrong_constructor.pf
@@ -1,0 +1,11 @@
+union Color { Red Blue }
+
+theorem T: all c:Color, P:bool. if P then c = c
+proof
+  arbitrary c:Color, P:bool
+  assume p: P
+  switch c {
+    case Blue { . }
+    case Red { . }
+  }
+end

--- a/test/should-error/givens_switch_union_wrong_constructor.pf.err
+++ b/test/should-error/givens_switch_union_wrong_constructor.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/givens_switch_union_wrong_constructor.pf:8.5-8.20: expected a case for Red not Blue
+Givens:
+	p: P


### PR DESCRIPTION
## Summary
- Closes #126.
- Extends user-facing error messages in `check_proof_of` to append `givens_str(env)` (the local proof environment) so the user sees the available premises alongside the error.
- Only one fixture (`test/should-error/cases_error2.pf.err`) changed — the rest of the touched error sites are either not exercised by current tests or had no local proofs in scope at the point of the error, so the new tail is empty.

## Sites touched in `check_proof_of`
- arbitrary / choose / obtain shape mismatches
- `assume` premise mismatches (with and without an explicit premise)
- `conclude … by ?` (need-to-show) and `evaluate` goal mismatches
- `suffices` expected-if-then errors
- PTuple synthesis-mode fallback (`failed to prove …`)
- Cases: bad `or`, alternative mismatch, case count
- Induction: type mismatch, missing all-formula, case count, constructor name/arity, IH mismatch
- Switch (bool + union): missing case, pattern, assumption mismatches, case count, constructor name/arity, non-union/bool subject

## Test plan
- [x] `python test-deduce.py --errors` — 164 fixtures pass under recursive-descent.
- [x] `python test-deduce.py --lib` — stdlib still validates under both parsers.
- [x] `python test-deduce.py --passable` — should-validate suite still passes under both parsers.
- [x] `python test-deduce.py --parser` — parser-error fixtures still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)