### PR TITLE
examples/replicate.pf: worked proof of a classic Haskell intro-FP function

### DIFF
--- a/examples/replicate.pf
+++ b/examples/replicate.pf
@@ -1,0 +1,73 @@
+// replicate.pf
+//
+// The classic Haskell intro-FP function:
+//
+//     replicate :: Int -> a -> [a]
+//     replicate n x = [x, x, ..., x]   -- n copies
+//
+// Below we define replicate over Nat and prove two correctness theorems:
+//
+//   1. replicate_add:      replicate(m + n, x) = replicate(m, x) ++ replicate(n, x)
+//   2. length_replicate:   length(replicate(n, x)) = fromNat(n)
+
+import Nat
+import List
+
+recursive replicate<T>(Nat, T) -> List<T> {
+  replicate(zero, x) = []
+  replicate(suc(n), x) = node(x, replicate(n, x))
+}
+
+assert replicate(ℕ3, 7) = [7, 7, 7]
+
+// replicate distributes over Nat addition into list concatenation.
+theorem replicate_add: all T:type. all m:Nat. all n:Nat, x:T.
+  replicate(m + n, x) = replicate(m, x) ++ replicate(n, x)
+proof
+  arbitrary T:type
+  induction Nat
+  case zero {
+    arbitrary n:Nat, x:T
+    expand replicate | operator++.
+  }
+  case suc(m') assume IH: all n:Nat, x:T.
+      replicate(m' + n, x) = replicate(m', x) ++ replicate(n, x) {
+    arbitrary n:Nat, x:T
+    equations
+      replicate(suc(m') + n, x)
+          = replicate(suc(m' + n), x)               by expand operator+.
+      ... = node(x, replicate(m' + n, x))           by expand replicate.
+      ... = node(x, replicate(m', x) ++ replicate(n, x))
+                                                    by replace IH[n, x].
+      ... = # node(x, replicate(m', x)) ++ replicate(n, x) #
+                                                    by expand operator++.
+      ... = # replicate(suc(m'), x) ++ replicate(n, x) #
+                                                    by expand replicate.
+  }
+end
+
+// The length of replicate(n, x) is n (converted from Nat to UInt because
+// `length` returns UInt).
+theorem length_replicate: all T:type. all n:Nat. all x:T.
+  length(replicate(n, x)) = fromNat(n)
+proof
+  arbitrary T:type
+  induction Nat
+  case zero {
+    arbitrary x:T
+    have zero_eq: fromNat(zero) = 0 by evaluate
+    expand replicate | length
+    replace zero_eq.
+  }
+  case suc(n') assume IH: all x:T. length(replicate(n', x)) = fromNat(n') {
+    arbitrary x:T
+    have suc_eq: suc(n') = ℕ1 + n' by nat_suc_one_add[n']
+    equations
+      length(replicate(suc(n'), x))
+          = length(node(x, replicate(n', x)))      by expand replicate.
+      ... = 1 + length(replicate(n', x))           by expand length.
+      ... = 1 + fromNat(n')                        by replace IH[x].
+      ... = fromNat(ℕ1 + n')                       by symmetric fromNat_add[ℕ1, n']
+      ... = # fromNat(suc(n')) #                   by replace suc_eq.
+  }
+end


### PR DESCRIPTION
## Summary

Adds a new top-level `examples/` directory and seeds it with `examples/replicate.pf`, a worked proof of the classic Haskell intro-FP function `replicate :: Nat -> T -> List<T>` (not currently in `lib/`). Produced during a new-user UAT pass.

Two theorems are proved:

- `replicate_add`: `replicate(m + n, x) = replicate(m, x) ++ replicate(n, x)` — distributivity over list append, by induction on `m`.
- `length_replicate`: `length(replicate(n, x)) = fromNat(n)` — the canonical "length is `n`" theorem, with the `Nat → UInt` bridge via `fromNat_add` + `nat_suc_one_add`.

Both proofs pass under both parsers (`--recursive-descent` and `--lalr`).

## Friction filed as separate issues

The UAT pass surfaced three rough edges that a new user hits writing this very proof:

- [#450](https://github.com/jsiek/deduce/issues/450) — `expand X` inside `equations` chains gives no hint about `#...#` mark syntax when the unfolding lives on the RHS.
- [#451](https://github.com/jsiek/deduce/issues/451) — `length` returns `UInt` but `replicate` (and `induction`) are `Nat`-shaped, so the natural `length(replicate(n, x)) = n` doesn't even type-check.
- [#452](https://github.com/jsiek/deduce/issues/452) — `replace eq | expand foo` fails with "need to be in goal-directed mode for expand", jargon a beginner cannot decode.

## Test plan

- [x] `python deduce.py examples/replicate.pf` → valid
- [x] `python deduce.py --lalr examples/replicate.pf` → valid
- [ ] Reviewer sanity-check: does `examples/` belong at the repo root next to `lib/` and `test/`, or would you prefer a different location?

🤖 Generated with [Claude Code](https://claude.com/claude-code)