### PR TITLE
Fix #445: include expected return type in overload-resolution error

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2133,6 +2133,39 @@ def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
     # print('}}}')
     return ret
 
+def overload_mismatch_annotation(loc, overload_funty, arg_types, ret_ty):
+  """Return a short annotation explaining why this overload doesn't fit, or
+  ``None`` if neither side matches (in which case the bare overload type is
+  already informative on its own). The annotation distinguishes the two
+  common confusing cases: arguments line up but the return type is wrong,
+  or vice versa."""
+  match overload_funty:
+    case FunctionType(_, typarams, param_types, return_type):
+      type_params = type_names(loc, typarams)
+      args_match = (len(param_types) == len(arg_types))
+      if args_match:
+        m = {}
+        try:
+          for (pt, at) in zip(param_types, arg_types):
+            type_match(loc, type_params, pt, at, m)
+        except MatchFailed:
+          args_match = False
+      ret_matches = True
+      if ret_ty is not None:
+        m = {}
+        try:
+          type_match(loc, type_params, return_type, ret_ty, m)
+        except MatchFailed:
+          ret_matches = False
+      if args_match and ret_ty is not None and not ret_matches:
+        return 'argument types match, but result type ' + str(return_type) \
+               + " doesn't match expected " + str(ret_ty)
+      if ret_ty is not None and ret_matches and not args_match:
+        return "result type matches, but argument types don't"
+      return None
+    case _:
+      return None
+
 def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, call):
   if get_verbose():
       print('tc_call_helper(' + str(call) + ') rator type: ' + str(new_rator.typeof))
@@ -2161,11 +2194,18 @@ def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, 
                 pass
       if num_matches == 0:
           arg_types = [type_synth_term(arg, env, None, []).typeof for arg in args]
-          user_error(loc, 'could not find a match for function call:\n\t' \
-                + str(call) + '\n'\
-                + 'argument types: ' + ', '.join([str(t) for t in arg_types]) + '\n'\
-                + 'overloads:\n\t' \
-                + '\n\t'.join([str(ty) for (x,ty) in overloads]))
+          msg = 'could not find a match for function call:\n\t' \
+                + str(call) + '\n' \
+                + 'argument types: ' + ', '.join([str(t) for t in arg_types]) + '\n'
+          if ret_ty is not None:
+              msg += 'expected return type: ' + str(ret_ty) + '\n'
+          msg += 'overloads:'
+          for (x, ty) in overloads:
+              annotation = overload_mismatch_annotation(loc, ty, arg_types, ret_ty)
+              msg += '\n\t' + str(ty)
+              if annotation is not None:
+                  msg += '   <-- ' + annotation
+          user_error(loc, msg)
       elif num_matches > 1:
           user_error(loc, 'in call to ' + str(new_rator) + '\n'\
                 + 'ambiguous overloads:\n' \

--- a/test/should-error/overload2.pf.err
+++ b/test/should-error/overload2.pf.err
@@ -1,6 +1,7 @@
 ./test/should-error/overload2.pf:16.26-16.30: could not find a match for function call:
 	f(c)
 argument types: C
+expected return type: bool
 overloads:
-	(fn A -> bool)
-	(fn B -> bool)
+	(fn A -> bool)   <-- result type matches, but argument types don't
+	(fn B -> bool)   <-- result type matches, but argument types don't

--- a/test/should-error/overload_return_type.pf
+++ b/test/should-error/overload_return_type.pf
@@ -1,0 +1,7 @@
+// Regression test for #445: when overload resolution fails because of the
+// expected return type, the error message should report that expected
+// return type and annotate which overloads matched args vs. return.
+import Nat
+import UInt
+
+define n : Nat = 1 + 2

--- a/test/should-error/overload_return_type.pf.err
+++ b/test/should-error/overload_return_type.pf.err
@@ -1,0 +1,7 @@
+./test/should-error/overload_return_type.pf:7.18-7.23: could not find a match for function call:
+	1 + 2
+argument types: UInt, UInt
+expected return type: Nat
+overloads:
+	(fn Nat, Nat -> Nat)   <-- result type matches, but argument types don't
+	(fn UInt, UInt -> UInt)   <-- argument types match, but result type UInt doesn't match expected Nat


### PR DESCRIPTION
## Summary

Fixes [#445](https://github.com/jsiek/deduce/issues/445).

When overload resolution fails for a call like `1 + 2` in `define n : Nat = 1 + 2`, the diagnostic previously listed `argument types: UInt, UInt` and an overloads section that included `(fn UInt, UInt -> UInt)` — an exact match on argument types — with no mention of the *expected return type* `Nat`. To a beginner this looks self-contradictory: there's literally an overload whose arg types match.

This change:

- Reports the expected return type (when one is known) under `argument types:` as `expected return type: ...`.
- For each listed overload, annotates whether it's a partial match:
  - `<-- argument types match, but result type X doesn't match expected Y`
  - `<-- result type matches, but argument types don't`

### Before

```
could not find a match for function call:
	1 + 2
argument types: UInt, UInt
overloads:
	(fn (fn UInt -> UInt), (fn UInt -> UInt) -> (fn UInt -> UInt))
	(fn UInt, UInt -> UInt)
	(fn Int, Int -> Int)
	(fn UInt, Int -> Int)
	(fn Int, UInt -> Int)
	(fn Nat, Nat -> Nat)
```

### After

```
could not find a match for function call:
	1 + 2
argument types: UInt, UInt
expected return type: Nat
overloads:
	(fn (fn UInt -> UInt), (fn UInt -> UInt) -> (fn UInt -> UInt))
	(fn UInt, UInt -> UInt)   <-- argument types match, but result type UInt doesn't match expected Nat
	(fn Int, Int -> Int)
	(fn UInt, Int -> Int)
	(fn Int, UInt -> Int)
	(fn Nat, Nat -> Nat)   <-- result type matches, but argument types don't
```

## Test plan

- [x] Added [`test/should-error/overload_return_type.pf`](test/should-error/overload_return_type.pf) covering the issue's exact reproducer.
- [x] Updated [`test/should-error/overload2.pf.err`](test/should-error/overload2.pf.err) (its message now picks up the `expected return type: bool` line and the new per-overload annotation).
- [x] `python test-deduce.py --errors` passes.
- [ ] Full `python test-deduce.py` (lib + validate + errors + prelude) passes on both parsers (running locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)