### PR TITLE
Tighten mypy: mcp_server, error, parser-surface, lsp/library (toward --strict)

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -3647,13 +3647,13 @@ class Define(Declaration):
       return
     extend(export_env, base_name(self.name), self.name, self.location)
 
-uniquified_modules: dict = {}
+uniquified_modules: "dict[str, List[Statement]]" = {}
 
-def get_uniquified_modules():
+def get_uniquified_modules() -> "dict[str, List[Statement]]":
   global uniquified_modules
   return uniquified_modules
 
-def add_uniquified_module(module_name, ast):
+def add_uniquified_module(module_name: str, ast: "List[Statement]") -> None:
   global uniquified_modules
   uniquified_modules[module_name] = ast
 

--- a/error.py
+++ b/error.py
@@ -1,5 +1,7 @@
 import contextlib
-from typing import NoReturn
+from typing import Any, List, NoReturn, Optional
+
+from lark.tree import Meta
 
 import style
 
@@ -10,21 +12,42 @@ class Diagnostic(Exception):
   errors and control-flow signals (``InternalError``, ``MatchFailed``)
   intentionally do not inherit from this -- they should not be caught
   by the sink machinery."""
-  pass
+
+  # Post-construction-stashed structured fields: every helper that
+  # raises a ``Diagnostic`` (``user_error``, ``incomplete_error``,
+  # ``static_error``, ``match_failed``, ``add_diagnostic``,
+  # ``add_incomplete``) attaches ``location`` and ``message_body`` so
+  # library/LSP/MCP callers can reconstruct ``Diagnostic`` objects
+  # without regex-parsing ``str(exc)``. Declared at the base so every
+  # subclass shares the same shape — mypy then accepts the post-hoc
+  # ``exc.location = ...`` / ``exc.message_body = ...`` assignments
+  # without ``attr-defined`` errors.
+  location: Meta
+  message_body: str
 
 class UserError(Diagnostic):
-  pass
+  # Set by ``user_error`` / ``add_diagnostic`` to 0; currently no
+  # caller reads it, but keeping the slot reserves the field so an
+  # incidental ``exc.depth`` access keeps type-checking. Dead-code
+  # removal is its own cleanup.
+  depth: int
 
 class InternalError(Exception):
   pass
 
 class IncompleteProof(Diagnostic):
-  pass
+  depth: int
+  # Set by ``incomplete_error`` / ``add_incomplete``: optional
+  # structured fields for the LSP/MCP refine pipeline (the goal AST
+  # and the type-checking env at the hole). ``None`` outside of
+  # opted-in flows.
+  formula: Optional[Any]
+  env: Optional[Any]
 
-def get_location_text_lines(location):
+def get_location_text_lines(location: Meta) -> List[str]:
   if not location.empty:
     try:
-      with open(location.filename, 'r') as f:
+      with open(getattr(location, 'filename'), 'r') as f:
         lines = list(f.readlines())
         return lines[location.line-1:location.end_line]
     except OSError:
@@ -32,21 +55,21 @@ def get_location_text_lines(location):
       # that may not exist on disk. Returning an empty source excerpt
       # keeps str(ParseError) from crashing -- the location header
       # still carries the file:line:col coordinates.
-      return ''
+      return []
   else:
-    return ''
+    return []
 
-def error_header(location):
+def error_header(location: Meta) -> str:
   if not location.empty:
     header = '{file}:{line1}.{column1}-{line2}.{column2}:' \
-        .format(file=location.filename,
+        .format(file=getattr(location, 'filename'),
                 line1=location.line, column1=location.column,
                 line2=location.end_line, column2=location.end_column)
     return style.blue(header) + ' '
   else:
     return '' # Don't want to risk returning None ever leading to issues
 
-def error_program_text(location):
+def error_program_text(location: Meta) -> str:
   if not location.empty:
     lines = get_location_text_lines(location)
     if not lines:
@@ -92,19 +115,19 @@ class ErrorSink:
   keeps its raise-on-first-error behavior — preserving CLI semantics
   and the ``goal_at`` / MCP query paths that depend on it.
   """
