### PR TITLE
Fix #476: bump static.yml setup-python to v5, align on 3.13

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,9 +40,9 @@ jobs:
 
       # Set up Python environment
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.13.1'
+          python-version: '3.13'
 
       # Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Follow-up to [#478](https://github.com/jsiek/deduce/pull/478). PR [#477](https://github.com/jsiek/deduce/pull/477) bumped `test_deduce.yml` to `actions/setup-python@v5` and Python 3.13; this brings the gh-pages deploy workflow ([.github/workflows/static.yml](.github/workflows/static.yml)) in line.

- `actions/setup-python@v4` → `@v5`
- `python-version: '3.13.1'` → `'3.13'` (matches the Makefile and the bumped `test_deduce.yml`; pinned patch version was unnecessary).

(`actions/checkout` in this workflow was already on `@v4`.)

## Test plan

- [ ] CI green on the branch
- [ ] gh-pages deploy still works on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)