### PR TITLE
docs: document <T> type instantiation in TacticsCheatSheet

### DIFF
--- a/gh_pages/doc/TacticsCheatSheet.md
+++ b/gh_pages/doc/TacticsCheatSheet.md
@@ -48,7 +48,9 @@ If a name on this page is unfamiliar, follow the link in the Reference column fo
 
 | Form | Meaning |
 | --- | --- |
-| `lemma[t1, t2]` | Instantiate the leading `∀` variables. Produces a proof term. |
+| `lemma<T1, T2>` | Instantiate the leading type `∀` variables (when the leading `∀` binds types). |
+| `lemma[t1, t2]` | Instantiate the leading term `∀` variables. Produces a proof term. |
+| `lemma<T>[t1, t2]` | Combined: instantiate type variables, then term variables. |
 | `apply lemma to p` | Modus ponens: given `lemma : if P then Q` and `p : P`, returns a proof of `Q`. |
 | `apply lemma to p1, p2` | Same, when the antecedent is `P1 and P2` — the comma builds the conjunction. |
 | `apply lemma[t] to p` | Combined instantiation and modus ponens. |


### PR DESCRIPTION
## Summary

- Add `lemma<T1, T2>` and `lemma<T>[t1, t2]` rows to the "Applying lemmas" table in [gh_pages/doc/TacticsCheatSheet.md](gh_pages/doc/TacticsCheatSheet.md).
- Tighten the existing `lemma[t1, t2]` wording from "leading ∀ variables" to "leading term ∀ variables".

Closes #503.

## Motivation

Per the issue, the cheat sheet currently describes `lemma[t1, t2]` as instantiating "leading ∀ variables", but `[...]` only instantiates the leading *term* ∀. A beginner attempt like

```deduce
... by symmetric append_assoc[T, xs, concat(xss'), concat(yss)]
```

errors with a message telling the user to write `append_assoc<T>` — i.e. the `<...>` form, which is documented in [Reference.md:1311](gh_pages/doc/Reference.md:1311) but not in the cheat sheet beginners reach for first.

## Test plan

- [x] Render the table mentally and confirm the new rows fit the existing two-column `Form | Meaning` shape.
- [x] No code paths touched; only a Markdown doc file under `gh_pages/doc/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)