-  def __init__(self):
+  def __init__(self) -> None:
     self.errors: list[Diagnostic] = []
 
-  def add(self, exc: 'Diagnostic'):
+  def add(self, exc: 'Diagnostic') -> None:
     self.errors.append(exc)
 
-  def __bool__(self):
+  def __bool__(self) -> bool:
     return bool(self.errors)
 
-  def __len__(self):
+  def __len__(self) -> int:
     return len(self.errors)
 
-def user_error(location, msg):
+def user_error(location: Meta, msg: str) -> NoReturn:
   exc = UserError(error_header(location) + msg)
   exc.depth = 0
   # Attach structured fields so library/LSP/MCP callers can build
@@ -114,10 +137,12 @@ def user_error(location, msg):
   exc.message_body = msg
   raise exc
 
-def internal_error(location, msg) -> NoReturn:
+def internal_error(location: Meta, msg: str) -> NoReturn:
   raise InternalError(error_header(location) + msg)
 
-def incomplete_error(location, msg, *, formula=None, env=None):
+def incomplete_error(location: Meta, msg: str, *,
+                     formula: Optional[Any] = None,
+                     env: Optional[Any] = None) -> NoReturn:
   exc = IncompleteProof(error_header(location) + msg)
   exc.depth = 0
   exc.location = location
@@ -129,10 +154,10 @@ def incomplete_error(location, msg, *, formula=None, env=None):
   exc.env = env
   raise exc
 
-def warning(location, msg):
+def warning(location: Meta, msg: str) -> None:
   print(error_header(location) + msg)
 
-def wrap_user_error(inner, context):
+def wrap_user_error(inner: BaseException, context: str) -> UserError:
   """Return a new Exception that re-raises ``inner`` with ``context``
   appended to the message, preserving the structured ``location`` and
   ``message_body`` attributes set by error()/incomplete_error()/
@@ -169,10 +194,10 @@ def wrap_user_error(inner, context):
 # own raise site rather than waiting for a top-level catch. None
 # outside of an opted-in run, so CLI / goal_at / MCP behaviour is
 # untouched.
-_active_sink = None
+_active_sink: Optional[ErrorSink] = None
 
 
-def set_active_sink(sink):
+def set_active_sink(sink: Optional[ErrorSink]) -> Optional[ErrorSink]:
   """Install ``sink`` as the active error sink and return the
   previously installed sink (so callers can restore it on exit
   exactly the way ``check_deduce`` does in its try/finally)."""
@@ -181,7 +206,7 @@ def set_active_sink(sink):
   _active_sink = sink
   return prev
 
-def get_active_sink():
+def get_active_sink() -> Optional[ErrorSink]:
   return _active_sink
 
 # Depth counter for nested speculative_probe blocks. While > 0,
@@ -194,7 +219,7 @@ _speculative_depth = 0
 
 
 @contextlib.contextmanager
-def speculative_probe():
+def speculative_probe() -> Any:
   """Make a speculative proof-checker probe well-behaved when an
   error sink is active.
 
@@ -231,7 +256,7 @@ def speculative_probe():
   finally:
     _speculative_depth -= 1
 
-def add_diagnostic(location, msg):
+def add_diagnostic(location: Meta, msg: str) -> None:
   """Record a user-visible diagnostic in the active sink and *return
   normally*, unlike :func:`user_error` which raises. Use at sites whose
   enclosing function can tolerate falling through.
@@ -255,7 +280,9 @@ def add_diagnostic(location, msg):
   exc.message_body = msg
   _active_sink.add(exc)
 
-def add_incomplete(location, msg, formula=None, env=None):
+def add_incomplete(location: Meta, msg: str,
+                   formula: Optional[Any] = None,
+                   env: Optional[Any] = None) -> None:
   """Record a user-visible diagnostic in the active sink and *return
   normally*, unlike :func:`user_error` which raises. Use at sites whose
   enclosing function can tolerate falling through.
@@ -283,16 +310,20 @@ def add_incomplete(location, msg, formula=None, env=None):
 class StaticError(Diagnostic):
   pass
 
