### PR TITLE
[codex] Add stdlib documentation comments

### DIFF
--- a/lib/Base.pf
+++ b/lib/Base.pf
@@ -1,5 +1,14 @@
 module Base
 
+/*
+  Core propositional facts used throughout the standard library.
+
+  This file deliberately stays small and dependency-free: it gives
+  reusable lemmas about booleans, negation, implication, iff, and
+  common proof patterns such as contrapositive reasoning.
+*/
+
+// Eliminate the left side of a disjunction when it is known false.
 theorem or_not: all P:bool, Q:bool.
   if (P or Q) and not P
   then Q
@@ -15,6 +24,7 @@ proof
   }
 end
 
+// Boolean excluded middle: every boolean is either true or false.
 theorem ex_mid: all b:bool. b or not b
 proof
   arbitrary b:bool
@@ -24,6 +34,7 @@ proof
   }
 end
 
+// Disjunction is symmetric.
 theorem or_sym: all P:bool, Q:bool.  (P or Q) = (Q or P)
 proof
   arbitrary P:bool, Q:bool
@@ -33,6 +44,7 @@ proof
   }
 end
 
+// Conjunction is symmetric.
 theorem and_sym: all P:bool, Q:bool.  (P and Q) = (Q and P)
 proof
   arbitrary P:bool, Q:bool
@@ -42,6 +54,7 @@ proof
   }
 end
 
+// Relate a proposition to equality with the boolean value true.
 theorem eq_true: all P:bool. P ⇔ (P = true)
 proof
   arbitrary P:bool
@@ -51,6 +64,7 @@ proof
   }
 end
 
+// Relate negation to equality with the boolean value false.
 theorem eq_false: all P:bool. not P ⇔ P = false
 proof
   arbitrary P:bool
@@ -60,6 +74,7 @@ proof
   }
 end
 
+// Convert a logical iff into boolean equality.
 theorem iff_equal: all P:bool, Q:bool.
   if (P ⇔ Q)  
   then P = Q

--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -2,28 +2,41 @@ module BigO
 
 import UInt
 
+/*
+  Elementary asymptotic notation for functions `UInt -> UInt`.
+
+  The relation `f ≲ g` means that, after some threshold `n0`, `f` is
+  bounded above by a constant multiple of `g`. The relation `f ≈ g`
+  is the induced two-sided equivalence.
+*/
+
+// Pointwise addition of cost functions.
 fun operator + (f : fn UInt -> UInt, g : fn UInt -> UInt) {
   fun x:UInt {
     f(x) + g(x)
   }
 }
 
+// Pointwise multiplication of cost functions.
 fun operator * (f : fn UInt -> UInt, g : fn UInt -> UInt) {
   fun x:UInt {
     f(x) * g(x)
   }
 }
 
+// Scale a cost function by a constant.
 fun operator * (k : UInt, g : fn UInt -> UInt) {
   fun x:UInt {
     k * g(x)
   }
 }
 
+// Big-O preorder.
 fun operator ≲ (f : fn UInt -> UInt, g : fn UInt -> UInt) {
   some n0 :UInt, c:UInt. all n:UInt. if n0 ≤ n then f(n) ≤ c * g(n)
 }
 
+// Asymptotic equivalence.
 fun operator ≈ (f : fn UInt -> UInt, g : fn UInt -> UInt) {
   (f ≲ g) and (g ≲ f)
 }
@@ -301,4 +314,3 @@ proof
     by apply log_sum_less_equal_product[f,g] to f_pos, g_pos
   A, B
 end
-

--- a/lib/Int.pf
+++ b/lib/Int.pf
@@ -4,6 +4,14 @@ import Nat
 import UInt
 import Base
 
+/*
+  Signed integers represented as nonnegative values `pos(n)` and
+  negative successors `negsuc(n)`, where `negsuc(0)` is -1.
+
+  This module gathers the definitions, addition/subtraction,
+  multiplication, literals, and order facts for Int.
+*/
+
 public import IntDefs
 public import IntAddSub
 public import IntMult
@@ -15,7 +23,7 @@ export zero
 export suc
 export fromNat
 
-// Properties of Less-Than or Equal
+// Properties of less-than or equal.
 
 theorem int_less_equal_refl: all n:Int. n ≤ n
 proof

