### PR TITLE
test: parser-error fixtures for #208 (obtain/apply/rule/assume)

### DIFF
--- a/test/parse/apply_no_to.pf
+++ b/test/parse/apply_no_to.pf
@@ -1,0 +1,4 @@
+theorem t : false
+proof
+  apply foo bar
+end

--- a/test/parse/apply_no_to.pf.err
+++ b/test/parse/apply_no_to.pf.err
@@ -1,0 +1,11 @@
+./test/parse/apply_no_to.pf:1.1-3.12: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+./test/parse/apply_no_to.pf:3.3-3.12: while parsing apply-to (use a logical implication)
+	conclusion ::= "apply" proof "to" proof
+
+
+  apply foo bar
+            ^^^
+
+./test/parse/apply_no_to.pf:3.13-3.16: expected "to" after implication part of "apply", not
+	bar

--- a/test/parse/assume_bad.pf
+++ b/test/parse/assume_bad.pf
@@ -1,0 +1,4 @@
+theorem t : if true then true
+proof
+  assume 42
+end

--- a/test/parse/assume_bad.pf.err
+++ b/test/parse/assume_bad.pf.err
@@ -1,0 +1,14 @@
+./test/parse/assume_bad.pf:1.1-3.9: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  assume 42
+  ^^^^^^^^^
+
+./test/parse/assume_bad.pf:3.3-3.12: expected an assumption:
+	"assume" label ":" formula
+
+
+  assume 42
+         ^^
+./test/parse/assume_bad.pf:3.10-3.12: expected an identifier, not
+	"42"

--- a/test/parse/obtain_no_from.pf
+++ b/test/parse/obtain_no_from.pf
@@ -1,0 +1,4 @@
+theorem t : false
+proof
+  obtain x where p : true bar
+end

--- a/test/parse/obtain_no_from.pf.err
+++ b/test/parse/obtain_no_from.pf.err
@@ -1,0 +1,8 @@
+./test/parse/obtain_no_from.pf:1.1-3.26: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  obtain x where p : true bar
+                          ^^^
+
+./test/parse/obtain_no_from.pf:3.27-3.30: expected "from" after "where" part of "obtain", not
+	bar

--- a/test/parse/obtain_no_where.pf
+++ b/test/parse/obtain_no_where.pf
@@ -1,0 +1,4 @@
+theorem t : false
+proof
+  obtain x bar
+end

--- a/test/parse/obtain_no_where.pf.err
+++ b/test/parse/obtain_no_where.pf.err
@@ -1,0 +1,8 @@
+./test/parse/obtain_no_where.pf:1.1-3.11: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  obtain x bar
+           ^^^
+
+./test/parse/obtain_no_where.pf:3.12-3.15: expected "where" after variables of "obtain", not
+	bar

--- a/test/parse/rule_bad_keyword.pf
+++ b/test/parse/rule_bad_keyword.pf
@@ -1,0 +1,4 @@
+theorem t : false
+proof
+  rule foo
+end

--- a/test/parse/rule_bad_keyword.pf.err
+++ b/test/parse/rule_bad_keyword.pf.err
@@ -1,0 +1,7 @@
+./test/parse/rule_bad_keyword.pf:1.1-3.7: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+
+  rule foo
+  ^^^^^^^^
+
+./test/parse/rule_bad_keyword.pf:3.3-3.11: expected "induction" or "inversion" after "rule", not "foo"

--- a/test/parse/rule_no_case.pf
+++ b/test/parse/rule_no_case.pf
@@ -1,0 +1,4 @@
+theorem t : false
+proof
+  rule induction P
+end

--- a/test/parse/rule_no_case.pf.err
+++ b/test/parse/rule_no_case.pf.err
@@ -1,0 +1,10 @@
+./test/parse/rule_no_case.pf:1.1-3.19: while parsing
+	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
+./test/parse/rule_no_case.pf:3.3-3.19: while parsing
+	conclusion ::= "rule" "induction" identifier rule_ind_case*
+
+
+  rule induction P
+  ^^^^^^^^^^^^^^^^
+
+./test/parse/rule_no_case.pf:3.3-3.19: rule induction needs at least one "case" branch


### PR DESCRIPTION
## Summary

Addresses #208 by adding six parser-error fixtures that target previously-uncovered raise sites in `rec_desc_parser.py`:

| Fixture | Error message |
|---|---|
| `obtain_no_where.pf` | `expected "where" after variables of "obtain"` |
| `obtain_no_from.pf` | `expected "from" after "where" part of "obtain"` |
| `apply_no_to.pf` | `expected "to" after implication part of "apply"` |
| `rule_bad_keyword.pf` | `expected "induction" or "inversion" after "rule"` |
| `rule_no_case.pf` | `rule induction needs at least one "case" branch` |
| `assume_bad.pf` | `expected an assumption: "assume" label ":" formula` (wraps inner `parse_assumption` failure) |

Each is the smallest fragment that triggers the targeted error and uses no stdlib symbols. Each `.err` fixture was generated via `python test-deduce.py --generate-error <path>`.

## Test plan

- [x] `python test-deduce.py --parser` (all parse fixtures, RD only) — passes
- [ ] CI: full `make tests` matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)