### PR TITLE
Fix #215: escape analysis for recursive function bodies

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2172,7 +2172,7 @@ def check_recursive_call(call, recfun, subterms):
   # print('rator_name = ' + rator_name(call.rator))
   if rator_name(call.rator) != recfun:
       return
-  increment_recursive_call_count()  
+  increment_recursive_call_count()
 
   if isinstance(call.args[0], VarRef):
     if not (call.args[0].get_name() in subterms):
@@ -2185,6 +2185,104 @@ def check_recursive_call(call, recfun, subterms):
           + "expected first argument to be " \
           + " or ".join([base_name(x) for x in subterms]) \
           + ", not " + str(call.args[0]))
+
+def _is_recfun_ref(node, recfun):
+  if isinstance(node, ResolvedVar):
+    return node.name == recfun
+  if isinstance(node, OverloadedVar):
+    return recfun in node.resolved_names
+  if isinstance(node, Var):
+    return node.name == recfun
+  return False
+
+def _escape_error(loc, recfun):
+  user_error(loc,
+        "the name '" + base_name(recfun) + "'"
+        + " of a recursive function may only appear as the operator"
+        + " of a function call within its own body")
+
+def check_no_recfun_escape(term, recfun):
+  # Walk ``term`` and raise an error if ``recfun`` (the uniquified
+  # name of the enclosing recursive function) appears anywhere other
+  # than as the (optionally type-instantiated) operator of a Call.
+  # This is the escape analysis from issue #215: it stops a body from
+  # smuggling the recursive function out via a let-binding, an
+  # argument position, or a return value, which would otherwise let
+  # callers loop without the first-argument decreases check.
+  if term is None:
+    return
+  if isinstance(term, VarRef):
+    if _is_recfun_ref(term, recfun):
+      _escape_error(term.location, recfun)
+    return
+  match term:
+    case Call(loc, ty, rator, args):
+      _check_rator_no_escape(rator, recfun)
+      for a in args:
+        check_no_recfun_escape(a, recfun)
+    case TermInst(loc, ty, subject, type_args, inferred):
+      check_no_recfun_escape(subject, recfun)
+    case Generic(loc, ty, typarams, body):
+      check_no_recfun_escape(body, recfun)
+    case Conditional(loc, ty, cond, thn, els):
+      check_no_recfun_escape(cond, recfun)
+      check_no_recfun_escape(thn, recfun)
+      check_no_recfun_escape(els, recfun)
+    case TAnnote(loc, ty, subject, typ):
+      check_no_recfun_escape(subject, recfun)
+    case Lambda(loc, ty, vars, body):
+      check_no_recfun_escape(body, recfun)
+    case Switch(loc, ty, subject, cases):
+      check_no_recfun_escape(subject, recfun)
+      for c in cases:
+        check_no_recfun_escape(c.body, recfun)
+    case Array(loc, ty, elements):
+      for e in elements:
+        check_no_recfun_escape(e, recfun)
+    case MakeArray(loc, ty, subject):
+      check_no_recfun_escape(subject, recfun)
+    case ArrayGet(loc, ty, subject, position):
+      check_no_recfun_escape(subject, recfun)
+      check_no_recfun_escape(position, recfun)
+    case TLet(loc, ty, var, rhs, body):
+      check_no_recfun_escape(rhs, recfun)
+      check_no_recfun_escape(body, recfun)
+    case Mark(loc, ty, subject):
+      check_no_recfun_escape(subject, recfun)
+    case And(loc, ty, args):
+      for a in args:
+        check_no_recfun_escape(a, recfun)
+    case Or(loc, ty, args):
+      for a in args:
+        check_no_recfun_escape(a, recfun)
+    case IfThen(loc, ty, premise, conclusion):
+      check_no_recfun_escape(premise, recfun)
+      check_no_recfun_escape(conclusion, recfun)
+    case All(loc, ty, var, pos, body):
+      check_no_recfun_escape(body, recfun)
+    case Some(loc, ty, vars, body):
+      check_no_recfun_escape(body, recfun)
+    case Int() | Bool() | Hole() | Omitted():
+      pass
+    case _:
+      # Other AST nodes (e.g. RecFun, GenRecFun appearing as values)
+      # are conservatively rejected if they reference the recfun
+      # name, allowed otherwise.
+      if _is_recfun_ref(term, recfun):
+        _escape_error(term.location, recfun)
+
+def _check_rator_no_escape(rator, recfun):
+  # At a Call rator position, a direct VarRef to ``recfun`` is the
+  # only place the name is legal; TermInst wrapping such a VarRef
+  # (the ``@foo<T>(...)`` syntax) is the same shape. Anything else
+  # is recursively walked as a non-rator subterm.
+  if isinstance(rator, VarRef):
+    return
+  match rator:
+    case TermInst(loc, ty, subject, type_args, inferred):
+      _check_rator_no_escape(subject, recfun)
+    case _:
+      check_no_recfun_escape(rator, recfun)
 
 # Helper for check_type: a bare reference to a generic union (one with N>0
 # type parameters) is ill-formed. The arity check used to live in a separate
