### PR TITLE
[codex] Add next-hole editor shortcuts

### DIFF
--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -317,6 +317,7 @@ OpenAI, or IU REALLMs depending on backend choice):
 | `M-.`     | Jump to symbol's definition                                        | `xref-find-definitions`          | eglot          |
 | `M-,`     | Pop the xref stack                                                 | `xref-go-back`                   | eglot          |
 | `M-x imenu` | Outline of top-level declarations                                | `imenu`                          | eglot          |
+| `C-c C-n` | Move to the next standalone `?` hole                               | `deduce-mode-next-hole`          | `deduce-mode`  |
 | `C-c C-g` | Goal + givens at cursor                                            | `deduce-show-goal-at-point`      | `deduce-lsp`   |
 | `C-c C-r` | Apply the suggested template at hole                               | `deduce-lsp-refine-hole`         | `deduce-lsp`   |
 | `C-c C-c` | Prompt for variable, replace `?` with case skeleton                | `deduce-lsp-case-split`          | `deduce-lsp`   |

--- a/editor/emacs/deduce-mode.el
+++ b/editor/emacs/deduce-mode.el
@@ -293,6 +293,46 @@ at true symbol edges."
   "Font-lock keywords for `deduce-mode'.")
 
 
+(defun deduce-mode--identifier-char-p (pos)
+  "Return non-nil if POS is on a Deduce identifier character."
+  (and (<= (point-min) pos)
+       (< pos (point-max))
+       (memq (char-syntax (char-after pos)) '(?w ?_))))
+
+(defun deduce-mode--standalone-hole-at-p (pos)
+  "Return non-nil if POS is a standalone proof hole."
+  (and (eq (char-after pos) ??)
+       (not (deduce-mode--identifier-char-p (1- pos)))
+       (not (deduce-mode--identifier-char-p (1+ pos)))))
+
+(defun deduce-mode--search-next-hole (limit)
+  "Search forward for the next standalone proof hole before LIMIT."
+  (let ((found nil))
+    (while (and (not found)
+                (search-forward "?" limit t))
+      (when (deduce-mode--standalone-hole-at-p (1- (point)))
+        (setq found t)))
+    found))
+
+(defun deduce-mode-next-hole ()
+  "Move point to the next standalone `?' proof hole.
+
+Search starts after point and wraps once at end of buffer."
+  (interactive)
+  (let ((start (point))
+        found)
+    (unless (eobp)
+      (forward-char 1))
+    (setq found (deduce-mode--search-next-hole nil))
+    (unless found
+      (goto-char (point-min))
+      (setq found (deduce-mode--search-next-hole start)))
+    (if found
+        (goto-char (match-beginning 0))
+      (goto-char start)
+      (user-error "No proof hole found"))))
+
+
 (defvar deduce-mode-syntax-table
   (let ((st (make-syntax-table)))
     ;; Comment markers.  `/' is the first character of `/*' (start
@@ -368,6 +408,8 @@ steps; LSP integration lives in `deduce-lsp.el'.
   ;; Indentation (Step 3).  TAB and (via electric-indent-mode) RET
   ;; both call this.
   (setq-local indent-line-function #'deduce-mode-indent-line))
+
+(define-key deduce-mode-map (kbd "C-c C-n") #'deduce-mode-next-hole)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pf\\'" . deduce-mode))

--- a/editor/emacs/test/deduce-mode-test.el
+++ b/editor/emacs/test/deduce-mode-test.el
@@ -183,6 +183,34 @@ and `Pos' default-faced inside `Foo<Bar>'."
               'font-lock-warning-face)))
 
 
+(ert-deftest deduce-mode/next-hole-bound-to-c-c-c-n ()
+  "`C-c C-n' in deduce-mode-map runs `deduce-mode-next-hole'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-n"))
+              #'deduce-mode-next-hole)))
+
+
+(ert-deftest deduce-mode/next-hole-moves-to-next-standalone-question-mark ()
+  "Move to the next hole, skipping identifier suffixes."
+  (with-temp-buffer
+    (insert "define done?: bool = true\nproof\n  ?\n  ?\nend\n")
+    (deduce-mode)
+    (goto-char (point-min))
+    (deduce-mode-next-hole)
+    (should (= (line-number-at-pos) 3))
+    (deduce-mode-next-hole)
+    (should (= (line-number-at-pos) 4))))
+
+
+(ert-deftest deduce-mode/next-hole-wraps-once ()
+  "At the last hole, move to the first hole in the buffer."
+  (with-temp-buffer
+    (insert "proof\n  ?\n  ?\nend\n")
+    (deduce-mode)
+    (goto-char (point-max))
+    (deduce-mode-next-hole)
+    (should (= (line-number-at-pos) 2))))
+
+
 (ert-deftest deduce-mode/sorry-gets-warning-face ()
   (should (eq (deduce-mode-test--face-at
                "sorry"

--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -66,6 +66,10 @@ lockstep with it.
   `deduce/goalAt` request at the cursor and renders the goal +
   givens in a dedicated *Deduce Goal* Output channel.  Mirror of
   Emacs's `C-c C-g` / `deduce-show-goal-at-point`.
+- **Next-hole command** — `Ctrl+Alt+N` (or Command Palette:
+  *Deduce: Go to next hole*) moves the cursor to the next
+  standalone `?` proof hole, wrapping once at end of file.  Mirror
+  of Emacs's `C-c C-n` / `deduce-mode-next-hole`.
 - **Structured-editing commands** — five commands that transform
   a `?` hole into a step closer to a complete proof.  Mirror of
   Emacs's `C-c C-{r,c,i,e,f}` bindings (`deduce-lsp.el`):

--- a/editor/vscode/extension.js
+++ b/editor/vscode/extension.js
@@ -173,6 +173,8 @@ function activate(context) {
     // can fire immediately without repositioning.
 
     context.subscriptions.push(
+        vscode.commands.registerCommand('deduce.nextHole', () =>
+            nextHoleCommand()),
         vscode.commands.registerCommand('deduce.refineHole', () =>
             applyCodeActionByTitle(client, 'Refine hole', 'No refinement available at point.')),
         vscode.commands.registerCommand('deduce.induction', () =>
@@ -538,6 +540,45 @@ function textDocumentPosition(editor) {
     };
 }
 
+function nextHoleCommand() {
+    const editor = ensureDeduceEditor();
+    if (!editor) return;
+    const doc = editor.document;
+    const startOffset = doc.offsetAt(editor.selection.active);
+    const foundOffset = findNextHoleOffset(doc.getText(), startOffset);
+    if (foundOffset === undefined) {
+        vscode.window.showInformationMessage('Deduce: no proof hole found.');
+        return;
+    }
+    const pos = doc.positionAt(foundOffset);
+    editor.selection = new vscode.Selection(pos, pos);
+    editor.revealRange(new vscode.Range(pos, pos));
+}
+
+function findNextHoleOffset(text, startOffset) {
+    const after = findHoleOffsetInRange(text, Math.min(startOffset + 1, text.length), text.length);
+    if (after !== undefined) return after;
+    return findHoleOffsetInRange(text, 0, startOffset);
+}
+
+function findHoleOffsetInRange(text, startOffset, endOffset) {
+    for (let i = startOffset; i < endOffset; i++) {
+        if (text[i] === '?' && isStandaloneHoleAt(text, i)) {
+            return i;
+        }
+    }
+    return undefined;
+}
+
+function isStandaloneHoleAt(text, index) {
+    return !isDeduceIdentifierChar(text[index - 1])
+        && !isDeduceIdentifierChar(text[index + 1]);
+}
+
+function isDeduceIdentifierChar(ch) {
+    return ch !== undefined && /[A-Za-z0-9_?!']/.test(ch);
+}
+
 // Translate an LSP WorkspaceEdit's {changes: {uri: TextEdit[]}} shape
 // into a vscode.WorkspaceEdit, then apply it via the workspace API.
 // We don't use client.protocol2CodeConverter because it expects fully
@@ -723,4 +764,9 @@ function deactivate() {
     return client.stop();
 }
 
-module.exports = { activate, deactivate };
+module.exports = {
+    activate,
+    deactivate,
+    findNextHoleOffset,
+    isStandaloneHoleAt,
+};

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -61,6 +61,11 @@
         "category": "Deduce"
       },
       {
+        "command": "deduce.nextHole",
+        "title": "Deduce: Go to next hole",
+        "category": "Deduce"
+      },
+      {
         "command": "deduce.refineHole",
         "title": "Deduce: Refine hole at cursor",
         "category": "Deduce"
@@ -95,6 +100,11 @@
       {
         "command": "deduce.showGoal",
         "key": "ctrl+alt+g",
+        "when": "editorTextFocus && editorLangId == deduce"
+      },
+      {
+        "command": "deduce.nextHole",
+        "key": "ctrl+alt+n",
         "when": "editorTextFocus && editorLangId == deduce"
       },
       {


### PR DESCRIPTION
## Summary
- add an Emacs `deduce-mode-next-hole` command on `C-c C-n`
- add a VS Code `deduce.nextHole` command on `Ctrl+Alt+N`
- document both shortcuts and add Emacs regression coverage

Fixes #523

## Validation
- `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-mode-test -f ert-run-tests-batch-and-exit`
- `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-lsp-test -f ert-run-tests-batch-and-exit`
- `node --check editor/vscode/extension.js`
- `git diff --check`