### PR TITLE
[codex] Add UInt multiplication cancellation lemmas

### DIFF
--- a/lib/UIntMult.pf
+++ b/lib/UIntMult.pf
@@ -271,3 +271,73 @@ proof
   replace toNat_mult
   apply pos_mult_both_sides_of_less to zn, xy
 end
+
+theorem uint_pos_mult_left_cancel: all n:UInt, x:UInt, y:UInt.
+  (if 0 < n and n * x = n * y then x = y)
+proof
+  arbitrary n:UInt, x:UInt, y:UInt
+  assume prem
+  have zn0: toNat((0:UInt)) < toNat(n) by apply toNat_less to (conjunct 0 of prem)
+  have toNat_zero: toNat((0:UInt)) = ℕ0 by evaluate
+  have zn: ℕ0 < toNat(n) by replace toNat_zero in zn0
+  have nxy: toNat(n) * toNat(x) = toNat(n) * toNat(y) by {
+    have xy: toNat(n * x) = toNat(n * y) by replace (conjunct 1 of prem).
+    replace symmetric toNat_mult[n, x] | symmetric toNat_mult[n, y]
+    xy
+  }
+  have xy: toNat(x) = toNat(y) by apply pos_mult_left_cancel[toNat(n), toNat(x), toNat(y)] to zn, nxy
+  apply uint_toNat_injective to xy
+end
+
+theorem uint_pos_mult_right_cancel: all n:UInt, x:UInt, y:UInt.
+  (if 0 < n and x * n = y * n then x = y)
+proof
+  arbitrary n:UInt, x:UInt, y:UInt
+  replace uint_mult_commute[x, n] | uint_mult_commute[y, n]
+  uint_pos_mult_left_cancel
+end
+
+theorem uint_pos_mult_left_cancel_less: all n:UInt, x:UInt, y:UInt.
+  (if 0 < n and n * x < n * y then x < y)
+proof
+  arbitrary n:UInt, x:UInt, y:UInt
+  assume prem
+  have nxy: toNat(n) * toNat(x) < toNat(n) * toNat(y) by {
+    have xy: toNat(n * x) < toNat(n * y) by apply toNat_less to (conjunct 1 of prem)
+    replace toNat_mult in xy
+  }
+  have xy: toNat(x) < toNat(y) by apply mult_cancel_left_less to nxy
+  apply less_toNat to xy
+end
+
+theorem uint_pos_mult_right_cancel_less: all n:UInt, x:UInt, y:UInt.
+  (if 0 < n and x * n < y * n then x < y)
+proof
+  arbitrary n:UInt, x:UInt, y:UInt
+  replace uint_mult_commute[x, n] | uint_mult_commute[y, n]
+  uint_pos_mult_left_cancel_less
+end
+
+theorem uint_pos_mult_left_cancel_less_equal: all n:UInt, x:UInt, y:UInt.
+  (if 0 < n and n * x ≤ n * y then x ≤ y)
+proof
+  arbitrary n:UInt, x:UInt, y:UInt
+  assume prem
+  have zn0: toNat((0:UInt)) < toNat(n) by apply toNat_less to (conjunct 0 of prem)
+  have toNat_zero: toNat((0:UInt)) = ℕ0 by evaluate
+  have zn: ℕ0 < toNat(n) by replace toNat_zero in zn0
+  have nxy: toNat(n) * toNat(x) ≤ toNat(n) * toNat(y) by {
+    have xy: toNat(n * x) ≤ toNat(n * y) by apply toNat_less_equal to (conjunct 1 of prem)
+    replace toNat_mult in xy
+  }
+  have xy: toNat(x) ≤ toNat(y) by apply pos_mult_left_cancel_less_equal[toNat(n), toNat(x), toNat(y)] to zn, nxy
+  apply less_equal_toNat to xy
+end
+
+theorem uint_pos_mult_right_cancel_less_equal: all n:UInt, x:UInt, y:UInt.
+  (if 0 < n and x * n ≤ y * n then x ≤ y)
+proof
+  arbitrary n:UInt, x:UInt, y:UInt
+  replace uint_mult_commute[x, n] | uint_mult_commute[y, n]
+  uint_pos_mult_left_cancel_less_equal
+end


### PR DESCRIPTION
## Summary
- add UInt positive multiplication cancellation lemmas for equality, <, and <=
- include left and right variants, reusing Nat cancellation through toNat conversions

Fixes #517

## Tests
- python3 deduce.py lib/UIntMult.pf
- python3 deduce.py lib/UInt.pf
- python3 test-deduce.py
- git diff --check