--- a/lib/IntAddSub.pf
+++ b/lib/IntAddSub.pf
@@ -4,6 +4,13 @@ import UInt
 import Base
 import IntDefs
 
+/*
+  Theorems about Int signs, negation, addition, and subtraction.
+
+  The implementation reduces integer arithmetic to unsigned arithmetic
+  on absolute values plus a sign calculation.
+*/
+
 // Properties of signs
 
 lemma sign_pos: all n:UInt. sign(pos(n)) = positive

--- a/lib/IntDefs.pf
+++ b/lib/IntDefs.pf
@@ -4,10 +4,11 @@ public import UInt
 import Base
 
 /*
+  Core Int definitions.
 
- This mechanization of integer arithmetic is adapted from the Integer
- module in the Agda standard library.
-
+  This mechanization of integer arithmetic is adapted from the Integer
+  module in the Agda standard library. `pos(n)` represents nonnegative
+  integers and `negsuc(n)` represents `-(1+n)`.
 */
 
 // Can't make Int opaque right now because the parser uses pos.
@@ -155,4 +156,3 @@ opaque fun operator ≤(a : Int, y : Int) {
     }
   }
 }
-

--- a/lib/IntMult.pf
+++ b/lib/IntMult.pf
@@ -6,6 +6,14 @@ import Base
 import IntDefs
 import IntAddSub
 
+/*
+  Theorems about Int multiplication.
+
+  Multiplication is defined by combining signs and multiplying
+  absolute values; these proofs establish the expected sign cases and
+  algebraic laws.
+*/
+
 // Properties of Multiplication
 
 lemma mult_pos_pos: all x:UInt, y:UInt. pos(x) * pos(y) = pos(x * y)

--- a/lib/Maps.pf
+++ b/lib/Maps.pf
@@ -1,14 +1,24 @@
 import Set
 import Option
 
+/*
+  Helpers for total maps represented as functions.
+
+  `update(f, x, v)` is the map equal to `f` everywhere except at
+  `x`, where it returns `v`.
+*/
+
+// Function composition.
 fun operator ∘ <T,U,V>(g:fn U->V, f:fn T->U) {
   fun x:T { g(f(x)) }
 }
 
+// Point update for a function-backed map.
 fun update<T, U>(f:fn T->U, x:T, v:U) {
   fun y:T { if y = x then v else f(y) }
 }
 
+// Looking up the updated key returns the new value.
 theorem update_eq :
   < T, U > all f: fn (T) -> U, x:T, v:U.
   update(f, x, v)(x) = v
@@ -18,6 +28,7 @@ proof
   expand update.
 end
 
+// Looking up a different key returns the original map value.
 theorem update_not_eq :
   < T, U > all f: fn (T) -> U, x:T, v:U, y:T.
   if not (x = y)
@@ -37,6 +48,7 @@ proof
   }
 end
 
+// A later update at the same key shadows an earlier one.
 theorem update_shadow : all T:type, U:type. all f:fn(T)->U, x:T, v:U, w:U.
   update(update(f, x, v), x, w) = update(f, x, w)
 proof
@@ -50,6 +62,7 @@ proof
   }
 end
 
+// Updates at distinct keys commute.
 theorem update_permute :
   < T, U > all f:fn(T)->U, x:T, v:U, w:U, y:T.
   if not (x = y)
@@ -171,4 +184,3 @@ proof
   arbitrary x:T, y:T
   expand flip.
 end
-

--- a/lib/MultiSet.pf
+++ b/lib/MultiSet.pf
@@ -1,8 +1,12 @@
 module MultiSet
 
 /*
-  Represent multisets as function to Nat.
-  */
+  Multisets represented as count functions from elements to UInt.
+
+  A multiset keeps multiplicity but not order. `cnt(M)(x)` is the
+  number of occurrences of `x`, `m_one(x)` is a singleton multiset,
+  and `P ⨄ Q` adds multiplicities pointwise.
+*/
 
 import Base
 import UInt
@@ -12,24 +16,29 @@ opaque union MultiSet<T> {
   m_fun(fn(T) -> UInt)
 }
 
