### PR TITLE
Add documentation comments to lib/List.pf

### DIFF
--- a/lib/List.pf
+++ b/lib/List.pf
@@ -1,3 +1,13 @@
+/*
+  Singly-linked lists over an element type T, together with the
+  standard operations (length, append, reverse, map, fold, zip,
+  filter, get, take, drop, ...) and theorems relating them.
+
+  The two constructors are `empty` (also written `[]`) and
+  `node(x, xs)`. The literal syntax `[1, 2, 3]` desugars to
+  `node(1, node(2, node(3, empty)))`.
+*/
+
 import Base
 import UInt
 import Option
@@ -6,51 +16,68 @@ import MultiSet
 import Pair
 import Maps
 
+// A list is either empty or a node carrying a head element and a tail list.
 union List<T> {
   empty
   node(T, List<T>)
 }
 
+// Number of elements in the list.
 recursive length<E>(List<E>) -> UInt {
   length(empty) = 0
   length(node(n, next)) = 1 + length(next)
 }
 
+// Does the list contain the given element?
 recursive contains<E>(List<E>, E) -> bool {
   contains(empty, x) = false
   contains(node(y, next), x) = (y = x) or contains(next, x)
 }
 
+// List concatenation (append). `xs ++ ys` is the list whose elements
+// are those of `xs` followed by those of `ys`.
 recursive operator ++ <E>(List<E>, List<E>) -> List<E> {
   operator ++([], ys) = ys
   operator ++(node(n, xs), ys) = node(n, xs ++ ys)
 }
 
+// Reverse the order of the elements.
 recursive reverse<E>(List<E>) -> List<E> {
   reverse([]) = []
   reverse(node(n, next)) = reverse(next) ++ [n]
 }
 
+// Convert the list to a set: the set of all elements that appear,
+// discarding both order and how many times each element occurs.
 recursive set_of<T>(List<T>) -> Set<T> {
   set_of(empty) = ∅
   set_of(node(x, xs)) = single(x) ∪ set_of(xs)
 }
 
+// Convert the list to a multiset: discards order but preserves the
+// number of occurrences of each element.
 recursive mset_of<T>(List<T>) -> MultiSet<T> {
   mset_of(empty) = m_empty()
   mset_of(node(x, xs)) = m_one(x) ⨄ mset_of(xs)
 }
 
+// Apply `f` to every element, producing a list of the same length.
 recursive map<T,U>(List<T>, fn T->U) -> List<U> {
   map(empty, f) = empty
   map(node(x, ls), f) = node(f(x), map(ls, f))
 }
 
+// Right fold: combine the elements right-to-left, starting from `u`,
+// using the binary operation `c`. Equivalent to
+// `c(x0, c(x1, ... c(x_{n-1}, u) ...))`.
 recursive foldr<T,U>(List<T>, U, fn T,U->U) -> U {
   foldr(empty, u, c) = u
   foldr(node(t, ls), u, c) = c(t, foldr(ls, u, c))
 }
 
