### PR TITLE
Fix #469: index-shift reduction rule in ArrayGet.reduce

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -1949,7 +1949,7 @@ class ArrayGet(Term):
         if index is not None and 0 <= index and index < len(elements):
           return elements[index].reduce(env)
         # Don't signal an error for out-of-bounds! -Jeremy
-      case MakeArray(loc2, _, list_term):
+      case MakeArray(loc2, marr_ty, list_term):
         # Peel as many leading `node` constructors off the list as the
         # index calls for. This lets `array(node(x, xs))[0]` reduce to
         # `x` even when the tail `xs` is not concrete, which is what
@@ -1967,6 +1967,21 @@ class ArrayGet(Term):
                 i -= 1
               case _:
                 break
+        else:
+          # Index-shift rule (#469): when the position is symbolic but
+          # has a "successor"-shaped constructor (UInt `dub_inc` /
+          # `inc_dub`, or Nat `suc`), peel one leading node off the list
+          # and rebuild the access with the decremented index. This
+          # unblocks inductive proofs over a universally-quantified index.
+          match list_term:
+            case Call(_, _, TermInst(_, _, ctor, _, _), [_hd, tl]) \
+                 if _is_named(ctor, 'node'):
+              new_pos = _array_index_predecessor(position_red, env)
+              if new_pos is not None:
+                new_subject = MakeArray(loc2, marr_ty, tl)
+                new_get = ArrayGet(self.location, self.typeof,
+                                   new_subject, new_pos)
+                return new_get.reduce(env)
     return ArrayGet(self.location, self.typeof, subject_red, position_red)
 
 @dataclass
@@ -4003,6 +4018,93 @@ def uint_inc(loc, x):
         return mkDubInc(loc, get_arg(x))
     else:
         internal_error(loc, 'not a UInt constructor: ' + str(x))
