### PR TITLE
Parallel in-process test runner: make tests 10x faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,21 @@ TEST_ERROR_DIR = ./test/should-error
 TEST_IMPORT_DIR = ./test/test-imports
 EXAMPLES_DIR = ./examples
 
-default: tests-tokens tests tests-lib
+default: tests-tokens tests
 
 tests-tokens:
 	$(PYTHON) ./gh_pages/scripts/keywords.py
 
+# Fast parallel in-process sweep. Matches the coverage of
+# ``test-deduce.py`` default mode (lib + should-validate + test/prelude
+# + should-error with ``.err`` diff), runs ~15x faster by paying the
+# prelude bootstrap once in the parent and forking worker processes
+# that inherit the populated AST cache via copy-on-write.
+tests:
+	$(PYTHON) tools/test_runner_inproc.py
+
+# Per-category targets kept for granular debugging; ``make tests``
+# above is the fast all-in-one entry point.
 tests-should-validate:
 	$(PYTHON) ./deduce.py --recursive-descent $(TEST_PASS_DIR) --dir $(LIB_DIR) --dir $(TEST_IMPORT_DIR)
 	$(PYTHON) ./deduce.py --lalr $(TEST_PASS_DIR) --dir $(LIB_DIR) --dir $(TEST_IMPORT_DIR)
@@ -19,11 +29,9 @@ tests-should-error:
 	$(PYTHON) ./deduce.py --recursive-descent $(TEST_ERROR_DIR) --error --dir $(LIB_DIR)
 	$(PYTHON) ./deduce.py --lalr $(TEST_ERROR_DIR) --error --dir $(LIB_DIR)
 
-tests-lib: 
+tests-lib:
 	$(PYTHON) ./deduce.py ./lib --recursive-descent --dir $(LIB_DIR)
 	$(PYTHON) ./deduce.py ./lib --lalr --dir $(LIB_DIR)
-
-tests: tests-should-validate tests-should-error
 
 tests-examples:
 	$(PYTHON) ./deduce.py --recursive-descent $(EXAMPLES_DIR)

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -138,6 +138,7 @@ def check_file(
     content: Optional[str] = None,
     collect_errors: bool = False,
     debugger=None,
+    prewarm_modules: Sequence[str] = (),
 ) -> CheckResult:
     """Run the Deduce pipeline on ``filename`` and return a CheckResult.
 
@@ -171,6 +172,17 @@ def check_file(
                             ``lsp.query.check`` opts in to this so
                             every error in the buffer becomes its own
                             editor diagnostic.
+        prewarm_modules:    Module names to pre-load into the
+                            ``uniquified_modules`` cache during prelude
+                            bootstrap, but **not** prepended as imports
+                            to ``filename``. Useful for batch test
+                            runners where many files independently
+                            ``import`` a fixed set of library modules:
+                            paying the parse+uniquify once amortises
+                            across the whole batch, while keeping the
+                            user-visible import surface identical to
+                            ``--no-stdlib`` semantics. Becomes part of
+                            the prelude cache key alongside ``prelude``.
         debugger:           When given, attached to the active session
                             via ``flags.set_debugger`` for the user
                             file's check_proofs / reduce hooks (Phase
@@ -193,6 +205,7 @@ def check_file(
         return _check_file_locked(
             filename, tracing_functions, prelude, content,
             collect_errors=collect_errors, debugger=debugger,
+            prewarm_modules=prewarm_modules,
         )
 
 
@@ -203,13 +216,14 @@ def _check_file_locked(
     content: Optional[str],
     collect_errors: bool,
     debugger,
+    prewarm_modules: Sequence[str] = (),
 ) -> CheckResult:
     """Body of ``check_file``, run under the global pipeline lock."""
     # Prelude bootstrap runs without a debugger attached -- the user
     # asked to step through their own file, not lib/.  Phase 5 plan
     # rationale: this is the only sensible default and avoids PR #269's
     # "first prelude statement traps" bug in long-lived daemons.
-    _prepare_state(tuple(prelude))
+    _prepare_state(tuple(prelude), tuple(prewarm_modules))
     # Each user-file check forks a fresh ctx from the post-prelude
     # baseline so successive checks produce reproducible names.  See
     # ``UniquifyContext`` and the ``_post_prelude_ctx`` machinery
@@ -411,9 +425,13 @@ _TRACKED_SCALARS: tuple[tuple[Any, str], ...] = (
     (_proof_checker, "name_id"),
 )
 
-# The prelude key (tuple of module names) that the snapshot below was
-# captured for. ``None`` until the first ``check_file`` call.
-_prelude_key: Optional[tuple[str, ...]] = None
+# The cache key (prelude tuple, prewarm tuple) the snapshot below was
+# captured for. ``None`` until the first ``check_file`` call. The
+# prewarm half is the set of modules pre-loaded into
+# ``uniquified_modules`` without being injected as imports -- batch
+# test runners use this to amortise lib parsing across a sweep while
+# keeping per-file import semantics intact.
+_prelude_key: Optional[tuple[tuple[str, ...], tuple[str, ...]]] = None
 
 # Snapshot of ``_TRACKED_CONTAINERS`` taken right after the prelude
 # load. Each entry is a fresh shallow copy of the live container.
@@ -433,21 +451,28 @@ _prelude_scalars: Optional[dict[tuple[str, str], Any]] = None
 _post_prelude_ctx: Optional[UniquifyContext] = None
 
 
-def _prepare_state(prelude_key: tuple[str, ...]) -> None:
+def _prepare_state(
+    prelude_key: tuple[str, ...],
+    prewarm_key: tuple[str, ...] = (),
+) -> None:
     """Make the global pipeline state ready for a fresh check.
 
