### PR TITLE
Fix #491: apply alpha-equiv parallel walk to FunctionType.__eq__

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -158,6 +158,8 @@ def _alpha_equiv(t1, t2, env1, env2) -> bool:
     return _alpha_equiv_some(t1, t2, env1, env2)
   if isinstance(t1, TLet):
     return _alpha_equiv_tlet(t1, t2, env1, env2)
+  if isinstance(t1, FunctionType):
+    return _alpha_equiv_function_type(t1, t2, env1, env2)
   # Default: structural walk. TermInst/TAnnote already unwrapped, so
   # a class mismatch here is real.
   if type(t1) is not type(t2):
@@ -296,6 +298,26 @@ def _alpha_equiv_tlet(t1, t2, env1, env2) -> bool:
   return _alpha_equiv(t1.body, t2.body,
                       _bind(env1, t1.var, tag),
                       _bind(env2, t2.var, tag))
+
+
+def _alpha_equiv_function_type(t1, t2, env1, env2) -> bool:
+  # The only `Type`-level binder: `type_params` is a list of names
+  # bound in `param_types` and `return_type`. Same parallel-walk
+  # pattern as `_alpha_equiv_lambda`, but `type_params` carries no
+  # per-parameter type annotation -- it's just names.
+  if not isinstance(t2, FunctionType):
+    return False
+  if len(t1.type_params) != len(t2.type_params):
+    return False
+  if len(t1.param_types) != len(t2.param_types):
+    return False
+  tags = [object() for _ in t1.type_params]
+  new_env1 = _bind_all(env1, list(zip(t1.type_params, tags)))
+  new_env2 = _bind_all(env2, list(zip(t2.type_params, tags)))
+  for (p1, p2) in zip(t1.param_types, t2.param_types):
+    if not _alpha_equiv(p1, p2, new_env1, new_env2):
+      return False
+  return _alpha_equiv(t1.return_type, t2.return_type, new_env1, new_env2)
 
 
 @dataclass
@@ -591,14 +613,7 @@ class FunctionType(Type):
       + ' -> ' + str(self.return_type) + ')'
 
   def __eq__(self, other):
-    match other:
-      case FunctionType(l2, tv2, pts2, rt2):
-        ret = True
-        for (pt1, pt2) in zip(self.param_types, pts2):
-          ret = ret and pt1 == pt2
-        return ret and self.return_type == rt2
-      case _:
-        return False
+    return _alpha_equiv_function_type(self, other, {}, {})
 
   def free_vars(self):
     fvs = [pt.free_vars() for pt in self.param_types] \