-def static_error(location, msg):
+def static_error(location: Meta, msg: str) -> NoReturn:
   exc = StaticError(error_header(location) + msg)
   exc.location = location
   exc.message_body = msg
   raise exc
 
 class MatchFailed(Exception):
-  pass
+  # Stashed the same way as ``Diagnostic`` subclasses (see base-class
+  # comment) so the LSP/MCP query API can read e.location /
+  # e.message_body uniformly across exception types.
+  location: Meta
+  message_body: str
 
-def match_failed(location, msg):
+def match_failed(location: Meta, msg: str) -> NoReturn:
   exc = MatchFailed(error_header(location) + msg)
   exc.location = location
   exc.message_body = msg
@@ -302,13 +333,14 @@ MAX_ERR_DEPTH = 2
 
 # Parse Errors need to carry around some extra data
 class ParseError(Exception):
-  def __init__(self, loc, msg, depth=0, missing=False, last=False):
+  def __init__(self, loc: Meta, msg: str, depth: int = 0,
+               missing: bool = False, last: bool = False) -> None:
     super().__init__(msg)
     self.loc = loc
     self.depth = depth
     self.missing = missing
     self.last = last
-    self.trace = []
+    self.trace: List['ParseError'] = []
     # Aliases that match the attribute names attached to Exception by
     # error()/incomplete_error()/static_error()/match_failed(), so the
     # query API can read e.location / e.message_body uniformly across
@@ -316,21 +348,21 @@ class ParseError(Exception):
     self.location = loc
     self.message_body = msg
 
-  def extend(self, loc, msg):
+  def extend(self, loc: Meta, msg: str) -> 'ParseError':
     self.trace.append(ParseError(loc, msg))
     return self
 
-  def base_message(self):
+  def base_message(self) -> str:
     return super().__str__()
 
-  def error_base(self):
+  def error_base(self) -> str:
     base =  error_header(self.loc) + super().__str__()
     if self.trace:
       base = "\n" + base
     return base
   # return "\n".join([x.error_str() for x in reversed(self.trace[:MAX_ERR_DEPTH])]) + base
 
-  def __str__(self):
+  def __str__(self) -> str:
     # base =  error_header(self.loc) + super().__str__()
     # if self.trace:
     #   base = "\n" + base

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -121,9 +121,14 @@ class CheckResult:
     exception: Optional[BaseException]
     module_name: str
     ast: Optional[Any]
-    errors: Optional[list] = None  # populated by __post_init__ when not provided
+    # In collect-errors mode every entry is a ``Diagnostic``; in
+    # single-error fallback mode (see ``__post_init__``) the list
+    # carries whatever was raised — including non-``Diagnostic``
+    # exceptions like ``InternalError``. Typed as ``BaseException`` so
+    # both shapes flow through unchanged.
+    errors: Optional[list[BaseException]] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.errors is None:
             # Default: a single-error result (or no error). Mirrors the
             # historical ``exception`` field so unchanged callers see
