### PR TITLE
Fix #452: friendlier error for goal-directed tactic in fact position

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -822,10 +822,47 @@ def check_proof(proof, env):
       else:
         return mkEqual(loc, a, c)
     case _:
-      user_error(proof.location, 'need to be in goal-directed mode for\n\t' + str(proof))
+      user_error(proof.location, goal_only_proof_error(proof))
   if get_verbose():
     print('\t=> ' + str(ret))
   return ret
+
+# Tactic-keyword name used for each "goal-only" Proof class. These tactics
+# transform the current goal rather than producing a proof of a formula, so
+# they can only be checked by `check_proof_of`, not `check_proof`.
+GOAL_ONLY_TACTIC_NAME = {
+  ApplyDefsGoal: 'expand',
+  RewriteGoal: 'replace',
+  SimplifyGoal: 'simplify',
+  EvaluateGoal: 'evaluate',
+  Suffices: 'suffices',
+  Induction: 'induction',
+  RuleInduction: 'induction',
+  RuleInversion: 'cases',
+  Cases: 'cases',
+  SwitchProof: 'switch',
+}
+
+def goal_only_proof_error(proof):
+  """Error message for a proof that can only be used in goal-directed mode.
+
+  Detects common user mistakes (e.g. chaining tactics with `|` as in
+  ``replace eq | expand X``) and offers actionable advice instead of the
+  internal phrase "need to be in goal-directed mode".
+  """
+  tactic = GOAL_ONLY_TACTIC_NAME.get(type(proof))
+  if tactic is None:
+    return 'a proof of a formula is expected here, not the tactic\n\t' \
+        + str(proof)
+  return '`' + tactic + '` is a goal-directed tactic — it transforms ' \
+      + 'the current goal, but it does not by itself produce a proof of a ' \
+      + 'formula. It cannot be used here.\n\n' \
+      + 'If you wrote something like `replace eq | ' + tactic + ' ...` or ' \
+      + '`expand f | ' + tactic + ' ...`, note that `|` separates ' \
+      + 'arguments to the leading tactic, not a sequence of tactics. ' \
+      + 'To run tactics in sequence, write them as separate proof steps:\n' \
+      + '\treplace eq\n' \
+      + '\t' + tactic + ' ...'
 
 def get_type_args(ty):
   if isinstance(ty, VarRef):

--- a/test/should-error/chain_replace_expand.pf
+++ b/test/should-error/chain_replace_expand.pf
@@ -1,0 +1,8 @@
+import Nat
+
+theorem chain_replace_expand: all n:Nat. ℕ1 + n = ℕ1 + n
+proof
+  arbitrary n:Nat
+  have h: suc(n) = ℕ1 + n by nat_suc_one_add[n]
+  conclude ℕ1 + n = ℕ1 + n by replace h | expand lit.
+end

--- a/test/should-error/chain_replace_expand.pf.err
+++ b/test/should-error/chain_replace_expand.pf.err
@@ -1,0 +1,5 @@
+./test/should-error/chain_replace_expand.pf:7.43-7.53: `expand` is a goal-directed tactic — it transforms the current goal, but it does not by itself produce a proof of a formula. It cannot be used here.
+
+If you wrote something like `replace eq | expand ...` or `expand f | expand ...`, note that `|` separates arguments to the leading tactic, not a sequence of tactics. To run tactics in sequence, write them as separate proof steps:
+	replace eq
+	expand ...


### PR DESCRIPTION
## Summary

Closes #452.

When a user wrote `replace eq | expand X`, the parser put the `expand X` into the equation list of the `replace`, and checking that fact-position proof fell through to the default `_` case in `check_proof` with the cryptic message:

```
need to be in goal-directed mode for
    expand lit .
```

"Goal-directed mode" is internal jargon — it doesn't tell the user what to do.

The fallthrough now produces a message that:
- names the tactic (`expand`, `replace`, `simplify`, `evaluate`, `suffices`, `induction`, `cases`, `switch`),
- explains that the tactic transforms the current goal rather than producing a proof of a formula,
- calls out the most likely cause (chaining tactics with `|`, which actually separates *arguments* to the leading tactic), and
- suggests a concrete rewrite.

Example new output for the reproduction in the issue:

```
repro.pf:7.43-7.53: `expand` is a goal-directed tactic — it transforms the current goal, but it does not by itself produce a proof of a formula. It cannot be used here.

If you wrote something like `replace eq | expand ...` or `expand f | expand ...`, note that `|` separates arguments to the leading tactic, not a sequence of tactics. To run tactics in sequence, write them as separate proof steps:
    replace eq
    expand ...
```

## Test plan

- [x] `python test-deduce.py` passes (both parsers, lib + should-validate + should-error + prelude)
- [x] New fixture `test/should-error/chain_replace_expand.pf` exercises the new message
- [x] Verified the rewritten suggestion (two separate proof steps) makes the original `repro` proof check
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)