### PR TITLE
Hint at `#...#` mark when replace fails on unmarked side

### DIFF
--- a/proof_checker.py
+++ b/proof_checker.py
@@ -2122,6 +2122,42 @@ def expand_backward_mark_hint(formula, var, env):
       return ''
 
 
+def replace_backward_mark_hint(formula, eq, env):
+  # Mirror of `expand_backward_mark_hint` for the `replace` tactic: when
+  # `replace eq` fails inside a marked equation `# L # = R` because the
+  # eq's LHS doesn't appear on the marked side, but it *would* match on
+  # the unmarked side, suggest wrapping that side in `#...#`.
+  if count_marks(formula) != 1:
+    return ''
+  match formula:
+    case Call(_, _, rator, [side0, side1]) \
+         if isinstance(rator, VarRef) and rator.get_name() == '=':
+      marks0 = count_marks(side0)
+      marks1 = count_marks(side1)
+      if marks0 == 1 and marks1 == 0:
+        other = side1
+        other_label = 'right-hand side'
+      elif marks0 == 0 and marks1 == 1:
+        other = side0
+        other_label = 'left-hand side'
+      else:
+        return ''
+      try:
+        reset_num_rewrites()
+        rewrite_aux(formula.location, other, eq, env)
+      except Exception:
+        return ''
+      if get_num_rewrites() == 0:
+        return ''
+      return ('\nThe ' + other_label + ' does contain a match, but `replace` ' \
+              'only rewrites inside the marked subterm. Inside an `equations` ' \
+              'block, the left-hand side of each step is implicitly marked. ' \
+              'To rewrite the ' + other_label + ' instead, wrap that side in `#...#`:\n' \
+              '\t# ' + str(other) + ' #')
+    case _:
+      return ''
+
+
 def expand_definitions(loc, formula, defs, env):
   num_marks = count_marks(formula)
   if num_marks == 0:
@@ -2232,7 +2268,8 @@ def apply_rewrites(loc, formula, eqns, env, *, display_formula=None):
             msg += '\n(which auto-rule normalization reduced to:\n\t' \
                    + str(new_formula) + ')'
         msg += '\nwhile trying to replace using the below equation, left to right\n\t' + str(eq) \
-               + auto_simplified_hint(new_formula)
+               + auto_simplified_hint(new_formula) \
+               + replace_backward_mark_hint(formula, eq, env)
         user_error(loc, msg)
     new_formula = new_formula.reduce(env)
       

--- a/test/should-error/replace_backward_mark_hint.pf
+++ b/test/should-error/replace_backward_mark_hint.pf
@@ -1,0 +1,18 @@
+// Follow-up to #450: when `replace eq` fails inside an `equations` step
+// because the eq's LHS doesn't appear on the marked side but would match
+// on the unmarked side, the error message should hint at the `#...#`
+// mark form to flip direction.
+import UInt
+import List
+
+theorem hint_test: all x:UInt. all xs:List<UInt>. all ys:List<UInt>.
+  if xs = ys
+  then node(x, ys) = node(x, xs)
+proof
+  arbitrary x:UInt
+  arbitrary xs:List<UInt>
+  arbitrary ys:List<UInt>
+  assume h: xs = ys
+  equations
+    node(x, ys) = node(x, xs)   by replace h.
+end

--- a/test/should-error/replace_backward_mark_hint.pf.err
+++ b/test/should-error/replace_backward_mark_hint.pf.err
@@ -1,0 +1,11 @@
+./test/should-error/replace_backward_mark_hint.pf:17.36-17.45:
+could not find any matches for
+	xs
+in
+	#node(x, ys)# = node(x, xs)
+(which auto-rule normalization reduced to:
+	node(x, ys))
+while trying to replace using the below equation, left to right
+	xs = ys
+The right-hand side does contain a match, but `replace` only rewrites inside the marked subterm. Inside an `equations` block, the left-hand side of each step is implicitly marked. To rewrite the right-hand side instead, wrap that side in `#...#`:
+	# node(x, xs) #


### PR DESCRIPTION
Follow-up to #450 / #464, which added this hint for `expand`. `replace` has the same backward-rewrite-in-equations gap.

## Summary

- Inside an `equations` block, the LHS of each step is implicitly wrapped in `#...#`, so `replace eq` only rewrites on the LHS. When the user's equation matches on the RHS instead, the bare `could not find any matches` error gives no pointer at the `#...#` mark form that flips the rewrite direction.
- Added `replace_backward_mark_hint(formula, eq, env)` mirroring `expand_backward_mark_hint`. Probes with `rewrite_aux` against the unmarked side; only fires when a match would actually be found there. Wired into the `apply_rewrites` user_error site.

## Example

Before:
```
could not find any matches for
    xs
in
    #node(x, ys)# = node(x, xs)
(which auto-rule normalization reduced to:
    node(x, ys))
while trying to replace using the below equation, left to right
    xs = ys
```

After (with the new tail line):
```
... (same as above) ...
The right-hand side does contain a match, but `replace` only rewrites inside the marked subterm. Inside an `equations` block, the left-hand side of each step is implicitly marked. To rewrite the right-hand side instead, wrap that side in `#...#`:
    # node(x, xs) #
```

## Test plan
- [x] Added `test/should-error/replace_backward_mark_hint.pf` covering the new hint.
- [x] `python test-deduce.py --errors` passes (no existing fixtures changed).
- [x] Manual repro: applying the suggested `#...#` form closes the proof.
- [x] Negative case (eq's LHS appears on neither side, e.g. goal already reduced to `true`): hint does not fire; existing `auto_simplified_hint` still appears.
- [x] Both parsers (recursive-descent + lalr) produce identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)