### PR TITLE
Rewrite binder __eq__ as parallel walk with two-sided renaming

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -113,6 +113,191 @@ class AST:
     return self._map_children(lambda x: x.reduce(env))
 
 
+def alpha_equiv(t1, t2) -> bool:
+  """Test alpha-equivalence between two ASTs.
+
+  Uses a parallel walk with a two-sided binding environment: each
+  side tracks ``name -> fresh tag`` for the names it has bound. At
+  a variable reference, look up the name in the side's environment:
+  if bound on both sides, the tags must match; if bound on one side
+  only, the terms are not alpha-equivalent; if free on both, the
+  names must match (modulo the pre/post-uniquify isolation that
+  ``Var.__eq__`` already encodes).
+
+  Used by ``Lambda.__eq__`` / ``All.__eq__`` / ``Some.__eq__`` /
+  ``TLet.__eq__``. Replaces the older approach of substituting one
+  body to rename binders before comparing -- that approach was
+  per-comparison O(|body|) allocation and got the asymmetric case
+  (``Lambda(y, Var(x))`` vs ``Lambda(x, Var(x))``, the constant-x
+  function vs the identity function) wrong in one direction.
+  """
+  return _alpha_equiv(t1, t2, {}, {})
+
+
+def _alpha_equiv(t1, t2, env1, env2) -> bool:
+  # TermInst / TAnnote are transparent for equality -- existing
+  # __eq__ methods unwrap them. Unwrap on both sides so the rest of
+  # this function only deals with the wrapped term.
+  while isinstance(t1, (TermInst, TAnnote)):
+    t1 = t1.subject
+  while isinstance(t2, (TermInst, TAnnote)):
+    t2 = t2.subject
+  # Fast path: top-level (no renaming in scope). Defer to existing
+  # __eq__ which encodes the leaf-level cross-class semantics.
+  if not env1 and not env2:
+    return t1 == t2
+  if not isinstance(t1, AST):
+    return t1 == t2
+  if isinstance(t1, (Var, OverloadedVar, ResolvedVar, RecFun, GenRecFun)):
+    return _alpha_equiv_varref(t1, t2, env1, env2)
+  if isinstance(t1, Lambda):
+    return _alpha_equiv_lambda(t1, t2, env1, env2)
+  if isinstance(t1, All):
+    return _alpha_equiv_all(t1, t2, env1, env2)
+  if isinstance(t1, Some):
+    return _alpha_equiv_some(t1, t2, env1, env2)
+  if isinstance(t1, TLet):
+    return _alpha_equiv_tlet(t1, t2, env1, env2)
+  # Default: structural walk. TermInst/TAnnote already unwrapped, so
+  # a class mismatch here is real.
+  if type(t1) is not type(t2):
+    return False
+  for fld in dc_fields(t1):
+    if fld.name in t1._NON_STRUCTURAL_FIELDS:
+      continue
+    if not _alpha_equiv_value(getattr(t1, fld.name),
+                              getattr(t2, fld.name), env1, env2):
+      return False
+  return True
+
+
+def _alpha_equiv_value(v1, v2, env1, env2) -> bool:
+  if isinstance(v1, AST):
+    return _alpha_equiv(v1, v2, env1, env2)
+  if isinstance(v1, list):
+    if not isinstance(v2, list) or len(v1) != len(v2):
+      return False
+    return all(_alpha_equiv_value(a, b, env1, env2) for a, b in zip(v1, v2))
+  if isinstance(v1, tuple):
+    if not isinstance(v2, tuple) or len(v1) != len(v2):
+      return False
+    return all(_alpha_equiv_value(a, b, env1, env2) for a, b in zip(v1, v2))
+  return v1 == v2
+
+
+def _varref_name(t):
+  # Var / OverloadedVar / ResolvedVar / RecFun / GenRecFun all expose
+  # a canonical name -- the first three via get_name(), the others
+  # via .name. Unified here so dispatch can stay flat.
+  if isinstance(t, (Var, ResolvedVar)):
+    return t.name
+  if isinstance(t, OverloadedVar):
+    return t.resolved_names[0]
+  return t.name  # RecFun / GenRecFun
+
+
+def _alpha_equiv_varref(t1, t2, env1, env2) -> bool:
+  # Names of comparable kinds. If t2 is not a comparable kind, fail.
+  if not isinstance(t2, (Var, OverloadedVar, ResolvedVar, RecFun, GenRecFun)):
+    return False
+  n1 = _varref_name(t1)
+  n2 = _varref_name(t2)
+  in1 = n1 in env1
+  in2 = n2 in env2
+  if in1 != in2:
+    # One bound, the other free -- not equal.
+    return False
+  if in1:
+    # Both bound -- tags must match (i.e. same binder pair).
+    if env1[n1] is not env2[n2]:
+      return False
+  else:
+    # Both free -- names must match.
+    if n1 != n2:
+      return False
+  # Phase isolation, mirroring the existing __eq__ rules:
+  #   * Var (pre-uniquify) only matches Var / RecFun / GenRecFun
+  #   * OverloadedVar / ResolvedVar (post-uniquify) match each other
+  #     and RecFun / GenRecFun, never Var
+  #   * RecFun / GenRecFun match any variant by name (no phase)
+  if isinstance(t1, (RecFun, GenRecFun)):
+    return True
+  if isinstance(t1, Var):
+    return isinstance(t2, (Var, RecFun, GenRecFun))
+  return isinstance(t2, (OverloadedVar, ResolvedVar, RecFun, GenRecFun))
+
+
+def _alpha_equiv_binder_types(vars1, vars2, env1, env2) -> bool:
+  # Shared by Lambda / Some: matched (name, type) pairs where `None`
+  # types match any concrete type. Types are compared under the
+  # *outer* envs -- the inner binder names are added only for the
+  # body. This matters when a type annotation references an outer
+  # bound name (e.g. `Set<T>` in `all T:type. all A:Set<T>. ...`).
+  if len(vars1) != len(vars2):
+    return False
+  for ((_, t1), (_, t2)) in zip(vars1, vars2):
+    if t1 is not None and t2 is not None and not _alpha_equiv(t1, t2, env1, env2):
+      return False
+  return True
+
+
+def _bind(env, name, tag):
+  new = dict(env)
+  new[name] = tag
+  return new
+
+
+def _bind_all(env, pairs):
+  new = dict(env)
+  for (name, tag) in pairs:
+    new[name] = tag
+  return new
+
+
+def _alpha_equiv_lambda(t1, t2, env1, env2) -> bool:
+  if not isinstance(t2, Lambda):
+    return False
+  if not _alpha_equiv_binder_types(t1.vars, t2.vars, env1, env2):
+    return False
+  tags = [object() for _ in t1.vars]
+  new_env1 = _bind_all(env1, [(x, tag) for ((x, _), tag) in zip(t1.vars, tags)])
+  new_env2 = _bind_all(env2, [(y, tag) for ((y, _), tag) in zip(t2.vars, tags)])
+  return _alpha_equiv(t1.body, t2.body, new_env1, new_env2)
+
+
+def _alpha_equiv_all(t1, t2, env1, env2) -> bool:
+  if not isinstance(t2, All):
+    return False
+  (x, tx) = t1.var
+  (y, ty) = t2.var
+  if tx is not None and ty is not None and not _alpha_equiv(tx, ty, env1, env2):
+    return False
+  tag = object()
+  return _alpha_equiv(t1.body, t2.body, _bind(env1, x, tag), _bind(env2, y, tag))
+
+
+def _alpha_equiv_some(t1, t2, env1, env2) -> bool:
+  if not isinstance(t2, Some):
+    return False
+  if not _alpha_equiv_binder_types(t1.vars, t2.vars, env1, env2):
+    return False
+  tags = [object() for _ in t1.vars]
+  new_env1 = _bind_all(env1, [(x, tag) for ((x, _), tag) in zip(t1.vars, tags)])
+  new_env2 = _bind_all(env2, [(y, tag) for ((y, _), tag) in zip(t2.vars, tags)])
+  return _alpha_equiv(t1.body, t2.body, new_env1, new_env2)
+
+
+def _alpha_equiv_tlet(t1, t2, env1, env2) -> bool:
+  if not isinstance(t2, TLet):
+    return False
+  if not _alpha_equiv(t1.rhs, t2.rhs, env1, env2):
+    return False
+  tag = object()
+  return _alpha_equiv(t1.body, t2.body,
+                      _bind(env1, t1.var, tag),
+                      _bind(env2, t2.var, tag))
+
+
 @dataclass
 class Type(AST):
 
