### PR TITLE
docs: fix Nat/UInt mismatch in first `arbitrary` example (#444)

### DIFF
--- a/gh_pages/doc/ProofIntro.md
+++ b/gh_pages/doc/ProofIntro.md
@@ -158,9 +158,10 @@ end
 In the proof of `length_node42` it did not matter that the element in
 the node was `42`. We can generalize this theorem by using an `all`
 formula. We begin the formula with `all x:UInt.` to say that the
-formula must be true for all natural numbers and the variable `x` will
-be used to refer to the natural number.  We then replace the `42` in
-the formula with `x` to obtain the following theorem statement.
+formula must be true for all unsigned integers and the variable `x`
+will be used to refer to the unsigned integer.  We then replace the
+`42` in the formula with `x` to obtain the following theorem
+statement.
 
     theorem length_uint_one: all x:UInt. length([x]) = 1
     proof
@@ -169,8 +170,14 @@ the formula with `x` to obtain the following theorem statement.
 
 Deduce responds with
 
-    incomplete proof:
-        all x:Nat. length([x]) = 1
+    incomplete proof
+    Goal:
+        (all x:UInt. length([x]) = 1)
+    Advice:
+        Prove this "all" formula with:
+            arbitrary x:UInt
+        followed by a proof of:
+            length([x]) = 1
 
 The most straightforward way to prove an `all` formula in Deduce is
 with an `arbitrary` statement. When you use `arbitrary` you are
@@ -181,17 +188,18 @@ but we could have chosen a different name.
 
     theorem length_uint_one: all x:UInt. length([x]) = 1
     proof
-      arbitrary x:Nat
+      arbitrary x:UInt
       ?
     end
 
 Deduce responds with
 
-    incomplete proof:
+    incomplete proof
+    Goal:
         length([x]) = 1
 
 We don't know anything about this hypothetical `x` other than it being
-a natural number. But as we previously observed, we don't need any
+an unsigned integer. But as we previously observed, we don't need any
 more information about `x` in this example.  We complete the proof as
 before, using the definitions of `length`.
 The notation `2* length` is shorthand for `length | length`.


### PR DESCRIPTION
## Summary

Fixes #444. The first `arbitrary` example in [`gh_pages/doc/ProofIntro.md`](gh_pages/doc/ProofIntro.md) (the "Generalizing with `all` formulas" section) was self-inconsistent:

- The theorem said `all x:UInt.` but the example tactic was `arbitrary x:Nat`.
- The "Deduce responds with" transcripts were in the pre-advice format (`incomplete proof:` on a single line, with goal type printed as `Nat`).
- The prose called a `UInt` a "natural number" twice.

This is the first `arbitrary` example a beginner reads, so the inconsistency teaches a wrong rule (especially when combined with #447, where `arbitrary x:Nat` is silently accepted).

## Changes

- Line 161: "natural numbers" → "unsigned integers" (twice).
- Line 184: `arbitrary x:Nat` → `arbitrary x:UInt`.
- Lines 170–173 transcript: replaced the stale `incomplete proof: all x:Nat. ...` snippet with the current `Goal:`/`Advice:` format, including the `arbitrary x:UInt` suggestion so the next code block flows naturally from it.
- Lines 188–191 transcript: same format update, no advice section (matches the simpler examples earlier in the file at line 56–58).
- Line 194: "natural number" → "unsigned integer".

The `{.deduce^#length_uint_one}` literate-code block further down already used `arbitrary x:UInt`, so the doc was self-contradictory; this aligns the prose/transcript with the code block.

## Test plan

- [x] `python test-deduce.py --site` — regenerates the doc test files and runs them under both parsers; all `is valid`.
- [ ] Spot-check rendered Markdown on the live site after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)