+
+def isSuc(t):
+  match t:
+    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+         if base_name(n) == 'suc':
+      return True
+    case _:
+      return False
+
+def _array_index_predecessor(pos, env):
+    """Compute the predecessor of `pos` as an AST, for the index-shift
+    rule in `ArrayGet.reduce` (#469).  Returns None when no decrement
+    can be produced -- in which case the caller leaves the array access
+    unreduced.
+
+    Handles these positive-shape positions:
+      * `1 + j` / `j + 1` (UInt) -> j  (the form produced by
+        `induction UInt` / `case with i'. 1 + i'`)
+      * `dub_inc(j)`      (UInt) -> `inc_dub(j)`
+      * `inc_dub(j)`      (UInt) -> 2*j, computed via `_uint_double`
+      * `suc(j)`          (Nat)  -> j
+    """
+    one_plus_arg = _try_match_one_plus(pos)
+    if one_plus_arg is not None:
+      return one_plus_arg
+    loc = pos.location
+    if isSuc(pos):
+      return get_arg(pos)
+    if isDubInc(pos):
+      inc_dub_name = env.base_to_unique('inc_dub')
+      if inc_dub_name is None:
+        return None
+      return mkIncDub(loc, get_arg(pos), cname=inc_dub_name)
+    if isIncDub(pos):
+      return _uint_double(loc, get_arg(pos), env)
+    return None
+
+def _try_match_one_plus(t):
+    """If `t` is `1 + x` or `x + 1` (a Call to `+` with a numeric `1`
+    on either side), return the non-`1` argument.  Otherwise return None.
+    """
+    if not isinstance(t, Call) or len(t.args) != 2:
+      return None
+    name = rator_name(t.rator)
+    if name == 'no_name' or base_name(name) != '+':
+      return None
+    a, b = t.args
+    if (isUInt(a) and uintToInt(a) == 1) \
+       or (isNat(a) and natToInt(a) == 1):
+      return b
+    if (isUInt(b) and uintToInt(b) == 1) \
+       or (isNat(b) and natToInt(b) == 1):
+      return a
+    return None
+
+def _uint_double(loc, x, env):
+    """Return `2 * x` as a UInt AST.  Tries to reduce structurally
+    (handling the three UInt constructor shapes); for a symbolic `x`
+    falls back to a `Call` to the private library helper `dub` if it
+    is reachable in `env`.  Returns None if neither path works.
+    """
+    if isBZero(x):
+      bzero_name = env.base_to_unique('bzero')
+      if bzero_name is None:
+        return None
+      return mkBZero(loc, zname=bzero_name)
+    if isDubInc(x):
+      # 2 * dub_inc(k) = dub_inc(inc_dub(k))
+      dub_inc_name = env.base_to_unique('dub_inc')
+      inc_dub_name = env.base_to_unique('inc_dub')
+      if dub_inc_name is None or inc_dub_name is None:
+        return None
+      return mkDubInc(loc, mkIncDub(loc, get_arg(x), cname=inc_dub_name),
+                      cname=dub_inc_name)
+    if isIncDub(x):
+      # 2 * inc_dub(k) = dub_inc(2 * k)
+      inner = _uint_double(loc, get_arg(x), env)
+      if inner is None:
+        return None
+      dub_inc_name = env.base_to_unique('dub_inc')
+      if dub_inc_name is None:
+        return None
+      return mkDubInc(loc, inner, cname=dub_inc_name)
+    dub_name = env.base_to_unique('dub')
+    if dub_name is None:
+      return None
+    return Call(loc, None, ResolvedVar(loc, None, dub_name), [x])
 
 # The parsers use this function to create unsigned integer literals.
 def intToUInt(loc, n, bzero='bzero', dubinc='dub_inc',

--- a/test/should-validate/array5.pf
+++ b/test/should-validate/array5.pf
@@ -1,0 +1,69 @@
+// Issue #469: index-shift reduction for ArrayGet on a MakeArray subject
+// with a node-headed list and a positive symbolic index.  Without the
+// new rule in `ArrayGet.reduce`, an inductive proof over a universally
+// quantified index gets stuck on `array(node(x, xs))[i]` because there
+// is no reduction (or library lemma) that steps it to
+// `array(xs)[i - 1]`.
+import UInt
+import List
+import Option
+
+// Direct smoke test: the new rule fires when the index has the
+// `1 + i'` shape (the form `induction UInt` produces in its successor
+// case), peeling one node off the list and decrementing the index.
+theorem array_index_shift_one_plus:
+  all x:UInt. all xs:List<UInt>. all i':UInt.
+  (array(node(x, xs)))[1 + i'] = (array(xs))[i']
+proof
+  arbitrary x:UInt
+  arbitrary xs:List<UInt>
+  arbitrary i':UInt
+  .
+end
+
+// The acceptance test from #469: arrays and `get` agree at every
+// in-bounds index.
+theorem array_get_consistent : all l:List<UInt>. all i:UInt.
+  if i < length(l)
+  then just((array(l))[i]) = get(l, i)
+proof
+  have lem: all i:UInt. all l:List<UInt>.
+    if i < length(l) then just((array(l))[i]) = get(l, i)
+    by {
+    induction UInt
+    case 0 {
+      arbitrary l:List<UInt>
+      switch l {
+        case empty {
+          assume h: 0 < length(@empty<UInt>)
+          conclude false by expand length in h
+        }
+        case node(x, xs) {
+          assume _h: 0 < length(node(x, xs))
+          expand get.
+        }
+      }
+    }
+    case with i'. 1 + i' assume IH {
+      arbitrary l:List<UInt>
+      switch l {
+        case empty {
+          assume h: (1 + i') < length(@empty<UInt>)
+          have h2: (1 + i') < 0 by expand length in h
+          conclude false by apply uint_not_less_zero[1 + i'] to h2
+        }
+        case node(x, xs) {
+          assume h: (1 + i') < length(node(x, xs))
+          have less_xs: i' < length(xs) by {
+            have h2: (1 + i') < (1 + length(xs)) by expand length in h
+            apply uint_add_both_sides_of_less[1, i', length(xs)] to h2
+          }
+          expand get
+          apply IH[xs] to less_xs
+        }
+      }
+    }
+  }
+  arbitrary l:List<UInt>, i:UInt
+  lem[i][l]
+end

--- a/test/unit/test_array_get_index_shift.py
+++ b/test/unit/test_array_get_index_shift.py
@@ -1,0 +1,157 @@
+"""Unit tests for the ArrayGet index-shift rule (issue #469).
+
+The rule peels one leading ``node(...)`` off a ``MakeArray`` subject
+when the position term has a positive constructor shape, rebuilding
+the access with the decremented index.
+
+These tests target the cases that cannot be reached from a ``.pf``
+source file outside the ``UInt`` module, because ``UInt`` is an
+``opaque union`` and so its constructors (``bzero``, ``dub_inc``,
+``inc_dub``) are not visible to user code.  In particular, the
+``inc_dub(symbolic)`` decrement path -- whose predecessor is the
+private library helper ``dub`` and so is reachable only via a name
+lookup in ``env`` -- has no other coverage.
+"""
+
+from __future__ import annotations
+
+from lark.tree import Meta
+
+import abstract_syntax as ast
+
+
+def _meta() -> Meta:
+    return Meta()
+
+
+def _int_ty() -> ast.IntType:
+    return ast.IntType(_meta())
+
+
+def _array_ty() -> ast.ArrayType:
+    return ast.ArrayType(_meta(), _int_ty())
+
+
+def _term_binding() -> ast.TermBinding:
+    # The bindings themselves are only looked up by name
+    # (`base_to_unique`); their `typ` / `defn` content is unused by
+    # the index-shift rule, so a placeholder type is fine.
+    return ast.TermBinding(_meta(), module='UInt', typ=_int_ty())
+
+
+def _make_env_with_uint_helpers() -> ast.Env:
+    """Build a minimal `Env` with uniquified UInt constructor and
+    helper names registered.  The rule looks these up via
+    `base_to_unique`; their bindings only need to be present.
+    """
+    env = ast.Env()
+    for unique_name in ('bzero.0', 'dub_inc.0', 'inc_dub.0', 'dub.0'):
+        env.dict[unique_name] = _term_binding()
+    return env
+
+
+def _node_ctor() -> ast.TermInst:
+    return ast.TermInst(
+        _meta(), None,
+        ast.ResolvedVar(_meta(), None, 'node.0'),
+        [_int_ty()], False,
+    )
+
+
+def _node(hd: ast.Term, tl: ast.Term) -> ast.Call:
+    return ast.Call(_meta(), None, _node_ctor(), [hd, tl])
+
+
+def _call_resolved(name: str, args: list[ast.Term]) -> ast.Call:
+    return ast.Call(
+        _meta(), None,
+        ast.ResolvedVar(_meta(), None, name),
+        args,
+    )
+
+
+def _build_array_get(position: ast.Term) -> ast.ArrayGet:
+    x = ast.Var(_meta(), None, 'x')
+    xs = ast.Var(_meta(), None, 'xs')
+    make_array = ast.MakeArray(_meta(), _array_ty(), _node(x, xs))
+    return ast.ArrayGet(_meta(), _int_ty(), make_array, position)
+
+
+def _assert_peeled_to(reduced: ast.Term, expected_index_base: str,
+                      expected_index_arg_name: str) -> None:
+    """The reduced term should be ``array(xs)[<expected_index>]`` where
+    ``<expected_index>`` is a Call to a function/constructor whose base
+    name matches `expected_index_base`, applied to the single Var
+    `expected_index_arg_name`.
+    """
+    assert isinstance(reduced, ast.ArrayGet), \
+        f'expected ArrayGet, got {type(reduced).__name__}: {reduced}'
+    assert isinstance(reduced.subject, ast.MakeArray), \
+        f'expected MakeArray, got {type(reduced.subject).__name__}: {reduced.subject}'
+    inner = reduced.subject.subject
+    assert isinstance(inner, ast.Var) and inner.name == 'xs', \
+        f'expected the tail Var `xs`, got {inner}'
+    pos = reduced.position
+    assert isinstance(pos, ast.Call), \
+        f'expected the decremented position to be a Call, got {pos}'
+    rator_name = pos.rator.name if hasattr(pos.rator, 'name') else None
+    assert rator_name is not None and ast.base_name(rator_name) == expected_index_base, \
+        f'expected position rator base name {expected_index_base!r}, got {rator_name!r}'
+    assert len(pos.args) == 1
+    arg = pos.args[0]
+    assert isinstance(arg, ast.Var) and arg.name == expected_index_arg_name, \
+        f'expected position arg Var({expected_index_arg_name!r}), got {arg}'
+
+
+def test_inc_dub_symbolic_falls_back_to_dub_call():
+    """`array(node(x, xs))[inc_dub(i')]` reduces to
+    `array(xs)[dub(i')]` when `i'` is symbolic.  The rule's
+    `_uint_double` helper has no structural shape to peel and so
+    falls back to building a `Call` to the library `dub` helper
+    that it finds in `env`.
+    """
+    env = _make_env_with_uint_helpers()
+    iprime = ast.Var(_meta(), None, "iprime")
+    inc_dub_iprime = _call_resolved('inc_dub.0', [iprime])
+    reduced = _build_array_get(inc_dub_iprime).reduce(env)
+    _assert_peeled_to(reduced,
+                      expected_index_base='dub',
+                      expected_index_arg_name='iprime')
+
+
+def test_dub_inc_symbolic_peels_structurally():
+    """`array(node(x, xs))[dub_inc(i')]` reduces structurally to
+    `array(xs)[inc_dub(i')]` without needing the `dub` fallback.
+    """
+    env = _make_env_with_uint_helpers()
+    iprime = ast.Var(_meta(), None, "iprime")
+    dub_inc_iprime = _call_resolved('dub_inc.0', [iprime])
+    reduced = _build_array_get(dub_inc_iprime).reduce(env)
+    _assert_peeled_to(reduced,
+                      expected_index_base='inc_dub',
+                      expected_index_arg_name='iprime')
+
+
+def test_inc_dub_symbolic_without_dub_in_env_does_not_reduce():
+    """When the lib `dub` helper is not in env, the rule has nothing
+    to fall back to and must leave the access unreduced -- the proof
+    checker's existing equality and rewriting machinery has to take
+    over from there.
+    """
+    env = _make_env_with_uint_helpers()
+    del env.dict['dub.0']
+    iprime = ast.Var(_meta(), None, "iprime")
+    inc_dub_iprime = _call_resolved('inc_dub.0', [iprime])
+    array_get = _build_array_get(inc_dub_iprime)
+    reduced = array_get.reduce(env)
+    # No peeling: the subject's list-spine is still `node(x, xs)` and
+    # the position is still `inc_dub(iprime)`.
+    assert isinstance(reduced, ast.ArrayGet)
+    assert isinstance(reduced.subject, ast.MakeArray)
+    inner = reduced.subject.subject
+    assert isinstance(inner, ast.Call), \
+        f'expected the list-spine to still be a node-Call, got {inner}'
+    assert ast.base_name(inner.rator.subject.name) == 'node'
+    pos = reduced.position
+    assert isinstance(pos, ast.Call)
+    assert ast.base_name(pos.rator.name) == 'inc_dub'


### PR DESCRIPTION
## Summary

Resolves [#469](https://github.com/jsiek/deduce/issues/469) via option (1) from the issue: a built-in reduction rule in `ArrayGet.reduce` that peels one leading `node(...)` off a `MakeArray` subject when the position is symbolic but has a positive constructor shape. Without this, an inductive proof over a universally quantified index gets stuck on `array(node(x, xs))[i]` because there is no reduction (or library lemma) that steps it to `array(xs)[i - 1]`.

Positive shapes recognized (in `_array_index_predecessor`):

- `1 + j` / `j + 1` (UInt) → `j` &mdash; the form `induction UInt`'s `case with i'. 1 + i'` produces
- `dub_inc(j)` (UInt) → `inc_dub(j)` &mdash; structural
- `inc_dub(j)` (UInt) → 2·j, computed by `_uint_double` (structural for `bzero`/`dub_inc(k)`/`inc_dub(k)`; falls back to a `Call` to the lib `dub` helper, looked up via `env.base_to_unique('dub')`, for a symbolic `j`)
- `suc(j)` (Nat) → `j`

If the position has no recognized positive shape, or the `dub` lookup fails, the rule leaves the access unreduced &mdash; the proof checker's existing equality and rewriting machinery takes over.

## Tests

- **[`test/should-validate/array5.pf`](https://github.com/jsiek/deduce/blob/claude/lucid-wilbur-2db62a/test/should-validate/array5.pf)** &mdash; the acceptance test from #469 (`array_get_consistent: all l. all i. if i < length(l) then just(array(l)[i]) = get(l, i)`), plus a smaller `array_index_shift_one_plus` smoke test that exercises the `1 + i'` path. Both pass under the recursive-descent and LALR parsers.
- **[`test/unit/test_array_get_index_shift.py`](https://github.com/jsiek/deduce/blob/claude/lucid-wilbur-2db62a/test/unit/test_array_get_index_shift.py)** &mdash; pytest unit tests that drive `ArrayGet.reduce` directly with a hand-built env. These cover the `inc_dub(symbolic) → dub(symbolic)` fallback (impossible to construct from a `.pf` test outside the UInt module because UInt is `opaque union`) and a guard for the no-`dub`-in-env case so the rule doesn't quietly start producing partial garbage if the env shape changes.

Both sets of new tests were verified to fail at the expected line on the unpatched tree.

## Test plan

- [x] `python test-deduce.py` &mdash; lib + should-validate + should-error pass under both parsers
- [x] `python -m pytest test/unit/` &mdash; 404 tests pass, including the 3 new ones
- [x] Confirmed `test/should-validate/array5.pf` and the two non-guard pytest cases fail on the unpatched tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)