@@ -137,7 +142,7 @@ def check_file(
     prelude: Sequence[str] = (),
     content: Optional[str] = None,
     collect_errors: bool = False,
-    debugger=None,
+    debugger: Optional[Any] = None,
     prewarm_modules: Sequence[str] = (),
 ) -> CheckResult:
     """Run the Deduce pipeline on ``filename`` and return a CheckResult.
@@ -215,7 +220,7 @@ def _check_file_locked(
     prelude: Sequence[str],
     content: Optional[str],
     collect_errors: bool,
-    debugger,
+    debugger: Optional[Any],
     prewarm_modules: Sequence[str] = (),
 ) -> CheckResult:
     """Body of ``check_file``, run under the global pipeline lock."""
@@ -329,7 +334,11 @@ def _check_file_impl(
                     and (s.using is not None or s.hiding is not None)
                 }
                 imports = [
-                    Import(Meta(), name, visibility="private")
+                    # `Meta` is from lark.tree and has minimal type
+                    # stubs (mypy reports its constructor as untyped).
+                    # Tag the call with `type: ignore[no-untyped-call]`;
+                    # the runtime behavior is unchanged.
+                    Import(Meta(), name, visibility="private")  # type: ignore[no-untyped-call]
                     for name in prelude
                     if name not in user_filtered_modules
                 ]

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -39,7 +39,7 @@ import os
 import sys
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +147,25 @@ def _to_serializable(obj: Any) -> Any:
     return obj
 
 
+def _to_dict_or_none(obj: Any) -> Optional[dict[str, Any]]:
+    """Typed wrapper: serialize an optional dataclass to a dict-or-None.
+
+    The query helpers that feed the @mcp.tool functions return either
+    a frozen dataclass or None; `_to_serializable` collapses that to
+    `dict[str, Any] | None`, but its declared return type is `Any`
+    (it has to cover the recursive list/scalar branches too). This
+    wrapper pins the type at the @mcp.tool boundary so the tool's
+    declared return type narrows cleanly under --strict."""
+    return cast(Optional[dict[str, Any]], _to_serializable(obj))
+
+
+def _to_list_of_dicts(items: Any) -> list[dict[str, Any]]:
+    """Typed wrapper: serialize an iterable of dataclasses to a list
+    of dicts. Pairs with _to_dict_or_none for tools whose query helper
+    returns a sequence."""
+    return cast(list[dict[str, Any]], _to_serializable(items))
+
+
 def _read_file(path: str) -> str:
     """Read a file with the same encoding ``check_file`` uses."""
     with open(path, "r", encoding="utf-8") as f:
@@ -154,7 +173,7 @@ def _read_file(path: str) -> str:
 
 
 @mcp.tool()
-def check_file(path: str) -> dict:
+def check_file(path: str) -> dict[str, Any]:
     """Run the Deduce pipeline on ``path`` and return diagnostics.
 
     The standard library at ``lib/`` is auto-prepended unless the
@@ -170,7 +189,7 @@ def check_file(path: str) -> dict:
 
 
 @mcp.tool()
-def goal_at(path: str, line: int, column: int) -> Optional[dict]:
+def goal_at(path: str, line: int, column: int) -> Optional[dict[str, Any]]:
     """Return the proof obligation visible at ``line``:``column``.
 
     Lines and columns are 1-indexed (matching the location text in
@@ -190,11 +209,11 @@ def goal_at(path: str, line: int, column: int) -> Optional[dict]:
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
     goal = query.goal_at(path, content, pos, prelude=_prelude_for(path))
-    return _to_serializable(goal)
+    return _to_dict_or_none(goal)
 
 
 @mcp.tool()
-def definition_of(path: str, line: int, column: int) -> Optional[dict]:
+def definition_of(path: str, line: int, column: int) -> Optional[dict[str, Any]]:
     """Return the source location of the symbol at ``line``:``column``.
 
     Returns ``None`` when the cursor isn't on a resolvable symbol or
@@ -204,11 +223,11 @@ def definition_of(path: str, line: int, column: int) -> Optional[dict]:
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
     loc = query.definition_of(path, content, pos, prelude=_prelude_for(path))
-    return _to_serializable(loc)
+    return _to_dict_or_none(loc)
 
 
 @mcp.tool()