+// The multiplicity/count function for a multiset.
 opaque fun cnt<T>(M : MultiSet<T>) {
   switch M {
     case m_fun(f) { f }
   }
 }
 
+// Empty multiset: every element has count zero.
 opaque fun m_empty<T>() {
   m_fun(λy:T{0})
 }
 
+// Singleton multiset: `x` has count one and all other elements zero.
 opaque fun m_one<T>(x:T) {
   m_fun(λy:T{if x = y then 1 else 0})
 }
 
+// Multiset sum, adding counts pointwise.
 opaque fun operator ⨄ <T>(P: MultiSet<T>, Q: MultiSet<T>) {
   m_fun(λx:T{ cnt(P)(x) + cnt(Q)(x) })
 }
 
+// Representation helper used by the multiset proofs below.
 lemma cnt_m_fun: all T:type, f: fn T -> UInt. cnt(m_fun(f)) = f
 proof
   arbitrary T:type, f:(fn T -> UInt)

--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -2,6 +2,16 @@ module Nat
 
 import Option
 import Base
+
+/*
+  Public entry point for natural numbers.
+
+  This module re-exports the Nat definition, arithmetic, order,
+  division, parity, powers/logarithms, and summation support, then
+  adds cross-cutting facts such as boolean equality, gcd, and literal
+  arithmetic rewrite support.
+*/
+
 public import NatDefs
 public import NatAdd
 public import NatMonus
@@ -593,4 +603,3 @@ proof
 end
 
 auto lit_one_expt
-

--- a/lib/NatAdd.pf
+++ b/lib/NatAdd.pf
@@ -4,6 +4,14 @@ import Base
 import NatDefs
 
 /*
+  Theorems about Nat literals and addition.
+
+  This file proves neutral-element, associativity, commutativity, and
+  monotonicity facts for `+`, and registers the literal rewrites that
+  make arithmetic on Nat literals evaluate smoothly.
+*/
+
+/*
  Properties of lit
  */
  
@@ -28,6 +36,7 @@ auto suc_lit
  Properties of Addition
  */
 
+// Zero is the left identity for addition.
 lemma zero_add: all n:Nat.
   zero + n = n
 proof
@@ -37,6 +46,7 @@ end
 
 auto zero_add
 
+// Literal zero is also the left identity.
 theorem nat_zero_add: all y:Nat.
   lit(zero) + y = y
 proof
@@ -46,6 +56,7 @@ end
 
 auto nat_zero_add
 
+// Zero is the right identity for addition.
 lemma add_zero: all n:Nat.
   n + zero = n
 proof

--- a/lib/NatDefs.pf
+++ b/lib/NatDefs.pf
@@ -1,29 +1,44 @@
 module Nat
 
+/*
+  Core Nat definitions.
+
+  `Nat` is the unary natural number type with constructors `zero`
+  and `suc`. This file defines the primitive operations that the Nat
+  theorem files prove properties about: arithmetic, comparisons,
+  division helpers, literals, parity predicates, powers, and logs.
+*/
+
+// Unary natural numbers.
 union Nat {
   zero
   suc(Nat)
 }
 
+// Addition by recursion on the left argument.
 recursive operator +(Nat,Nat) -> Nat {
   operator +(zero, m) = m
   operator +(suc(n), m) = suc(n + m)
 }
 
+// Multiplication by repeated addition.
 recursive operator *(Nat,Nat) -> Nat {
   operator *(zero, m) = zero
   operator *(suc(n), m) = m + (n * m)
 }
 
+// Exponentiation: `expt(p, n)` is `n` raised to power `p`.
 recursive expt(Nat, Nat) -> Nat {
   expt(zero, n) = suc(zero)
   expt(suc(p), n) = n * expt(p, n)
 }
 
+// Infix exponentiation, with the base written before the exponent.
 fun operator ^(a : Nat, b : Nat)  {
   expt(b, a)
 }
 