@@ -1012,21 +1197,7 @@ class Lambda(Term):
         + indent*' ' + '}'
 
   def __eq__(self, other):
-      if not isinstance(other, Lambda):
-          return False
-      if len(self.vars) != len(other.vars):
-          return False
-      # `None` (pre-typecheck or syntactically omitted) matches any type;
-      # only two concrete types differing makes the binders unequal.
-      for ((x,t1),(y,t2)) in zip(self.vars, other.vars):
-          if t1 is not None and t2 is not None and t1 != t2:
-              return False
-      # ResolvedVar so the substituted bodies compare equal to the
-      # uniquified-name references already in `other.body`.
-      ren = {x: ResolvedVar(self.location, t2, y) \
-             for ((x,t1),(y,t2)) in zip(self.vars, other.vars) }
-      new_body = self.body.substitute(ren)
-      return new_body == other.body
+      return _alpha_equiv_lambda(self, other, {}, {})
 
   def reduce(self, env):
     if get_eval_all():
@@ -1827,6 +1998,9 @@ class TLet(Term):
     new_body = self.body.uniquify(body_env, ctx)
     return TLet(self.location, self.typeof, new_var, new_rhs, new_body)
 
+  def __eq__(self, other):
+    return _alpha_equiv_tlet(self, other, {}, {})
+
 @dataclass
 class Hole(Term):
 