-def refine_at(path: str, line: int, column: int) -> Optional[dict]:
+def refine_at(path: str, line: int, column: int) -> Optional[dict[str, Any]]:
     """Propose a refinement template for the hole at ``line``:``column``.
 
     The cursor must sit on (or immediately adjacent to) a ``?`` token.
@@ -235,13 +254,13 @@ def refine_at(path: str, line: int, column: int) -> Optional[dict]:
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
     edit = query.refine_at(path, content, pos, prelude=_prelude_for(path))
-    return _to_serializable(edit)
+    return _to_dict_or_none(edit)
 
 
 @mcp.tool()
 def case_split_at(
     path: str, line: int, column: int, variable: str
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Generate a case-split skeleton at the hole at ``line``:``column``,
     splitting on ``variable``.
 
@@ -266,7 +285,7 @@ def case_split_at(
     edit = query.case_split_at(
         path, content, pos, variable, prelude=_prelude_for(path)
     )
-    return _to_serializable(edit)
+    return _to_dict_or_none(edit)
 
 
 @mcp.tool()
@@ -294,7 +313,7 @@ def splittable_vars_at(path: str, line: int, column: int) -> list[str]:
 @mcp.tool()
 def induction_skeleton_at(
     path: str, line: int, column: int
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Generate an ``induction T`` skeleton for the goal at ``line``:``column``.
 
     The cursor must sit on (or immediately adjacent to) a ``?`` token
@@ -321,13 +340,13 @@ def induction_skeleton_at(
     edit = query.induction_skeleton_at(
         path, content, pos, prelude=_prelude_for(path)
     )
-    return _to_serializable(edit)
+    return _to_dict_or_none(edit)
 
 
 @mcp.tool()
 def eliminate_at(
     path: str, line: int, column: int, label: str
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Generate a tactic that uses ``label`` to derive a fact (or
     discharge the goal) at the hole at ``line``:``column``.
 
@@ -357,7 +376,7 @@ def eliminate_at(
     edit = query.eliminate_at(
         path, content, pos, label, prelude=_prelude_for(path)
     )
-    return _to_serializable(edit)
+    return _to_dict_or_none(edit)
 
 
 @mcp.tool()
@@ -384,7 +403,7 @@ def eliminable_vars_at(
 @mcp.tool()
 def fill_from_given_at(
     path: str, line: int, column: int, label: str
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Fill the hole at ``line``:``column`` with ``conclude <goal> by
     <label>``.
 
@@ -405,7 +424,7 @@ def fill_from_given_at(
     edit = query.fill_from_given_at(
         path, content, pos, label, prelude=_prelude_for(path)
     )
-    return _to_serializable(edit)
+    return _to_dict_or_none(edit)
 
 
 @mcp.tool()
@@ -429,7 +448,7 @@ def matching_givens_at(
 @mcp.tool()
 def preview_conclude_at(
     path: str, line: int, column: int, label: str
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Preview ``conclude <goal> by <label>`` modulo auto-rule
     normalization at the hole at ``line``:``column``.
 
@@ -476,7 +495,7 @@ def apply_at(
     path: str, line: int, column: int,
     theorem: str,
     args: Optional[list[str]] = None,
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Preview ``apply <theorem>[<args>] to ?`` at the hole at
     ``line``:``column``.
 
@@ -524,7 +543,7 @@ def apply_at(
 @mcp.tool()
 def preview_replace_at(
     path: str, line: int, column: int, equation: str
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Preview the result of ``replace <equation>`` at the hole at
     ``line``:``column``.
 
@@ -558,13 +577,13 @@ def preview_replace_at(
     preview = query.preview_replace_at(
         path, content, pos, equation, prelude=_prelude_for(path)
     )
-    return _to_serializable(preview)
+    return _to_dict_or_none(preview)
 
 
 @mcp.tool()
 def preview_expand_at(
     path: str, line: int, column: int, names: list[str]
-) -> Optional[dict]:
+) -> Optional[dict[str, Any]]:
     """Preview the result of ``expand <names>`` at the hole at
     ``line``:``column``.
 
