### PR TITLE
Fix #492: expand property-test generators (typeof / post-uniquify / compound terms)

### DIFF
--- a/test/properties/test_compound_terms.py
+++ b/test/properties/test_compound_terms.py
@@ -1,0 +1,365 @@
+"""Property-based tests for compound formulas, transparent wrappers,
+and Recursive-function cross-class equality.
+
+The substitute-side properties in
+[`test_substitute_uniquify.py`](test_substitute_uniquify.py) only
+cover ``Var`` / ``Int`` / ``Bool`` / ``Call``. The alpha-equiv tests
+in [`test_alpha_equiv.py`](test_alpha_equiv.py) cover ``Some`` /
+``All`` / ``Lambda`` / ``TLet`` but never substitute through them.
+This file fills both gaps:
+
+* Substitute-side identity properties on terms that include the
+  remaining formula constructors (``And`` / ``Or`` / ``IfThen`` /
+  ``All`` / ``Some``).
+* ``TermInst`` and ``TAnnote`` wrap a subject term and unwrap on
+  comparison — both directions of ``alpha_equiv`` should pierce
+  through them.
+* ``RecFun`` / ``GenRecFun`` compare by name across the post-uniquify
+  variable forms; ``substitute`` on either is identity. The cross-class
+  branches in [abstract_syntax.py:3435](../../abstract_syntax.py) and
+  [abstract_syntax.py:3547](../../abstract_syntax.py) have no property
+  coverage today.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+from lark.tree import Meta
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    All,
+    And,
+    Bool,
+    Call,
+    GenRecFun,
+    IfThen,
+    Int,
+    IntType,
+    Or,
+    OverloadedVar,
+    PVar,
+    RecFun,
+    ResolvedVar,
+    Some,
+    TAnnote,
+    TermInst,
+    Var,
+    alpha_equiv,
+    reset_reduced_defs,
+)
+
+
+NAMES = ["x", "y", "z"]
+ABSENT_KEY = "__never_in_compound_terms__"
+
+
+def _m() -> Meta:
+    return Meta()
+
+
+# ---------- Leaf and compound generators --------------------------------
+
+var_st = st.builds(lambda v: Var(_m(), None, v), st.sampled_from(NAMES))
+int_st = st.builds(lambda n: Int(_m(), None, n), st.integers(-5, 5))
+bool_st = st.builds(lambda b: Bool(_m(), None, b), st.booleans())
+leaf_st = st.one_of(var_st, int_st, bool_st)
+
+
+# Closed binder name pool — kept disjoint from ``NAMES`` so substitute
+# keys can't accidentally hit a binder and produce capture-shaped
+# weirdness. ``All`` / ``Some`` use these as their bound variable
+# names.
+BINDER_NAMES = ["b1", "b2", "b3"]
+
+
+# Recursive compound generator covering the formula constructors that
+# weren't exercised by ``lambda_free_term_st`` plus ``Call`` so we
+# still build interesting nested terms. Bound names in ``All`` /
+# ``Some`` are drawn from a disjoint pool to keep substitute behaviour
+# predictable; the body strategy is the recursive ``children``, which
+# may reference the binder by name — that's fine, we never substitute
+# binder names below.
+compound_term_st = st.recursive(
+    leaf_st,
+    lambda children: st.one_of(
+        st.builds(
+            lambda args: And(_m(), None, list(args)),
+            st.lists(children, min_size=2, max_size=3),
+        ),
+        st.builds(
+            lambda args: Or(_m(), None, list(args)),
+            st.lists(children, min_size=2, max_size=3),
+        ),
+        st.builds(
+            lambda p, c: IfThen(_m(), None, p, c),
+            children,
+            children,
+        ),
+        st.builds(
+            lambda v, body: All(_m(), None, (v, IntType(_m())), (0, 1), body),
+            st.sampled_from(BINDER_NAMES),
+            children,
+        ),
+        st.builds(
+            lambda v, body: Some(_m(), None, [(v, IntType(_m()))], body),
+            st.sampled_from(BINDER_NAMES),
+            children,
+        ),
+        st.builds(
+            lambda rator, args: Call(_m(), None, rator, list(args)),
+            children,
+            st.lists(children, min_size=1, max_size=2),
+        ),
+    ),
+    max_leaves=6,
+)
+
+
+# A wrapped-term generator nests zero-or-more ``TermInst`` / ``TAnnote``
+# wrappers around a compound term. Both wrappers are documented as
+# transparent for equality and alpha-equivalence.
+def _wrap_term_inst(t):
+    return TermInst(_m(), None, t, [IntType(_m())])
+
+
+def _wrap_tannote(t):
+    return TAnnote(_m(), None, t, IntType(_m()))
+
+
+wrapped_term_st = st.recursive(
+    compound_term_st,
+    lambda children: st.one_of(
+        st.builds(_wrap_term_inst, children),
+        st.builds(_wrap_tannote, children),
+    ),
+    max_leaves=3,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_reduced_defs():
+    reset_reduced_defs()
+    yield
+
+
+# ---------- substitute identity properties on compound formulas --------
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(compound_term_st)
+def test_substitute_empty_is_identity_compound(t):
+    assert t.substitute({}) == t
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(compound_term_st, leaf_st)
+def test_substitute_absent_key_is_identity_compound(t, replacement):
+    assert t.substitute({ABSENT_KEY: replacement}) == t
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(compound_term_st, st.sampled_from(NAMES))
+def test_substitute_self_var_is_identity_compound(t, name):
+    # ``{name: Var(name)}`` is the identity substitution for pre-uniquify
+    # Vars. Every node — formula constructors included — survives equal.
+    self_var = Var(_m(), None, name)
+    assert t.substitute({name: self_var}) == t
+
+
+# ---------- TermInst / TAnnote: transparent wrappers --------------------
+
+
+@given(compound_term_st)
+def test_term_inst_alpha_equiv_unwraps(t):
+    wrapped = TermInst(_m(), None, t, [IntType(_m())])
+    assert alpha_equiv(wrapped, t)
+    assert alpha_equiv(t, wrapped)
+
+
+@given(compound_term_st)
+def test_tannote_alpha_equiv_unwraps(t):
+    wrapped = TAnnote(_m(), None, t, IntType(_m()))
+    assert alpha_equiv(wrapped, t)
+    assert alpha_equiv(t, wrapped)
+
+
+@given(compound_term_st)
+def test_nested_wrapper_alpha_equiv_unwraps(t):
+    # TermInst around TAnnote around the term — both layers must unwrap.
+    wrapped = TermInst(
+        _m(), None,
+        TAnnote(_m(), None, t, IntType(_m())),
+        [IntType(_m())],
+    )
+    assert alpha_equiv(wrapped, t)
+    assert alpha_equiv(t, wrapped)
+
+
+@given(compound_term_st)
+def test_term_inst_eq_unwraps(t):
+    # TermInst.__eq__ falls through to subject comparison for any other
+    # class — including formulas. This is what lets pattern matches over
+    # post-typecheck ASTs ignore the wrapper.
+    wrapped = TermInst(_m(), None, t, [IntType(_m())])
+    assert wrapped == t
+
+
+@given(compound_term_st)
+def test_tannote_eq_unwraps(t):
+    wrapped = TAnnote(_m(), None, t, IntType(_m()))
+    assert wrapped == t
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(wrapped_term_st, wrapped_term_st)
+def test_alpha_equiv_wrappers_compose_symmetrically(t1, t2):
+    # If the wrapped terms are alpha-equivalent in one direction, they
+    # are in the other. Exercises the unwrap loop in ``_alpha_equiv``.
+    assert alpha_equiv(t1, t2) == alpha_equiv(t2, t1)
+
+
+# ---------- RecFun / GenRecFun cross-class equality --------------------
+
+# Names follow the post-uniquify mangling so the cross-class equality
+# corresponds to the shape that actually appears post-typecheck.
+RECFUN_NAMES = ["foo.S0", "bar.S1", "baz.S2"]
+
+
+def _make_recfun(name):
+    return RecFun(_m(), name, [], [], IntType(_m()), [], visibility='public')
+
+
+def _make_genrecfun(name):
+    return GenRecFun(
+        _m(), name, [], [], IntType(_m()),
+        Int(_m(), None, 0), IntType(_m()),
+        Int(_m(), None, 0), PVar(_m(), 'pv.S0'),
+        visibility='public',
+    )
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_recfun_equals_resolved_var_by_name(name):
+    rf = _make_recfun(name)
+    rv = ResolvedVar(_m(), None, name)
+    assert rf == rv
+    assert rv == rf
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_recfun_equals_overloaded_var_by_name(name):
+    rf = _make_recfun(name)
+    ov = OverloadedVar(_m(), None, [name])
+    assert rf == ov
+    assert ov == rf
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_recfun_equals_var_by_name(name):
+    # RecFun is name-equal even to a pre-uniquify Var (the phase-
+    # isolation rule is between Var <-> OverloadedVar / ResolvedVar
+    # only; RecFun is exempt). Documented at
+    # [abstract_syntax.py:3440](../../abstract_syntax.py).
+    rf = _make_recfun(name)
+    v = Var(_m(), None, name)
+    assert rf == v
+    assert v == rf
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_recfun_equals_term_inst_subject(name):
+    rf = _make_recfun(name)
+    rv = ResolvedVar(_m(), None, name)
+    wrapped = TermInst(_m(), None, rv, [IntType(_m())])
+    assert rf == wrapped
+    assert wrapped == rf
+
+
+@given(st.sampled_from(RECFUN_NAMES), st.sampled_from(RECFUN_NAMES))
+def test_recfun_recfun_equality_by_name(n1, n2):
+    rf1 = _make_recfun(n1)
+    rf2 = _make_recfun(n2)
+    assert (rf1 == rf2) == (n1 == n2)
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_recfun_substitute_is_identity(name):
+    # ``RecFun.substitute`` returns self unconditionally — recursive
+    # definitions can't be alpha-renamed at use sites without breaking
+    # the global recursion link.
+    rf = _make_recfun(name)
+    assert rf.substitute({name: Int(_m(), None, 999)}) is rf
+    assert rf.substitute({}) is rf
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_genrecfun_equals_resolved_var_by_name(name):
+    gf = _make_genrecfun(name)
+    rv = ResolvedVar(_m(), None, name)
+    assert gf == rv
+    assert rv == gf
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_genrecfun_equals_overloaded_var_by_name(name):
+    gf = _make_genrecfun(name)
+    ov = OverloadedVar(_m(), None, [name])
+    assert gf == ov
+    assert ov == gf
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_genrecfun_equals_var_by_name(name):
+    gf = _make_genrecfun(name)
+    v = Var(_m(), None, name)
+    assert gf == v
+    assert v == gf
+
+
+@given(st.sampled_from(RECFUN_NAMES), st.sampled_from(RECFUN_NAMES))
+def test_genrecfun_genrecfun_equality_by_name(n1, n2):
+    gf1 = _make_genrecfun(n1)
+    gf2 = _make_genrecfun(n2)
+    assert (gf1 == gf2) == (n1 == n2)
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_genrecfun_substitute_is_identity(name):
+    gf = _make_genrecfun(name)
+    assert gf.substitute({name: Int(_m(), None, 999)}) is gf
+    assert gf.substitute({}) is gf
+
+
+# ---------- RecFun under alpha_equiv (cross-phase, free reference) ------
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_recfun_alpha_equiv_with_resolved_var(name):
+    # The post-uniquify analogue: a free RecFun reference is alpha-
+    # equivalent to a ResolvedVar with the same name (and similarly
+    # for OverloadedVar). This is the cross-class branch in
+    # ``_alpha_equiv_varref``.
+    rf = _make_recfun(name)
+    rv = ResolvedVar(_m(), None, name)
+    ov = OverloadedVar(_m(), None, [name])
+    assert alpha_equiv(rf, rv)
+    assert alpha_equiv(rv, rf)
+    assert alpha_equiv(rf, ov)
+    assert alpha_equiv(ov, rf)
+
+
+@given(st.sampled_from(RECFUN_NAMES))
+def test_genrecfun_alpha_equiv_with_resolved_var(name):
+    gf = _make_genrecfun(name)
+    rv = ResolvedVar(_m(), None, name)
+    ov = OverloadedVar(_m(), None, [name])
+    assert alpha_equiv(gf, rv)
+    assert alpha_equiv(rv, gf)
+    assert alpha_equiv(gf, ov)
+    assert alpha_equiv(ov, gf)

--- a/test/properties/test_post_uniquify.py
+++ b/test/properties/test_post_uniquify.py
@@ -44,7 +44,6 @@ from abstract_syntax import (  # noqa: E402
     Lambda,
     OverloadedVar,
     ResolvedVar,
-    Term,
     Var,
     alpha_equiv,
     reset_reduced_defs,

--- a/test/properties/test_post_uniquify.py
+++ b/test/properties/test_post_uniquify.py
@@ -1,0 +1,319 @@
+"""Property-based tests for the post-uniquify AST shape.
+
+After ``uniquify_deduce`` runs, every variable reference is an
+``OverloadedVar`` (or, post-typecheck, a ``ResolvedVar``) with a
+mangled name like ``"x.S0"``; pre-uniquify ``Var`` no longer appears.
+The companion tests in [`test_substitute_uniquify.py`](test_substitute_uniquify.py)
+and [`test_typeof.py`](test_typeof.py) generate pre-uniquify shapes
+only, which leaves the post-uniquify substitute / equality / reduce
+paths unexercised — exactly the paths most of the recent bug fixes
+(#480, #484, #490) lived on.
+
+These tests pin down the invariants that the post-uniquify forms
+must satisfy in isolation:
+
+* Phase isolation: a pre-uniquify ``Var`` never compares equal to a
+  post-uniquify ``OverloadedVar`` / ``ResolvedVar`` with the same
+  underlying name.
+* ``substitute`` never silently downgrades the post-uniquify form
+  (an ``OverloadedVar`` miss stays ``OverloadedVar``, a ``ResolvedVar``
+  miss stays ``ResolvedVar``).
+* ``copy`` produces an independent ``resolved_names`` list on
+  ``OverloadedVar`` — mutating one side does not affect the other.
+* ``Lambda`` alpha-equivalence and ``substitute`` work on the
+  post-uniquify body shape, which #490 made well-defined but the
+  prior generator could not exercise.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+from lark.tree import Meta
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    AST,
+    Bool,
+    Call,
+    Int,
+    Lambda,
+    OverloadedVar,
+    ResolvedVar,
+    Term,
+    Var,
+    alpha_equiv,
+    reset_reduced_defs,
+)
+
+
+# Pool of post-uniquify names. ``generate_name`` would produce shapes
+# like ``"x.S0"`` / ``"y.S1"``; we use the same ``base.suffix`` shape
+# so ``base_name`` and the str-rendering helpers behave the same.
+POST_NAMES = ["x.S0", "y.S1", "z.S2"]
+
+
+def _m() -> Meta:
+    return Meta()
+
+
+# ---------- Post-uniquify generators ------------------------------------
+
+ovar_st = st.builds(
+    lambda n: OverloadedVar(_m(), None, [n]),
+    st.sampled_from(POST_NAMES),
+)
+rvar_st = st.builds(
+    lambda n: ResolvedVar(_m(), None, n),
+    st.sampled_from(POST_NAMES),
+)
+int_st = st.builds(lambda n: Int(_m(), None, n), st.integers(-5, 5))
+bool_st = st.builds(lambda b: Bool(_m(), None, b), st.booleans())
+
+post_leaf_st = st.one_of(ovar_st, rvar_st, int_st, bool_st)
+
+post_term_st = st.recursive(
+    post_leaf_st,
+    lambda children: st.builds(
+        lambda rator, args: Call(_m(), None, rator, list(args)),
+        children,
+        st.lists(children, min_size=1, max_size=3),
+    ),
+    max_leaves=6,
+)
+
+
+# Lambda body generator: keeps the body in the post-uniquify shape so
+# that ``Lambda.__eq__`` (which delegates to ``_alpha_equiv_lambda``)
+# is well-defined.
+def _lambda_with_binder(binder, body):
+    return Lambda(_m(), None, [(binder, None)], body)
+
+
+post_lambda_st = st.builds(
+    _lambda_with_binder,
+    st.sampled_from(POST_NAMES),
+    post_term_st,
+)
+
+
+def _walk(node):
+    if isinstance(node, AST):
+        yield node
+        for fld in node.__dataclass_fields__:
+            if fld == 'typeof':
+                continue
+            yield from _walk_value(getattr(node, fld))
+
+
+def _walk_value(v):
+    if isinstance(v, AST):
+        yield from _walk(v)
+    elif isinstance(v, (list, tuple)):
+        for x in v:
+            yield from _walk_value(x)
+
+
+@pytest.fixture(autouse=True)
+def _reset_reduced_defs():
+    reset_reduced_defs()
+    yield
+
+
+# ---------- Phase isolation --------------------------------------------
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_var_never_equals_overloaded_var(name):
+    # Pre- and post-uniquify references must compare unequal even when
+    # they nominally refer to the same identifier.
+    pre = Var(_m(), None, name)
+    post = OverloadedVar(_m(), None, [name])
+    assert pre != post
+    assert post != pre
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_var_never_equals_resolved_var(name):
+    pre = Var(_m(), None, name)
+    post = ResolvedVar(_m(), None, name)
+    assert pre != post
+    assert post != pre
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_overloaded_and_resolved_var_cross_equal_on_chosen_name(name):
+    # Documented symmetry between the two post-uniquify forms (see
+    # [abstract_syntax.py:990](../../abstract_syntax.py) /
+    # [abstract_syntax.py:1088](../../abstract_syntax.py)).
+    ov = OverloadedVar(_m(), None, [name])
+    rv = ResolvedVar(_m(), None, name)
+    assert ov == rv
+    assert rv == ov
+
+
+@given(st.sampled_from(POST_NAMES), st.sampled_from(POST_NAMES))
+def test_overloaded_var_equality_uses_chosen_name_only(name1, name2):
+    # ``OverloadedVar.__eq__`` compares ``resolved_names[0]`` only.
+    # Trailing candidates don't matter for equality.
+    ov1 = OverloadedVar(_m(), None, [name1, "extra.S99"])
+    ov2 = OverloadedVar(_m(), None, [name2])
+    assert (ov1 == ov2) == (name1 == name2)
+
+
+# ---------- substitute never downgrades the post-uniquify form ---------
+
+
+@given(post_term_st)
+def test_substitute_miss_preserves_post_uniquify_class(t):
+    # The key is not in ``POST_NAMES``, so every reference inside ``t``
+    # is a miss. Every variable reference in the result must stay
+    # post-uniquify (``OverloadedVar`` / ``ResolvedVar``) — never
+    # silently degraded to the pre-uniquify ``Var``.
+    s = t.substitute({"__never__.S999": Int(_m(), None, 0)})
+    for n in _walk(s):
+        if type(n) is Var:
+            pytest.fail(f"pre-uniquify Var appeared in substituted output: {n}")
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_overloaded_var_miss_stays_overloaded_var(name):
+    ov = OverloadedVar(_m(), None, [name])
+    s = ov.substitute({"__never__.S999": Int(_m(), None, 0)})
+    assert isinstance(s, OverloadedVar)
+    assert s.resolved_names == [name]
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_resolved_var_miss_stays_resolved_var(name):
+    # The specific invariant called out in #492: a ``ResolvedVar``
+    # under ``substitute`` must never reintroduce an ``OverloadedVar``.
+    rv = ResolvedVar(_m(), None, name)
+    s = rv.substitute({"__never__.S999": Int(_m(), None, 0)})
+    assert isinstance(s, ResolvedVar)
+    assert not isinstance(s, OverloadedVar)
+    assert s.name == name
+
+
+# ---------- substitute hit returns the replacement ---------------------
+
+
+@given(st.sampled_from(POST_NAMES), int_st)
+def test_overloaded_var_hit_returns_replacement(name, replacement):
+    ov = OverloadedVar(_m(), None, [name])
+    assert ov.substitute({name: replacement}) is replacement
+
+
+@given(st.sampled_from(POST_NAMES), int_st)
+def test_resolved_var_hit_returns_replacement(name, replacement):
+    rv = ResolvedVar(_m(), None, name)
+    assert rv.substitute({name: replacement}) is replacement
+
+
+# ---------- copy independence ------------------------------------------
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_overloaded_var_copy_has_independent_name_list(name):
+    # ``OverloadedVar.copy`` wraps ``resolved_names`` in ``list(...)``
+    # so later mutation on one side cannot leak into the other.
+    ov = OverloadedVar(_m(), None, [name, "alt.S77"])
+    c = ov.copy()
+    assert c.resolved_names == ov.resolved_names
+    ov.resolved_names.append("mutated.S88")
+    assert "mutated.S88" not in c.resolved_names
+
+
+# ---------- Lambda body under substitute (post-uniquify shape) ----------
+
+
+@given(st.sampled_from(POST_NAMES), st.sampled_from(POST_NAMES))
+def test_lambda_alpha_renaming_post_uniquify(x, y):
+    # The post-uniquify analogue of the alpha-renaming sanity check in
+    # [test_alpha_equiv.py](test_alpha_equiv.py). ``Lambda(x, OV(x)) ==
+    # Lambda(y, OV(y))`` under alpha-renaming, regardless of the
+    # mangled suffix.
+    l1 = Lambda(_m(), None, [(x, None)], OverloadedVar(_m(), None, [x]))
+    l2 = Lambda(_m(), None, [(y, None)], OverloadedVar(_m(), None, [y]))
+    assert l1 == l2
+
+
+@given(st.sampled_from(POST_NAMES), st.sampled_from(POST_NAMES))
+def test_lambda_self_reference_resolved_var(x, y):
+    l1 = Lambda(_m(), None, [(x, None)], ResolvedVar(_m(), None, x))
+    l2 = Lambda(_m(), None, [(y, None)], ResolvedVar(_m(), None, y))
+    assert l1 == l2
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_lambda_substitute_miss_leaves_body_unchanged(x):
+    # Substituting with a key that doesn't appear anywhere in a
+    # ``Lambda`` (neither binder nor body) is structurally a no-op:
+    # the resulting Lambda has the same binder and a body equal to
+    # the original.
+    lam = Lambda(_m(), None, [(x, None)], Int(_m(), None, 42))
+    other = "other.S999"
+    assert other not in POST_NAMES
+    s = lam.substitute({other: Int(_m(), None, 0)})
+    assert isinstance(s, Lambda)
+    assert s.body == Int(_m(), None, 42)
+    assert s.vars[0][0] == x
+
+
+@given(st.sampled_from(POST_NAMES))
+def test_lambda_substitute_rewrites_free_body_reference(x):
+    # ``Lambda(x.S0, OV(other.S999))`` with ``{other.S999: Int(7)}``
+    # must rewrite the body to ``Int(7)`` (the reference is free
+    # w.r.t. the binder). This exercises ``substitute`` recursing
+    # into a Lambda body in the post-uniquify shape — the case #490
+    # made well-defined.
+    other = "other.S999"
+    assert other != x and other not in POST_NAMES
+    body = OverloadedVar(_m(), None, [other])
+    lam = Lambda(_m(), None, [(x, None)], body)
+    repl = Int(_m(), None, 7)
+    s = lam.substitute({other: repl})
+    assert isinstance(s, Lambda)
+    assert s.body == repl
+    # Binder unchanged.
+    assert s.vars[0][0] == x
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(post_lambda_st)
+def test_lambda_copy_equals_under_alpha_equiv(lam):
+    c = lam.copy()
+    assert lam == c
+    assert alpha_equiv(lam, c)
+    # And a fresh top-level rename of the binder also stays
+    # alpha-equivalent. Build a copy with a different binder name
+    # and the body rewritten via substitute, then verify alpha-equiv.
+    old = lam.vars[0][0]
+    new = "fresh.S101"
+    assert new != old
+    renamed_body = lam.body.substitute({old: OverloadedVar(_m(), None, [new])})
+    renamed = Lambda(_m(), None, [(new, None)], renamed_body)
+    assert lam == renamed
+
+
+# ---------- composition: post-uniquify substitute interacts cleanly -----
+
+
+@given(post_term_st)
+def test_substitute_empty_is_identity_post_uniquify(t):
+    assert t.substitute({}) == t
+
+
+@given(post_term_st, st.sampled_from(POST_NAMES))
+def test_post_uniquify_term_self_var_substitute_is_identity(t, name):
+    # ``{name: OV([name])}`` is an identity-of-the-post-uniquify-form
+    # substitution — every miss reuses self (via the
+    # ``new_typeof is self.typeof`` short-circuit), every hit returns
+    # the equal OverloadedVar. The whole term should be equal to the
+    # input under post-uniquify equality.
+    self_ref = OverloadedVar(_m(), None, [name])
+    assert t.substitute({name: self_ref}) == t

