### PR TITLE
Fix #204: handle Array/MakeArray in proof-side AST walkers

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1988,19 +1988,36 @@ class ArrayGet(Term):
   def reduce(self, env):
     subject_red = self.subject.reduce(env)
     position_red = self.position.reduce(env)
+    index = None
+    if isNat(position_red):
+      index = natToInt(position_red)
+    elif isUInt(position_red):
+      index = uintToInt(position_red)
     match subject_red:
       case Array(loc2, _, elements):
-        index = None
-        if isNat(position_red):
-          index = natToInt(position_red)
-        elif isUInt(position_red):
-          index = uintToInt(position_red)
-        else:
-            user_error(self.location, "array access expected number index, not " + str(position_red))
-        if not (index is None):
-          if 0 <= index and index < len(elements):
-            return elements[index].reduce(env)
-          # Don't signal an error for out-of-bounds! -Jeremy
+        if index is None:
+          user_error(self.location, "array access expected number index, not " + str(position_red))
+        if 0 <= index and index < len(elements):
+          return elements[index].reduce(env)
+        # Don't signal an error for out-of-bounds! -Jeremy
+      case MakeArray(loc2, _, list_term):
+        # Peel as many leading `node` constructors off the list as the
+        # index calls for. This lets `array(node(x, xs))[0]` reduce to
+        # `x` even when the tail `xs` is not concrete, which is what
+        # makes arrays useful inside proofs.
+        if index is not None and index >= 0:
+          cur = list_term
+          i = index
+          while True:
+            match cur:
+              case Call(_, _, TermInst(_, _, ctor, _, _), [hd, tl]) \
+                   if _is_named(ctor, 'node'):
+                if i == 0:
+                  return hd.reduce(env)
+                cur = tl
+                i -= 1
+              case _:
+                break
     return ArrayGet(self.location, self.typeof, subject_red, position_red)
     
   def substitute(self, sub):

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1995,9 +1995,9 @@ class ArrayGet(Term):
       index = uintToInt(position_red)
     match subject_red:
       case Array(loc2, _, elements):
-        if index is None:
-          user_error(self.location, "array access expected number index, not " + str(position_red))
-        if 0 <= index and index < len(elements):
+        # If the index is not a concrete number (e.g. a free variable in
+        # a proof), leave the access unreduced rather than erroring.
+        if index is not None and 0 <= index and index < len(elements):
           return elements[index].reduce(env)
         # Don't signal an error for out-of-bounds! -Jeremy
       case MakeArray(loc2, _, list_term):

--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -5189,6 +5189,10 @@ def count_marks(formula):
       return 0
     case ArrayGet(loc, tyof, arr, ind):
       return count_marks(arr) + count_marks(ind)
+    case Array(loc, tyof, elements):
+      return sum([count_marks(elt) for elt in elements])
+    case MakeArray(loc, tyof, subject):
+      return count_marks(subject)
     case _:
       internal_error(formula.location, 'in count_marks function, unhandled ' + str(formula))
 
@@ -5245,6 +5249,11 @@ def find_mark(formula):
     case ArrayGet(loc2, tyof, arr, ind):
       find_mark(arr)
       find_mark(ind)
+    case Array(loc2, tyof, elements):
+      for elt in elements:
+          find_mark(elt)
+    case MakeArray(loc2, tyof, subject):
+      find_mark(subject)
     case _:
       internal_error(formula.location, 'in find_mark function, unhandled ' + str(formula))
 
@@ -5296,6 +5305,11 @@ def replace_mark(formula, replacement):
       return formula
     case ArrayGet(loc2, tyof, arr, ind):
       return ArrayGet(loc2, tyof, replace_mark(arr, replacement), replace_mark(ind, replacement))
+    case Array(loc2, tyof, elements):
+      return Array(loc2, tyof,
+                   [replace_mark(elt, replacement) for elt in elements])
+    case MakeArray(loc2, tyof, subject):
+      return MakeArray(loc2, tyof, replace_mark(subject, replacement))
     case _:
       internal_error(formula.location, 'in replace_mark function, unhandled ' + str(formula))
 
