### PR TITLE
Add Claude workflow plumbing: PR-merge hook + auto-close-parent action

### DIFF
--- a/.claude/hooks/pr-subtask-reminder.sh
+++ b/.claude/hooks/pr-subtask-reminder.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+msg=""
+if echo "$cmd" | grep -qE '(^|[[:space:]&|;])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+  msg='REMINDER (gh pr create): If this PR addresses a multi-part issue (one with a sub-task checklist or GitHub sub-issues), do BOTH of the following: (1) In the PR title/body use "Addresses #N (X portion)" or "Refs #N" — NOT "Closes #N" / "Fixes #N", which auto-close the parent even when the body says "remains". (2) In the PR body, explicitly list which sub-tasks this PR completes and which remain. Skip this reminder if the PR fully resolves a single-task issue.'
+elif echo "$cmd" | grep -qE '(^|[[:space:]&|;])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+  msg='REMINDER (gh pr merge): This PR was just merged. Identify the parent issue (the one whose sub-task this PR completed) and check its remaining sub-tasks via `gh issue view N`. Then: (a) If more sub-tasks remain — post a comment on the parent listing what is now done vs. what remains, AND remove the "in progress" label if present (`gh issue edit N --remove-label "in progress"`). (b) If this PR completed the LAST sub-task — close the parent issue (`gh issue close N`) with a closing comment summarizing the completed work. Skip entirely if the PR resolved a single-task issue (GitHub already auto-closed it).'
+fi
+if [ -n "$msg" ]; then
+  jq -n --arg msg "$msg" '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $msg}}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pr-subtask-reminder.sh",
+            "if": "Bash(gh pr *)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/auto_close_parent.yml
+++ b/.github/workflows/auto_close_parent.yml
@@ -1,0 +1,37 @@
+name: Auto-close parent when all sub-issues closed
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  maybe-close-parent:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parent if all sub-issues are done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CLOSED_ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -e
+          parent_json=$(gh api "repos/$REPO/issues/$CLOSED_ISSUE/parent" 2>/dev/null) || {
+            echo "Issue #$CLOSED_ISSUE has no parent — nothing to do."
+            exit 0
+          }
+          parent_num=$(printf '%s' "$parent_json" | jq -r '.number')
+          parent_state=$(printf '%s' "$parent_json" | jq -r '.state')
+          if [ "$parent_state" != "open" ]; then
+            echo "Parent #$parent_num is already $parent_state — nothing to do."
+            exit 0
+          fi
+          open_count=$(gh api --paginate "repos/$REPO/issues/$parent_num/sub_issues" --jq '.[].state' | grep -c '^open$' || true)
+          if [ "$open_count" = "0" ]; then
+            echo "All sub-issues of #$parent_num are closed. Closing parent."
+            gh issue close "$parent_num" --repo "$REPO" --reason completed --comment "All sub-issues complete — closing automatically."
+          else
+            echo "$open_count sub-issues of #$parent_num still open. Leaving parent open."
+          fi


### PR DESCRIPTION
## Summary

Two pieces of plumbing for managing multi-part issues:

- **PostToolUse hook** (`.claude/hooks/pr-subtask-reminder.sh`, wired up in `.claude/settings.json`) — fires when Claude runs `gh pr create` or `gh pr merge` and injects a reminder via `additionalContext`. On `create`, nudges Claude to use \"Addresses #N (X portion)\" / \"Refs #N\" wording (not auto-closing). On `merge`, nudges Claude to check the parent's remaining sub-tasks, remove the \"in progress\" label, or close the parent if it was the last sub-task.
- **Auto-close-parent workflow** (`.github/workflows/auto_close_parent.yml`) — triggers on \`issues: closed\`. Fetches the closed issue's parent via the sub-issues REST API; if the parent is still open and has zero open sub-issues remaining, closes it with a comment.

Together they make multi-part issue tracking maintain itself: child sub-issue closes → parent's progress bar updates (built-in GitHub behavior) → parent auto-closes when the last child closes (new workflow); Claude gets nudged to update labels and reference issues correctly along the way (hook).

## Limitations

- Auto-close uses \`GITHUB_TOKEN\`, so closing a parent does NOT cascade to a grandparent. Two-level hierarchies — the common case here — are covered. Promote to a PAT later if deeper nesting is needed.
- If a sub-issue is closed as \"not planned\", it still counts as closed and may close the parent.

## Test plan

- [ ] Merge to main (workflows only activate from the default branch for `issues` events).
- [ ] Create a throwaway parent issue with 2 sub-issues, close both, confirm parent auto-closes with the bot comment.
- [ ] Confirm the hook fires by opening a `gh pr create` from a Claude session and looking for the reminder in the spinner / transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)