### PR TITLE
Fix #472: add pyproject.toml, ruff to CI, bump CI versions

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -12,16 +12,19 @@ jobs:
 
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content to github runner.
+        uses: actions/checkout@v4 # checkout the repository content to github runner.
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.12 #install the python needed
+          python-version: '3.13' # match the Makefile
       - name: Install dependencies
         run: |
             python -m pip install --upgrade pip
             if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
             if [ -f ./gh_pages/requirements.txt ]; then pip install -r ./gh_pages/requirements.txt; fi
+            pip install ruff
+      - name: Lint with ruff
+        run: ruff check .
       - name: Check known tokens
         run: python ./gh_pages/scripts/keywords.py
       - name: execute py script # run file

--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -77,7 +77,6 @@ known_tokens = {
     'MORETHAN': 'operator',
     'NOT': 'keyword',
     'NAT': 'keyword',
-    'PUBLIC': 'keyword',
     'OBTAIN': 'keyword',
     'OF': 'keyword',
     'OPAQUE': 'keyword',

--- a/parser.py
+++ b/parser.py
@@ -5,7 +5,6 @@ from lark import Lark, Token, Tree, logger, exceptions
 from flags import *
 from error import *
 
-from lark import logger
 import logging
 #logger.setLevel(logging.DEBUG)
 

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -4886,7 +4886,7 @@ def match_induction_conjuncts(frm, fun, fun_ty, ind_ty):
       
       return conjuncts
     case _:
-      user_error(frm.location, f"Invalid form for inductive declaration theorem. \
+      user_error(frm.location, "Invalid form for inductive declaration theorem. \
             Inductive theorems should be of the form: \n\t \
             all P : fn T -> bool. if prem then all x : T. P(x)")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "deduce"
+version = "0.0.0"
+description = "Proof checker and small functional language for teaching logic"
+# The code uses Python 3.12 f-string syntax (PEP 701: quote reuse and
+# backslash escapes inside f-strings), so 3.12 is the real floor; CI and
+# the Makefile use 3.13.
+requires-python = ">=3.12"
+license = { file = "LICENSE" }
+dependencies = [
+    "lark==1.2.2",
+]
+
+[project.urls]
+Homepage = "https://github.com/jsiek/deduce"
+Documentation = "https://jsiek.github.io/deduce/"
+
+[tool.ruff]
+target-version = "py313"
+exclude = [
+    "__pycache__",
+    "tmp",
+    "lark",
+    "editor",
+    "live_code_vercel_api",
+    "autograder_docker",
+    "gh_pages/pages",
+    "gh_pages/deduce-code",
+]
+
+[tool.ruff.lint]
+# Narrow starting ruleset: the pyflakes rules that pass cleanly today and
+# catch real bugs (undefined names, duplicate dict keys, redefined symbols,
+# stray f-strings). Other pyflakes rules (F401 unused-import, F403/F405
+# star-import side-effects, F841 unused-locals) are deliberately deferred
+# until the codebase is incrementally cleaned up. See issue #472.
+select = ["F541", "F601", "F811", "F821"]
+
+[tool.mypy]
+# Relaxed starter config. The proof-checker core (~11k LOC) is largely
+# untyped today; turning on --strict at the project level would produce
+# thousands of errors. The plan in #472 is to declare per-module overrides
+# and tighten one module at a time.
+python_version = "3.12"
+ignore_missing_imports = true
+warn_unused_ignores = false
+warn_redundant_casts = true
+no_implicit_optional = true

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -476,7 +476,7 @@ def main(argv: list[str]) -> int:
         regenerate_dir(PARSE_DIR)
         return 0
     if flags["site"]:
-        print(f"=== --site: generate doc_*.pf and check (parallel) ===")
+        print("=== --site: generate doc_*.pf and check (parallel) ===")
         bootstrap_prewarm(lib_modules)
         _, fails = time_section("site doc files × 2 parsers",
                                 lambda: run_site(workers))
@@ -495,14 +495,14 @@ def main(argv: list[str]) -> int:
     print(f"Discovered {len(lib_modules)} lib modules; workers={workers}")
 
     if flags["cli"]:
-        print(f"\n=== --cli: deduce.py CLI sanity check ===")
+        print("\n=== --cli: deduce.py CLI sanity check ===")
         _, fails = time_section("deduce.py ./example.pf", run_cli_test)
         total_failures.extend(fails)
 
     # Lib pool: clean state (no shared cache).
     if flags["lib"]:
         reset_prelude_cache()
-        print(f"\n=== lib (both parsers, parallel) ===")
+        print("\n=== lib (both parsers, parallel) ===")
         _, fails = time_section("lib × 2 parsers",
                                 lambda: run_lib_parallel(workers))
         total_failures.extend(fails)
@@ -514,7 +514,7 @@ def main(argv: list[str]) -> int:
         bootstrap_prelude(lib_modules)
         print(f"\n  {'bootstrap prelude (parent)':32s}  "
               f"{time.perf_counter() - t0:6.2f}s")
-        print(f"=== test/prelude (both parsers, parallel) ===")
+        print("=== test/prelude (both parsers, parallel) ===")
         _, fails = time_section("test/prelude × 2 parsers",
                                 lambda: run_prelude_parallel(workers))
         total_failures.extend(fails)
@@ -528,13 +528,13 @@ def main(argv: list[str]) -> int:
               f"{time.perf_counter() - t0:6.2f}s")
 
     if flags["passable"]:
-        print(f"=== should-validate (both parsers, parallel) ===")
+        print("=== should-validate (both parsers, parallel) ===")
         _, fails = time_section("should-validate × 2 parsers",
                                 lambda: run_validate_parallel(workers))
         total_failures.extend(fails)
 
     if flags["errors"]:
-        print(f"\n=== should-error (RD only, parallel) ===")
+        print("\n=== should-error (RD only, parallel) ===")
         _, fails = time_section("should-error",
                                 lambda: run_err_diff_parallel(
                                     ERROR_DIR, "recursive-descent", workers))


### PR DESCRIPTION
Closes #472 (first pass).

## Summary

- New `pyproject.toml` declares project metadata, the `lark==1.2.2` dependency, and starter `[tool.ruff]` / `[tool.mypy]` config blocks.
- Bumps `actions/checkout@v2` → `@v4` and `actions/setup-python@v2` → `@v5`; aligns CI Python (3.12) with the Makefile (3.13).
- Adds a `ruff check .` step to CI.
- Fixes the real bugs the new ruleset uncovered.

## Ruff ruleset

Intentionally narrow at first: `F541, F601, F811, F821`. These pass cleanly on the codebase after the fixes in this PR and catch the bug categories most worth flagging on a teaching project (duplicate dict keys, undefined names, redefined-while-unused, stray f-strings).

Broader pyflakes rules — `F401` unused-import (56 hits), `F841` unused-local (486 hits), and the star-import diagnostics `F403`/`F405` (1741 hits) — are deferred to follow-up PRs per the issue's plan of tightening per-module. The config block is set up so flipping rules on later is one line of `select` plus an audit pass.

Mypy is **not** wired into CI yet. The `[tool.mypy]` block is here so the relaxed defaults are committed and a follow-up PR only has to add the CI step. Per the issue, the dataclass-field cleanup (step 5: declare `Call.type_args`, `Lambda.env`, `Predicate.rule_induction_name`, etc.) is also follow-up work — strict mypy is needed to catch them, and that's a bigger PR than this infrastructure landing.

## Bugs caught by the new ruleset

- `gh_pages/scripts/keywords.py`: `'PUBLIC'` listed twice in `known_tokens` (lines 80 and 92). The misplaced one between NAT and OBTAIN is removed; the alphabetised one after PROOF is kept. Both had identical values so `python ./gh_pages/scripts/keywords.py` still passes (it just checks set-equality with Lark terminals).
- `parser.py`: `logger` imported twice from `lark` (line 4 and line 8). Removed the redundant second import.
- `proof_checker.py:4889` + `test-deduce.py` (6 sites): `f"..."` with no `{}` placeholders — purely cosmetic, dropped the `f` prefix.

## Test plan

- [x] `tmp/venv/bin/ruff check .` → all checks passed
- [x] `python3.13 ./gh_pages/scripts/keywords.py` → exit 0 (verifies the `PUBLIC` dedup is safe against the Lark grammar)
- [x] `python3.13 deduce.py example.pf` → valid (recursive-descent)
- [x] `python3.13 deduce.py --lalr example.pf` → valid
- [ ] CI: lint + test-deduce.py (site, default, parser) on 3.13 + checkout@v4 / setup-python@v5
- [ ] Full local `python test-deduce.py` sweep (running alongside CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)