### PR TITLE
Tighten mypy: enable warn_return_any on abstract_syntax.py

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -145,9 +145,9 @@ def _alpha_equiv(t1, t2, env1, env2) -> bool:
   # Fast path: top-level (no renaming in scope). Defer to existing
   # __eq__ which encodes the leaf-level cross-class semantics.
   if not env1 and not env2:
-    return t1 == t2
+    return bool(t1 == t2)
   if not isinstance(t1, AST):
-    return t1 == t2
+    return bool(t1 == t2)
   if isinstance(t1, (Var, OverloadedVar, ResolvedVar, RecFun, GenRecFun)):
     return _alpha_equiv_varref(t1, t2, env1, env2)
   if isinstance(t1, Lambda):
@@ -184,7 +184,7 @@ def _alpha_equiv_value(v1, v2, env1, env2) -> bool:
     if not isinstance(v2, tuple) or len(v1) != len(v2):
       return False
     return all(_alpha_equiv_value(a, b, env1, env2) for a, b in zip(v1, v2))
-  return v1 == v2
+  return bool(v1 == v2)
 
 
 def _varref_name(t):
@@ -380,7 +380,7 @@ def copy_dict(d):
 def maybe_str(o: Optional[str], default='') -> str:
   return str(o) if o is not None else default
 
-def maybe_pretty_print(o: Optional[Any], indent, default='') -> str:
+def maybe_pretty_print(o: Optional["Proof"], indent: int, default: str = '') -> str:
   return o.pretty_print(indent) if o is not None else default
 
 class UniquifyContext:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,3 +172,17 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 warn_return_any = true
+
+# abstract_syntax.py is too big for a one-shot --strict adoption
+# (~1192 errors against full --strict — see #506). Ratchet the
+# heavyweight bits on one flag at a time, cheapest first; once they
+# are all on, move the module into the unified strict block above.
+# Order so far (per the table in #506):
+#   warn_return_any        (4 errors, fixed here)
+#   disallow_any_generics  (6 errors, next)
+#   disallow_untyped_calls (16)
+#   check_untyped_defs     (77)
+#   disallow_untyped_defs  (493)
+[[tool.mypy.overrides]]
+module = ["abstract_syntax"]
+warn_return_any = true


### PR DESCRIPTION
## Summary

First per-flag step toward putting `abstract_syntax.py` under full `--strict` (per issue #506's flag-cost table, `warn_return_any` is the cheapest unset flag for this module at 4 errors).

- Fixes 4 `no-any-return` errors in `abstract_syntax.py`
- Adds a per-module `[[tool.mypy.overrides]]` block enabling `warn_return_any = true` so any regression is caught in CI
- Project-wide `mypy .` still clean (33 source files)

## What changed

In `abstract_syntax.py`:
- `_alpha_equiv` (lines 148, 150): wrap `t1 == t2` in `bool(...)` — the dataclass `__eq__` overrides aren't annotated, so `==` returns `Any`.
- `_alpha_equiv_value` (line 187): same shape, wrap `v1 == v2` in `bool(...)`.
- `maybe_pretty_print` (line 384): retype parameter as `Optional[\"Proof\"]` (was `Optional[Any]`) so the `pretty_print` return type is `str`, not `Any`. All 9 callers pass `self.body`, which is always `Proof`. Also annotate `indent: int` and `default: str`.

In `pyproject.toml`: new per-module override block for `abstract_syntax` with `warn_return_any = true`. Comment notes the remaining per-flag order (`disallow_any_generics` 6 → `disallow_untyped_calls` 16 → `check_untyped_defs` 77 → `disallow_untyped_defs` 493) so the next sub-PR can pick up.

Addresses #506 (warn_return_any portion for abstract_syntax.py).

## Test plan

- [x] `mypy --warn-return-any abstract_syntax.py --follow-imports=silent` — Success
- [x] `mypy .` project-wide — Success: no issues found in 33 source files
- [ ] CI: `make tests tests-lib` (both parsers) — running

🤖 Generated with [Claude Code](https://claude.com/claude-code)