@@ -2082,17 +2256,7 @@ class All(Formula):
                    new_body)
 
   def __eq__(self, other):
-    if not isinstance(other, All):
-      return False
-    x, tx = self.var
-    y, ty = other.var
-    # `None` (pre-typecheck or syntactically omitted) matches any type;
-    # only two concrete types being different makes the binders unequal.
-    if tx is not None and ty is not None and tx != ty:
-      return False
-    sub = { y: ResolvedVar(self.location, None, x) }
-    result = self.body == other.body.substitute(sub)
-    return result
+    return _alpha_equiv_all(self, other, {}, {})
 
   def uniquify(self, env, ctx):
     body_env = {x:y for (x,y) in env.items()}
@@ -2140,14 +2304,7 @@ class Some(Formula):
     return Some(self.location, self.typeof, new_vars, new_body)
 
   def __eq__(self, other):
-    if not isinstance(other, Some):
-      return False
-    if all([tx == ty for ((x,tx),(y,ty))in zip(self.vars, other.vars)]):
-      sub = {y: ResolvedVar(self.location, None, x) \
-             for ((x,tx),(y,ty)) in zip(self.vars, other.vars)}
-      return self.body == other.body.substitute(sub)
-    else:
-      return False
+    return _alpha_equiv_some(self, other, {}, {})
   
 ################ Proofs ######################################
   

--- a/test/properties/conftest.py
+++ b/test/properties/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+sys.argv = [str(REPO_ROOT / "deduce.py")]
+
+from flags import set_quiet_mode  # noqa: E402
+
+set_quiet_mode(True)

--- a/test/properties/test_alpha_equiv.py
+++ b/test/properties/test_alpha_equiv.py
@@ -28,7 +28,6 @@ from abstract_syntax import (  # noqa: E402
     Lambda,
     Some,
     TLet,
-    TypeType,
     Var,
     alpha_equiv,
 )