@@ -594,7 +613,7 @@ def preview_expand_at(
     preview = query.preview_expand_at(
         path, content, pos, names, prelude=_prelude_for(path)
     )
-    return _to_serializable(preview)
+    return _to_dict_or_none(preview)
 
 
 @mcp.tool()
@@ -604,7 +623,7 @@ def available_lemmas_at(
     column: int,
     query: Optional[str] = None,
     limit: int = 50,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """Search for theorems/lemmas/postulates relevant at a position.
 
     The cursor at ``line``:``column`` is interpreted as follows:
@@ -647,11 +666,11 @@ def available_lemmas_at(
         prelude=_prelude_for(path),
         limit=limit,
     )
-    return [_to_serializable(m) for m in matches]
+    return _to_list_of_dicts(matches)
 
 
 @mcp.tool()
-def auto_rules_at(path: str, line: int, column: int) -> list[dict]:
+def auto_rules_at(path: str, line: int, column: int) -> list[dict[str, Any]]:
     """Return ``auto`` rewrite rules in scope at ``line``:``column``.
 
     Lines and columns are 1-indexed.  Each entry has ``name`` (the
@@ -670,11 +689,11 @@ def auto_rules_at(path: str, line: int, column: int) -> list[dict]:
     content = _read_file(path)
     pos = query.Position(line=line, column=column)
     rules = query.auto_rules_at(path, content, pos, prelude=_prelude_for(path))
-    return _to_serializable(rules)
+    return _to_list_of_dicts(rules)
 
 
 @mcp.tool()
-def list_symbols(path: str) -> list[dict]:
+def list_symbols(path: str) -> list[dict[str, Any]]:
     """Return all top-level declarations in ``path``.
 
     Includes theorems, lemmas, postulates, defines, recursive
@@ -686,7 +705,7 @@ def list_symbols(path: str) -> list[dict]:
     """
     content = _read_file(path)
     syms = query.list_symbols(path, content, prelude=_prelude_for(path))
-    return _to_serializable(syms)
+    return _to_list_of_dicts(syms)
 
 
 def main() -> None:

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -4483,7 +4483,7 @@ def auto_rules_at(
     for module_name, module_ast in cached_modules.items():
         if module_name == user_module:
             continue
-        for stmt in module_ast or ():
+        for stmt in module_ast:
             if isinstance(stmt, (Theorem, Postulate)):
                 formula_by_name[stmt.name] = str(stmt.what)
     if result.ast is not None:
@@ -4496,9 +4496,7 @@ def auto_rules_at(
     for module_name in sorted(cached_modules.keys()):
         if module_name == user_module:
             continue
-        module_ast = cached_modules.get(module_name)
-        if module_ast is None:
-            continue
+        module_ast = cached_modules[module_name]
         for stmt in module_ast:
             if isinstance(stmt, Auto):
                 rules.append(_auto_rule_from_stmt(stmt, module_name, formula_by_name))

--- a/parser.py
+++ b/parser.py
@@ -3,24 +3,24 @@ from lark import Lark, Token, exceptions
 from flags import *
 from error import *
 
-filename = '???'
+filename: str = '???'
 
-def set_filename(fname):
+def set_filename(fname: str) -> None:
     global filename
     filename = fname
 
-def get_filename():
+def get_filename() -> str:
     global filename
     return filename
 
 
-deduce_directory = '???'
+deduce_directory: str = '???'
 
-def set_deduce_directory(dir):
+def set_deduce_directory(dir: str) -> None:
     global deduce_directory
     deduce_directory = dir
 
-def get_deduce_directory():
+def get_deduce_directory() -> str:
     global deduce_directory
     return deduce_directory
 
@@ -30,7 +30,7 @@ def get_deduce_directory():
 
 lark_parser = None
 
-def init_parser():
+def init_parser() -> None:
   global lark_parser
   lark_file = get_deduce_directory() + "/Deduce.lark"
   lark_parser = Lark(open(lark_file, encoding="utf-8").read(),
@@ -843,7 +843,9 @@ def parse_tree_to_ast(e, parent):
 def token_str(token, program_text):
     return program_text[token.start_pos:token.end_pos]
 
-def parse(program_text, trace = False, error_expected = False):
+def parse(program_text: str,
+          trace: "bool | VerboseLevel" = False,
+          error_expected: bool = False) -> "list[Statement]":
   try:    
     # if trace:
     #     print('lexing!')
@@ -855,6 +857,7 @@ def parse(program_text, trace = False, error_expected = False):
     #     print('')
     if trace:
         print('parsing!')
+    assert lark_parser is not None, "init_parser() must be called before parse()"
     parse_tree = lark_parser.parse(program_text)
     if trace:
         print('parse tree: ')

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -23,10 +23,10 @@
 #    reduce some formulas and terms automatically.
 
 from dataclasses import dataclass
-from typing import List, Tuple, cast
+from typing import List, Optional, Tuple, cast
 
 from abstract_syntax import *
-from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, IncompleteProof, match_failed, MatchFailed, wrap_user_error, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe
+from error import user_error, incomplete_error, internal_error, warning, error_header, Diagnostic, ErrorSink, IncompleteProof, match_failed, MatchFailed, wrap_user_error, get_active_sink, set_active_sink, add_incomplete, add_diagnostic, speculative_probe
 from flags import get_verbose, set_verbose, print_verbose, VerboseLevel, get_target_hole_location, get_debugger
 import style
 
@@ -5266,7 +5266,9 @@ def check_proofs(stmt, env: Env):
   if _dbg is not None:
     _dbg.after_statement(stmt, env)
 
-def check_deduce(ast, module_name, modified, tracing_functions, error_sink=None):
+def check_deduce(ast: List[Statement], module_name: str, modified: bool,
+                 tracing_functions: List[str],
+                 error_sink: Optional[ErrorSink] = None) -> List[Statement]:
   """Run the four-phase pipeline (process_declarations, type_check_stmt,
   collect_env, check_proofs) over ``ast``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,6 @@ module = [
     "style",
     "lsp.benchmark",
     "lsp.library",
-    "lsp.mcp_server",
     "claude_fill_hole.__main__",
     "claude_fill_hole.agent",
     "claude_fill_hole.anthropic_backend",
@@ -152,6 +151,24 @@ disallow_any_generics = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_untyped_decorators = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+warn_return_any = true
+
+# lsp/mcp_server.py uses `@mcp.tool()` from the `mcp` package, which
+# is an optional dev-only dep that the CI workflow does not install
+# (same pattern as `pygls` for `lsp/lsp_server.py` — see comment on
+# global `disallow_untyped_decorators` above). Under
+# `ignore_missing_imports = true`, `mcp.tool` resolves to `Any` on
+# CI, which makes every decorated function "untyped" and trips
+# disallow_untyped_decorators. Listed in its own override block with
+# the strict bits but without the decorator check, since mypy refuses
+# to merge two overrides setting conflicting values for the same key.
+[[tool.mypy.overrides]]
+module = ["lsp.mcp_server"]
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 warn_return_any = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ module = [
     "flags",
     "style",
     "lsp.benchmark",
+    "lsp.mcp_server",
     "claude_fill_hole.__main__",
     "claude_fill_hole.agent",
     "claude_fill_hole.anthropic_backend",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ module = [
     "flags",
     "style",
     "lsp.benchmark",
+    "lsp.library",
     "lsp.mcp_server",
     "claude_fill_hole.__main__",
     "claude_fill_hole.agent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ exclude = [
 [[tool.mypy.overrides]]
 module = [
     "deduce",
+    "error",
     "compiler.closure",
     "compiler.compile_prelude",
     "compiler.emit_c",

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -8,24 +8,24 @@ from lark import Lark, Token
 from error import *
 from edit_distance import closest_keyword, edit_distance
 
-filename = '???'
+filename: str = '???'
 
-def set_filename(fname):
+def set_filename(fname: str) -> None:
     global filename
     filename = fname
 
-def get_filename():
+def get_filename() -> str:
     global filename
     return filename
 
 
-deduce_directory = '???'
+deduce_directory: str = '???'
 
-def set_deduce_directory(dir):
+def set_deduce_directory(dir: str) -> None:
     global deduce_directory
     deduce_directory = dir
 
-def get_deduce_directory():
+def get_deduce_directory() -> str:
     global deduce_directory
     return deduce_directory
 
@@ -46,7 +46,7 @@ accessiblity_keywords = {'OPAQUE', 'PRIVATE', 'PUBLIC'}
 
 lark_parser: Optional[Lark] = None
 
-def init_parser():
+def init_parser() -> None:
   global lark_parser
   lark_file = get_deduce_directory() + "/Deduce.lark"
   lark_parser = Lark(open(lark_file, encoding="utf-8").read(),
@@ -94,9 +94,12 @@ def consume_token(expected, display, context = "", advice=""):
   
 check_closest_kwd = False
 
-def parse(program_text, trace = False, error_expected = False):
+def parse(program_text: str,
+          trace: "bool | VerboseLevel" = False,
+          error_expected: bool = False) -> "list[Statement]":
   global token_list, current_position, check_closest_kwd
   try:
+    assert lark_parser is not None, "init_parser() must be called before parse()"
     lexed = lark_parser.lex(program_text)
     token_list = []
     current_position = 0


### PR DESCRIPTION
Continuation of the per-module `--strict` push.  Stacked on #500 (which is stacked on #497).

## What this PR does

Three commits, each closes one or more modules to per-module `--strict`:

1. **`8eb0858` — `lsp/mcp_server.py` (26 → 0)** — typed-wrapper pattern. Every `@mcp.tool()` function returns a dict/list serialized via `_to_serializable(obj: Any) -> Any`, which under `--strict` collides with the tool's declared `-> dict[str, Any]` (`no-any-return`). Added two typed helpers `_to_dict_or_none(obj) -> Optional[dict[str, Any]]` and `_to_list_of_dicts(items) -> list[dict[str, Any]]` next to `_to_serializable` and swap every `return _to_serializable(...)` site to use them. 15 bare `dict` annotations widened to `dict[str, Any]` at the same time.

2. **`8e45107` — `error.py` (63 → 0)** — post-hoc-stashed exception attributes (same family as #480 / #487 for AST classes). The helpers `user_error` / `incomplete_error` / `static_error` / `match_failed` / `add_diagnostic` / `add_incomplete` all do `exc = UserError(...); exc.location = loc; exc.message_body = msg; raise exc`. Declared `location: Meta` and `message_body: str` on the `Diagnostic` base class so every subclass inherits the same shape — mypy then accepts the post-hoc assignments without `attr-defined` errors. `IncompleteProof` additionally gets `formula: Optional[Any]` and `env: Optional[Any]` (the LSP/MCP refine pipeline's fields). `MatchFailed` (an internal non-Diagnostic exception that uses the same pattern) gets its own declarations. Plus 14 plain function annotations.

3. **`9efdadd` — parser/check_deduce surface + `lsp/library.py` (16 → 0)** — annotates the foundational entry points (`set_filename`, `set_deduce_directory`, `init_parser`, `parse` in both `parser.py` and `rec_desc_parser.py`; `get_uniquified_modules` / `add_uniquified_module` in `abstract_syntax.py`; `check_deduce` in `proof_checker.py`) so `lsp/library.py` stops failing strict on `Call to untyped function in typed context`. The `parse(..., trace: bool | VerboseLevel = False, ...)` widens its trace parameter to match what callers pass (`get_verbose()` from flags.py — see `b7dbdf3` for that union). `CheckResult.errors` widened to `Optional[list[BaseException]]` because the fallback `__post_init__` branch puts non-Diagnostic exceptions in there. The `Meta()` (lark constructor) call gets `# type: ignore[no-untyped-call]` since lark has no public stubs.

## Strict overrides after this PR

20 modules. Remaining (in expected-cost order):

| Module | Errors |
| --- | ---: |
| `lsp/debugger.py` | 35 |
| `lsp/dap_server.py` | 45 |
| `lsp/lsp_server.py` | 70 |
| `lsp/query.py` | 126 |
| `parser.py` | 298 |
| `proof_checker.py` | 1055 |
| `abstract_syntax.py` | 1103 |
| `rec_desc_parser.py` | 1224 |

The cumulative effect of this PR series is visible in the big-three drops: `proof_checker.py` 1320 → 1055, `abstract_syntax.py` 1192 → 1103. Each `--strict` flag adopted in a high-traffic surface module sheds untyped-call errors downstream.

## Test plan

- [x] `mypy --strict lsp/{mcp_server,library}.py error.py --follow-imports=silent` all clean
- [x] `mypy .` clean
- [x] `ruff check .` clean
- [x] `make tests` (both parsers) green
- [x] `make tests-lib` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)