### PR TITLE
[codex] Add UInt strong induction

### DIFF
--- a/lib/UIntAdd.pf
+++ b/lib/UIntAdd.pf
@@ -636,3 +636,29 @@ proof
   expand Q in apply uint_induction[Q] to base, ind_case
 end
 
+theorem uint_strong_induction: all P: fn UInt -> bool, n:UInt.
+  if (all j:UInt. if (all i:UInt. if i < j then P(i)) then P(j))
+  then P(n)
+proof
+  arbitrary P: fn UInt -> bool, n:UInt
+  assume prem
+  define Q = fun j:Nat { P(fromNat(j)) }
+  have nat_step: all j:Nat. if (all i:Nat. if i < j then Q(i)) then Q(j) by {
+    arbitrary j:Nat
+    assume IH: all i:Nat. if i < j then Q(i)
+    expand Q
+    have smaller: all i:UInt. if i < fromNat(j) then P(i) by {
+      arbitrary i:UInt
+      assume i_lt_j
+      have nat_i_lt_j: toNat(i) < toNat(fromNat(j)) by apply toNat_less to i_lt_j
+      have nat_i_lt_j': toNat(i) < j by replace uint_toNat_fromNat in nat_i_lt_j
+      have Qi: Q(toNat(i)) by apply IH[toNat(i)] to nat_i_lt_j'
+      have Pi: P(fromNat(toNat(i))) by expand Q in Qi
+      conclude P(i) by replace uint_fromNat_toNat in Pi
+    }
+    conclude P(fromNat(j)) by apply prem[fromNat(j)] to smaller
+  }
+  have Qn: Q(toNat(n)) by apply strong_induction[Q, toNat(n)] to nat_step
+  have Pn: P(fromNat(toNat(n))) by expand Q in Qn
+  conclude P(n) by replace uint_fromNat_toNat in Pn
+end

--- a/lib/UIntDiv.pf
+++ b/lib/UIntDiv.pf
@@ -48,21 +48,14 @@ private fun UIntDivPred(n:UInt) {
   all m:UInt. if 0 < m then some r:UInt. (n / m) * m + r = n and r < m
 }
 
-private fun NatHasUIntDivPred(k:Nat) {
-  all n:UInt. if toNat(n) = k then UIntDivPred(n)
-}
-
 lemma uint_division: all n:UInt, m:UInt.
   if 0 < m
   then some r:UInt. (n/m)*m + r = n and r < m
 proof
-  have SI: all j:Nat. if (all i:Nat. if i < j then NatHasUIntDivPred(i))
-                      then NatHasUIntDivPred(j) by {
-    arbitrary j:Nat
-    assume prem: all i:Nat. if i < j then NatHasUIntDivPred(i)
-    expand NatHasUIntDivPred
+  have SI: all nn:UInt. if (all i:UInt. if i < nn then UIntDivPred(i))
+                        then UIntDivPred(nn) by {
     arbitrary nn:UInt
-    assume tn_j: toNat(nn) = j
+    assume prem: all i:UInt. if i < nn then UIntDivPred(i)
     expand UIntDivPred
     arbitrary m:UInt
     assume m_pos: 0 < m
@@ -87,13 +80,9 @@ proof
             by apply uint_less_add_pos[nn ∸ m, m] to expand lit | fromNat in m_pos
           replace step1 in step2
         }
-        have tnm_lt_tn: toNat(nn ∸ m) < toNat(nn) by apply toNat_less to nm_n
-        have tnm_lt_j: toNat(nn ∸ m) < j by replace tn_j in tnm_lt_tn
-        have IH_a: NatHasUIntDivPred(toNat(nn ∸ m)) by apply prem to tnm_lt_j
-        have IH_b: UIntDivPred(nn ∸ m)
-          by apply (expand NatHasUIntDivPred in IH_a)[nn ∸ m] to .
+        have IH_a: UIntDivPred(nn ∸ m) by apply prem to nm_n
         have IH_c: some r:UInt. ((nn ∸ m) / m) * m + r = (nn ∸ m) and r < m
-          by apply (expand UIntDivPred in IH_b)[m] to m_pos
+          by apply (expand UIntDivPred in IH_a)[m] to m_pos
         obtain r0 where R: ((nn ∸ m) / m) * m + r0 = (nn ∸ m) and r0 < m from IH_c
         choose r0
         have conj0: (nn / m) * m + r0 = nn by {
@@ -110,8 +99,7 @@ proof
     }
   }
   arbitrary n:UInt
-  have Q: NatHasUIntDivPred(toNat(n)) by apply strong_induction[NatHasUIntDivPred, toNat(n)] to SI
-  have R: UIntDivPred(n) by apply (expand NatHasUIntDivPred in Q)[n] to .
+  have R: UIntDivPred(n) by apply uint_strong_induction[UIntDivPred, n] to SI
   expand UIntDivPred in R
 end
 


### PR DESCRIPTION
## Summary
- add `uint_strong_induction` to the `UInt` stdlib
- switch `uint_division` to use direct `UInt` strong induction
- remove the intermediate `NatHasUIntDivPred` bridge

## Why
Issue #513 asks for a direct strong induction principle for `UInt` so proofs do not need to detour through `Nat`. `lib/UIntDiv.pf` had exactly that detour; this change adds the missing theorem and uses it at the motivating call site.

Fixes #513

## Validation
- `python3.13 ./deduce.py ./lib --recursive-descent --dir ./lib`
- `python3.13 ./deduce.py ./lib --lalr --dir ./lib`