--- a/test/properties/test_alpha_equiv.py
+++ b/test/properties/test_alpha_equiv.py
@@ -1,0 +1,205 @@
+"""Property-based tests for the alpha_equiv helper and the four binder
+__eq__ methods (Lambda / All / Some / TLet) that delegate to it.
+
+These tests assert the *equivalence-relation* axioms (reflexivity,
+symmetry, transitivity) plus a few alpha-renaming sanity checks that
+the old substitute-based __eq__ silently got wrong --
+``Lambda(x, Var(x)) == Lambda(x, Var(x))`` returned False before this
+refactor because substituting ``{x: ResolvedVar(x)}`` produced a body
+whose ResolvedVar(x) compared unequal to the other side's Var(x).
+"""
+
+import sys
+from pathlib import Path
+
+from hypothesis import HealthCheck, given, settings, strategies as st
+from lark.tree import Meta
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    All,
+    Bool,
+    Call,
+    Int,
+    IntType,
+    Lambda,
+    Some,
+    TLet,
+    TypeType,
+    Var,
+    alpha_equiv,
+)
+
+
+NAMES = ["x", "y", "z"]
+
+
+def _m() -> Meta:
+    return Meta()
+
+
+var_st = st.builds(lambda v: Var(_m(), None, v), st.sampled_from(NAMES))
+int_st = st.builds(lambda n: Int(_m(), None, n), st.integers(-5, 5))
+bool_st = st.builds(lambda b: Bool(_m(), None, b), st.booleans())
+leaf_st = st.one_of(var_st, int_st, bool_st)
+
+
+# Full grammar including binders. Now usable as the comparison
+# subject thanks to the alpha-equiv refactor.
+term_st = st.recursive(
+    leaf_st,
+    lambda children: st.one_of(
+        st.builds(
+            lambda v, body: Lambda(_m(), None, [(v, None)], body),
+            st.sampled_from(NAMES),
+            children,
+        ),
+        st.builds(
+            lambda v, body: All(_m(), None, (v, IntType(_m())), (0, 1), body),
+            st.sampled_from(NAMES),
+            children,
+        ),
+        st.builds(
+            lambda v, body: Some(_m(), None, [(v, IntType(_m()))], body),
+            st.sampled_from(NAMES),
+            children,
+        ),
+        st.builds(
+            lambda v, rhs, body: TLet(_m(), None, v, rhs, body),
+            st.sampled_from(NAMES),
+            children,
+            children,
+        ),
+        st.builds(
+            lambda rator, args: Call(_m(), None, rator, args),
+            children,
+            st.lists(children, min_size=1, max_size=2),
+        ),
+    ),
+    max_leaves=6,
+)
+
+
+def _rename_in_var(t, old, new):
+    """Substitute Var(old) -> Var(new) in a term, *not* respecting
+    binders. Used only to build alpha-renamed test inputs where the
+    caller has already ensured ``old`` is free."""
+    if isinstance(t, Var) and t.name == old:
+        return Var(_m(), None, new)
+    if isinstance(t, Call):
+        return Call(_m(), None, _rename_in_var(t.rator, old, new),
+                    [_rename_in_var(a, old, new) for a in t.args])
+    return t
+
+
+# ---------- equivalence-relation axioms ----------------------------------
+
+
+@given(term_st)
+def test_alpha_equiv_reflexive(t):
+    assert alpha_equiv(t, t)
+    assert t == t
+
+
+@given(term_st, term_st)
+def test_alpha_equiv_symmetric(a, b):
+    assert alpha_equiv(a, b) == alpha_equiv(b, a)
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(term_st, term_st, term_st)
+def test_alpha_equiv_transitive(a, b, c):
+    if alpha_equiv(a, b) and alpha_equiv(b, c):
+        assert alpha_equiv(a, c)
+
+
+# ---------- alpha-renaming preservation ----------------------------------
+
+
+@given(st.sampled_from(NAMES))
+def test_lambda_same_binder_self_reference(x):
+    # The bug fixed by this refactor:
+    # Lambda(x, Var(x)) == Lambda(x, Var(x)) used to be False.
+    body = Call(_m(), None, Var(_m(), None, x), [Int(_m(), None, 0)])
+    l1 = Lambda(_m(), None, [(x, None)], body)
+    l2 = Lambda(_m(), None, [(x, None)], body)
+    assert l1 == l2
+
+
+@given(st.sampled_from(NAMES), st.sampled_from(NAMES))
+def test_lambda_alpha_renaming(x, y):
+    # Lambda(x, Var(x)) == Lambda(y, Var(y))
+    l_x = Lambda(_m(), None, [(x, None)], Var(_m(), None, x))
+    l_y = Lambda(_m(), None, [(y, None)], Var(_m(), None, y))
+    assert l_x == l_y
+
+
+@given(st.sampled_from(NAMES), st.sampled_from(NAMES))
+def test_all_alpha_renaming(x, y):
+    all_x = All(_m(), None, (x, IntType(_m())), (0, 1), Var(_m(), None, x))
+    all_y = All(_m(), None, (y, IntType(_m())), (0, 1), Var(_m(), None, y))
+    assert all_x == all_y
+
+
+@given(st.sampled_from(NAMES), st.sampled_from(NAMES))
+def test_some_alpha_renaming(x, y):
+    some_x = Some(_m(), None, [(x, IntType(_m()))], Var(_m(), None, x))
+    some_y = Some(_m(), None, [(y, IntType(_m()))], Var(_m(), None, y))
+    assert some_x == some_y
+
+
+@given(st.sampled_from(NAMES), st.sampled_from(NAMES), int_st)
+def test_tlet_alpha_renaming(x, y, rhs):
+    tlet_x = TLet(_m(), None, x, rhs, Var(_m(), None, x))
+    tlet_y = TLet(_m(), None, y, rhs, Var(_m(), None, y))
+    assert tlet_x == tlet_y
+
+
+# ---------- detection of real differences --------------------------------
+
+
+def test_lambda_body_difference_detected():
+    l1 = Lambda(_m(), None, [("x", None)], Int(_m(), None, 1))
+    l2 = Lambda(_m(), None, [("x", None)], Int(_m(), None, 2))
+    assert l1 != l2
+
+
+def test_lambda_arity_difference_detected():
+    l1 = Lambda(_m(), None, [("x", None)], Int(_m(), None, 0))
+    l2 = Lambda(_m(), None, [("x", None), ("y", None)], Int(_m(), None, 0))
+    assert l1 != l2
+
+
+def test_capture_not_introduced():
+    # Lambda(x, Var(y)) should NOT equal Lambda(y, Var(y)) -- the
+    # free `y` in the LHS body is different from the bound `y` of
+    # the RHS body. (Alpha-equiv on free names compares by name.)
+    l1 = Lambda(_m(), None, [("x", None)], Var(_m(), None, "y"))
+    l2 = Lambda(_m(), None, [("y", None)], Var(_m(), None, "y"))
+    assert l1 != l2
+
+
+def test_nested_lambda_shadowing():
+    # Lambda(x, Lambda(y, Var(y))) == Lambda(a, Lambda(b, Var(b)))
+    # under alpha-renaming.
+    l1 = Lambda(_m(), None, [("x", None)],
+                Lambda(_m(), None, [("y", None)], Var(_m(), None, "y")))
+    l2 = Lambda(_m(), None, [("a", None)],
+                Lambda(_m(), None, [("b", None)], Var(_m(), None, "b")))
+    assert l1 == l2
+
+
+def test_nested_lambda_inner_uses_outer():
+    # Lambda(x, Lambda(y, Var(x))) renamed to Lambda(a, Lambda(b, Var(a))).
+    l1 = Lambda(_m(), None, [("x", None)],
+                Lambda(_m(), None, [("y", None)], Var(_m(), None, "x")))
+    l2 = Lambda(_m(), None, [("a", None)],
+                Lambda(_m(), None, [("b", None)], Var(_m(), None, "a")))
+    assert l1 == l2
+    # But Lambda(a, Lambda(b, Var(b))) is different.
+    l3 = Lambda(_m(), None, [("a", None)],
+                Lambda(_m(), None, [("b", None)], Var(_m(), None, "b")))
+    assert l1 != l3