+// Left fold: combine the elements left-to-right, starting from `u`,
+// using the binary operation `c`. Equivalent to
+// `c(... c(c(u, x0), x1) ..., x_{n-1})`.
 recursive foldl<T,U>(List<T>, U, fn U,T->U) -> U {
   foldl(empty, u, c) = u
   foldl(node(t, ls), u, c) = foldl(ls, c(u, t), c)
@@ -81,6 +108,9 @@ recursive interval(Nat, Nat) -> List<Nat> {
 define range : fn Nat,Nat -> List<Nat> = λ b, e { interval(e ∸ b, b) }
 */
 
+// Pair up corresponding elements from two lists. The result has
+// length equal to the shorter input; extra elements of the longer
+// list are discarded.
 recursive zip<T,U>(List<T>, List<U>) -> List< Pair<T, U> > {
   zip(empty, ys) = empty
   zip(node(x, xs'), ys) =
@@ -90,6 +120,8 @@ recursive zip<T,U>(List<T>, List<U>) -> List< Pair<T, U> > {
     }
 }
 
+// Inverse of `zip`: split a list of pairs into a pair of lists,
+// each holding the corresponding component.
 recursive unzip<T,U>(List< Pair<T, U> >) -> Pair< List<T>, List<U> > {
   unzip(empty) = pair(@empty<T>, @empty<U>)
   unzip(node(p, ps)) =
@@ -97,6 +129,7 @@ recursive unzip<T,U>(List< Pair<T, U> >) -> Pair< List<T>, List<U> > {
     pair(node(first(p), first(xys)), node(second(p), second(xys)))
 }
 
+// Keep only the elements that satisfy the predicate `P`.
 recursive filter<E>(List<E>, fn (E)->bool) -> List<E> {
   filter(empty, P) = empty
   filter(node(x, ls), P) =
@@ -104,6 +137,8 @@ recursive filter<E>(List<E>, fn (E)->bool) -> List<E> {
     else filter(ls, P)
 }
 
+// Remove the first occurrence of `y` from the list. If `y` is not
+// present, the list is returned unchanged.
 recursive remove<T>(List<T>, T) -> List<T> {
   remove(empty, y) = empty
   remove(node(x, xs'), y) =
@@ -113,6 +148,7 @@ recursive remove<T>(List<T>, T) -> List<T> {
       node(x, remove(xs', y))
 }
 
+// Remove every occurrence of `y` from the list.
 recursive remove_all<T>(List<T>, T) -> List<T> {
   remove_all(empty, y) = empty
   remove_all(node(x, xs'), y) =
@@ -122,6 +158,9 @@ recursive remove_all<T>(List<T>, T) -> List<T> {
       node(x, remove_all(xs', y))
 }
 
+// Lookup the element at position `i` (0-indexed). Returns
+// `just(x)` if the index is in range, or `none` if it is past
+// the end of the list.
 recursive get<T>(List<T>, UInt) -> Option<T> {
   get(empty, i) = none
   get(node(x, xs), i) =
@@ -131,6 +170,8 @@ recursive get<T>(List<T>, UInt) -> Option<T> {
        get(xs, i ∸ 1)
 }
 
+// The prefix of length `n`. If the list has fewer than `n`
+// elements, the whole list is returned.
 recursive take<T>(List<T>, UInt) -> List<T> {
   take(empty, n) = empty
   take(node(x, xs), n) =
@@ -138,6 +179,8 @@ recursive take<T>(List<T>, UInt) -> List<T> {
     else node(x, take(xs, n ∸ 1))
 }
 
+// Drop the first `n` elements and return the rest. If the list
+// has fewer than `n` elements, the result is empty.
 recursive drop<T>(List<T>, UInt) -> List<T> {
   drop(empty, n) = empty
   drop(node(x, xs'), n) =
@@ -145,6 +188,8 @@ recursive drop<T>(List<T>, UInt) -> List<T> {
     else drop(xs', n ∸ 1)
 }
 
+// The first element, as an `Option`: `just(x)` if non-empty,
+// otherwise `none`.
 fun head<T>(ls : List<T>) {
   switch ls {
     case empty { @none<T> }
@@ -152,6 +197,8 @@ fun head<T>(ls : List<T>) {
   }
 }
 
+// All elements after the first. Returns the empty list when given
+// an empty list.
 fun tail<T>(ls : List<T>) {
   switch ls {
     case empty { @empty<T> }
@@ -161,6 +208,7 @@ fun tail<T>(ls : List<T>) {
 
 /********************** Theorems *********************************/
 
+// Length distributes over append: |xs ++ ys| = |xs| + |ys|.
 theorem length_append: all U :type, xs :List<U>, ys :List<U>.
   length(xs ++ ys) = length(xs) + length(ys)
 proof
@@ -182,6 +230,7 @@ proof
   }
 end
 
+// A list whose length is zero must be the empty list.
 theorem length_zero_empty: all T:type, xs:List<T>.
   if length(xs) = 0
   then xs = empty
@@ -194,6 +243,7 @@ proof
   }
 end
 
+// Append is associative: the order of grouping does not matter.
 theorem append_assoc: all U :type, xs :List<U>, ys :List<U>, zs:List<U>.
   (xs ++ ys) ++ zs = xs ++ (ys ++ zs)
 proof
@@ -214,6 +264,9 @@ end
 
 associative operator++ <T> in List<T>
 
+// The empty list is a right identity for append. (The matching
+// left identity, `[] ++ xs = xs`, follows directly from the
+// definition of `++`.)
 theorem append_empty: all U :type, xs :List<U>.
   xs ++ [] = xs
 proof
@@ -230,6 +283,7 @@ proof
   }
 end
 
+// Reversing a list preserves its length.
 theorem length_reverse: all U :type, xs :List<U>.
   length(reverse(xs)) = length(xs)
 proof
@@ -252,6 +306,7 @@ proof
   }
 end
 
+// Reversing an append swaps and reverses the two parts.
 theorem reverse_append: all U :type, xs :List<U>, ys :List<U>.
   reverse(xs ++ ys) = reverse(ys) ++ reverse(xs)
 proof
@@ -277,6 +332,7 @@ proof
   }
 end
 
+// `map` preserves length: the output has one entry per input.
 theorem length_map: all T:type, f:fn T->T, xs:List<T>.
   length(map(xs, f)) = length(xs)
 proof
@@ -295,6 +351,8 @@ proof
   }
 end
 
+// Mapping a function that is pointwise the identity leaves the
+// list unchanged.
 theorem map_id: all T:type, f:fn T->T. if (all x:T. f(x) = x) then
    all xs:List<T>. map(xs, f) = xs
 proof
@@ -314,6 +372,7 @@ proof
   }
 end
 
+// `map` distributes over append.
 theorem map_append: all T:type, U:type, f: fn T->U, ys:List<T>, xs:List<T>.
   map(xs ++ ys, f) = map(xs,f) ++ map(ys, f)
 proof
@@ -338,6 +397,8 @@ proof
   }
 end
 
+// Map fusion: mapping `f` and then `g` is the same as mapping
+// the composition `g ∘ f` once.
 theorem map_compose: all T:type, U:type, V:type, f:fn T->U, g:fn U->V, ls :List<T>.
   map(map(ls, f), g) = map(ls, g ∘ f)
 proof
@@ -355,6 +416,9 @@ proof
   }
 end
 
+// Zipping any list with an empty list on the right gives an empty
+// list. (The matching empty-on-the-left case follows directly from
+// the definition of `zip`.)
 theorem zip_empty_right: all T:type, U:type, xs:List<T>.
     zip(xs, empty : List<U>) = empty
 proof
@@ -364,6 +428,8 @@ proof
   case node(x, xs') { evaluate }
 end
 
+// `zip` commutes with `map`: zipping after mapping each side equals
+// mapping `pairfun(f, g)` over the zipped list.
 theorem zip_map: all T1:type, T2:type, U1:type, U2:type,
   f : fn T1 -> T2, g : fn U1 -> U2, xs:List<T1>, ys:List<U1>.
   zip(map(xs, f), map(ys, g)) = map(zip(xs,ys), pairfun(f,g))
@@ -417,6 +483,7 @@ proof
 end
 */
 
+// A list whose `set_of` is empty must itself be empty.
 theorem set_of_empty: all T:type, xs:List<T>.
   if set_of(xs) = ∅
   then xs = empty
@@ -434,6 +501,8 @@ proof
   }
 end
 
+// `set_of` distributes over append, with union as the corresponding
+// operation on sets.
 theorem set_of_append: all T:type, xs:List<T>, ys:List<T>.
   set_of(xs ++ ys) = set_of(xs) ∪ set_of(ys)
 proof
@@ -450,6 +519,7 @@ proof
   }
 end
 
+// A list whose `mset_of` is the empty multiset must itself be empty.
 theorem mset_of_empty: all T:type, xs:List<T>.
   if mset_of(xs) = @m_empty<T>()
   then xs = empty
@@ -471,6 +541,8 @@ proof
   }
 end
 
+// Forgetting multiplicity after building the multiset gives the same
+// result as building the set directly: `set_of_mset ∘ mset_of = set_of`.
 theorem som_mset_eq_set: all T:type, xs:List<T>.
   set_of_mset(mset_of(xs)) = set_of(xs)
 proof
@@ -490,6 +562,7 @@ proof
   }
 end
 
+// After `remove_all(xs, y)`, `y` is no longer in the resulting set.
 theorem not_set_of_remove_all: all W:type, xs:List<W>, y:W.
   not (y ∈ set_of(remove_all(xs, y)))
 proof
@@ -532,6 +605,7 @@ proof
   }
 end
 
+// Taking zero elements always yields the empty list.
 theorem take_zero: all E:type, xs:List<E>.
   take(xs, 0) = []
 proof
@@ -546,6 +620,7 @@ proof
   }
 end
 
+// Taking the first `length(xs)` elements of `xs ++ ys` recovers `xs`.
 theorem take_append: all E:type, xs:List<E>, ys:List<E>.
   take(xs ++ ys, length(xs)) = xs
 proof
@@ -563,6 +638,8 @@ proof
   }  
 end
   
+// Length of `drop` plus the number dropped equals the original length,
+// provided we did not try to drop more than was there.
 theorem length_drop: all E:type, xs:List<E>, n:UInt.
   if n ≤ length(xs)
   then length(drop(xs, n)) + n = length(xs)
@@ -603,6 +680,7 @@ proof
   }
 end
 
+// Alias for `length_drop`.
 theorem len_drop: all E:type, xs:List<E>, n:UInt.
   if n ≤ length(xs)
   then length(drop(xs, n)) + n = length(xs)
@@ -610,6 +688,7 @@ proof
   length_drop
 end
   
+// Dropping more elements than the list contains leaves an empty list.
 theorem length_drop_zero: all E:type, xs:List<E>, n:UInt.
   if length(xs) < n
   then length(drop(xs, n)) = 0
@@ -644,6 +723,7 @@ proof
   }
 end
 
+// Dropping zero elements leaves the list unchanged.
 theorem drop_zero_identity: all E:type, xs:List<E>.
   drop(xs, 0) = xs
 proof
@@ -657,6 +737,7 @@ proof
   }
 end
 
+// Dropping `length(xs)` elements from `xs ++ ys` leaves just `ys`.
 theorem drop_append: all E:type, xs:List<E>, ys:List<E>.
   drop(xs ++ ys, length(xs)) = ys
 proof
@@ -674,6 +755,8 @@ proof
   }
 end
 
+// Looking up index `i` after dropping the first `n` elements is the
+// same as looking up index `n + i` in the original list.
 theorem get_drop: all T:type, xs:List<T>, n:UInt, i:UInt, d:T.
   get(drop(xs, n), i) = get(xs, n + i)
 proof
@@ -699,6 +782,8 @@ proof
   }
 end
 
+// If the index falls within `xs`, then `get` on `xs ++ ys` returns
+// the same element as `get` on `xs` alone.
 theorem get_append_front: all T:type, xs:List<T>, ys:List<T>, i:UInt.
   if i < length(xs)
   then get(xs ++ ys, i) = get(xs, i)
@@ -734,6 +819,8 @@ proof
   }
 end
 
+// Indexing past `xs` into `xs ++ ys` is the same as indexing into
+// `ys` by the offset.
 theorem get_append_back: all T:type, xs:List<T>, ys:List<T>, i:UInt.
   get(xs ++ ys, length(xs) + i) = get(ys, i)
 proof
@@ -750,6 +837,7 @@ proof
   }
 end
 
+// An out-of-range index returns `none`.
 theorem get_none: all T:type, xs:List<T>, i:UInt.
   if length(xs) <= i
   then get(xs, i) = none
@@ -787,6 +875,9 @@ proof
   }
 end
 
+// If two lists have the same multiset, they have the same underlying
+// set. (The converse fails: equal sets can arise from different
+// multiplicities.)
 theorem mset_equal_implies_set_equal: all T:type, xs:List<T>, ys:List<T>.
   if mset_of(xs) = mset_of(ys)
   then set_of(xs) = set_of(ys)
@@ -800,8 +891,9 @@ proof
            ... = set_of(ys)                   by som_mset_eq_set<T>[ys]
 end
 
+// If the left list is non-empty, the head of `L ++ R` is the head of `L`.
 theorem head_append: all E:type, L:List<E>, R:List<E>.
-  if 0 < length(L) 
+  if 0 < length(L)
   then head(L ++ R) = head(L)
 proof
   arbitrary E:type
@@ -823,8 +915,9 @@ proof
   }
 end
 
+// If the left list is non-empty, the tail of `L ++ R` is `tail(L) ++ R`.
 theorem tail_append: all E:type, L:List<E>, R:List<E>.
-  if 0 < length(L) 
+  if 0 < length(L)
   then tail(L ++ R) = tail(L) ++ R
 proof
   arbitrary E:type


### PR DESCRIPTION
## Summary

- Add a brief `//` doc comment above every definition (`union`, `recursive`, `fun`) in `lib/List.pf` explaining what it computes.
- Add a brief `//` doc comment above every theorem in `lib/List.pf` summarizing what it states.
- Add a `/* … */` header at the top of the file describing what the module contains.

Addresses #99 (List.pf portion). Other stdlib files can get the same treatment in follow-up PRs; this PR keeps the scope to one file so the diff stays reviewable. No semantic change — only comments.

The issue was filed in response to a student finding `List.pf` hard to follow because it lacked any commentary on the operations or theorems.

## Test plan
- [x] \`python deduce.py --recursive-descent --quiet lib/List.pf\` → \`lib/List.pf is valid\`
- [x] \`python deduce.py --lalr --quiet lib/List.pf\` → \`lib/List.pf is valid\`
- [x] \`python test-deduce.py --lib\` → all tests passed (both parsers, 32 lib modules)
- [ ] \`python test-deduce.py\` (full suite — lib + should-validate + should-error + prelude)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)