### PR TITLE
Fix #502: generalize map_append to fn T->U

### DIFF
--- a/lib/List.pf
+++ b/lib/List.pf
@@ -314,17 +314,17 @@ proof
   }
 end
 
-theorem map_append: all T:type, f: fn T->T, ys:List<T>, xs:List<T>.
+theorem map_append: all T:type, U:type, f: fn T->U, ys:List<T>, xs:List<T>.
   map(xs ++ ys, f) = map(xs,f) ++ map(ys, f)
 proof
-  arbitrary T:type
-  arbitrary f:fn T->T, ys:List<T>
+  arbitrary T:type, U:type
+  arbitrary f:fn T->U, ys:List<T>
   induction List<T>
   case empty {
     equations
       map(@empty<T> ++ ys, f)
           = map(ys, f)                          by expand operator++.
-      ... =# @empty<T> ++ map(ys, f) #          by expand operator++.
+      ... =# @empty<U> ++ map(ys, f) #          by expand operator++.
       ... =# map(@empty<T>, f) ++ map(ys, f) #  by expand map.
   }
   case node(x, xs')

--- a/test/should-validate/map_append_cross_type.pf
+++ b/test/should-validate/map_append_cross_type.pf
@@ -1,0 +1,16 @@
+import UInt
+import List
+
+theorem map_append_cross_type:
+  all f: fn UInt -> bool, xs:List<UInt>, ys:List<UInt>.
+  map(xs ++ ys, f) = map(xs, f) ++ map(ys, f)
+proof
+  arbitrary f: fn UInt -> bool, xs:List<UInt>, ys:List<UInt>
+  map_append<UInt, bool>[f, ys, xs]
+end
+
+private define is_zero : fn UInt -> bool = fun n:UInt { n = 0 }
+private define A : List<UInt> = node(0, node(1, empty))
+private define B : List<UInt> = node(2, node(0, empty))
+
+assert map(A ++ B, is_zero) = map(A, is_zero) ++ map(B, is_zero)


### PR DESCRIPTION
## Summary

- Generalize `map_append` in `lib/List.pf` from `f: fn T->T` to `f: fn T->U` (matches the existing polymorphic style of `map_compose`).
- The existing proof goes through unchanged except for one intermediate-term type annotation in the empty case (`empty<T>` → `empty<U>` at the step where `map(_, f)` has produced a `List<U>`).
- Add `test/should-validate/map_append_cross_type.pf` to lock in the cross-type instantiation as a regression test — it instantiates `map_append<UInt, bool>` at `λn. n = 0`, which would not have type-checked under the old signature.

## Motivation (from the issue)

Trying to prove the naturality of `concat`,

```deduce
map(concat(xss), f) = concat(map(xss, fun ys:List<T> { map(ys, f) }))
```

needs `map_append` at `fn T->U`. Without this generalization, users have to re-prove the lemma inline.

Closes #502.

## Test plan

- [x] `python deduce.py --recursive-descent lib/List.pf` is valid
- [x] `python deduce.py --lalr lib/List.pf` is valid
- [x] `python deduce.py --recursive-descent test/should-validate/map_append_cross_type.pf` is valid
- [x] `python deduce.py --lalr test/should-validate/map_append_cross_type.pf` is valid
- [x] `python test-deduce.py --lib` passes
- [x] `python test-deduce.py --passable` passes
- [x] `python test-deduce.py --errors` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)