--- a/test/properties/test_substitute_uniquify.py
+++ b/test/properties/test_substitute_uniquify.py
@@ -1,0 +1,226 @@
+"""Property-based tests for AST.substitute and AST.uniquify.
+
+These tests build small terms via Hypothesis strategies and assert
+invariants that should hold for any term in the generated subset.
+The generator covers Var, Int, Bool, Call, and Lambda.
+
+Lambda equality is only well-defined post-uniquify (Lambda.__eq__
+substitutes bodies with ResolvedVar, which compares False against the
+pre-uniquify Var — see abstract_syntax.py:1024). So the substitute
+properties use the Lambda-free sub-grammar (Var, Int, Bool, Call),
+and the uniquify properties use the full grammar but never compare
+Lambda nodes structurally.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+from lark.tree import Meta
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    AST,
+    Bool,
+    Call,
+    Int,
+    Lambda,
+    UniquifyContext,
+    Var,
+    reset_reduced_defs,
+)
+
+
+NAMES = ["x", "y", "z"]
+ABSENT_KEY = "__never_in_generated_terms__"
+
+
+def _m() -> Meta:
+    return Meta()
+
+
+var_st = st.builds(lambda v: Var(_m(), None, v), st.sampled_from(NAMES))
+int_st = st.builds(lambda n: Int(_m(), None, n), st.integers(-5, 5))
+bool_st = st.builds(lambda b: Bool(_m(), None, b), st.booleans())
+
+leaf_st = st.one_of(var_st, int_st, bool_st)
+
+
+lambda_free_term_st = st.recursive(
+    leaf_st,
+    lambda children: st.builds(
+        lambda rator, args: Call(_m(), None, rator, args),
+        children,
+        st.lists(children, min_size=1, max_size=3),
+    ),
+    max_leaves=6,
+)
+
+term_with_binders_st = st.recursive(
+    leaf_st,
+    lambda children: st.one_of(
+        st.builds(
+            lambda v, body: Lambda(_m(), None, [(v, None)], body),
+            st.sampled_from(NAMES),
+            children,
+        ),
+        st.builds(
+            lambda rator, args: Call(_m(), None, rator, args),
+            children,
+            st.lists(children, min_size=1, max_size=2),
+        ),
+    ),
+    max_leaves=6,
+)
+
+
+def _walk(node):
+    if isinstance(node, AST):
+        yield node
+        for fld in node.__dataclass_fields__:
+            yield from _walk_value(getattr(node, fld))
+
+
+def _walk_value(v):
+    if isinstance(v, AST):
+        yield from _walk(v)
+    elif isinstance(v, (list, tuple)):
+        for x in v:
+            yield from _walk_value(x)
+
+
+def _fresh_uniquify_env():
+    # `overwrite` requires the sentinel `"no overload"` key. Free vars
+    # in the generated terms are pre-seeded so undefined-var errors
+    # don't fire.
+    return {
+        "no overload": {},
+        "x": ["x.seed"],
+        "y": ["y.seed"],
+        "z": ["z.seed"],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_reduced_defs():
+    reset_reduced_defs()
+    yield
+
+
+# ---------- substitute ---------------------------------------------------
+
+
+@given(lambda_free_term_st)
+def test_substitute_empty_is_identity(t):
+    assert t.substitute({}) == t
+
+
+@given(lambda_free_term_st, lambda_free_term_st)
+def test_substitute_absent_key_is_identity(t, replacement):
+    assert t.substitute({ABSENT_KEY: replacement}) == t
+
+
+@given(lambda_free_term_st, st.sampled_from(NAMES))
+def test_substitute_var_with_itself_is_identity(t, name):
+    self_var = Var(_m(), None, name)
+    assert t.substitute({name: self_var}) == t
+
+
+@given(lambda_free_term_st, st.sampled_from(NAMES))
+def test_var_substitute_hit_returns_replacement(t, name):
+    assert Var(_m(), None, name).substitute({name: t}) == t
+
+
+@given(int_st, lambda_free_term_st)
+def test_int_substitute_is_stable(n, replacement):
+    assert n.substitute({"x": replacement}) == n
+
+
+@given(bool_st, lambda_free_term_st)
+def test_bool_substitute_is_stable(b, replacement):
+    assert b.substitute({"x": replacement}) == b
+
+
+# ---------- copy ---------------------------------------------------------
+
+
+@given(lambda_free_term_st)
+def test_copy_is_equal_but_distinct(t):
+    c = t.copy()
+    assert c == t
+    assert c is not t
+
+
+@given(lambda_free_term_st)
+def test_copy_is_idempotent(t):
+    assert t.copy().copy() == t
+
+
+@given(lambda_free_term_st)
+def test_substitute_does_not_mutate_input(t):
+    before = str(t)
+    t.substitute({"x": Int(_m(), None, 999)})
+    assert str(t) == before
+
+
+@given(
+    lambda_free_term_st,
+    st.sampled_from(NAMES),
+    st.sampled_from(NAMES),
+    lambda_free_term_st,
+)
+def test_substitute_composition(t, k1, k2, replacement):
+    # For lambda-free terms (no binders to capture):
+    #   t.subst({k1: u}).subst({k2: v}) == t.subst({k1: u.subst({k2:v}), k2: v})
+    # when k1 != k2. Composition law under the assumption that no
+    # binders shadow the keys — which is automatic here.
+    if k1 == k2:
+        return
+    u = Var(_m(), None, k2)  # references k2 so sub2 has work to do
+    v = replacement
+    left = t.substitute({k1: u}).substitute({k2: v})
+    right = t.substitute({k1: u.substitute({k2: v}), k2: v})
+    assert left == right
+
+
+# ---------- uniquify ----------------------------------------------------
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(term_with_binders_st)
+def test_uniquify_produces_distinct_binder_names(t):
+    out = t.uniquify(_fresh_uniquify_env(), UniquifyContext())
+    binder_names = [
+        x for n in _walk(out) if isinstance(n, Lambda) for (x, _) in n.vars
+    ]
+    assert len(binder_names) == len(set(binder_names)), (
+        f"duplicate binders after uniquify: {binder_names}"
+    )
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(term_with_binders_st)
+def test_uniquify_is_deterministic(t):
+    out1 = t.uniquify(_fresh_uniquify_env(), UniquifyContext())
+    out2 = t.uniquify(_fresh_uniquify_env(), UniquifyContext())
+    assert str(out1) == str(out2)
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(term_with_binders_st)
+def test_uniquify_does_not_mutate_input(t):
+    before = str(t)
+    t.uniquify(_fresh_uniquify_env(), UniquifyContext())
+    after = str(t)
+    assert before == after
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(term_with_binders_st)
+def test_uniquify_eliminates_plain_var(t):
+    out = t.uniquify(_fresh_uniquify_env(), UniquifyContext())
+    assert not any(isinstance(n, Var) for n in _walk(out))


### PR DESCRIPTION
## Summary

- `Lambda` / `All` / `Some` / `TLet` `__eq__` no longer substitute one body to rename binders before comparing. They now call a single `alpha_equiv` helper that walks both terms in parallel, threading a per-side `name → fresh-tag` map. Same asymptotic walk count as before but with **no per-comparison AST allocation**, and phase-agnostic — works on pre-uniquify, post-uniquify, and post-typecheck ASTs.
- Fixes two latent bugs:
  - `Lambda(x, Var(x)) == Lambda(x, Var(x))` previously returned `False` (the substitute produced a `ResolvedVar(x)` that compared unequal to a pre-uniquify `Var(x)` on the other side).
  - `alpha_equiv` was silently asymmetric — `Lambda(y, Var(x))` (constant-x) compared equal to `Lambda(x, Var(x))` (identity) in one direction but not the other, because a free `x` in one body was being matched against a bound `x` in the other.
- Gives `TLet` an explicit `__eq__`. It had been relying on `@dataclass`'s default, which compared `location` and so reported `False` for two structurally equal `TLet`s from different parse positions. (Unreferenced in production — no regression risk.)
- Adds `test/properties/` with two Hypothesis-based test modules:
  - `test_alpha_equiv.py` — reflexivity / symmetry / transitivity + alpha-renaming sanity for each binder + capture-avoidance + nested binder cases.
  - `test_substitute_uniquify.py` — pre-existing seed of property tests for `substitute` / `uniquify` / `copy`.

Microbenchmark of a depth-N nested Lambda comparison ([tmp/bench_alpha_equiv.py](tmp/bench_alpha_equiv.py), `tmp/` is gitignored — not part of the PR):

| depth | old (substitute) | new (alpha_equiv) | speedup |
|------:|-----------------:|------------------:|--------:|
|    10 |          114.5µs |             11.0µs |   10.4× |
|    50 |         2618.5µs |             55.1µs |   47.5× |
|   200 |        41889.8µs |            282.6µs |  148.2× |
|   400 |       167343.2µs |            753.4µs |  222.1× |

The old approach was O(N²) — substitute walked the body at each binder level, allocating fresh AST nodes for every reference. The new walk is O(N) with no allocation in the hot path.

## Test plan

- [x] `make tests` — passes (both parsers, full corpus, ~37s).
- [x] `python3.13 -m pytest test/properties/ test/lsp/` — all 1006 + 27 = 1033 tests pass.
- [x] Smoke-check `Lambda(x, Var(x)) == Lambda(x, Var(x))` now `True`; alpha-renamed lambdas equate; capture introduction does not.
- [x] Microbenchmark — speedup grows linearly with binder depth, matching the O(N²) → O(N) analysis.

## Follow-ups not in this PR

- `FunctionType.__eq__` currently ignores `type_params` entirely. With this helper in place the same parallel-walk fix is straightforward, but it's a Type-level (not Term/Formula) binder and worth its own PR.
- Property generators don't yet emit `typeof` annotations or post-uniquify `OverloadedVar` shapes; expanding them is the natural next step for the property-test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)