--- a/test/properties/test_alpha_equiv.py
+++ b/test/properties/test_alpha_equiv.py
@@ -22,7 +22,9 @@ if str(REPO_ROOT) not in sys.path:
 from abstract_syntax import (  # noqa: E402
     All,
     Bool,
+    BoolType,
     Call,
+    FunctionType,
     Int,
     IntType,
     Lambda,
@@ -202,3 +204,132 @@ def test_nested_lambda_inner_uses_outer():
     l3 = Lambda(_m(), None, [("a", None)],
                 Lambda(_m(), None, [("b", None)], Var(_m(), None, "b")))
     assert l1 != l3
+
+
+# ---------- FunctionType: the only Type-level binder ---------------------
+#
+# FunctionType binds `type_params` over its `param_types` and `return_type`.
+# Before #491, `FunctionType.__eq__` ignored `type_params` entirely:
+# fn<T> T -> T compared *equal* to fn<> Int -> Int (different arities) and
+# fn<T> T -> T compared *equal* to fn<U> U -> U only by accident (the body
+# references the bound name, which differs between sides). The parallel
+# walk fixes both.
+
+
+def _ft_id(tv):
+    # fn<tv> tv -> tv  -- the polymorphic identity type, with binder
+    # name `tv`. Constructed so the body references the bound name
+    # through a Var, which is how the parser emits type-param uses.
+    return FunctionType(_m(), [tv],
+                        [Var(_m(), None, tv)],
+                        Var(_m(), None, tv))
+
+
+@given(st.sampled_from(NAMES), st.sampled_from(NAMES))
+def test_function_type_alpha_renaming(x, y):
+    # fn<x> x -> x == fn<y> y -> y -- alpha-renaming of the bound
+    # type parameter.
+    assert _ft_id(x) == _ft_id(y)
+
+
+def test_function_type_type_params_arity_difference_detected():
+    # The bug fixed by #491: previously, two FunctionTypes whose
+    # param/return types were structurally equal but whose
+    # `type_params` had different *lengths* compared equal.
+    poly = _ft_id("T")
+    mono = FunctionType(_m(), [],
+                        [Var(_m(), None, "T")],
+                        Var(_m(), None, "T"))
+    assert poly != mono
+
+
+def test_function_type_capture_not_introduced():
+    # fn<x> y -> y  vs  fn<y> y -> y. The first has `y` free, the
+    # second has `y` bound. Alpha-equiv must distinguish them.
+    free_y = FunctionType(_m(), ["x"],
+                          [Var(_m(), None, "y")],
+                          Var(_m(), None, "y"))
+    bound_y = FunctionType(_m(), ["y"],
+                           [Var(_m(), None, "y")],
+                           Var(_m(), None, "y"))
+    assert free_y != bound_y
+
+
+def test_function_type_param_count_difference_detected():
+    f1 = FunctionType(_m(), [], [IntType(_m())], IntType(_m()))
+    f2 = FunctionType(_m(), [], [IntType(_m()), IntType(_m())], IntType(_m()))
+    assert f1 != f2
+
+
+def test_function_type_return_type_difference_detected():
+    f1 = FunctionType(_m(), [], [IntType(_m())], IntType(_m()))
+    f2 = FunctionType(_m(), [], [IntType(_m())], BoolType(_m()))
+    assert f1 != f2
+
+
+def test_function_type_two_params_alpha_renamed():
+    # fn<A, B> A -> B  ==  fn<X, Y> X -> Y  (parallel renaming of two binders)
+    f1 = FunctionType(_m(), ["A", "B"],
+                      [Var(_m(), None, "A")],
+                      Var(_m(), None, "B"))
+    f2 = FunctionType(_m(), ["X", "Y"],
+                      [Var(_m(), None, "X")],
+                      Var(_m(), None, "Y"))
+    assert f1 == f2
+    # But swapping the order of usage breaks the equivalence:
+    # fn<X, Y> Y -> X is *not* the same as fn<A, B> A -> B.
+    f3 = FunctionType(_m(), ["X", "Y"],
+                      [Var(_m(), None, "Y")],
+                      Var(_m(), None, "X"))
+    assert f1 != f3
+
+
+def test_function_type_nested_in_lambda_annotation():
+    # The Lambda annotation `fn<T> T -> T` is alpha-renamable inside
+    # the type position of a Lambda binder.
+    l1 = Lambda(_m(), None, [("f", _ft_id("T"))], Int(_m(), None, 0))
+    l2 = Lambda(_m(), None, [("f", _ft_id("U"))], Int(_m(), None, 0))
+    assert l1 == l2
+
+
+# Add a FunctionType generator to the pool. Bodies reference either
+# a bound type-param or an outer free name -- both shapes exercise
+# the binding-env lookup. We use `IntType` / `BoolType` as
+# non-variable leaves so the generator can terminate without forcing
+# a type variable in every position.
+
+type_leaf_st = st.one_of(
+    st.builds(lambda: IntType(_m())),
+    st.builds(lambda: BoolType(_m())),
+    st.builds(lambda v: Var(_m(), None, v), st.sampled_from(NAMES)),
+)
+
+
+function_type_st = st.recursive(
+    type_leaf_st,
+    lambda children: st.builds(
+        lambda tps, pts, rt: FunctionType(_m(), tps, pts, rt),
+        st.lists(st.sampled_from(NAMES), min_size=0, max_size=2, unique=True),
+        st.lists(children, min_size=0, max_size=2),
+        children,
+    ),
+    max_leaves=5,
+)
+
+
+@given(function_type_st)
+def test_function_type_reflexive(t):
+    assert t == t
+    assert alpha_equiv(t, t)
+
+
+@given(function_type_st, function_type_st)
+def test_function_type_symmetric(a, b):
+    assert (a == b) == (b == a)
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(function_type_st, function_type_st, function_type_st)
+def test_function_type_transitive(a, b, c):
+    if a == b and b == c:
+        assert a == c


### PR DESCRIPTION
## Summary

`FunctionType` is the only `Type`-level binder — `type_params` bind names that appear in `param_types` and `return_type`. The old `__eq__` (abstract_syntax.py:593) ignored `type_params` entirely:

```python
def __eq__(self, other):
    match other:
      case FunctionType(l2, tv2, pts2, rt2):
        ret = True
        for (pt1, pt2) in zip(self.param_types, pts2):
          ret = ret and pt1 == pt2
        return ret and self.return_type == rt2
      case _:
        return False
```

This made `fn<T> T -> T` compare equal to `fn<> Int -> Int` (different binder arities, accidentally agreeing on the body when the names happened to align), and it lacked the alpha-renaming story for two function types whose bodies reference different type-param names.

Apply the same parallel-walk pattern PR #490 introduced for the term-level binders (`Lambda` / `All` / `Some` / `TLet`):

1. New `_alpha_equiv_function_type` helper alongside the existing binder helpers.
2. Generates one fresh tag per `type_params` pair, binds both sides under the renaming env, compares `param_types` and `return_type` under the extended envs.
3. `FunctionType.__eq__` body is now a one-liner that delegates to the helper.
4. `_alpha_equiv` dispatch grows a `FunctionType` arm so the helper is also used when recursing into a function type that appears inside an outer binder (e.g. a `Lambda` parameter annotation, an `All`'s var-type, a `TypeInst`'s `arg_types`).

## Tests

New property tests in `test/properties/test_alpha_equiv.py` cover:

- Alpha-renaming of the bound type-parameter (`fn<x> x -> x` ↔ `fn<y> y -> y`).
- Binder-arity mismatch — the original bug (`fn<T> T -> T` ≠ `fn<> T -> T`).
- Capture avoidance — `fn<x> y -> y` (with `y` free) is *not* `fn<y> y -> y` (with `y` bound).
- Param-count / return-type difference detection.
- Parallel two-binder renaming (`fn<A, B> A -> B` ↔ `fn<X, Y> X -> Y` but ≠ `fn<X, Y> Y -> X`).
- Nesting inside a `Lambda` parameter annotation (verifies the new dispatch arm).
- Hypothesis-driven reflexivity / symmetry / transitivity over a `function_type_st` generator.

## Test plan

- [x] `python3.13 -m pytest test/properties/ test/lsp/` — 1029 tests pass.
- [x] `make tests` — full corpus, both parsers — 44s, all pass.

## Follow-ups not in this PR

- Property generators still don't emit `typeof` annotations or post-uniquify shapes (#492 covers this).

Closes #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)