### PR TITLE
Fix #450: hint at `#...#` mark when expand fails on unmarked side

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2048,6 +2048,43 @@ def expand_residual_hint(residual, defs, env):
           'Chain another expand with `|` (e.g. `expand f | f.`) or use `N*f` to unfold further.')
 
 
+def expand_backward_mark_hint(formula, var, env):
+  # When `expand X` fails inside a marked equation `# L # = R` (or the
+  # mirrored form), expand only saw the marked side. If unfolding X on
+  # the *other* side would succeed, suggest wrapping that side in
+  # `#...#`. This is the common newcomer trip-up in `equations` blocks,
+  # where the LHS of each step is implicitly marked: an `expand` whose
+  # unfolding belongs on the RHS fails with a confusing "could not find
+  # a place to expand" error and no pointer at the mark form.
+  if count_marks(formula) != 1:
+    return ''
+  match formula:
+    case Call(_, _, rator, [side0, side1]) \
+         if isinstance(rator, VarRef) and rator.get_name() == '=':
+      marks0 = count_marks(side0)
+      marks1 = count_marks(side1)
+      if marks0 == 1 and marks1 == 0:
+        other = side1
+        other_label = 'right-hand side'
+      elif marks0 == 0 and marks1 == 1:
+        other = side0
+        other_label = 'left-hand side'
+      else:
+        return ''
+      if not _expand_would_progress(other, [var], env):
+        return ''
+      display_name = name2str(var.get_name()) if isinstance(var, VarRef) \
+                     else str(var)
+      return ('\nThe ' + other_label + ' contains `' + display_name \
+              + '`, but `expand` only unfolds inside the marked subterm. ' \
+              'Inside an `equations` block, the left-hand side of each step is ' \
+              'implicitly marked. To unfold the ' + other_label \
+              + ' instead, wrap that side in `#...#`:\n' \
+              '\t# ' + str(other) + ' #')
+    case _:
+      return ''
+
+
 def expand_definitions(loc, formula, defs, env):
   num_marks = count_marks(formula)
   if num_marks == 0:
@@ -2116,7 +2153,8 @@ def expand_definitions(loc, formula, defs, env):
           user_error(loc, 'could not find a place to expand definition of ' \
                 + name2str(var.name) \
                 + ' in:\n' + '\t' + str(new_formula) \
-                + auto_simplified_hint(new_formula))
+                + auto_simplified_hint(new_formula) \
+                + expand_backward_mark_hint(formula, var, env))
 
   if num_marks == 0:          
       return check_formula(new_formula, env)

--- a/test/should-error/expand_backward_mark_hint.pf
+++ b/test/should-error/expand_backward_mark_hint.pf
@@ -1,0 +1,15 @@
+// Issue #450: when `expand X` fails inside an `equations` step but X
+// would unfold on the other side of the equation, the error message
+// should hint that the user can wrap the other side in `#...#`.
+import UInt
+import List
+
+theorem hint_test: all x:UInt. all xs:List<UInt>.
+  node(x, xs ++ @empty<UInt>) = node(x, xs) ++ @empty<UInt>
+proof
+  arbitrary x:UInt
+  arbitrary xs:List<UInt>
+  equations
+    node(x, xs ++ @empty<UInt>)
+        = node(x, xs) ++ @empty<UInt>   by expand operator++.
+end

--- a/test/should-error/expand_backward_mark_hint.pf.err
+++ b/test/should-error/expand_backward_mark_hint.pf.err
@@ -1,4 +1,4 @@
-test/should-error/expand_backward_mark_hint.pf:14.44-14.61: could not find a place to expand definition of ++ in:
+./test/should-error/expand_backward_mark_hint.pf:14.44-14.61: could not find a place to expand definition of ++ in:
 	node(x, xs ++ @[]<UInt>)
 The right-hand side contains `++`, but `expand` only unfolds inside the marked subterm. Inside an `equations` block, the left-hand side of each step is implicitly marked. To unfold the right-hand side instead, wrap that side in `#...#`:
 	# node(x, xs) ++ @[]<UInt> #

--- a/test/should-error/expand_backward_mark_hint.pf.err
+++ b/test/should-error/expand_backward_mark_hint.pf.err
@@ -1,0 +1,4 @@
+test/should-error/expand_backward_mark_hint.pf:14.44-14.61: could not find a place to expand definition of ++ in:
+	node(x, xs ++ @[]<UInt>)
+The right-hand side contains `++`, but `expand` only unfolds inside the marked subterm. Inside an `equations` block, the left-hand side of each step is implicitly marked. To unfold the right-hand side instead, wrap that side in `#...#`:
+	# node(x, xs) ++ @[]<UInt> #


### PR DESCRIPTION
Closes #450.

## Summary

- Inside an `equations` block the LHS of each step is implicitly marked, so `expand X` only unfolds on the LHS. When the user writes a step whose unfolding belongs on the RHS, expand fails with a confusing `could not find a place to expand definition of X` and no pointer to the fix (wrap the RHS in `#...#`).
- After expand fails, detect the marked-equation context (`# L # = R` or the mirror), check whether running expand on the *other* side would actually progress, and if so append a hint that names the side and shows the exact `# ... #` to write.
- The progress check reuses `_expand_would_progress`, so the hint is suppressed when the definition is genuinely stuck on a free variable (e.g. `ℕ1 + m` with `m` a variable).

## Example

Before:
```
could not find a place to expand definition of ++ in:
    node(x, replicate(m, x) ++ @[]<T>)
```

After:
```
could not find a place to expand definition of ++ in:
    node(x, replicate(m, x) ++ @[]<T>)
The right-hand side contains `++`, but `expand` only unfolds inside the marked subterm. Inside an `equations` block, the left-hand side of each step is implicitly marked. To unfold the right-hand side instead, wrap that side in `#...#`:
    # node(x, replicate(m, x)) ++ @[]<T> #
```

## Test plan
- [x] Added `test/should-error/expand_backward_mark_hint.pf` covering the new hint.
- [x] `python test-deduce.py --errors` passes (no existing fixtures changed).
- [x] `python test-deduce.py --passable` passes.
- [x] Reproduction from the issue (auto-marked LHS in `equations`) now suggests the right `#...#` form, and applying that suggestion makes the proof valid.
- [x] Negative case (def doesn't appear on either side, e.g. expand fully simplifies to `true`) does not fire the hint.
- [x] Negative case (def is "stuck" because the arg is a free variable) does not fire the hint.

## Follow-up (not in this PR)

`replace` (apply_rewrites) has the same backward-rewrite-in-equations gap and could grow an analogous hint. Left out here to keep this fix focused on the issue's title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)