--- a/test/properties/test_typeof.py
+++ b/test/properties/test_typeof.py
@@ -1,0 +1,249 @@
+"""Property-based tests for the ``typeof`` annotation on Term subclasses.
+
+The ``typeof`` field on ``Term`` is a cached type annotation populated
+by the type checker. It is non-structural for equality and copy, but
+``substitute`` *does* rewrite it via the ``on_typeof`` hook in
+``Term.substitute`` / ``Term._map_children`` (see
+[abstract_syntax.py:74](../../abstract_syntax.py) and
+[abstract_syntax.py:315](../../abstract_syntax.py)).
+
+#480 fixed a class of bugs where ``typeof`` was a post-hoc-assigned
+attribute that disappeared after ``_map_children`` rebuilt the node;
+#484 fixed inconsistencies where the substituted ``typeof`` would
+silently drop. These tests cover the surviving invariant: after
+``copy`` / ``substitute``, the ``typeof`` annotation on every node
+that had one is the same type (or its substitution image).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+from lark.tree import Meta
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from abstract_syntax import (  # noqa: E402
+    AST,
+    Bool,
+    BoolType,
+    Call,
+    FunctionType,
+    Int,
+    IntType,
+    Term,
+    Var,
+    reset_reduced_defs,
+)
+
+
+NAMES = ["x", "y", "z"]
+
+
+def _m() -> Meta:
+    return Meta()
+
+
+# ---------- Type pool ----------------------------------------------------
+
+# Closed types only (no type parameters, no free type variables). This
+# keeps ``Type.substitute(sub)`` insensitive to the term-level
+# substitutions we apply below, so the property reduces to "typeof is
+# preserved" rather than "typeof is rewritten by the same substitution".
+int_type_st = st.builds(lambda: IntType(_m()))
+bool_type_st = st.builds(lambda: BoolType(_m()))
+ground_type_st = st.one_of(int_type_st, bool_type_st)
+
+type_st = st.recursive(
+    ground_type_st,
+    lambda children: st.builds(
+        lambda params, ret: FunctionType(_m(), [], list(params), ret),
+        st.lists(children, min_size=1, max_size=2),
+        children,
+    ),
+    max_leaves=4,
+)
+
+# Each generated term gets either no typeof (the pre-typecheck shape)
+# or one drawn from the pool.
+optional_type_st = st.one_of(st.none(), type_st)
+
+
+# ---------- Annotated term pool -----------------------------------------
+
+annotated_var_st = st.builds(
+    lambda v, ty: Var(_m(), ty, v),
+    st.sampled_from(NAMES),
+    optional_type_st,
+)
+annotated_int_st = st.builds(
+    lambda n, ty: Int(_m(), ty, n),
+    st.integers(-5, 5),
+    optional_type_st,
+)
+annotated_bool_st = st.builds(
+    lambda b, ty: Bool(_m(), ty, b),
+    st.booleans(),
+    optional_type_st,
+)
+annotated_leaf_st = st.one_of(annotated_var_st, annotated_int_st, annotated_bool_st)
+
+annotated_term_st = st.recursive(
+    annotated_leaf_st,
+    lambda children: st.builds(
+        lambda rator, args, ty: Call(_m(), ty, rator, list(args)),
+        children,
+        st.lists(children, min_size=1, max_size=3),
+        optional_type_st,
+    ),
+    max_leaves=6,
+)
+
+
+def _walk(node):
+    # Structural pre-order walk that skips the ``typeof`` field.
+    # ``typeof`` is non-structural and its rewrites under substitute
+    # are what we are testing on the node itself — recursing into it
+    # here would also misalign the parallel walk in the Var-hit case,
+    # since the replacement typically has a different (or absent)
+    # typeof.
+    if isinstance(node, AST):
+        yield node
+        for fld in node.__dataclass_fields__:
+            if fld == 'typeof':
+                continue
+            yield from _walk_value(getattr(node, fld))
+
+
+def _walk_value(v):
+    if isinstance(v, AST):
+        yield from _walk(v)
+    elif isinstance(v, (list, tuple)):
+        for x in v:
+            yield from _walk_value(x)
+
+
+@pytest.fixture(autouse=True)
+def _reset_reduced_defs():
+    reset_reduced_defs()
+    yield
+
+
+# ---------- copy preserves typeof ---------------------------------------
+
+
+@given(annotated_term_st)
+def test_copy_preserves_typeof(t):
+    c = t.copy()
+    for orig, copied in zip(_walk(t), _walk(c)):
+        if isinstance(orig, Term):
+            assert isinstance(copied, Term)
+            assert copied.typeof == orig.typeof
+
+
+# ---------- substitute preserves typeof (no key in term) ----------------
+
+
+@given(annotated_term_st)
+def test_substitute_empty_preserves_typeof(t):
+    s = t.substitute({})
+    for orig, after in zip(_walk(t), _walk(s)):
+        if isinstance(orig, Term):
+            assert isinstance(after, Term)
+            assert after.typeof == orig.typeof
+
+
+# ---------- substitute propagates typeof through Term.substitute ---------
+
+
+@given(annotated_term_st, annotated_term_st)
+def test_substitute_absent_key_preserves_typeof(t, replacement):
+    # The substitution name never appears in the generated term, so
+    # every node is rebuilt via ``_map_children`` (or, for VarRef, via
+    # ``subst_typeof``). The cached ``typeof`` must survive.
+    s = t.substitute({"__absent__": replacement})
+    for orig, after in zip(_walk(t), _walk(s)):
+        if isinstance(orig, Term):
+            assert isinstance(after, Term)
+            assert after.typeof == orig.typeof
+
+
+@given(annotated_term_st, st.sampled_from(NAMES))
+def test_substitute_self_var_preserves_typeof(t, name):
+    # ``{name: Var(name, None)}`` is the identity substitution as far as
+    # variable references are concerned. For non-VarRef nodes (whose
+    # typeof goes through ``on_typeof``) the cached annotation must
+    # survive. For ``Var(name)`` nodes that match the key, the result
+    # is the replacement Var — so we skip that case in the comparison.
+    self_var = Var(_m(), None, name)
+    s = t.substitute({name: self_var})
+    for orig, after in zip(_walk(t), _walk(s)):
+        if not isinstance(orig, Term):
+            continue
+        if isinstance(orig, Var) and orig.name == name:
+            # Substituted to ``self_var`` (typeof=None) — typeof is the
+            # replacement's, not the original's.
+            continue
+        assert isinstance(after, Term)
+        assert after.typeof == orig.typeof
+
+
+# ---------- Var.substitute: hit case loses original typeof --------------
+
+
+@given(type_st, type_st, st.sampled_from(NAMES))
+def test_var_hit_takes_replacements_typeof(t1, t2, name):
+    # A ``Var`` with ``typeof=t1`` that is hit by a substitution
+    # returns the replacement (with the replacement's own typeof),
+    # *not* the original ``Var`` with its annotation. This pins down
+    # the documented behaviour in [abstract_syntax.py:916](../../abstract_syntax.py).
+    original = Var(_m(), t1, name)
+    replacement = Int(_m(), t2, 7)
+    s = original.substitute({name: replacement})
+    assert s.typeof == t2
+
+
+# ---------- Var.substitute: miss case routes through subst_typeof -------
+
+
+@given(type_st, st.sampled_from(NAMES))
+def test_var_miss_keeps_own_typeof(t, name):
+    # ``Var(name=foo, typeof=t)`` substituted with a key for ``bar``
+    # rebuilds (or short-circuits to) a Var with the same typeof.
+    other = "bar"
+    assert other not in NAMES
+    v = Var(_m(), t, name)
+    s = v.substitute({other: Int(_m(), None, 0)})
+    assert isinstance(s, Var)
+    assert s.name == name
+    assert s.typeof == t
+
+
+# ---------- Type-side: substitute on closed types is identity-equal -----
+
+
+@given(type_st)
+def test_type_substitute_closed_is_identity_equal(ty):
+    # The pool only generates closed types. Applying a term-level
+    # substitution to one must leave it equal to itself. This is the
+    # supporting invariant that makes the term-level properties above
+    # behave as "typeof is preserved" rather than "rewritten".
+    assert ty.substitute({"x": Int(_m(), None, 0)}) == ty
+
+
+# ---------- typeof field survives _map_children -------------------------
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow])
+@given(annotated_term_st)
+def test_typeof_field_survives_map_children(t):
+    # Hits the same code path as #480/#484: rebuild the term through
+    # ``_map_children`` (here via ``copy``) and confirm every node's
+    # ``typeof`` is still a Type (or None), not silently dropped.
+    c = t.copy()
+    for n in _walk(c):
+        if isinstance(n, Term):
+            assert n.typeof is None or isinstance(n.typeof, AST)


### PR DESCRIPTION
## Summary

Extends the property-test suite from [#490](https://github.com/jsiek/deduce/pull/490) along **all three** axes described in [#492](https://github.com/jsiek/deduce/issues/492). Three new files, 47 new property tests, no production-code changes.

### What's added

**[`test/properties/test_typeof.py`](test/properties/test_typeof.py) — 8 tests** (item 1 in #492)

- Closed-type pool generator (`IntType`, `BoolType`, `FunctionType` over the pool).
- Annotated term generator (`Var` / `Int` / `Bool` / `Call` with optional `typeof`).
- Properties: `copy` preserves typeof on every node; identity / absent-key / self-var substitutions preserve typeof on non-hit nodes; `Var` hit takes the replacement's typeof; `Var` miss keeps its own; closed types are identity-equal under `Type.substitute`; `typeof` survives `_map_children`.

**[`test/properties/test_post_uniquify.py`](test/properties/test_post_uniquify.py) — 17 tests** (item 2 in #492)

- Post-uniquify generators emitting `OverloadedVar` / `ResolvedVar` with mangled names like `"x.S0"`, plus a post-uniquify `Lambda` body generator.
- Phase isolation (`Var \!= OverloadedVar`, `Var \!= ResolvedVar`), cross-class equality (`OverloadedVar([n]) == ResolvedVar(n)`), `OverloadedVar.__eq__` using `resolved_names[0]` only.
- The specific invariant called out in #492: `ResolvedVar.substitute(sub)` on a miss **never** reintroduces an `OverloadedVar`; `OverloadedVar.substitute(sub)` on a miss **never** downgrades to `Var`.
- `OverloadedVar.copy` produces an independent `resolved_names` list.
- `Lambda` alpha-renaming and free-body-reference rewriting under `substitute` on the post-uniquify shape — the case [#490](https://github.com/jsiek/deduce/pull/490) made well-defined but the prior generator could not exercise.

**[`test/properties/test_compound_terms.py`](test/properties/test_compound_terms.py) — 22 tests** (item 3 in #492)

- Compound formula generator covering `And` / `Or` / `IfThen` / `All` / `Some` (previously only `lambda_free_term_st` shapes were exercised on the substitute side).
- `TermInst` / `TAnnote` wrapper generator; properties that both wrappers unwrap on both sides of `alpha_equiv` and on `__eq__`, with a nested `TermInst(TAnnote(t))` case and a symmetry property under random nesting.
- `RecFun` / `GenRecFun` cross-class equality with `ResolvedVar` / `OverloadedVar` / `Var` (and `TermInst` around any of those), exercising the branches in [`_alpha_equiv_varref`](abstract_syntax.py) and the `__eq__` arms in [abstract_syntax.py:3435](abstract_syntax.py) / [abstract_syntax.py:3547](abstract_syntax.py).
- `RecFun.substitute` and `GenRecFun.substitute` return `self` unconditionally.

## Test plan

- [x] `python3.13 -m pytest test/properties/ -v` — 74 passed (27 pre-existing + 47 new)
- [x] `python3.13 -m ruff check test/properties/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)