@@ -4186,6 +4284,7 @@ def type_check_fun_case(fun_case, name, params, returns, body_env, cases_present
       case PatternBool(loc, val):
         pat_params = []
     new_body = type_check_term(fun_case.body, returns, body_env, name, pat_params)
+    check_no_recfun_escape(new_body, name)
     return FunCase(fun_case.location, fun_case.rator,
                    fun_case.pattern, fun_case.parameters, new_body)
 

--- a/test/should-error/recfun_escape_arg.pf
+++ b/test/should-error/recfun_escape_arg.pf
@@ -1,0 +1,12 @@
+import Nat
+
+fun apply2(f : fn Nat,Nat -> Nat, x : Nat, y : Nat) {
+  f(x, y)
+}
+
+recursive add(Nat,Nat) -> Nat {
+  add(zero, m) = m
+  add(suc(n), m) = add(n, apply2(add, suc(n), m))
+}
+
+print add(suc(zero), zero)

--- a/test/should-error/recfun_escape_arg.pf.err
+++ b/test/should-error/recfun_escape_arg.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/recfun_escape_arg.pf:9.34-9.37: the name 'add' of a recursive function may only appear as the operator of a function call within its own body

--- a/test/should-error/recfun_escape_conditional.pf
+++ b/test/should-error/recfun_escape_conditional.pf
@@ -1,0 +1,14 @@
+import Nat
+
+fun call_it(f : fn Nat,Nat -> Nat, x : Nat, y : Nat) {
+  f(x, y)
+}
+
+recursive add(Nat,Nat) -> Nat {
+  add(zero, m) = m
+  add(suc(n), m) =
+    define alias = if true then add else add;
+    call_it(alias, n, m)
+}
+
+print add(suc(zero), zero)

--- a/test/should-error/recfun_escape_conditional.pf.err
+++ b/test/should-error/recfun_escape_conditional.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/recfun_escape_conditional.pf:10.33-10.36: the name 'add' of a recursive function may only appear as the operator of a function call within its own body

--- a/test/should-error/recfun_escape_let.pf
+++ b/test/should-error/recfun_escape_let.pf
@@ -1,0 +1,10 @@
+import Nat
+
+recursive add(Nat,Nat) -> Nat {
+  add(zero, m) = m
+  add(suc(n), m) =
+    define rec = add;
+    add(n, rec(suc(n), m))
+}
+
+print add(suc(zero), zero)

--- a/test/should-error/recfun_escape_let.pf.err
+++ b/test/should-error/recfun_escape_let.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/recfun_escape_let.pf:6.18-6.21: the name 'add' of a recursive function may only appear as the operator of a function call within its own body

--- a/test/should-error/recfun_escape_terminst.pf
+++ b/test/should-error/recfun_escape_terminst.pf
@@ -1,0 +1,10 @@
+import Nat
+
+recursive ident<T>(Nat, T) -> T {
+  ident(zero, x) = x
+  ident(suc(n), x) =
+    define rec = @ident<T>;
+    rec(n, x)
+}
+
+print ident(suc(zero), zero)

--- a/test/should-error/recfun_escape_terminst.pf.err
+++ b/test/should-error/recfun_escape_terminst.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/recfun_escape_terminst.pf:6.19-6.24: the name 'ident' of a recursive function may only appear as the operator of a function call within its own body


### PR DESCRIPTION
## Summary

- Implements the proposed simple fix for [#215](https://github.com/jsiek/deduce/issues/215): a `recursive` function's name may only appear as the (possibly type-instantiated) operator of a function call within its own body. Any other position — let-binding RHS, argument to another call, conditional branch, `@foo<T>` in non-rator position, etc. — is rejected.
- Closes the loophole where `define rec = add; ... rec(...)` (or passing the recfun to a higher-order helper) bypassed the first-argument-decreases check, causing `RecursionError: maximum recursion depth exceeded` at runtime.

## What changed

- `proof_checker.py`: adds `check_no_recfun_escape` (and a small `_check_rator_no_escape` helper for the legal rator-position cases, including `@foo<T>(...)`). Called once per `FunCase` body after type checking, with the uniquified recfun name.
- The walker is intentionally syntactic. A Lambda whose body invokes the recfun is still allowed, because the use inside the Lambda is at rator position. This matches the scope of the simple fix in the issue.

## Tests

Four new `test/should-error` fixtures exercise distinct escape sites:

| Test | Escape site |
| --- | --- |
| `recfun_escape_let.pf` | `TLet` RHS (the original issue example) |
| `recfun_escape_arg.pf` | `Call` argument |
| `recfun_escape_conditional.pf` | `if … then add else add` branch |
| `recfun_escape_terminst.pf` | `TermInst`-wrapped generic recfun in non-rator position |

The full suite (lib + should-validate + should-error + prelude, both parsers) still passes.

## Test plan

- [x] `python3.13 test-deduce.py --lib`
- [x] `python3.13 test-deduce.py --passable`
- [x] `python3.13 test-deduce.py --errors`
- [x] `python3.13 test-deduce.py` (default)
- [x] Original issue reproducer now errors at the offending site instead of recursing forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)