### PR TITLE
Fix #447: arbitrary rejects type mismatch with all-quantifier bound type

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1351,15 +1351,21 @@ def check_proof_of(proof, formula, env):
 
       if isinstance(formula, TLet):
         formula = formula.reduceLets(env)
-      
+
       match formula:
         case All(loc2, tyof, var2, (s, e), formula2):
+          x2, ty2 = var2
+          if ty != ty2:
+            add_diagnostic(loc, "arbitrary expects " + base_name(x)
+                  + " to have type\n\t" + str(ty2)
+                  + "\nbut got type\n\t" + str(ty))
+            return
           sub = {}
           sub[ var2[0] ] = OverloadedVar(loc, var[1], [ var[0] ])
-          
+
           frm2 = formula2.substitute(sub)
 
-          if s != 0: 
+          if s != 0:
             frm2 = update_all_head(frm2)
 
           body_env = env.declare_term_vars(loc, [var])

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -24,7 +24,7 @@
 
 from abstract_syntax import *
 from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, ErrorSink, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe
-from flags import get_verbose, set_verbose, print_verbose, VerboseLevel, get_target_hole_location, get_debugger
+from flags import get_verbose, set_verbose, print_verbose, VerboseLevel, get_target_hole_location, get_debugger, get_unique_names, set_unique_names
 
 imported_modules = set()
 checked_modules = set()
@@ -1355,7 +1355,15 @@ def check_proof_of(proof, formula, env):
       match formula:
         case All(loc2, tyof, var2, (s, e), formula2):
           x2, ty2 = var2
-          if ty != ty2:
+          # Compare display forms so this catches user-facing mismatches
+          # (Nat vs UInt) without false-flagging two type variables that
+          # share a source name but were uniquified separately (e.g. the
+          # theorem's `T` vs an `arbitrary T:type` in the same proof).
+          saved = get_unique_names()
+          set_unique_names(False)
+          mismatch = str(ty) != str(ty2)
+          set_unique_names(saved)
+          if mismatch:
             add_diagnostic(loc, "arbitrary expects " + base_name(x)
                   + " to have type\n\t" + str(ty2)
                   + "\nbut got type\n\t" + str(ty))

--- a/test/should-error/arbitrary_type_mismatch.pf
+++ b/test/should-error/arbitrary_type_mismatch.pf
@@ -1,0 +1,5 @@
+theorem t: all x:UInt. length([x]) = 1
+proof
+  arbitrary x:Nat
+  expand 2*length.
+end

--- a/test/should-error/arbitrary_type_mismatch.pf
+++ b/test/should-error/arbitrary_type_mismatch.pf
@@ -1,3 +1,7 @@
+import UInt
+import Nat
+import List
+
 theorem t: all x:UInt. length([x]) = 1
 proof
   arbitrary x:Nat

--- a/test/should-error/arbitrary_type_mismatch.pf.err
+++ b/test/should-error/arbitrary_type_mismatch.pf.err
@@ -1,4 +1,4 @@
-test/should-error/arbitrary_type_mismatch.pf:3.3-3.18: arbitrary expects x to have type
+./test/should-error/arbitrary_type_mismatch.pf:7.3-7.18: arbitrary expects x to have type
 	UInt
 but got type
 	Nat

--- a/test/should-error/arbitrary_type_mismatch.pf.err
+++ b/test/should-error/arbitrary_type_mismatch.pf.err
@@ -1,0 +1,4 @@
+test/should-error/arbitrary_type_mismatch.pf:3.3-3.18: arbitrary expects x to have type
+	UInt
+but got type
+	Nat


### PR DESCRIPTION
## Summary
- Fixes [#447](https://github.com/jsiek/deduce/issues/447) — `arbitrary x:Nat` was silently accepted for `all x:UInt. ...`.
- In `proof_checker.py`'s `AllIntro` rule, compare the user-annotated type to the all-quantifier's bound type and emit a diagnostic on mismatch instead of substituting the wrong type into the body.
- Adds a `should-error` regression test mirroring the issue's repro.

## Background
The previous code did `sub[var2[0]] = OverloadedVar(loc, var[1], [var[0]])` using the *user's* type, so the body got type-checked under the wrong binder type. The implicit `Nat -> UInt` coercion (and structurally generic bodies) made the mismatch invisible at the body level, so the broken proof still validated and could even be instantiated at real `UInt` values.

## New diagnostic
```
arbitrary expects x to have type
	UInt
but got type
	Nat
```

## Test plan
- [x] Repro from the issue now errors (Nat, Int, bool all rejected; both `--recursive-descent` and `--lalr`).
- [x] Happy path `arbitrary x:UInt` for `all x:UInt. ...` still validates.
- [ ] Full `make` (tests + tests-lib) under both parsers — run by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)