@@ -5640,6 +5654,15 @@ def rewrite_aux(loc, formula, equation, env, depth = -1):
     case ArrayGet(loc2, tyof, arr, ind):
       return ArrayGet(loc, tyof, rewrite_aux(loc, arr, equation, env, depth - 1),
                       rewrite_aux(loc, ind, equation, env, depth - 1))
+
+    case Array(loc2, tyof, elements):
+      return Array(loc, tyof,
+                   [rewrite_aux(loc, elt, equation, env, depth - 1)
+                    for elt in elements])
+
+    case MakeArray(loc2, tyof, subject):
+      return MakeArray(loc, tyof,
+                       rewrite_aux(loc, subject, equation, env, depth - 1))
   
     case TLet(loc2, tyof, var, rhs, body):
       return TLet(loc2, tyof, var, rewrite_aux(loc, rhs, equation, env, depth - 1),

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -5055,6 +5055,10 @@ def find_rec_calls(name, term, env):
     case ArrayGet(loc2, tyof, arr, ind):
       return find_rec_calls(name, arr, env) \
           + find_rec_calls(name, ind, env)
+    case Array(loc2, tyof, elements):
+      return sum([find_rec_calls(name, elt, env) for elt in elements], [])
+    case MakeArray(loc2, tyof, subject):
+      return find_rec_calls(name, subject, env)
     case TLet(loc2, tyof, var, rhs, body):
       return find_rec_calls(name, rhs, env) \
           + find_rec_calls(name, body, env)

--- a/test/should-validate/array4.pf
+++ b/test/should-validate/array4.pf
@@ -1,0 +1,44 @@
+// Issue #204: arrays should be supported inside formulas.
+// Exercises Array / MakeArray cases in count_marks, find_mark,
+// replace_mark, rewrite_aux (abstract_syntax.py) and find_rec_calls
+// (proof_checker.py).
+import UInt
+import List
+import Option
+
+theorem array_replace_universal: all l:List<UInt>.
+  if l = [42]
+  then just((array(l))[0]) = head(l)
+proof
+  arbitrary l:List<UInt>
+  assume hl: l = [42]
+  replace hl
+  expand head.
+end
+
+theorem array_with_mark: all l:List<UInt>.
+  if l = [7]
+  then #(array(l))[0]# = 7
+proof
+  arbitrary l:List<UInt>
+  assume hl: l = [7]
+  replace hl.
+end
+
+theorem mark_inside_make_array: all l:List<UInt>.
+  if l = [9]
+  then (array(#l#))[0] = 9
+proof
+  arbitrary l:List<UInt>
+  assume hl: l = [9]
+  replace hl.
+end
+
+theorem array_make_in_formula: all l:List<UInt>.
+  if l = [1, 2, 3]
+  then (array(l))[2] = 3
+proof
+  arbitrary l:List<UInt>
+  assume hl: l = [1, 2, 3]
+  replace hl.
+end

--- a/test/should-validate/array4.pf
+++ b/test/should-validate/array4.pf
@@ -1,10 +1,45 @@
 // Issue #204: arrays should be supported inside formulas.
 // Exercises Array / MakeArray cases in count_marks, find_mark,
 // replace_mark, rewrite_aux (abstract_syntax.py) and find_rec_calls
-// (proof_checker.py).
+// (proof_checker.py), plus the partial-spine reduction in
+// ArrayGet.reduce.
 import UInt
 import List
 import Option
+
+theorem arrtest_uint : all l : List<UInt>.
+  if 0 < length(l) then
+  just((array(l))[0]) = head(l)
+proof
+  arbitrary l:List<UInt>
+  switch l {
+    case empty {
+      assume h: 0 < length(@empty<UInt>)
+      conclude false by expand length in h
+    }
+    case node(x, xs) {
+      assume _h: 0 < length(node(x, xs))
+      expand head.
+    }
+  }
+end
+
+theorem array_node_head_index_zero: all x:UInt. all xs:List<UInt>.
+  (array(node(x, xs)))[0] = x
+proof
+  arbitrary x:UInt
+  arbitrary xs:List<UInt>
+  .
+end
+
+theorem array_node_head_index_one: all x:UInt. all y:UInt. all xs:List<UInt>.
+  (array(node(x, node(y, xs))))[1] = y
+proof
+  arbitrary x:UInt
+  arbitrary y:UInt
+  arbitrary xs:List<UInt>
+  .
+end
 
 theorem array_replace_universal: all l:List<UInt>.
   if l = [42]

--- a/test/should-validate/array4.pf
+++ b/test/should-validate/array4.pf
@@ -41,6 +41,18 @@ proof
   .
 end
 
+// Used to crash with "array access expected number index, not i" when
+// the array was a fully concrete `Array(elements)` and the index was a
+// free variable. Now leaves the access unreduced until the index is
+// known.
+theorem free_index_on_concrete_array: all i:UInt.
+  if i = 0 then (array([42]))[i] = 42
+proof
+  arbitrary i:UInt
+  assume hi: i = 0
+  replace hi.
+end
+
 theorem array_replace_universal: all l:List<UInt>.
   if l = [42]
   then just((array(l))[0]) = head(l)


### PR DESCRIPTION
## Summary

Issue [#204](https://github.com/jsiek/deduce/issues/204) — arrays were not usable in proofs. Three gaps; first two are bugs that crashed the checker outright, third is a missing reduction. All three are needed to close the issue's example proof.

### 1. Internal crash on `Array`/`MakeArray` in formulas

Five AST walkers had a case for `ArrayGet` but were missing cases for `Array` and `MakeArray`. Any formula that mentioned `array(...)` crashed with an "unhandled" internal error before the proof body was inspected.

Fixed in [`abstract_syntax.py`](abstract_syntax.py) (`count_marks`, `find_mark`, `replace_mark`, `rewrite_aux`) and [`proof_checker.py`](proof_checker.py) (`find_rec_calls`).

### 2. `user_error` on free-variable index

`ArrayGet.reduce` raised `user_error("array access expected number index, not …")` when the subject was a fully concrete `Array(elements)` and the index wasn't a concrete number. Dead code at runtime (type checking + runtime reduction ensure a numeric index), but it surfaced in proofs where the index is a free variable.

Fixed: just leave the access unreduced.

### 3. No reduction for a `MakeArray` subject with a node-headed list

`ArrayGet.reduce` only reduced `Array(elements)[i]`. When the list argument to `array(...)` had an unknown tail — exactly what happens after a `switch`/`induction` on a universally-quantified `List` — the access never reduced, so even after fixing (1) and (2) the proof stayed stuck on `array(node(x, xs))[0] = x`.

Fixed: peel leading `node(...)` constructors off a `MakeArray` subject. When the index is a known number and the list has at least `index+1` concrete leading nodes, the access reduces to the indexed element. When the spine runs out before the index, the term is left unreduced.

## End-to-end proof from #204

```deduce
theorem arrtest : all l : List<UInt>.
  if 0 < length(l) then just((array(l))[0]) = head(l)
proof
  arbitrary l:List<UInt>
  switch l {
    case empty {
      assume h: 0 < length(@empty<UInt>)
      conclude false by expand length in h
    }
    case node(x, xs) {
      assume _h: 0 < length(node(x, xs))
      expand head.
    }
  }
end
```

## Tests

[`test/should-validate/array4.pf`](test/should-validate/array4.pf) — 8 theorems covering each fix:

- `arrtest_uint` — exact proof from the issue.
- `array_node_head_index_zero` — `array(node(x, xs))[0] = x` (arbitrary `xs`).
- `array_node_head_index_one` — `array(node(x, node(y, xs))))[1] = y` — direct test of spine peeling at index 1.
- `free_index_on_concrete_array` — `if i = 0 then array([42])[i] = 42` — regression test for the `user_error` removal.
- `array_replace_universal`, `array_with_mark`, `mark_inside_make_array`, `array_make_in_formula` — exercise the new walker cases through `replace`/marks.

## Known follow-on (not in this PR)

`array(node(x, xs))[i] = array(xs)[i - 1]` for symbolic `i:UInt ≥ 1` still can't be derived — it would need conditional rewriting or an array stdlib lemma. An inductive proof of `if i < length(l) then just(array(l)[i]) = get(l, i)` gets stuck on this in the `node` step when `i ≠ 0`. Filing as a separate issue if you want the more general support.

## Test plan

- [x] `python deduce.py test/should-validate/array4.pf` valid
- [x] `python deduce.py --lalr test/should-validate/array4.pf` valid
- [x] `python test-deduce.py` — all tests pass (both parsers, all four test trees, ~38s)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)