-    First time we see ``prelude_key`` (or any time it changes): clear
-    every tracked container, run the prelude through the pipeline so
-    the lib modules end up cached in ``uniquified_modules`` /
-    ``checked_modules``, then take a snapshot.
+    First time we see ``(prelude_key, prewarm_key)`` (or any time
+    either changes): clear every tracked container, run the prelude
+    through the pipeline so the lib modules end up cached in
+    ``uniquified_modules`` / ``checked_modules``, optionally pre-load
+    any ``prewarm_key`` modules into the same cache (without
+    injecting them as imports into the user buffer), then take a
+    snapshot.
 
-    On subsequent calls with the same prelude key: just restore the
+    On subsequent calls with the same key: just restore the
     snapshot. The prelude reload is the expensive part (~3s for the
     full stdlib); restore is a handful of dict/set copies.
     """
     global _prelude_key, _prelude_snapshot, _prelude_scalars, _post_prelude_ctx
 
-    if _prelude_snapshot is not None and _prelude_key == prelude_key:
+    cache_key = (prelude_key, prewarm_key)
+    if _prelude_snapshot is not None and _prelude_key == cache_key:
         _restore_containers(_prelude_snapshot)
         _restore_scalars(_prelude_scalars)
         return
@@ -467,7 +492,23 @@ def _prepare_state(prelude_key: tuple[str, ...]) -> None:
             content="",
             ctx=bootstrap_ctx,
         )
-    _prelude_key = prelude_key
+    # Pre-warm phase: load each prewarm module into ``uniquified_modules``
+    # by uniquifying a buffer that imports it.  We feed them one at a
+    # time so dependency order doesn't matter -- each ``import`` chases
+    # its own dependencies via the cache mechanism.  The bootstrap env
+    # is discarded, so the prewarm imports don't show up at the
+    # user-file check site.
+    for name in prewarm_key:
+        if name in _abstract_syntax.uniquified_modules:
+            continue
+        _check_file_impl(
+            filename="__prewarm__.pf",
+            tracing_functions=(),
+            prelude=(name,),
+            content="",
+            ctx=bootstrap_ctx,
+        )
+    _prelude_key = cache_key
     _prelude_snapshot = _capture_containers()
     _prelude_scalars = _capture_scalars()
     _post_prelude_ctx = bootstrap_ctx.snapshot()

--- a/tools/test_runner_inproc.py
+++ b/tools/test_runner_inproc.py
@@ -1,0 +1,454 @@
+"""In-process test runner with multiprocessing.
+
+Mirrors ``test-deduce.py``'s should-validate / should-error sweeps,
+but runs every test in a worker pool forked from a parent process
+that has already paid the ~2.3s prelude bootstrap. Each worker
+inherits the populated ``uniquified_modules`` cache via copy-on-write
+fork(), so per-file checks pay only the per-file work.
+
+Cached lib ASTs are parser-agnostic (the cache key is the module
+name, and both parsers produce the same AST), so a single bootstrap
+serves both ``--recursive-descent`` and ``--lalr`` tasks. The worker
+flips the per-process parser flag before each ``check_file`` call.
+
+Usage:
+    python tools/test_runner_inproc.py                    # everything
+    python tools/test_runner_inproc.py --lib
+    python tools/test_runner_inproc.py --passable
+    python tools/test_runner_inproc.py --errors
+    python tools/test_runner_inproc.py --workers 4        # explicit pool size
+    python tools/test_runner_inproc.py --serial           # workers=1
+
+Coverage matches ``test-deduce.py`` default mode (lib + should-validate
++ test/prelude + should-error with .err diff).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import multiprocessing as mp
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+# Work around macOS sandbox profiles (notably Claude Code's seatbelt
+# sandbox) that deny ``sysconf(_SC_SEM_NSEMS_MAX)``. Python's
+# ``concurrent.futures.process._check_system_limits`` calls that
+# sysconf to verify enough POSIX semaphores are available; it catches
+# ``AttributeError``/``ValueError`` but lets ``PermissionError``
+# propagate, which would crash the pool before any worker spawns.
+# The check is purely advisory -- if the sysconf is denied we wrap it
+# and treat the limit as undetermined (matching the existing -1 path).
+import concurrent.futures.process as _ppmod
+
+_orig_check_system_limits = _ppmod._check_system_limits
+
+
+def _patched_check_system_limits() -> None:
+    try:
+        _orig_check_system_limits()
+    except PermissionError:
+        # sandbox-denied sysconf. multiprocessing.Pool still works on
+        # macOS in this regime; the check is the only blocker.
+        pass
+
+
+_ppmod._check_system_limits = _patched_check_system_limits
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+sys.argv = [str(REPO_ROOT / "deduce.py")] + sys.argv[1:]
+sys.setrecursionlimit(10000)
+
+from abstract_syntax import add_import_directory, init_import_directories
+from flags import set_quiet_mode, set_recursive_descent
+from lsp.library import check_file, reset_prelude_cache
+
+
+# Keep these as relative paths -- ``deduce.py``'s error messages
+# encode the filename as given to the checker, and the ``.err``
+# fixtures were captured against relative-path invocations.
+LIB_DIR = Path("lib")
+PASS_DIR = Path("test/should-validate")
+ERROR_DIR = Path("test/should-error")
+PRELUDE_DIR = Path("test/prelude")
+IMPORTS_DIR = Path("test/test-imports")
+EXAMPLE_FILE = Path("example.pf")
+
+
+# Module-level globals consumed by worker functions. The parent
+# populates these before forking the pool; workers inherit them via
+# copy-on-write. Avoids pickling a 32-entry tuple per task.
+_WORKER_PREWARM: tuple[str, ...] = ()
+# Same idea for the prelude-tests pool, which uses ``prelude=`` rather
+# than ``prewarm=``. The two cache configurations can't share a
+# bootstrap (different cache keys in ``_prepare_state``), so they get
+# separate pools.
+_WORKER_PRELUDE: tuple[str, ...] = ()
+
+
+def discover_lib_modules() -> tuple[str, ...]:
+    return tuple(sorted(p.stem for p in LIB_DIR.glob("*.pf")))
+
+
+def setup_paths() -> None:
+    # Run from the repo root so the relative paths above resolve and so
+    # error messages match the existing ``.err`` fixtures. The import
+    # directories must be ``./``-prefixed because ``test-deduce.py``
+    # was invoking ``deduce.py --dir ./lib --dir ./test/test-imports``
+    # and that prefix ends up in some error messages (the "declared as
+    # `lemma` in module X (<file>:<line>)" hint, in particular).
+    os.chdir(REPO_ROOT)
+    init_import_directories()
+    add_import_directory("./" + LIB_DIR.as_posix())
+    add_import_directory("./" + IMPORTS_DIR.as_posix())
+
+
+def list_pf(d: Path) -> list[str]:
+    # Return ``./test/<...>/foo.pf``-style paths to match how the
+    # ``.err`` fixtures were captured.
+    return sorted(f"./{d.as_posix()}/{p.name}" for p in d.iterdir() if p.suffix == ".pf")
+
+
+# ---------------------------------------------------------------------------
+# Worker functions (must be picklable for multiprocessing).
+# ---------------------------------------------------------------------------
+
+
+def _worker_validate(task: tuple[str, bool]) -> tuple[str, bool, str, str]:
+    """should-validate worker. ``task`` is (filename, recursive_descent).
+
+    Returns ``(file, ok, parser_label, error_message)``. State
+    (``_WORKER_PREWARM``, import dirs, cwd) is inherited from the
+    forking parent.
+    """
+    f, recursive_descent = task
+    set_recursive_descent(recursive_descent)
+    label = "recursive-descent" if recursive_descent else "lalr"
+    result = check_file(f, prewarm_modules=_WORKER_PREWARM)
+    return (f, result.ok, label, result.error_message or "")
+
+
+def _worker_lib(task: tuple[str, bool]) -> tuple[str, bool, str, str]:
+    """lib worker. Each lib file is checked with no prewarm so the
+    file (and its transitive imports of other lib modules) is freshly
+    parsed -- otherwise we'd just typecheck a cached AST that was
+    parsed once by the parent and never exercise the LALR parser on
+    lib code.
+    """
+    f, recursive_descent = task
+    set_recursive_descent(recursive_descent)
+    label = "recursive-descent" if recursive_descent else "lalr"
+    result = check_file(f)
+    return (f, result.ok, label, result.error_message or "")
+
+
+def _worker_prelude(task: tuple[str, bool]) -> tuple[str, bool, str, str]:
+    """test/prelude worker. Uses ``prelude=`` (injected imports), not
+    ``prewarm=``.  ``task`` is (filename, recursive_descent).
+    """
+    f, recursive_descent = task
+    set_recursive_descent(recursive_descent)
+    label = "recursive-descent" if recursive_descent else "lalr"
+    result = check_file(f, prelude=_WORKER_PRELUDE)
+    return (f, result.ok, label, result.error_message or "")
+
+
+def _worker_error(f: str) -> tuple[str, bool, str]:
+    """should-error worker. Returns ``(file, passed, message)``.
+
+    Reproduces the CLI's full stdout (warnings + error_message) and
+    diffs against the sibling ``.pf.err`` fixture using ``diff
+    --ignore-space-change`` so the matching semantics are identical
+    to the existing harness.
+    """
+    err_file = f + ".err"
+    if not os.path.isfile(err_file):
+        return (f, False, "missing .pf.err fixture")
+    set_recursive_descent(True)
+    set_quiet_mode(True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        result = check_file(f, prewarm_modules=_WORKER_PREWARM)
+        if not result.ok:
+            print(result.error_message)
+    if result.ok:
+        return (f, False, "expected error but file was valid")
+    actual = buf.getvalue()
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".tmp", delete=False, encoding="utf-8"
+    ) as tf:
+        tf.write(actual)
+        tmp_path = tf.name
+    try:
+        cp = subprocess.run(
+            ["diff", "--ignore-space-change", err_file, tmp_path],
+            capture_output=True, text=True,
+        )
+        if cp.returncode != 0:
+            return (f, False, f"error message diverged:\n{cp.stdout[:500]}")
+        return (f, True, "")
+    finally:
+        os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration.
+# ---------------------------------------------------------------------------
+
+
+def _make_fork_pool(workers: int):
+    """Create a fork-based ProcessPoolExecutor.
+
+    fork() snapshots the parent's address space, so workers inherit
+    the post-bootstrap ``uniquified_modules`` cache for free. On
+    macOS Python 3.8+, ``spawn`` is the default; we override.
+    """
+    fork_ctx = mp.get_context("fork")
+    return ProcessPoolExecutor(max_workers=workers, mp_context=fork_ctx)
+
+
+def bootstrap_prewarm(lib_modules: tuple[str, ...]) -> None:
+    """Pay the prelude bootstrap once in the parent (prewarm flavour).
+
+    Subsequent ``check_file`` calls (here in the parent, or in any
+    child forked off after this returns) hit the cache and skip the
+    expensive ``uniquify_deduce`` of every lib module.
+    """
+    global _WORKER_PREWARM
+    _WORKER_PREWARM = lib_modules
+    # ``content=""`` runs the pipeline on an empty buffer, which is
+    # enough to trip ``_prepare_state`` into building the prewarm
+    # snapshot. Cheapest valid trigger.
+    set_recursive_descent(True)
+    check_file("__warmup__.pf", content="", prewarm_modules=lib_modules)
+
+
+def bootstrap_prelude(lib_modules: tuple[str, ...]) -> None:
+    """Bootstrap with ``prelude=`` (implicit imports) instead of prewarm.
+
+    Workers forked after this will check files with the stdlib
+    injected -- this is what ``test/prelude/`` needs to exercise the
+    auto-prelude path.
+    """
+    global _WORKER_PRELUDE
+    _WORKER_PRELUDE = lib_modules
+    set_recursive_descent(True)
+    check_file("__warmup__.pf", content="", prelude=lib_modules)
+
+
+def run_lib_parallel(workers: int) -> list[tuple[str, str, str]]:
+    """Run ``lib/*.pf`` × both parsers with no shared cache.
+
+    Each task starts from a clean post-empty-bootstrap state, so lib
+    parsing is exercised per task and per parser -- matching what
+    ``python deduce.py --recursive-descent ./lib`` /
+    ``python deduce.py --lalr ./lib`` cover.
+    """
+    files = list_pf(LIB_DIR)
+    # Strip the ``./lib/`` prefix and re-add ``./`` so the path matches
+    # how ``test_deduce.py`` invokes it (``./lib/Nat.pf``).
+    tasks: list[tuple[str, bool]] = []
+    for f in files:
+        tasks.append((f, True))
+        tasks.append((f, False))
+
+    failures: list[tuple[str, str, str]] = []
+    if workers <= 1:
+        for t in tasks:
+            f, ok, label, msg = _worker_lib(t)
+            if not ok:
+                failures.append((f, label, msg))
+        return failures
+
+    with _make_fork_pool(workers) as ex:
+        for f, ok, label, msg in ex.map(_worker_lib, tasks, chunksize=2):
+            if not ok:
+                failures.append((f, label, msg))
+    return failures
+
+
+def run_validate_parallel(workers: int) -> list[tuple[str, str, str]]:
+    """Run should-validate × both parsers in parallel.
+
+    Returns a list of ``(file, parser_label, error_message)`` for
+    every failure.
+    """
+    files = list_pf(PASS_DIR) + [f"./{EXAMPLE_FILE.as_posix()}"]
+    tasks: list[tuple[str, bool]] = []
+    for f in files:
+        tasks.append((f, True))   # recursive-descent
+        tasks.append((f, False))  # lalr
+
+    failures: list[tuple[str, str, str]] = []
+    if workers <= 1:
+        for t in tasks:
+            f, ok, label, msg = _worker_validate(t)
+            if not ok:
+                failures.append((f, label, msg))
+        return failures
+
+    with _make_fork_pool(workers) as ex:
+        for f, ok, label, msg in ex.map(_worker_validate, tasks, chunksize=4):
+            if not ok:
+                failures.append((f, label, msg))
+    return failures
+
+
+def run_prelude_parallel(workers: int) -> list[tuple[str, str, str]]:
+    """Run ``test/prelude/`` × both parsers in a prelude-bootstrapped pool.
+
+    Only 14 files, but each runs against the stdlib-injected
+    pipeline, which is ~1.3s/file. With 2 parsers and 12 workers
+    that's a 7s phase reduced to ~3s.
+    """
+    files = list_pf(PRELUDE_DIR)
+    tasks: list[tuple[str, bool]] = []
+    for f in files:
+        tasks.append((f, True))
+        tasks.append((f, False))
+
+    failures: list[tuple[str, str, str]] = []
+    if workers <= 1:
+        for t in tasks:
+            f, ok, label, msg = _worker_prelude(t)
+            if not ok:
+                failures.append((f, label, msg))
+        return failures
+
+    with _make_fork_pool(workers) as ex:
+        for f, ok, label, msg in ex.map(_worker_prelude, tasks, chunksize=2):
+            if not ok:
+                failures.append((f, label, msg))
+    return failures
+
+
+def run_errors_parallel(workers: int) -> list[tuple[str, str, str]]:
+    """Run should-error in parallel. Recursive-descent parser only."""
+    files = list_pf(ERROR_DIR)
+    failures: list[tuple[str, str, str]] = []
+    if workers <= 1:
+        for f in files:
+            f, ok, msg = _worker_error(f)
+            if not ok:
+                failures.append((f, "recursive-descent", msg))
+        return failures
+
+    with _make_fork_pool(workers) as ex:
+        for f, ok, msg in ex.map(_worker_error, files, chunksize=4):
+            if not ok:
+                failures.append((f, "recursive-descent", msg))
+    return failures
+
+
+def time_section(label: str, fn) -> tuple[float, list]:
+    t0 = time.perf_counter()
+    result = fn()
+    dt = time.perf_counter() - t0
+    print(f"  {label:32s}  {dt:6.2f}s")
+    return dt, result
+
+
+def parse_args(argv: list[str]) -> tuple[bool, bool, bool, int]:
+    run_lib = "--lib" in argv
+    run_passable = "--passable" in argv
+    run_errors = "--errors" in argv
+    if not (run_lib or run_passable or run_errors):
+        run_lib = run_passable = run_errors = True
+
+    workers = max(1, (os.cpu_count() or 4))
+    if "--serial" in argv:
+        workers = 1
+    for i, a in enumerate(argv):
+        if a == "--workers" and i + 1 < len(argv):
+            workers = max(1, int(argv[i + 1]))
+    return run_lib, run_passable, run_errors, workers
+
+
+def main(argv: list[str]) -> int:
+    run_lib, run_passable, run_errors, workers = parse_args(argv)
+
+    setup_paths()
+    lib_modules = discover_lib_modules()
+    print(f"Discovered {len(lib_modules)} lib modules; workers={workers}")
+
+    total_failures: list[tuple[str, str, str]] = []
+    total_t0 = time.perf_counter()
+
+    # Phase 0: lib tests (clean state, no shared cache -- workers
+    # freshly parse each lib file with the requested parser). Run
+    # first so the empty-bootstrap state is what workers inherit.
+    if run_lib:
+        reset_prelude_cache()
+        print(f"\n=== lib (both parsers, parallel) ===")
+        _, fails = time_section(
+            "lib × 2 parsers",
+            lambda: run_lib_parallel(workers),
+        )
+        total_failures.extend(fails)
+
+    # Phase 1: prelude tests (only 14 × 2 parsers, but each needs the
+    # stdlib *injected* as imports, which is a different bootstrap from
+    # everything else). Get them out of the way before the larger
+    # prewarm-bootstrapped pool starts.
+    if run_passable:
+        reset_prelude_cache()
+        t0 = time.perf_counter()
+        bootstrap_prelude(lib_modules)
+        print(f"\n  {'bootstrap prelude (parent)':32s}  {time.perf_counter() - t0:6.2f}s")
+        print(f"=== test/prelude (both parsers, parallel) ===")
+        _, fails = time_section(
+            "test/prelude × 2 parsers",
+            lambda: run_prelude_parallel(workers),
+        )
+        total_failures.extend(fails)
+
+    # Phase 2: should-validate (both parsers) + should-error (RD only).
+    # Both use ``prewarm_modules=lib_modules``, so one bootstrap and
+    # one pool serves both. Reset the prelude-mode cache first.
+    if run_passable or run_errors:
+        reset_prelude_cache()
+        t0 = time.perf_counter()
+        bootstrap_prewarm(lib_modules)
+        print(f"\n  {'bootstrap prewarm (parent)':32s}  {time.perf_counter() - t0:6.2f}s")
+
+    if run_passable:
+        print(f"=== should-validate (both parsers, parallel) ===")
+        _, fails = time_section(
+            "should-validate × 2 parsers",
+            lambda: run_validate_parallel(workers),
+        )
+        total_failures.extend(fails)
+
+    if run_errors:
+        print(f"\n=== should-error (recursive-descent, parallel) ===")
+        _, fails = time_section(
+            "should-error",
+            lambda: run_errors_parallel(workers),
+        )
+        total_failures.extend(fails)
+
+    total_dt = time.perf_counter() - total_t0
+    print(f"\nTotal wall time: {total_dt:.2f}s")
+
+    if total_failures:
+        print(f"\n{len(total_failures)} FAILURE(s):")
+        for fpath, label, msg in total_failures[:20]:
+            print(f"  [{label}] {fpath}")
+            for line in str(msg).splitlines()[:3]:
+                print(f"      {line}")
+        if len(total_failures) > 20:
+            print(f"  ... and {len(total_failures) - 20} more")
+        return 1
+    print("\nAll tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Adds a `prewarm_modules` parameter to `lsp.library.check_file` so the lib AST cache can be populated once in a parent process and shared across many checks.
- Adds `tools/test_runner_inproc.py`: a multiprocessing test runner that bootstraps the prelude in the parent, then forks workers that inherit the populated `uniquified_modules` cache via copy-on-write.
- Repoints `make tests` (and `make default`) at the new runner. Per-category targets (`tests-should-validate`, `tests-should-error`, `tests-lib`) are kept around for granular debugging.

## Why

`test-deduce.py` was paying the ~2.3s prelude bootstrap per subprocess on every file (in `--errors`), and re-parsing every lib module per file in `--passable` because `--no-stdlib` defeated the existing in-process prelude cache. Both bottlenecks are addressed: the parent bootstraps once, workers inherit the cache, and a fork-based `ProcessPoolExecutor` provides parallelism across files and parsers.

## Numbers (same machine, back-to-back)

| | wall | user CPU |
|---|---:|---:|
| `test-deduce.py` (old default) | **316.8s** | 379.0s |
| `make` (new default) | **32.2s** | 216.1s |

~10x faster wall, ~1.8x less total CPU. All 391 test files pass (32 lib × 2 parsers + 14 prelude × 2 + 153 should-validate × 2 + 192 should-error × RD with `.err` diff). Existing LSP test suite still green (`pytest test/lsp/`).

## Coverage parity

The new runner matches `test-deduce.py` default mode phase for phase:

| phase | tasks | parser(s) | cache config |
|---|---:|---|---|
| lib | 32 × 2 | RD + LALR | none — workers freshly parse each lib file |
| test/prelude | 14 × 2 | RD + LALR | `prelude=lib_modules` (auto-prelude path) |
| should-validate | 153 × 2 | RD + LALR | `prewarm_modules=lib_modules` |
| should-error | 192 × 1 | RD only | `prewarm_modules=lib_modules`, `.err` diff |

The lib pool deliberately runs **without** a shared cache so LALR actually parses lib files instead of reading the RD-parsed AST out of the parent's bootstrap.

## CI change is NOT in this PR

`.github/workflows/test_deduce.yml` couldn't be committed because the OAuth scope this branch was pushed with doesn't allow workflow updates. To wire CI to the new runner, change one line in the "execute py script" step:

```diff
 - name: execute py script
   run: |
     python test-deduce.py --site
-    python test-deduce.py
+    python tools/test_runner_inproc.py
     python test-deduce.py --parser
```

That's the only manual step. `--site` and `--parser` stay on `test-deduce.py` because they exercise distinct code paths (doc generation + parser-error fixtures) and aren't the bottleneck.

## Reviewer notes

- Multiprocessing uses the `fork` start method explicitly (default on Linux; macOS now defaults to `spawn` and would lose the COW cache-sharing benefit, so we override).
- `tools/test_runner_inproc.py` contains a small monkey-patch of `concurrent.futures.process._check_system_limits` that catches `PermissionError` from `sysconf(SC_SEM_NSEMS_MAX)`. This is for sandboxed dev environments (Claude Code's seatbelt sandbox denies that sysconf); it's a no-op on Linux/CI where the sysconf succeeds.
- `_prepare_state`'s cache key in `lsp/library.py` changes from `tuple[str, ...]` to `(prelude_key, prewarm_key)`. All existing callers default `prewarm_modules=()`, so the prior cache-key shape is preserved.

## Test plan

- [ ] `make tests` passes locally
- [ ] `python tools/test_runner_inproc.py` passes
- [ ] `pytest test/lsp/` passes (LSP suite uses the same `check_file` entry point)
- [ ] CI green after applying the `test_deduce.yml` one-liner above

🤖 Generated with [Claude Code](https://claude.com/claude-code)