### PR TITLE
Tighten mypy toward --strict (follow-up to #479)

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -303,7 +303,6 @@ class Type(AST):
 
   def free_vars(self) -> Set[str]:
     internal_error(self.location, 'free_vars not implemented')
-    return set()
 
 
 @dataclass
@@ -3567,7 +3566,7 @@ class GenRecFun(Declaration):
 @dataclass
 class Define(Declaration):
   name: str
-  typ: Type
+  typ: Optional[Type]
   body: Term
 
   def str_header(self):

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -444,7 +444,7 @@ def emit_header(
         elif isinstance(d, ir.Global):
             ctx.top_globals.add(d.name)
 
-    def in_module(decl) -> bool:
+    def in_module(decl: ir.TopLevel) -> bool:
         return getattr(decl, "module", None) == module_name
 
     guard = "DEDUCE_" + _mangle(module_name) + "_H"

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -464,7 +464,7 @@ def verify(p: Program) -> None:
                 check_term(t, "assert_bool")
 
 
-def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
+def free_vars(t: Term, bound: frozenset[str] = frozenset()) -> set[str]:
     match t:
         case Var(name):
             return set() if name in bound else {name}
@@ -473,7 +473,7 @@ def free_vars(t: Term, bound: frozenset = frozenset()) -> set:
         case Lam(params, body):
             return free_vars(body, bound | set(params))
         case MkClosure(_, caps):
-            out: set = set()
+            out: set[str] = set()
             for c in caps:
                 out |= free_vars(c, bound)
             return out

--- a/edit_distance.py
+++ b/edit_distance.py
@@ -1,8 +1,10 @@
 from math import ceil
+from typing import Iterable, Optional
 
-def edit_distance(s1, s2):
+
+def edit_distance(s1: str, s2: str) -> int:
     m = len(s1); n = len(s2)
-    F = {}
+    F: dict[tuple[int, int], int] = {}
     F[(0, 0)] = 0
     for i in range(1, m+1):
         F[(i, 0)] = i
@@ -18,12 +20,12 @@ def edit_distance(s1, s2):
             F[(i, j)] = min(match, delete, insert)
     return F[(m, n)]
 
-def closest_keyword(word, keywords):
-    best_yet = None
+def closest_keyword(word: str, keywords: Iterable[str]) -> Optional[str]:
+    best_yet: Optional[tuple[str, int]] = None
     for kw in keywords:
         d = edit_distance(word, kw)
         if d <= ceil(len(word) / 6):
-            if best_yet == None or d < best_yet[1]:
+            if best_yet is None or d < best_yet[1]:
                 best_yet = (kw, d)
     if best_yet:
         return best_yet[0]

--- a/lsp/dap_server.py
+++ b/lsp/dap_server.py
@@ -212,7 +212,7 @@ class _DAPDebugger(Debugger):
         self._stop_reason = "step"
         super().after_function(name, env, return_value=return_value)
 
-    def _print(self, msg: str) -> None:  # type: ignore[override]
+    def _print(self, msg: str) -> None:
         """Override the text-mode helper so debugger-emitted messages
         (``-> call ...``, ``-> statement ...``, ``<- returned ...``,
         REPL output) reach the editor as DAP ``output`` events

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -22,7 +22,8 @@
 #    run the print and assert statements,
 #    reduce some formulas and terms automatically.
 
-from typing import cast
+from dataclasses import dataclass
+from typing import List, Tuple, cast
 
 from abstract_syntax import *
 from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,16 @@ exclude = [
 select = ["F401", "F541", "F601", "F811", "F821"]
 
 [tool.mypy]
-# Relaxed starter config (#479). The proof-checker core (~11k LOC) is
-# largely untyped; turning on --strict at the project level would
-# produce thousands of errors. Instead, every in-tree module is now
-# type-checked under this relaxed config — no per-module overrides
-# remain. Further tightening (per-module strict flags, decode-time
-# annotations, --check-untyped-defs, etc.) belongs in follow-up
-# issues so each step can be reviewed independently.
+# Starter config (#479) + first tightening pass toward --strict. The
+# proof-checker core (~11k LOC) is largely untyped, so the heavyweight
+# --strict flags (--check-untyped-defs, --disallow-untyped-defs,
+# --disallow-untyped-calls, --disallow-any-generics, --warn-return-any)
+# still produce hundreds to thousands of errors and remain off
+# globally; they are enabled per-module via [[tool.mypy.overrides]]
+# below as individual modules are cleaned up.
+#
+# The cheap --strict-equivalent flags are on globally: every flag in
+# the `[tool.mypy]` block below is one of the bits --strict turns on.
 #
 # The `exclude` list below skips paths that would otherwise produce
 # module-name collisions or live outside the source tree:
@@ -55,9 +58,13 @@ select = ["F401", "F541", "F601", "F811", "F821"]
 #     gh_pages/    match the ruff `exclude` list above.
 python_version = "3.12"
 ignore_missing_imports = true
-warn_unused_ignores = false
+warn_unused_ignores = true
 warn_redundant_casts = true
+warn_unreachable = true
 no_implicit_optional = true
+strict_equality = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
 exclude = [
     '^test/',
     '^test-deduce\.py$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,60 @@ exclude = [
     '^gh_pages/',
 ]
 
+# Per-module strict: modules that pass --strict get listed here so the
+# heavyweight bits (check_untyped_defs, disallow_untyped_defs,
+# disallow_untyped_calls, disallow_any_generics, warn_return_any,
+# disallow_incomplete_defs) are enforced going forward and any
+# regression is caught in CI. Add a module here once `mypy --strict
+# <module> --follow-imports=silent` is clean.
+#
+# The order of expected wins from the remaining error counts (mypy
+# 2.1.0, --python-version 3.12, against this config — measured
+# 2026-05-13):
+#
+#   lsp/benchmark.py                            (4 errors; transitive
+#                                                untyped calls into
+#                                                flags.py / lsp.library
+#                                                — touching those
+#                                                ripples wider)
+#   compiler/lower.py                           (8; missing annotations
+#                                                on helpers and lower_*
+#                                                methods)
+#   tools/claude_fill_hole/__main__.py          (13)
+#   tools/claude_fill_hole/anthropic_backend.py (13)
+#   tools/claude_fill_hole/openai_backend.py    (30)
+#   lsp/mcp_server.py                           (30)
+#   style.py                                    (31)
+#   lsp/debugger.py                             (38)
+#   lsp/dap_server.py                           (49)
+#   error.py                                    (65)
+#   lsp/lsp_server.py                           (74)
+#   lsp/query.py                                (132)
+#   parser.py                                   (310)
+#   abstract_syntax.py                          (1192)
+#   proof_checker.py                            (1337)
+#   rec_desc_parser.py                          (1348)
+#
+# NOTE: mypy does not honor `strict = true` inside per-module overrides
+# (the meta-flag is global-only). The bits it would turn on are set
+# individually below — the full --strict expansion minus the ones
+# already enabled globally above.
+[[tool.mypy.overrides]]
+module = [
+    "compiler.closure",
+    "compiler.compile_prelude",
+    "compiler.emit_c",
+    "compiler.ir",
+    "compiler.prune",
+    "edit_distance",
+    "claude_fill_hole.agent",
+    "claude_fill_hole.prompt",
+    "claude_fill_hole.schema",
+    "claude_fill_hole.validator",
+]
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+warn_return_any = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ no_implicit_optional = true
 strict_equality = true
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
+no_implicit_reexport = true
 exclude = [
     '^test/',
     '^test-deduce\.py$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,15 @@ warn_unreachable = true
 no_implicit_optional = true
 strict_equality = true
 disallow_subclassing_any = true
-disallow_untyped_decorators = true
+# disallow_untyped_decorators is intentionally NOT enabled globally:
+# lsp/lsp_server.py and lsp/mcp_server.py use `@server.feature(...)`
+# / `@mcp.tool(...)` from `pygls` and `mcp`, neither of which is
+# installed in CI (they're optional and only needed when running the
+# LSP/MCP servers). Under `ignore_missing_imports = true` those
+# packages resolve to Any, which makes every decorator from them
+# "untyped" and trips the flag. The flag is set per-module in the
+# strict overrides below so the protection still applies to modules
+# whose decorators are real.
 no_implicit_reexport = true
 exclude = [
     '^test/',
@@ -131,6 +139,7 @@ module = [
 disallow_any_generics = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
+disallow_untyped_decorators = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 warn_return_any = true

--- a/tools/claude_fill_hole/__main__.py
+++ b/tools/claude_fill_hole/__main__.py
@@ -319,7 +319,7 @@ def _build_backend(args: argparse.Namespace, api_key: str) -> Backend:
     """
     if args.backend == "anthropic":
         try:
-            import anthropic  # type: ignore[import-not-found]
+            import anthropic
         except ImportError as e:
             raise _BackendBuildError(
                 "the `anthropic` package is required for --backend anthropic; "
@@ -332,7 +332,7 @@ def _build_backend(args: argparse.Namespace, api_key: str) -> Backend:
 
     if args.backend == "openai-compat":
         try:
-            import openai  # type: ignore[import-not-found]
+            import openai
         except ImportError as e:
             raise _BackendBuildError(
                 "the `openai` package is required for --backend openai-compat; "

--- a/tools/claude_fill_hole/schema.py
+++ b/tools/claude_fill_hole/schema.py
@@ -120,7 +120,7 @@ def request_from_json(text: str) -> HoleFillRequest:
     return _request_from_dict(raw)
 
 
-def _request_from_dict(raw: dict) -> HoleFillRequest:
+def _request_from_dict(raw: dict[str, Any]) -> HoleFillRequest:
     range_raw = raw["holeRange"]
     hole_range = LspRange(
         start=LspPosition(

--- a/tools/claude_fill_hole/validator.py
+++ b/tools/claude_fill_hole/validator.py
@@ -22,7 +22,7 @@ import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 
 @dataclass(frozen=True)
@@ -158,7 +158,7 @@ class LspValidator(Validator):
     the LSP daemon's ``deduce/validateProof`` becomes the cheap path.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError(
             "LspValidator is a follow-up; use SubprocessValidator for now"
         )
@@ -209,7 +209,7 @@ class QueryOutcome:
 
     ok: bool
     goal: Optional[str] = None
-    givens: tuple = ()
+    givens: tuple[_Given, ...] = ()
     error: Optional[str] = None
 
 
@@ -233,7 +233,7 @@ class HoleQuerier:
         content: str,
         hole_start_offset: int,
         hole_end_offset: int,
-        prelude: tuple = (),
+        prelude: tuple[str, ...] = (),
         max_proof_text_bytes: int = 32 * 1024,
     ) -> None:
         self.file_path = file_path
@@ -319,7 +319,7 @@ class HoleQuerier:
         return QueryOutcome(ok=True, goal=ctx.goal, givens=givens)
 
 
-def _offset_to_line_col_1indexed(text: str, offset: int) -> tuple:
+def _offset_to_line_col_1indexed(text: str, offset: int) -> tuple[int, int]:
     """Convert a 0-indexed byte offset to a 1-indexed (line, column).
 
     Mirrors lsp.query._offset_to_line_col but lives here so HoleQuerier


### PR DESCRIPTION
Follow-up to #479. PR #488 wired mypy into CI with a relaxed config and removed all per-module overrides; this PR begins the tightening pass toward `--strict`.

## What this PR does

Four commits, each one a self-contained tightening step:

1. **Cheap globals (510a650)** — enable five bits of `--strict` that were either zero-cost or had < 5 errors:
   - `warn_unused_ignores` (3 unused ignores deleted)
   - `warn_unreachable` (1 dead `return set()`; `Define.typ` retyped `Optional[Type]` to match what the parser actually stores)
   - `strict_equality` (0 errors)
   - `disallow_subclassing_any` (0 errors)
   - `disallow_untyped_decorators` (0 errors locally, but see commit 4 — this one ended up moving to per-module)

2. **`no_implicit_reexport` (c0feb09)** — fix 6 sites where `proof_checker.py` was relying on `from abstract_syntax import *` to pull `dataclass` / `List` / `Tuple` in via implicit star-reexport. Imports them explicitly and enables the flag.

3. **Per-module `--strict` for 10 already-clean modules (a2f49bb)** — `[[tool.mypy.overrides]]` block turns on `disallow_untyped_defs`, `disallow_untyped_calls`, `disallow_any_generics`, `check_untyped_defs`, `warn_return_any`, `disallow_incomplete_defs` for:
   - `compiler/{closure, compile_prelude, prune, emit_c, ir}.py`
   - `edit_distance.py`
   - `tools/claude_fill_hole/{agent, prompt, schema, validator}.py`

   Five of those already passed `--strict` with no code changes; the other five had 1–4 errors each, fixed inline (mostly missing generic type args, one missing param annotation, a couple of `tuple = ()` defaults that became `tuple[T, ...] = ()`). Verified the overrides actually fire by injecting an untyped def into `edit_distance.py` and confirming mypy reports it.

   _Gotcha:_ mypy 2.1.0 silently ignores `strict = true` inside `[[tool.mypy.overrides]]` — the meta-flag is global-only. The bits it would set are enumerated individually. Documented in the pyproject comment.

4. **CI fix: move `disallow_untyped_decorators` to per-module (1c36371)** — the global flag passed locally but failed CI: `pygls` / `mcp` are optional deps not installed in CI, so under `ignore_missing_imports = true` their decorators resolve to `Any`, which trips the flag on every `@server.feature(...)` / `@mcp.tool(...)` site (35 errors). The flag stays in the per-module strict block (all 10 listed modules only use stdlib `@dataclass`), so the protection is preserved where it actually applies.

## Baseline error counts after this PR

Remaining per-module strict cost, in expected-win order:

| Module | Errors |
| --- | ---: |
| `lsp/benchmark.py` | 4 (transitive untyped calls into `flags.py` / `lsp.library`) |
| `compiler/lower.py` | 8 |
| `tools/claude_fill_hole/__main__.py` | 13 |
| `tools/claude_fill_hole/anthropic_backend.py` | 13 |
| `lsp/mcp_server.py` | 30 |
| `tools/claude_fill_hole/openai_backend.py` | 30 |
| `style.py` | 31 |
| `lsp/debugger.py` | 38 |
| `lsp/dap_server.py` | 49 |
| `error.py` | 65 |
| `lsp/lsp_server.py` | 74 |
| `lsp/query.py` | 132 |
| `parser.py` | 310 |
| `abstract_syntax.py` | 1192 |
| `proof_checker.py` | 1337 |
| `rec_desc_parser.py` | 1348 |

The big three (`abstract_syntax`, `proof_checker`, `rec_desc_parser`) account for ~73% of remaining strict errors — they will need a per-flag tightening approach (likely `check_untyped_defs` first, since most of their errors are inside `def` bodies the strict pass currently skips), not a one-shot strict adoption.

## Test plan

- [x] `mypy .` clean locally
- [x] `ruff check .` clean
- [x] Per-module strict catches regressions on listed modules (verified by injecting an untyped def into `edit_distance.py`)
- [x] `make tests` (both parsers) green
- [x] `make tests-lib` green
- [x] CI green (after commit 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)