### PR TITLE
Fix #481: enable F401 (unused-import) in ruff

### DIFF
--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -21,7 +21,7 @@ against; keep it stable.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Union
 
 
 # ---------- terms ----------

--- a/compiler/lower.py
+++ b/compiler/lower.py
@@ -16,7 +16,7 @@ Assert. MakeArray/ArrayGet/GenRecFun/Array etc. raise CompileError.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 import abstract_syntax as ast
 

--- a/error.py
+++ b/error.py
@@ -1,6 +1,5 @@
 import contextlib
 
-import flags
 import style
 
 class Diagnostic(Exception):

--- a/gh_pages/scripts/code_block_syntax_generator.py
+++ b/gh_pages/scripts/code_block_syntax_generator.py
@@ -1,6 +1,6 @@
 import os
 
-from keywords import get_known_tokens, get_pattern_types
+from keywords import get_pattern_types
 
 if __name__ == '__main__':
     pattern_types = get_pattern_types()

--- a/lsp/benchmark.py
+++ b/lsp/benchmark.py
@@ -37,7 +37,6 @@ Run::
 
 from __future__ import annotations
 
-import os
 import statistics
 import subprocess
 import sys

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -1449,7 +1449,7 @@ def _find_reference_at(ast_nodes, pos: Position, path: str) -> Optional[str]:
     """
     # Late import: lsp/query.py is the protocol-neutral surface, so we
     # don't pull in abstract_syntax until a query actually runs.
-    from abstract_syntax import AST, PVar, Var, VarRef
+    from abstract_syntax import AST, PVar, VarRef
 
     best: list[Optional[str]] = [None]
     best_span: list[Optional[int]] = [None]
@@ -2284,7 +2284,7 @@ def _induction_template(formula, env) -> Optional[str]:
     """Render an ``induction T`` skeleton if ``formula`` is
     ``all x:T. P(x)`` with T a multi-alternative union."""
     from abstract_syntax import (
-        All, TypeBinding, Union, VarRef, base_name, get_type_name,
+        All, TypeBinding, Union, VarRef, get_type_name,
     )
 
     if not isinstance(formula, All):
@@ -2546,8 +2546,7 @@ def _eliminate_template_for_formula(
     a non-None sentinel string when the shape is supported.
     """
     from abstract_syntax import (
-        All, And, Bool, Call, IfThen, Or, ResolvedVar, Some, TypeType,
-        VarRef, base_name,
+        All, And, Bool, Call, IfThen, Or, Some, VarRef,
     )
 
     if isinstance(formula, Bool):

--- a/parser.py
+++ b/parser.py
@@ -1,12 +1,7 @@
 from abstract_syntax import *
-import dataclasses
-from dataclasses import dataclass
-from lark import Lark, Token, Tree, logger, exceptions
+from lark import Lark, Token, exceptions
 from flags import *
 from error import *
-
-import logging
-#logger.setLevel(logging.DEBUG)
 
 filename = '???'
 

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -23,7 +23,7 @@
 #    reduce some formulas and terms automatically.
 
 from abstract_syntax import *
-from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, ErrorSink, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe
+from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe
 from flags import get_verbose, set_verbose, print_verbose, VerboseLevel, get_target_hole_location, get_debugger
 import style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,10 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-# Narrow starting ruleset: the pyflakes rules that pass cleanly today and
-# catch real bugs (undefined names, duplicate dict keys, redefined symbols,
-# stray f-strings). Other pyflakes rules (F401 unused-import, F403/F405
-# star-import side-effects, F841 unused-locals) are deliberately deferred
-# until the codebase is incrementally cleaned up. See issue #472.
-select = ["F541", "F601", "F811", "F821"]
+# Pyflakes rules enabled incrementally as the codebase is cleaned up
+# (see issue #481). F403/F405 (star-import side-effects) and F841
+# (unused-locals) are still deferred.
+select = ["F401", "F541", "F601", "F811", "F821"]
 
 [tool.mypy]
 # Relaxed starter config. The proof-checker core (~11k LOC) is largely

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -2,7 +2,7 @@
 # is to provide better error messages. -Jeremy
 
 from abstract_syntax import *