+// Maximum of two naturals.
 recursive max(Nat,Nat) -> Nat {
   max(zero, n) = n
   max(suc(m'), n) =
@@ -33,6 +48,7 @@ recursive max(Nat,Nat) -> Nat {
     }
 }
 
+// Minimum of two naturals.
 recursive min(Nat,Nat) -> Nat {
   min(zero, n) = zero
   min(suc(m'), n) =
@@ -42,6 +58,7 @@ recursive min(Nat,Nat) -> Nat {
     }
 }
 
+// Predecessor, with `pred(zero) = zero`.
 fun pred(n : Nat) {
   switch n {
     case zero { zero }
@@ -49,6 +66,7 @@ fun pred(n : Nat) {
   }
 }
 
+// Truncated subtraction: `x ∸ y` is zero when `y` is larger than `x`.
 recursive operator ∸(Nat,Nat) -> Nat {
   operator ∸(zero, m) = zero
   operator ∸(suc(n), m) =
@@ -58,6 +76,7 @@ recursive operator ∸(Nat,Nat) -> Nat {
     }
 }
 
+// Boolean less-than-or-equal.
 recursive operator ≤(Nat,Nat) -> bool {
   operator ≤(zero, m) = true
   operator ≤(suc(n'), m) =
@@ -162,4 +181,3 @@ define log2 : fn Nat -> Nat = λn{ find_log2(n, n, zero) }
 
 // Invariant: only apply lit to a literal Nat.
 fun lit(a : Nat) { a }
-

--- a/lib/NatDiv.pf
+++ b/lib/NatDiv.pf
@@ -10,6 +10,13 @@ import NatLess
 import NatEvenOdd
 
 /*
+  Theorems about Nat division, modulo, and divisibility.
+
+  The definitions live in `NatDefs.pf`; this file proves their basic
+  equations, bounds, and algebraic properties.
+*/
+
+/*
  Properties of div2
  */
 

--- a/lib/NatEvenOdd.pf
+++ b/lib/NatEvenOdd.pf
@@ -6,6 +6,13 @@ import NatAdd
 import NatMult
 
 /*
+  Nat parity support.
+
+  `is_even` and `is_odd` compute boolean parity, while `EvenNat` and
+  `OddNat` are existential propositions useful in proofs.
+*/
+
+/*
  Odd and Even Numbers
  */
 
@@ -224,4 +231,3 @@ proof
     fwd, bkwd
   }
 end
-

--- a/lib/NatLess.pf
+++ b/lib/NatLess.pf
@@ -8,6 +8,15 @@ import NatMonus
 import NatMult
 
 /*
+  Theorems about Nat order.
+
+  The primitive order is boolean-valued. This file connects `<` and
+  `≤`, proves reflexivity/transitivity/antisymmetry and arithmetic
+  monotonicity, and supplies common comparison lemmas used across the
+  numeric library.
+*/
+
+/*
  Properties of Less-Than, Greater∸Than, etc.
 */
 

--- a/lib/NatMonus.pf
+++ b/lib/NatMonus.pf
@@ -6,6 +6,14 @@ import NatDefs
 import NatAdd
 
 /*
+  Theorems about Nat truncated subtraction (`∸`).
+
+  Nat subtraction never goes below zero. These lemmas establish the
+  expected zero/cancellation laws and connect subtraction with
+  addition and order.
+*/
+
+/*
  Properties of Subtraction
  */
  

--- a/lib/NatMult.pf
+++ b/lib/NatMult.pf
@@ -7,6 +7,13 @@ import NatAdd
 import NatMonus
 
 /*
+  Theorems about Nat multiplication.
+
+  This file proves zero/one laws, distributivity, associativity,
+  commutativity, cancellation, and monotonicity facts for `*`.
+*/
+
+/*
  Properties of Multiplication
 */
 

--- a/lib/NatPowLog.pf
+++ b/lib/NatPowLog.pf
@@ -10,6 +10,13 @@ import NatLess
 import NatDiv
 
 /*
+  Theorems about powers of two, exponentiation, square, and logarithm.
+
+  The file starts from `pow2` and then develops the facts needed to
+  reason about `^`, `sqr`, and `log` over Nat.
+*/
+
+/*
  Properties of pow2
  */
  
@@ -589,4 +596,3 @@ proof
   }
   apply pos_find_log2_greater[n, n, zero] to prem
 end
-

--- a/lib/NatSum.pf
+++ b/lib/NatSum.pf
@@ -6,6 +6,14 @@ import NatMult
 import NatLess
 
 /*
+  Finite summation over Nat ranges.
+
+  `summation(k, s, f)` sums `f(s)`, ..., `f(s + k - 1)`. Theorems
+  here cover congruence, splitting off the next term, and
+  distributing summation over addition.
+*/
+
+/*
  Properties of Summation
  */
 
@@ -198,4 +206,3 @@ proof
   }
   replace add_commute[suc(zero),n] | C | D.
 end
-

--- a/lib/Option.pf
+++ b/lib/Option.pf
@@ -1,10 +1,16 @@
 module Option
 
+/*
+  Optional values. `none` represents absence; `just(x)` represents a
+  present value.
+*/
+
 union Option<T> {
   none
   just(T)
 }
 
+// Map a function over a present optional value.
 fun after<T,U>(o : Option<T>, f : fn (T) -> U) {
   switch o {
     case none { @none<U> }
@@ -12,6 +18,7 @@ fun after<T,U>(o : Option<T>, f : fn (T) -> U) {
   }
 }
 
+// Return the contained value, or the supplied default when it is absent.
 fun default<T>(o : Option<T>, y : T) {
   switch o {
     case none { y }

--- a/lib/Pair.pf
+++ b/lib/Pair.pf
@@ -1,37 +1,47 @@
+/*
+  Ordered pairs and their basic projections.
+*/
+
 union Pair<T,U> {
   pair(T,U)
 }
 
+// First component of a pair.
 fun first<T,U>(p : Pair<T,U>)  {
   switch p {
     case pair(x,y) { x }
   }
 }
 
+// Second component of a pair.
 fun second<T,U>(p : Pair<T,U>) {
   switch p {
     case pair(x,y) { y }
   }
 }
 
+// Map a pair componentwise.
 fun pairfun<T1,T2,U1,U2>(f : fn T1->T2, g : fn U1->U2) {
   fun p: Pair<T1,U1> {
     pair(f(first(p)), g(second(p)))
   }
 }
 
+// Projecting the first component of a pair returns the first argument.
 theorem first_pair: all T:type,U:type, x:T, y:U. first(pair(x,y)) = x
 proof
   arbitrary T:type,U:type, x:T, y:U
   expand first.
 end
   
+// Projecting the second component of a pair returns the second argument.
 theorem second_pair: all T:type,U:type, x:T, y:U. second(pair(x,y)) = y
 proof
   arbitrary T:type,U:type, x:T, y:U
   expand second.
 end
   
+// Every pair is recovered from its two projections.
 theorem pair_first_second: <T, U> all p:Pair<T, U>.
   pair(first(p), second(p)) = p
 proof
@@ -42,4 +52,3 @@ proof
     }
   }
 end
-

--- a/lib/Set.pf
+++ b/lib/Set.pf
@@ -1,5 +1,10 @@
 /*
-Represent sets as predicates, that is, functions to bool.
+  Sets represented extensionally as predicates, that is, functions
+  from elements to bool.
+
+  The concrete predicate representation is opaque, so clients reason
+  through membership, subset, union, intersection, and extensionality
+  lemmas rather than by depending on the representation directly.
 */
 
 import Base
@@ -8,12 +13,14 @@ opaque union Set<T> {
   char_fun(fn (T) -> bool)
 }
 
+// Reveal the characteristic predicate inside the implementation.
 opaque fun rep<T>(S : Set<T>) {
   switch S {
     case char_fun(f) { f }
   }
 }
 
+// Build a set from a predicate.
 opaque fun set_of_pred<T>(f : fn T -> bool) {
   char_fun(f)
 }
@@ -29,22 +36,27 @@ opaque fun empty_set<T>() {
   char_fun(λx:T{false})
 }
 
+// Singleton set containing exactly `x`.
 opaque fun single<V>(x : V) {
   char_fun(fun y:V {x = y})
 }
 
+// Set union.
 opaque fun operator ∪ <E>(P: Set<E>, Q: Set<E>) {
   char_fun(fun x:E { rep(P)(x) or rep(Q)(x) })
 }
 
+// Set intersection.
 opaque fun operator ∩ <T>(P : Set<T>, Q : Set<T>) {
   char_fun(fun x:T { rep(P)(x) and rep(Q)(x) })
 }
 
+// Membership.
 opaque fun operator ∈ <T>(x : T, S : Set<T>) {
   rep(S)(x)
 }
 
+// Subset relation.
 fun operator ⊆ <T>(P : Set<T>, Q : Set<T>) {
   all x:T. if x ∈ P then x ∈ Q
 }

--- a/lib/UInt.pf
+++ b/lib/UInt.pf
@@ -2,6 +2,16 @@ module UInt
 
 import Base
 import Nat
+
+/*
+  Public entry point for unsigned integers.
+
+  This module re-exports the UInt representation-independent API:
+  conversions to/from Nat, order, arithmetic, division, powers,
+  logarithms, and parity facts. Import this module when proving about
+  ordinary unsigned integer arithmetic.
+*/
+
 public import UIntDefs
 public import UIntToFrom
 public import UIntLess
@@ -17,5 +27,6 @@ export lit
 export zero
 export suc
 
-// Declaring at the end of the library, so that 
+// Declaring at the end of the library, so that the induction rule is
+// available after the supporting UInt facts have been loaded.
 inductive UInt by uint_induction

--- a/lib/UIntAdd.pf
+++ b/lib/UIntAdd.pf
@@ -6,6 +6,16 @@ import UIntDefs
 import UIntToFrom
 import UIntLess
 
+/*
+  Theorems about UInt addition.
+
+  Most proofs specify UInt operations by translating through `toNat`.
+  This file proves that UInt addition agrees with Nat addition, then
+  builds the usual identity, associativity, commutativity, cancellation,
+  and monotonicity lemmas.
+*/
+
+// UInt addition agrees with Nat addition under `toNat`.
 theorem toNat_add: all x:UInt, y:UInt.
   toNat(x + y) = toNat(x) + toNat(y)
 proof

--- a/lib/UIntDefs.pf
+++ b/lib/UIntDefs.pf
@@ -3,6 +3,15 @@ module UInt
 import Base
 import Nat
 
+/*
+  Core UInt definitions.
+
+  UInt uses a binary representation inspired by the Agda standard
+  library. The representation is opaque to clients; the public API
+  exposes arithmetic and order while `toNat` provides the specification
+  used in many proofs.
+*/
+
 // This follows the representation for binary numbers in the Agda
 // standard library. The representation is not the standard one, but
 // it is easier to work with.
@@ -13,12 +22,14 @@ opaque union UInt {
   inc_dub(UInt) // 1 + 2x
 }
 
+// Interpret a UInt as a Nat.
 opaque recursive toNat(UInt) -> Nat {
   toNat(bzero) = ℕ0
   toNat(dub_inc(x)) = ℕ2 * suc(toNat(x))
   toNat(inc_dub(x)) = suc(ℕ2 * toNat(x))
 }
 
+// Sanity checks documenting the first few binary representations.
 assert toNat(bzero)                   = ℕ0    //   0
 assert toNat(inc_dub(bzero))          = ℕ1    //   1
 assert toNat(dub_inc(bzero))          = ℕ2    //  10
@@ -198,4 +209,3 @@ fun min(x : UInt, y : UInt) {
   if x < y then x
   else y
 }
-

--- a/lib/UIntDiv.pf
+++ b/lib/UIntDiv.pf
@@ -9,6 +9,14 @@ import UIntAdd
 import UIntMonus
 import UIntMult
 
+/*
+  UInt division, modulo, and divisibility.
+
+  Division and modulo are defined by repeated subtraction over UInt.
+  The proofs below establish their Nat correspondence, divisor
+  bounds, inverse facts, and divisibility lemmas.
+*/
+
 recfun operator /(n : UInt, m : UInt) -> UInt
   measure n of UInt
 {

--- a/lib/UIntEvenOdd.pf
+++ b/lib/UIntEvenOdd.pf
@@ -5,6 +5,13 @@ public import UIntDefs
 import UIntAdd
 import UIntMult
 
+/*
+  UInt parity predicates.
+
+  `Even(n)` means `n` is twice another UInt, and `Odd(n)` means `n`
+  is one plus twice another UInt.
+*/
+
 fun Even(n : UInt) {
   some m:UInt. n = 2 * m
 }

--- a/lib/UIntLess.pf
+++ b/lib/UIntLess.pf
@@ -5,6 +5,16 @@ import Nat
 import UIntDefs
 import UIntToFrom
 
+/*
+  Theorems about UInt order.
+
+  The primitive UInt comparison is implemented over the binary
+  representation. This file connects it to Nat order through `toNat`
+  and develops the standard order laws and arithmetic monotonicity
+  lemmas used by the rest of the UInt library.
+*/
+
+// UInt less-than implies Nat less-than after conversion.
 theorem toNat_less: all x:UInt, y:UInt.
   if x < y then toNat(x) < toNat(y)
 proof
@@ -783,4 +793,3 @@ proof
     prem
   }
 end
-

--- a/lib/UIntMonus.pf
+++ b/lib/UIntMonus.pf
@@ -8,6 +8,14 @@ import UIntLess
 import UIntAdd
 import UIntMult
 
+/*
+  Theorems about UInt truncated subtraction (`∸`).
+
+  Subtraction is specified by conversion to Nat, and the lemmas here
+  provide zero laws, cancellation-style facts, and interaction with
+  addition and order.
+*/
+
 lemma inc_dub_monus_dub_inc_less: all x:UInt, y:UInt.
   if x < y
   then inc_dub(x) ∸ dub_inc(y) = bzero

--- a/lib/UIntMult.pf
+++ b/lib/UIntMult.pf
@@ -7,6 +7,14 @@ import UIntToFrom
 import UIntLess
 import UIntAdd
 
+/*
+  Theorems about UInt multiplication.
+
+  As with addition, the main specification theorem shows that UInt
+  multiplication agrees with Nat multiplication under `toNat`; the
+  rest of the file builds the usual algebraic and order facts.
+*/
+
 theorem toNat_mult: all x:UInt, y:UInt.
   toNat(x * y) = toNat(x) * toNat(y)
 proof

--- a/lib/UIntPowLog.pf
+++ b/lib/UIntPowLog.pf
@@ -8,6 +8,14 @@ import UIntMult
 import UIntMonus
 import UIntLess
 
+/*
+  Theorems about UInt exponentiation, square, powers of two, and log.
+
+  These facts mirror the Nat power/log library, with proofs typically
+  reducing correctness to the corresponding Nat theorem through
+  `toNat`.
+*/
+
 lemma expt_dub_inc: all n:UInt, p:UInt. n ^ dub_inc(p) = sqr(n * (n^p))
 proof
   arbitrary n:UInt, p:UInt

--- a/lib/UIntToFrom.pf
+++ b/lib/UIntToFrom.pf
@@ -4,6 +4,14 @@ import Base
 import Nat
 import UIntDefs
 
+/*
+  Conversion facts between Nat and UInt.
+
+  `fromNat` embeds natural numbers into UInt and `toNat` specifies
+  UInt values as natural numbers. The lemmas here are the bridge used
+  by most UInt arithmetic proofs.
+*/
+
 lemma from_zero: fromNat(ℕ0) = 0
 proof
   evaluate
@@ -209,4 +217,3 @@ proof
 end
 
 auto uint_equal
-

--- a/test/should-error/private_lemma_hint_stdlib.pf.err
+++ b/test/should-error/private_lemma_hint_stdlib.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/private_lemma_hint_stdlib.pf:13.3-13.12: 'zero_mult' is declared as a `lemma` in module Nat (./lib/NatMult.pf:13); lemmas are module-private and not accessible from other modules. To make it accessible here, change `lemma` to `theorem` there.
+./test/should-error/private_lemma_hint_stdlib.pf:13.3-13.12: 'zero_mult' is declared as a `lemma` in module Nat (./lib/NatMult.pf:20); lemmas are module-private and not accessible from other modules. To make it accessible here, change `lemma` to `theorem` there.


### PR DESCRIPTION
## Summary

- Adds module-level documentation comments across the standard library `.pf` files.
- Adds brief comments for core definitions and helper functions in small foundational modules such as `Base`, `Option`, `Pair`, `Set`, `Maps`, and `MultiSet`.
- Documents the role of the Nat, UInt, and Int component modules so students can more easily find definitions versus theorem families.

Makes progress on #99.

## Validation

- `make tests-lib`