-from lark import Lark, Token, logger, exceptions, tree
+from lark import Lark
 from error import *
 from edit_distance import closest_keyword, edit_distance
 

--- a/test/claude_fill_hole/test_anthropic_backend.py
+++ b/test/claude_fill_hole/test_anthropic_backend.py
@@ -17,9 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-import pytest
 
-from tools.claude_fill_hole.agent import AgentResult
 from tools.claude_fill_hole.anthropic_backend import AnthropicBackend
 from tools.claude_fill_hole.validator import QueryOutcome, ValidationOutcome
 

--- a/test/claude_fill_hole/test_main.py
+++ b/test/claude_fill_hole/test_main.py
@@ -13,7 +13,6 @@ import sys
 from io import StringIO
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/test/claude_fill_hole/test_openai_backend.py
+++ b/test/claude_fill_hole/test_openai_backend.py
@@ -13,9 +13,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-import pytest
 
-from tools.claude_fill_hole.agent import AgentResult
 from tools.claude_fill_hole.openai_backend import OpenAICompatBackend
 from tools.claude_fill_hole.validator import QueryOutcome, ValidationOutcome
 

--- a/test/claude_fill_hole/test_prompt.py
+++ b/test/claude_fill_hole/test_prompt.py
@@ -10,10 +10,8 @@ a small int) and the substitution behaviour.
 
 from __future__ import annotations
 
-import pytest
 
 from tools.claude_fill_hole.prompt import (
-    SCAFFOLD,
     build_system_prompt,
     build_user_message,
     slice_around_hole,

--- a/test/claude_fill_hole/test_schema.py
+++ b/test/claude_fill_hole/test_schema.py
@@ -8,8 +8,6 @@ from tools.claude_fill_hole.schema import (
     HoleFillRequest,
     HoleFillResponse,
     LemmaInfo,
-    LspPosition,
-    LspRange,
     Given,
     ValidationAttempt,
     progress_event,

--- a/test/claude_fill_hole/test_validator.py
+++ b/test/claude_fill_hole/test_validator.py
@@ -13,7 +13,6 @@ hidden tempfile lands somewhere we control).
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -23,9 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 from tools.claude_fill_hole.validator import (  # noqa: E402
     HoleQuerier,
-    QueryOutcome,
     SubprocessValidator,
-    ValidationOutcome,
 )
 
 

--- a/test/compile/run_determinism.py
+++ b/test/compile/run_determinism.py
@@ -12,7 +12,6 @@ Run from the repo root:
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 import tempfile

--- a/test/compile/run_headers.py
+++ b/test/compile/run_headers.py
@@ -23,7 +23,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
 
-from compiler import closure, emit_c, ir, lower, prune  # noqa: E402
+from compiler import closure, emit_c, lower, prune  # noqa: E402
 from abstract_syntax import (  # noqa: E402
     add_import_directory,
     init_import_directories,

--- a/test/compile/run_lower.py
+++ b/test/compile/run_lower.py
@@ -15,7 +15,6 @@ Run from the repo root:
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
 

--- a/test/compile/run_prelude_archive.py
+++ b/test/compile/run_prelude_archive.py
@@ -13,7 +13,6 @@ Run from the repo root:
 from __future__ import annotations
 
 import filecmp
-import os
 import shutil
 import subprocess
 import sys

--- a/test/compile/run_separate.py
+++ b/test/compile/run_separate.py
@@ -17,7 +17,6 @@ Run from the repo root:
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys

--- a/test/lsp/test_apply.py
+++ b/test/lsp/test_apply.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_dap_server.py
+++ b/test/lsp/test_dap_server.py
@@ -8,7 +8,6 @@ full request/response/event protocol.
 
 from __future__ import annotations
 
-import io
 import json
 import os
 import queue

--- a/test/lsp/test_debugger.py
+++ b/test/lsp/test_debugger.py
@@ -27,7 +27,6 @@ import io
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_debugger_completion.py
+++ b/test/lsp/test_debugger_completion.py
@@ -9,11 +9,9 @@ what the readline-facing ``_completer`` ultimately calls.
 from __future__ import annotations
 
 import io
-import os
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_debugger_repl.py
+++ b/test/lsp/test_debugger_repl.py
@@ -28,12 +28,11 @@ import io
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-from lsp.debugger import Debugger, DebuggerQuit  # noqa: E402
+from lsp.debugger import Debugger  # noqa: E402
 from lsp.library import check_file  # noqa: E402
 
 

--- a/test/lsp/test_fill_from_given.py
+++ b/test/lsp/test_fill_from_given.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_hole_context.py
+++ b/test/lsp/test_hole_context.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
 
 import pytest
 

--- a/test/lsp/test_preview.py
+++ b/test/lsp/test_preview.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_refine.py
+++ b/test/lsp/test_refine.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import pytest
 

--- a/test/lsp/test_state_isolation.py
+++ b/test/lsp/test_state_isolation.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_symbols.py
+++ b/test/lsp/test_symbols.py
@@ -20,7 +20,6 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from lsp.query import (  # noqa: E402
     Position,
-    SymbolInfo,
     SymbolKind,
     definition_of,
     list_symbols,

--- a/test/lsp/test_uniquify_determinism.py
+++ b/test/lsp/test_uniquify_determinism.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/test/lsp/test_validate_proof.py
+++ b/test/lsp/test_validate_proof.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))

--- a/tools/claude_fill_hole/__main__.py
+++ b/tools/claude_fill_hole/__main__.py
@@ -38,7 +38,7 @@ from .schema import (
     request_from_json,
     response_to_json,
 )
-from .validator import HoleQuerier, SubprocessValidator, ValidationOutcome
+from .validator import HoleQuerier, SubprocessValidator
 
 
 def _default_prelude(deduce_root: Path) -> tuple:

--- a/tools/claude_fill_hole/schema.py
+++ b/tools/claude_fill_hole/schema.py
@@ -13,7 +13,7 @@ forward the ``deduce/holeContextAt`` response unchanged.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 

--- a/tools/claude_fill_hole/validator.py
+++ b/tools/claude_fill_hole/validator.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path


### PR DESCRIPTION
## Summary

First slice of issue #481 — enable ruff rule **F401** (unused-import) and clean up the 56 violations that the previous narrow ruleset (#477) deferred.

- `ruff check --select F401 --fix .` against the tree (56 errors → 0).
- Added `F401` to `select` in `pyproject.toml` and refreshed the explanatory comment to point at #481.
- Dropped a now-stranded `#logger.setLevel(logging.DEBUG)` comment in `parser.py` since `logger`/`logging` are no longer imported.

## Manual review of the auto-fix

The issue called out a few cases that needed eyeball verification:

- **`pytest` in `test/claude_fill_hole/*` and `test/lsp/*`** — verified `grep -c "pytest\."` is 0 in every flagged file. None of these use `pytest.fixture`, `pytest.mark.*`, `pytest.raises`, etc.; the import was purely vestigial.
- **`lark.Tree`, `lark.logger`, `lark.exceptions`, `lark.tree`, `lark.Token` in the parsers** — neither `parser.py` nor `rec_desc_parser.py` is star-imported anywhere (`grep -rn "from parser import"` / `"from rec_desc_parser import"` only show explicit-name imports in `abstract_syntax.py`). `rec_desc_parser.py` had `Token` flagged because the only `Token` references in the file are local variable names like `intToken`.
- **`import flags` in `error.py`** — `error.py` does not use `flags.*` anywhere; nothing else in the tree accesses `error.flags`. Both `parser.py` and `rec_desc_parser.py` either import `flags` directly (`parser.py`) or never use it (`rec_desc_parser.py`).

## Test plan

- [x] `ruff check .` clean locally.
- [x] Smoke-tested both parsers on `lib/Nat.pf`.
- [ ] `make tests tests-lib` (both parsers) — running locally; CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #481 (F401 portion; F841 and F403/F405 remain as separate follow-ups, per the issue's recommended order).