### PR TITLE
[codex] Enable Ruff F841

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -466,18 +466,18 @@ def type_match(loc, tyvars, param_ty, arg_ty, matching):
      and param_ty.get_name() == arg_ty.get_name():
     return
   match (param_ty, arg_ty):
-    case (FunctionType(l1, tv1, pts1, rt1), FunctionType(l2, tv2, pts2, rt2)) \
+    case (FunctionType(_, tv1, pts1, rt1), FunctionType(_, tv2, pts2, rt2)) \
       if len(tv1) == len(tv2) and len(pts1) == len(pts2):
       for (pt1, pt2) in zip(pts1, pts2):
         type_match(loc, tyvars, pt1, pt2, matching)
       type_match(loc, tyvars, rt1, rt2, matching)
-    case (TypeInst(l1, n1, args1), TypeInst(l2, n2, args2)):
+    case (TypeInst(_, n1, args1), TypeInst(_, n2, args2)):
       if n1 != n2 or len(args1) != len(args2):
         match_failed(loc, str(arg_ty) + " does not match " + str(param_ty))
       for (arg1, arg2) in zip(args1, args2):
         type_match(loc, tyvars, arg1, arg2, matching)
     # How to handle GenericUnknownInst?
-    case (TypeInst(l1, n1, args1), GenericUnknownInst(l2, n2)):
+    case (TypeInst(_, n1, args1), GenericUnknownInst(_, n2)):
       if n1 != n2:
         match_failed(loc, str(arg_ty) + " does not match " + str(param_ty))
     case _:
@@ -492,7 +492,7 @@ def is_associative(loc, opname, typ, env):
     try:
       type_match(loc, type_params, ty, typ, matching)
       return True
-    except MatchFailed as e:
+    except MatchFailed:
       pass
   return False
 
@@ -500,15 +500,15 @@ def rator_name(rator):
   if isinstance(rator, VarRef):
     return rator.get_name()
   match rator:
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, name, _, _, _, _):
       return name
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty, body, terminates):
+    case GenRecFun(_, name, _, _, _, _, _, _, _):
       return name
-    case Lambda(loc, ty, vars, body):
+    case Lambda(_, _, _, _):
       return 'no_name'
-    case TermInst(loc3, tyof, arg2, tyargs):
+    case TermInst(_, _, arg2, _):
       return rator_name(arg2)
-    case Generic(loc2, tyof, typarams, body):
+    case Generic(_, _, _, _):
       return 'no_name'
     case _:
       return 'no_name'
@@ -516,7 +516,7 @@ def rator_name(rator):
 
 def flatten_assoc(op_name, trm):
   match trm:
-    case Call(loc2, tyof, rator, args) if rator_name(rator) == op_name:
+    case Call(_, _, rator, args) if rator_name(rator) == op_name:
       return sum([flatten_assoc(op_name, arg) for arg in args], [])
     case _:
       return [trm]
@@ -584,7 +584,7 @@ class OverloadType(Type):
 
   def __eq__(self, other):
     match other:
-      case OverloadType(l2, types2):
+      case OverloadType(_, types2):
         ret = True
         for ((x,t1), (y,t2)) in zip(self.types, types2):
           ret = ret and t1 == t2
@@ -638,7 +638,7 @@ class ArrayType(Type):
 
   def __eq__(self, other):
     match other:
-      case ArrayType(loc, elt_type):
+      case ArrayType(_, elt_type):
         return self.elt_type == elt_type
       case _:
         return False
@@ -657,7 +657,7 @@ class TypeInst(Type):
 
   def __eq__(self, other):
     match other:
-      case TypeInst(l, typ, arg_types):
+      case TypeInst(_, typ, arg_types):
         return self.typ == typ and \
           all([t1 == t2 for (t1, t2) in zip(self.arg_types, arg_types)])
       # case GenericUnknownInst(loc, typ):
@@ -681,7 +681,7 @@ class GenericUnknownInst(Type):
     match other:
       # case TypeInst(l, typ, arg_types):
       #   return self.typ == typ
-      case GenericUnknownInst(l, typ):
+      case GenericUnknownInst(_, typ):
         return self.typ == typ
       case _:
         return False
@@ -700,7 +700,7 @@ def get_type_name(ty):
   if isinstance(ty, VarRef):
     return ty
   match ty:
-    case TypeInst(l1, ty, type_args):
+    case TypeInst(_, ty, _):
       return get_type_name(ty)
     case _:
       raise InternalError('unhandled case in get_type_name: ' + repr(ty))
@@ -825,9 +825,9 @@ class Conditional(Term):
      cond = self.cond.reduce(env)
      if get_reduce_all():   # Does this work? Need to test!
          match cond:
-           case Bool(l1, tyof, True):
+           case Bool(_, _, True):
              return self.thn.reduce(env)
-           case Bool(l1, tyof, False):
+           case Bool(_, _, False):
              return self.els.reduce(env)
            case _:
              return Conditional(self.location, self.typeof, cond, self.thn, self.els)
@@ -835,9 +835,9 @@ class Conditional(Term):
          thn = self.thn.reduce(env)
          els = self.els.reduce(env)
          match cond:
-           case Bool(l1, tyof, True):
+           case Bool(_, _, True):
              return thn
-           case Bool(l1, tyof, False):
+           case Bool(_, _, False):
              return els
            case _:
              return Conditional(self.location, self.typeof, cond, thn, els)
@@ -1235,7 +1235,7 @@ def is_match(pattern, arg, subst):
     match pattern:
       case PatternBool(loc1, value):
         match arg:
-          case Bool(loc2, tyof, arg_value):
+          case Bool(_, _, arg_value):
             ret = arg_value == value
           case _ if isinstance(arg, VarRef):
             ret = False
@@ -1247,14 +1247,14 @@ def is_match(pattern, arg, subst):
           ret = constr == arg
         else:
           match arg:
-            case TermInst(loc3, tyof, arg2, tyargs):
+            case TermInst(_, _, arg2, _):
               ret = is_match(pattern, arg2, subst)
             case _:
               ret = False
 
       case PatternCons(loc1, constr, params):
         match arg:
-          case Call(loc2, cty, rator, args):
+          case Call(_, _, rator, args):
             # `rator` may be a (possibly term-instantiated) VarRef.
             inner = rator
             if isinstance(inner, TermInst):
@@ -1354,11 +1354,11 @@ def is_operator(trm):
   if isinstance(trm, VarRef):
     return is_operator_name(trm.get_name())
   match trm:
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, name, _, _, _, _):
       return is_operator_name(name)
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty, body, terminates):
+    case GenRecFun(_, name, _, _, _, _, _, _, _):
       return is_operator_name(name)
-    case TermInst(loc, tyof, subject, tyargs, inferred):
+    case TermInst(_, _, subject, _, _):
       return is_operator(subject)
     case _:
       return False
@@ -1368,11 +1368,11 @@ def operator_name(trm):
     nm = trm.get_name()
     return nm if get_unique_names() else base_name(nm)
   match trm:
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, name, _, _, _, _):
       return base_name(name)
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty, body, terminates):
+    case GenRecFun(_, name, _, _, _, _, _, _, _):
       return base_name(name)
-    case TermInst(loc, tyof, subject, tyargs):
+    case TermInst(_, _, subject, _):
       return operator_name(subject)
     case _:
       raise InternalError('operator_name, unexpected term ' + str(trm))
@@ -1385,7 +1385,7 @@ def is_prefix_operator(trm):
 
 def precedence(trm):
   match trm:
-    case Call(loc1, tyof, rator, args) if is_operator(rator):
+    case Call(_, _, rator, args) if is_operator(rator):
       op_name = operator_name(rator)
       if len(args) >= 2:
         return infix_precedence.get(op_name, None)
@@ -1398,7 +1398,7 @@ def precedence(trm):
 
 def left_child(parent, child):
   match parent:
-    case Call(loc1, tyof, rator, [left, right]):
+    case Call(_, _, _, [left, _]):
       return child is left
     case _:
       return False
@@ -1593,7 +1593,7 @@ class Call(Term):
     args = [arg.reduce(env) for arg in flat_args]
     ret = None
     match fun:
-      case Var(loc, ty, '=') | OverloadedVar(loc, ty, ['=']) | ResolvedVar(loc, ty, '='):
+      case Var(loc, _, '=') | OverloadedVar(loc, _, ['=']) | ResolvedVar(loc, _, '='):
         if args[0] == args[1]:
           ret = Bool(loc, BoolType(loc), True)
         elif constructor_conflict(args[0], args[1], env):
@@ -1604,7 +1604,7 @@ class Call(Term):
         ret = Call(self.location, self.typeof, fun,
                    flatten_assoc_list(rator_name(self.rator), args))
 
-      case Lambda(loc, ty, vars, body):
+      case Lambda(loc, _, vars, body):
         # Note (Phase 5 / Step 22): no debugger hook here.
         # ``do_call`` forwards to ``do_function_call`` which is
         # already hooked; trapping a second time here would
@@ -1622,8 +1622,8 @@ class Call(Term):
           display_name = rn
         ret = self.do_call(loc, vars, body, args, call_env, name=display_name)
     
-      case GenRecFun(loc, name, [], params, returns, measure, measure_ty,
-                   body, terminates):
+      case GenRecFun(loc, name, [], params, returns, _, _,
+                   body, _):
         if env.get_tracing(name):
           global recursion_depth
           recursion_depth += 1
@@ -1634,9 +1634,9 @@ class Call(Term):
                                body, subst, env, None,
                                display_args=args)
 
-      case TermInst(loc, tyof,
-                    GenRecFun(loc2, name, typarams, params, returns,
-                              measure, measure_ty, body, terminates),
+      case TermInst(loc, _,
+                    GenRecFun(_, name, typarams, params, returns,
+                              _, _, body, _),
                     type_args):
         subst = {k: v for ((k,t),v) in zip(params, args)}
         ret = do_function_call(loc, name, typarams, type_args, [x for (x,t) in params], args,
@@ -1646,13 +1646,13 @@ class Call(Term):
       case RecFun(loc, name, [], params, returns, cases):
         ret = self.do_recursive_call(loc, name, fun, [], [], params, args,
                                      returns, cases, is_assoc, env)
-      case TermInst(loc, tyof,
-                    RecFun(loc2, name, typarams, params, returns, cases),
+      case TermInst(loc, _,
+                    RecFun(_, name, typarams, params, returns, cases),
                     type_args):
         ret = self.do_recursive_call(loc, name, fun, typarams, type_args,
                                      params, args, returns, cases, is_assoc,
                                      env)
-      case Generic(loc2, tyof, typarams, body):
+      case Generic(_, _, typarams, body):
         internal_error(self.location, 'in reduction, call to generic\n\t' + str(self))
       case _:
         ret = Call(self.location, self.typeof, fun, args)
@@ -1788,9 +1788,9 @@ class SwitchCase(AST):
     new_pat = self.pattern.uniquify(env, ctx)
     body_env = {x:y for (x,y) in env.items()}
     match new_pat:
-      case PatternBool(loc, value):
+      case PatternBool(_, _):
         pass
-      case PatternCons(loc, constr, params):
+      case PatternCons(_, _, params):
         new_params = [generate_name(x, ctx) for x in params]
         for (old,new) in zip(params, new_params):
           overwrite(body_env, old, new, self.location)
@@ -1802,9 +1802,9 @@ class SwitchCase(AST):
     if not isinstance(other, SwitchCase):
       return False
     match self.pattern, other.pattern:
-      case PatternBool(loc1, value1), PatternBool(loc2, value2):
+      case PatternBool(_, value1), PatternBool(_, value2):
         return value1 == value2 and self.body == other.body
-      case PatternCons(loc1, constr1, params1), PatternCons(loc2, constr2, params2):
+      case PatternCons(_, constr1, params1), PatternCons(_, constr2, params2):
         # Use ResolvedVar in the rename so substituted-in references
         # compare equal to the (already uniquified) ResolvedVars in
         # `other.body`. Picking Var here would break post-uniquify
@@ -1888,7 +1888,7 @@ class TermInst(Term):
     subject_red = self.subject.reduce(env)
     type_args_red = [t.reduce(env) for t in self.type_args]
     match subject_red:
-      case Generic(loc2, tyof, typarams, body):
+      case Generic(_, _, typarams, body):
         # sub = {x:t for (x,t) in zip(typarams, self.type_args)}
         sub = {x:t for (x,t) in zip(typarams, type_args_red)}
         return body.substitute(sub)
@@ -2070,7 +2070,7 @@ class Bool(Formula):
 
 def list_of_and(arg):
   match arg:
-    case And(loc, tyof, args):
+    case And(_, _, args):
       return args
     case _:
       return [arg]
@@ -2082,7 +2082,7 @@ def flatten_and(args):
 
 def is_true(b):
   match b:
-    case Bool(loc, ty, val):
+    case Bool(_, _, val):
         return val
     case _:
         return False
@@ -2130,7 +2130,7 @@ class And(Formula):
     newer_args = []
     for arg in new_args:
       match arg:
-        case Bool(loc, ty, val):
+        case Bool(_, _, val):
           if val:  # true: throw this away
             pass
           else:    # false: the whole thing is false
@@ -2146,7 +2146,7 @@ class And(Formula):
 
 def list_of_or(arg):
   match arg:
-    case Or(loc, tyof, args):
+    case Or(_, _, args):
       return args
     case _:
       return [arg]
@@ -2175,7 +2175,7 @@ class Or(Formula):
     newer_args = []
     for arg in new_args:
       match arg:
-        case Bool(loc, ty, val):
+        case Bool(_, _, val):
           if val:  # true: the whole thing is true
             return arg 
           else:    # false: throw this away
@@ -2196,7 +2196,7 @@ class IfThen(Formula):
 
   def __str__(self):
     match self.conclusion:
-      case Bool(loc, tyof, False):
+      case Bool(_, _, False):
         return str(Call(self.location, self.typeof,
                         Var(self.location, None, 'not'),
                         [self.premise]))
@@ -2272,7 +2272,7 @@ class All(Formula):
   def reduce(self, env):
     new_body = self.body.reduce(env)
     match new_body:
-      case Bool(loc, tyof, b):
+      case Bool(_, _, _):
         if get_verbose():
           print('reduce ' + str(self) + '\n\t==> ' + str(new_body))
         return new_body
@@ -2308,12 +2308,12 @@ class Some(Formula):
         + '. ' + str(self.body)
   
   def reduce(self, env):
-    n = len(self.vars)
+    len(self.vars)
     new_body = self.body.reduce(env)
     match new_body:
-      case Bool(loc2, tyof, True):
+      case Bool(_, _, True):
         return new_body
-      case Bool(loc2, tyof, False):
+      case Bool(_, _, False):
         return new_body
       case _:
         return Some(self.location,
@@ -2676,7 +2676,7 @@ class PTuple(Proof):
 
 def extract_tuple(pf):
     match pf:
-      case PTuple(loc, pfs):
+      case PTuple(_, pfs):
         return pfs
       case _:
        return [pf]
@@ -3386,12 +3386,12 @@ class FunCase(AST):
     body_env = copy_dict(env)
 
     match new_pat:
-      case PatternCons(loc, cons, parameters):
+      case PatternCons(_, _, parameters):
         new_pat_params = [generate_name(x, ctx) for x in parameters]
         for (old, new) in zip(parameters, new_pat_params):
           overwrite(body_env, old, new, self.location)
         new_pat = new_pat.with_bindings(new_pat_params)
-      case PatternBool(loc, b):
+      case PatternBool(_, _):
         pass
 
     new_params = [generate_name(x, ctx) for x in self.parameters]
@@ -3940,18 +3940,18 @@ def split_equation(loc, equation, env):
     equation = equation.reduceLets(env)
     
   match equation:
-    case Call(loc1, tyof, rator, [L, R]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+    case Call(_, _, rator, [L, R]) if isinstance(rator, VarRef) and rator.get_name() == '=':
       return (L, R)
-    case All(loc1, tyof, var, pos, body):
+    case All(_, _, _, _, body):
       return split_equation(loc, body, env)
     case _:
       internal_error(loc, 'expected an equality, not ' + str(equation))
 
 def equation_vars(formula):
   match formula:
-    case Call(loc1, tyof, rator, [L, R]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+    case Call(loc1, _, rator, [_, _]) if isinstance(rator, VarRef) and rator.get_name() == '=':
       return []
-    case All(loc1, tyof, var, pos, body):
+    case All(loc1, _, var, _, body):
       x, t = var
       v = ResolvedVar(loc1, None, x)
       v.typeof = t
@@ -3961,24 +3961,24 @@ def equation_vars(formula):
       
 def is_equation(formula):
   match formula:
-    case Call(loc1, tyof, rator, [L, R]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+    case Call(_, _, rator, [_, _]) if isinstance(rator, VarRef) and rator.get_name() == '=':
       return True
-    case All(loc1, tyof, var, pos, body):
+    case All(_, _, _, _, body):
       return is_equation(body)
     case _:
       return False
 
 def isUInt(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
       return True
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'inc_dub':
         return isUInt(arg)
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'dub_inc':
         return isUInt(arg)
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'fromNat':
         return isNat(arg)
     case _:
@@ -3986,14 +3986,14 @@ def isUInt(t):
 
 def isBZero(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
       return True
     case _:
       return False
   
 def isDubInc(t):
   match t:
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
       if base_name(n) == 'dub_inc':
         return True
     case _:
@@ -4001,7 +4001,7 @@ def isDubInc(t):
   
 def isIncDub(t):
   match t:
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
       if base_name(n) == 'inc_dub':
         return True
     case _:
@@ -4009,7 +4009,7 @@ def isIncDub(t):
 
 def get_arg(t):
   match t:
-    case Call(loc, tyof1, rator, [arg]):
+    case Call(_, _, _, [arg]):
       return arg
     case _:
       raise InternalError('get_arg')
@@ -4035,7 +4035,7 @@ def uint_inc(loc, x):
 
 def isSuc(t):
   match t:
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
          if base_name(n) == 'suc':
       return True
     case _:
@@ -4153,12 +4153,12 @@ def intToNat(loc, n, zname='zero', sname='suc', ty=None):
 
 def isNat(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return True
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
          if base_name(n) == 'suc':
       return isNat(arg)
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
          if base_name(n) == 'lit':
       return isNat(arg)
     case _:
@@ -4166,7 +4166,7 @@ def isNat(t):
 
 def isLitNat(t):
   match t:
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
          if base_name(n) == 'lit':
       return isNat(arg)
     case _:
@@ -4174,7 +4174,7 @@ def isLitNat(t):
 
 def isLitUInt(t):
   match t:
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
          if base_name(n) == 'fromNat':
       return isLitNat(arg)
     case _:
@@ -4182,10 +4182,10 @@ def isLitUInt(t):
   
 def isInt(t):
   match t:
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'pos':
       return isUInt(arg)
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'negsuc':
       return isUInt(arg)
     case _:
@@ -4193,9 +4193,9 @@ def isInt(t):
   
 def getZero(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return n
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'suc':
       return getZero(arg)
     case _:
@@ -4203,9 +4203,9 @@ def getZero(t):
 
 def getSuc(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return False
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
       if base_name(n) == 'suc':
       return n
     case _:
@@ -4213,12 +4213,12 @@ def getSuc(t):
 
 def natToInt(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return 0
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'suc':
       return 1 + natToInt(arg)
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'lit':
       return natToInt(arg)
     case _:
@@ -4226,15 +4226,15 @@ def natToInt(t):
 
 def uintToInt(t):
   match t:
-    case (OverloadedVar(loc, tyof, [n, *_]) | ResolvedVar(loc, tyof, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
       return 0
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'dub_inc':
       return 2 * (1 + uintToInt(arg))
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'inc_dub':
       return 1 + 2 * uintToInt(arg)
-    case Call(loc, tyof1, (OverloadedVar(loc2, tyof2, [n, *_]) | ResolvedVar(loc2, tyof2, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'fromNat':
       return natToInt(arg)
     case _:
@@ -4260,18 +4260,18 @@ def mkIntLit(loc, n, sign):
 
 def isDeduceInt(t):
   match t:
-    case Call(loc, tyof1, (Var(loc2, tyof2, name) | OverloadedVar(loc2, tyof2, [name, *_]) | ResolvedVar(loc2, tyof2, name)), [arg]) if base_name(name) == 'pos':
+    case Call(_, _, (Var(_, _, name) | OverloadedVar(_, _, [name, *_]) | ResolvedVar(_, _, name)), [arg]) if base_name(name) == 'pos':
       return isUInt(arg)
-    case Call(loc, tyof1, (Var(loc2, tyof2, name) | OverloadedVar(loc2, tyof2, [name, *_]) | ResolvedVar(loc2, tyof2, name)), [arg]) if base_name(name) == 'negsuc':
+    case Call(_, _, (Var(_, _, name) | OverloadedVar(_, _, [name, *_]) | ResolvedVar(_, _, name)), [arg]) if base_name(name) == 'negsuc':
       return isUInt(arg)
     case _:
       return False
 
 def deduceIntToInt(t):
   match t:
-    case Call(loc, tyof1, (Var(loc2, tyof2, name) | OverloadedVar(loc2, tyof2, [name, *_]) | ResolvedVar(loc2, tyof2, name)), [arg]) if base_name(name) == 'pos':
+    case Call(_, _, (Var(_, _, name) | OverloadedVar(_, _, [name, *_]) | ResolvedVar(_, _, name)), [arg]) if base_name(name) == 'pos':
       return '+' + str(uintToInt(arg))
-    case Call(loc, tyof1, (Var(loc2, tyof2, name) | OverloadedVar(loc2, tyof2, [name, *_]) | ResolvedVar(loc2, tyof2, name)), [arg]) if base_name(name) == 'negsuc':
+    case Call(_, _, (Var(_, _, name) | OverloadedVar(_, _, [name, *_]) | ResolvedVar(_, _, name)), [arg]) if base_name(name) == 'negsuc':
       return '-' + str(1 + uintToInt(arg))
     case _:
       internal_error(t.location, 'deduceIntToInt: expected an int, not ' + str(t))
@@ -4280,7 +4280,7 @@ def is_constructor(constr_name, env):
   for (name,binding) in env.dict.items():
     if isinstance(binding, TypeBinding):
       match binding.defn:
-        case Union(loc2, name, typarams, alts):
+        case Union(_, _, _, alts):
           for constr in alts:
             if constr.name == constr_name:
               return True
@@ -4292,7 +4292,7 @@ def is_constr_term(term, env):
   if isinstance(term, VarRef):
     return is_constructor(term.get_name(), env)
   match term:
-    case TermInst(loc, ty, body):
+    case TermInst(_, _, body):
       return is_constr_term(body, env)
     case _:
       return False
@@ -4301,32 +4301,32 @@ def constr_name(term):
   if isinstance(term, VarRef):
     return term.get_name()
   match term:
-    case TermInst(loc, ty, body):
+    case TermInst(_, _, body):
       return constr_name(body)
     case _:
       raise InternalError('constr_name unhandled ' + str(term))
     
 def constructor_conflict(term1, term2, env):
   match (term1, term2):
-    case (Call(loc1, tyof1, rator1, rands1),
-          Call(loc2, tyof3, rator2, rands2)) if is_constr_term(rator1, env) and is_constr_term(rator2, env):
+    case (Call(_, _, rator1, rands1),
+          Call(_, _, rator2, rands2)) if is_constr_term(rator1, env) and is_constr_term(rator2, env):
      if constr_name(rator1) != constr_name(rator2):
        return True
      else:
        return any([constructor_conflict(rand1, rand2, env) \
                    for (rand1, rand2) in zip(rands1, rands2)])
-    case (Call(loc1, tyof1, rator1, rands1), term2) if is_constr_term(rator1, env) and is_constr_term(term2, env):
+    case (Call(_, _, rator1, rands1), term2) if is_constr_term(rator1, env) and is_constr_term(term2, env):
       if constr_name(rator1) != constr_name(term2):
         return True
     case (term1, term2) if is_constr_term(term1, env) and is_constr_term(term2, env):
       if constr_name(term1) != constr_name(term2):
         return True
-    case (term1, Call(loc2, tyof2, rator2, rands2)) if is_constr_term(term1, env) and is_constr_term(rator2, env):
+    case (term1, Call(_, _, rator2, rands2)) if is_constr_term(term1, env) and is_constr_term(rator2, env):
       if constr_name(term1) != constr_name(rator2):
         return True
-    case (Bool(_, tyof1, True), Bool(_, tyof2, False)):
+    case (Bool(_, _, True), Bool(_, _, False)):
       return True
-    case (Bool(_, tyof1, False), Bool(_, tyof2, True)):
+    case (Bool(_, _, False), Bool(_, _, True)):
       return True
   return False
 
@@ -4339,27 +4339,27 @@ def _is_named(node, base):
 
 def isNodeList(t):
   match t:
-    case TermInst(loc2, tyof2, ctor, tyargs, inferred) if _is_named(ctor, 'empty'):
+    case TermInst(_, _, ctor, _, _) if _is_named(ctor, 'empty'):
       return True
-    case Call(loc, tyof1, TermInst(loc2, tyof2, ctor, tyargs, inferred),
-              [arg, ls]) if _is_named(ctor, 'node'):
+    case Call(_, _, TermInst(_, _, ctor, _, _),
+              [_, ls]) if _is_named(ctor, 'node'):
       return isNodeList(ls)
     case _:
       return False
 
 def nodeListToList(t):
   match t:
-    case TermInst(loc2, tyof2, ctor, tyargs, inferred) if _is_named(ctor, 'empty'):
+    case TermInst(_, _, ctor, _, _) if _is_named(ctor, 'empty'):
       return []
-    case Call(loc, tyof1, TermInst(loc2, tyof2, ctor, tyargs, inferred),
+    case Call(_, _, TermInst(_, _, ctor, _, _),
               [arg, ls]) if _is_named(ctor, 'node'):
       return [arg] + nodeListToList(ls)
 
 def nodeListToString(t):
   match t:
-    case TermInst(loc2, tyof2, ctor, tyargs, inferred) if _is_named(ctor, 'empty'):
+    case TermInst(_, _, ctor, _, _) if _is_named(ctor, 'empty'):
       return ''
-    case Call(loc, tyof1, TermInst(loc2, tyof2, ctor, tyargs, inferred),
+    case Call(_, _, TermInst(_, _, ctor, _, _),
               [arg, ls]) if _is_named(ctor, 'node'):
       return str(arg) + ', ' + nodeListToString(ls)
 
@@ -4377,8 +4377,8 @@ def listToNodeList(loc, lst):
 
 def isEmptySet(t):
   match t:
-    case Call(loc2, tyof2, fun,
-              [Lambda(loc3, tyof3, vars, Bool(loc4, tyof4, False))]) \
+    case Call(_, _, fun,
+              [Lambda(_, _, _, Bool(_, _, False))]) \
               if base_name(rator_name(fun)) == 'char_fun':
       return True
     case _:
@@ -4655,9 +4655,9 @@ class Env:
   def _formula_of_proof_var(self, curr, name):
     if name in curr.keys():
       match curr[name]:
-        case ProofBinding(loc, formula):
+        case ProofBinding(_, formula):
           return formula
-        case TermBinding(loc, FunctionType()):
+        case TermBinding(_, FunctionType()):
           raise UserError('expected a proof but instead got term `' + base_name(name) + '`.'\
                         + '\nPerhaps you meant `expand ' + base_name(name) + '`?')
         case TermBinding():
@@ -4677,16 +4677,16 @@ class Env:
 
   def term_var_is_defined(self, tvar):
     match tvar:
-      case OverloadedVar(loc, tyof, resolved_names):
+      case OverloadedVar(_, _, resolved_names):
         return any([self._term_var_defined(self.dict, x) for x in resolved_names])
-      case ResolvedVar(loc, tyof, name):
+      case ResolvedVar(_, _, name):
         return self._term_var_defined(self.dict, name)
-      case Var(loc, tyof, name):
+      case Var(_, _, name):
         return self._term_var_defined(self.dict, name)
         
   def proof_var_is_defined(self, pvar):
     match pvar:
-      case PVar(loc, name):
+      case PVar(_, name):
         if self._formula_of_proof_var(self.dict, name):
           return True
         else:
@@ -4708,14 +4708,14 @@ class Env:
       
   def get_formula_of_proof_var(self, pvar):
     match pvar:
-      case PVar(loc, name):
+      case PVar(_, name):
         return self._formula_of_proof_var(self.dict, name)
       case _:
         raise Exception('get_formula_of_proof_var: expected PVar, not ' + str(pvar))
           
   def get_type_of_term_var(self, tvar):
     match tvar:
-      case OverloadedVar(loc, tyof, resolved_names):
+      case OverloadedVar(loc, _, resolved_names):
         looked_up = [(x, self._type_of_term_var(self.dict, x)) for x in resolved_names]
         # Drop candidates not in env (e.g., overloads from modules
         # that haven't been imported here).
@@ -4725,9 +4725,9 @@ class Env:
         if len(overloads) > 1:
           return OverloadType(loc, overloads)
         return overloads[0][1]
-      case ResolvedVar(loc, tyof, name):
+      case ResolvedVar(loc, _, name):
         return self._type_of_term_var(self.dict, name)
-      case Var(loc, tyof, name):
+      case Var(loc, _, name):
         return self._type_of_term_var(self.dict, name)
 
   def get_value_of_term_var(self, tvar):
@@ -4813,114 +4813,114 @@ class MarkException(BaseException):
 
 def count_marks(formula):
   match formula:
-    case Mark(loc2, tyof, subject):
+    case Mark(_, _, subject):
       return 1 + count_marks(subject)
-    case TermInst(loc2, tyof, subject, tyargs, inferred):
+    case TermInst(_, _, subject, _, _):
       return count_marks(subject)
     case Var() | OverloadedVar() | ResolvedVar():
       return 0
-    case Bool(loc2, tyof, val):
+    case Bool(_, _, _):
       return 0
-    case And(loc2, tyof, args):
+    case And(_, _, args):
       return sum([count_marks(arg) for arg in args])
-    case Or(loc2, tyof, args):
+    case Or(_, _, args):
       return sum([count_marks(arg) for arg in args])
-    case IfThen(loc2, tyof, prem, conc):
+    case IfThen(_, _, prem, conc):
       return count_marks(prem) + count_marks(conc)
-    case All(loc2, tyof, var, _, frm2):
+    case All(_, _, _, _, frm2):
       return count_marks(frm2)
-    case Some(loc2, tyof, vars, frm2):
+    case Some(_, _, _, frm2):
       return count_marks(frm2)
-    case Call(loc2, tyof, rator, args):
+    case Call(_, _, rator, args):
       return count_marks(rator) + sum([count_marks(arg) for arg in args])
-    case Switch(loc2, tyof, subject, cases):
+    case Switch(_, _, subject, cases):
       return count_marks(subject) + sum([count_marks(c) for c in cases])
-    case SwitchCase(loc2, pat, body):
+    case SwitchCase(_, _, body):
       return count_marks(body)
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, _, _, _, _, cases):
       return 0
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty, body, trm):
+    case GenRecFun(_, _, _, _, _, _, _, body, _):
       return 0
-    case Conditional(loc2, tyof, cond, thn, els):
+    case Conditional(_, _, cond, thn, els):
       return count_marks(cond) + count_marks(thn) + count_marks(els)
-    case Lambda(loc2, tyof, vars, body):
+    case Lambda(_, _, _, body):
       return count_marks(body)
-    case Generic(loc2, tyof, typarams, body):
+    case Generic(_, _, _, body):
       return count_marks(body)
-    case TAnnote(loc2, tyof, subject, typ):
+    case TAnnote(_, _, subject, _):
       return count_marks(subject)
-    case TLet(loc2, tyof, var, rhs, body):
+    case TLet(_, _, _, rhs, body):
       return count_marks(rhs) + count_marks(body)
-    case Hole(loc2, tyof):
+    case Hole(_, _):
       return 0
-    case Omitted(loc2, tyof):
+    case Omitted(_, _):
       return 0
-    case ArrayGet(loc, tyof, arr, ind):
+    case ArrayGet(_, _, arr, ind):
       return count_marks(arr) + count_marks(ind)
-    case Array(loc, tyof, elements):
+    case Array(_, _, elements):
       return sum([count_marks(elt) for elt in elements])
-    case MakeArray(loc, tyof, subject):
+    case MakeArray(_, _, subject):
       return count_marks(subject)
     case _:
       internal_error(formula.location, 'in count_marks function, unhandled ' + str(formula))
 
 def find_mark(formula):
   match formula:
-    case Mark(loc2, tyof, subject):
+    case Mark(_, _, subject):
       raise MarkException(subject)
-    case TermInst(loc2, tyof, subject, tyargs, inferred):
+    case TermInst(_, _, subject, _, _):
       find_mark(subject)
     case Var() | OverloadedVar() | ResolvedVar():
       pass
-    case Bool(loc2, tyof, val):
+    case Bool(_, _, _):
       pass
-    case And(loc2, tyof, args):
+    case And(_, _, args):
       for arg in args:
           find_mark(arg)
-    case Or(loc2, tyof, args):
+    case Or(_, _, args):
       for arg in args:
           find_mark(arg)
-    case IfThen(loc2, tyof, prem, conc):
+    case IfThen(_, _, prem, conc):
       find_mark(prem)
       find_mark(conc)
-    case All(loc2, tyof, var, pos, frm2):
+    case All(_, _, _, _, frm2):
       find_mark(frm2)
-    case Some(loc2, tyof, vars, frm2):
+    case Some(_, _, _, frm2):
       find_mark(frm2)
-    case Call(loc2, tyof, rator, args):
+    case Call(_, _, rator, args):
       find_mark(rator)
       for arg in args:
           find_mark(arg)
-    case Switch(loc2, tyof, subject, cases):
+    case Switch(_, _, subject, cases):
       find_mark(subject)
       for c in cases:
           find_mark(c)
-    case SwitchCase(loc2, pat, body):
+    case SwitchCase(_, _, body):
       find_mark(body)
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, _, _, _, _, cases):
       pass
-    case Conditional(loc2, tyof, cond, thn, els):
+    case Conditional(_, _, cond, thn, els):
       find_mark(cond)
       find_mark(thn)
       find_mark(els)
-    case Lambda(loc2, tyof, vars, body):
+    case Lambda(_, _, _, body):
       find_mark(body)
-    case Generic(loc2, tyof, typarams, body):
+    case Generic(_, _, _, body):
       find_mark(body)
-    case TAnnote(loc2, tyof, subject, typ):
+    case TAnnote(_, _, subject, _):
       find_mark(subject)
-    case TLet(loc2, tyof, var, rhs, body):
+    case TLet(_, _, _, rhs, body):
       find_mark(rhs)
       find_mark(body)
-    case Hole(loc2, tyof):
+    case Hole(_, _):
       pass
-    case ArrayGet(loc2, tyof, arr, ind):
+    case ArrayGet(_, _, arr, ind):
       find_mark(arr)
       find_mark(ind)
-    case Array(loc2, tyof, elements):
+    case Array(_, _, elements):
       for elt in elements:
           find_mark(elt)
-    case MakeArray(loc2, tyof, subject):
+    case MakeArray(_, _, subject):
       find_mark(subject)
     case _:
       internal_error(formula.location, 'in find_mark function, unhandled ' + str(formula))
@@ -4933,7 +4933,7 @@ def replace_mark(formula, replacement):
       return TermInst(loc2, tyof, replace_mark(subject, replacement), tyargs, inferred)
     case Var() | OverloadedVar() | ResolvedVar():
       return formula
-    case Bool(loc2, tyof, val):
+    case Bool(loc2, tyof, _):
       return formula
     case And(loc2, tyof, args):
       return And(loc2, tyof, [replace_mark(arg, replacement) for arg in args])
@@ -4954,7 +4954,7 @@ def replace_mark(formula, replacement):
                     [replace_mark(c, replacement) for c in cases])
     case SwitchCase(loc2, pat, body):
       return SwitchCase(loc2, pat, replace_mark(body, replacement))
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, _, typarams, _, _, cases):
       return formula
     case Conditional(loc2, tyof, cond, thn, els):
       return Conditional(loc2, tyof, replace_mark(cond, replacement),
@@ -4964,7 +4964,7 @@ def replace_mark(formula, replacement):
       return Lambda(loc2, tyof, vars, replace_mark(body, replacement))
     case Generic(loc2, tyof, typarams, body):
       return Generic(loc2, tyof, typarams, replace_mark(body, replacement))
-    case TAnnote(loc2, tyof, subject, typ):
+    case TAnnote(loc2, tyof, subject, _):
       return TAnnote(loc2, tyof, replace_mark(subject, replacement))
     case TLet(loc2, tyof, var, rhs, body):
       return TLet(loc2, tyof, var, replace_mark(rhs, replacement),
@@ -4995,14 +4995,14 @@ def remove_mark(formula):
       
 def extract_and(frm):
     match frm:
-      case And(loc, tyof, args):
+      case And(_, _, args):
         return args
       case _:
        return [frm]
 
 def extract_or(frm):
     match frm:
-      case Or(loc, tyof, args):
+      case Or(_, _, args):
         return args
       case _:
        return [frm]
@@ -5174,7 +5174,7 @@ def make_switch_for(meta, defs, subject, cases):
 
 def explicit_term_inst(term):
   match term:
-    case TermInst(loc2, tyof, subject, tyargs, inferred):
+    case TermInst(loc2, tyof, subject, tyargs, _):
       return TermInst(loc2, tyof, subject, tyargs, False)
     case Switch(loc2, tyof, subject, cases):
       return Switch(loc2, tyof, explicit_term_inst(subject),
@@ -5218,7 +5218,7 @@ def rewrite_aux(loc, formula, equation, env, depth = -1):
     rhs = try_rewrite(loc, formula, equation, env)
     inc_rewrites()
     return rhs
-  except MatchFailed as e:
+  except MatchFailed:
     if get_verbose():
       print('\tno match')
     pass
@@ -5228,7 +5228,7 @@ def rewrite_aux(loc, formula, equation, env, depth = -1):
                       tyargs, inferred)
     case OverloadedVar() | ResolvedVar() | Var():
       return formula
-    case Bool(loc2, tyof, val):
+    case Bool(loc2, tyof, _):
       return formula
     case And(loc2, tyof, args):
       return And(loc2, tyof, [rewrite_aux(loc, arg, equation, env, depth - 1) for arg in args])
@@ -5267,7 +5267,7 @@ def rewrite_aux(loc, formula, equation, env, depth = -1):
             old_num_rewrites = get_num_rewrites()
             try:
                new_tmp = rewrite_aux(loc, tmp, equation, env, depth)
-            except MatchFailed as e:
+            except MatchFailed:
                new_tmp = tmp
             new_num_rewrites = get_num_rewrites()
             if new_num_rewrites == old_num_rewrites:
@@ -5297,7 +5297,7 @@ def rewrite_aux(loc, formula, equation, env, depth = -1):
                     [rewrite_aux(loc, c, equation, env, depth - 1) for c in cases])
     case SwitchCase(loc2, pat, body):
       return SwitchCase(loc2, pat, rewrite_aux(loc, body, equation, env, depth - 1))
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(loc, _, typarams, _, _, cases):
       return formula
     case Conditional(loc2, tyof, cond, thn, els):
       return Conditional(loc2, tyof, rewrite_aux(loc, cond, equation, env, depth - 1),
@@ -5361,8 +5361,8 @@ def formula_match(loc, vars, pattern_frm, frm, matching, env):
     print("\tin  " + ','.join([str(x) for x in vars]))
     print("\twith " + ','.join([x + ' := ' + str(f) for (x,f) in matching.items()]))
   match (pattern_frm, frm):
-    case (TermInst(loc1, tyof1, subject1, tyargs1, inferred1),
-          TermInst(loc2, tyof2, subject2, tyargs2, inferred2)) \
+    case (TermInst(_, _, subject1, tyargs1, _),
+          TermInst(_, _, subject2, tyargs2, _)) \
           if len(tyargs1) == len(tyargs2):
       try:
         matching2 = dict(matching)
@@ -5371,13 +5371,13 @@ def formula_match(loc, vars, pattern_frm, frm, matching, env):
         formula_match(loc, vars, subject1, subject2, matching2, env)
         matching.clear()
         matching.update(matching2)
-      except MatchFailed as ex:
+      except MatchFailed:
         formula_match(loc, vars, subject1, frm, matching, env)
         
-    case (TermInst(loc2, tyof, subject, tyargs, inferred), _):
+    case (TermInst(_, _, subject, _, _), _):
       formula_match(loc, vars, subject, frm, matching, env)
       
-    case (_, TermInst(loc2, tyof, subject, tyargs, inferred)):
+    case (_, TermInst(_, _, subject, _, _)):
       formula_match(loc, vars, pattern_frm, subject, matching, env)
       
     case _ if isinstance(pattern_frm, VarRef) and isinstance(frm, VarRef) \
@@ -5392,7 +5392,7 @@ def formula_match(loc, vars, pattern_frm, frm, matching, env):
             print("formula_match, " + base_name(tyvar_name) + ' := ' + str(frm))
         matching[tyvar_name] = frm
         
-    case (Call(loc2, tyof2, goal_rator, goal_rands),
+    case (Call(_, _, goal_rator, goal_rands),
           Call(loc3, tyof3, rator, rands)):
       if False and get_verbose():
           print("matching Call with Call\n\trator pattern: " + str(goal_rator) + '\n'\
@@ -5418,17 +5418,17 @@ def formula_match(loc, vars, pattern_frm, frm, matching, env):
         match_failed(loc, "formula: " + str(frm) + "\n" \
                      + "does not match expected formula: " + str(pattern_frm))
         
-    case (And(loc2, tyof2, goal_args),
+    case (And(_, _, goal_args),
           And(loc3, tyof3, args)):
       for (goal_arg, arg) in zip(goal_args, args):
           new_goal_arg = goal_arg.substitute(matching)
           formula_match(loc, vars, new_goal_arg, arg, matching, env)
-    case (Or(loc2, tyof2, goal_args),
+    case (Or(_, _, goal_args),
           Or(loc3, tyof3, args)):
       for (goal_arg, arg) in zip(goal_args, args):
           new_goal_arg = goal_arg.substitute(matching)
           formula_match(loc, vars, new_goal_arg, arg, matching, env)
-    case (IfThen(loc2, tyof2, goal_prem, goal_conc),
+    case (IfThen(_, _, goal_prem, goal_conc),
           IfThen(loc3, tyof3, prem, conc)):
       formula_match(loc, vars, goal_prem, prem, matching, env)
       new_goal_conc = goal_conc.substitute(matching)
@@ -5443,20 +5443,19 @@ def formula_match(loc, vars, pattern_frm, frm, matching, env):
 
 def call_arity(call):
     match call:
-      case Call(loc2, tyof, rator, args):
+      case Call(_, _, _, args):
         return len(args)
       case _:
         return 1 #raise Exception('call_arity: not a call ' + str(call))
 
 def term_head(term):
     match term:
-      case Call(loc, ty1, rator, args):
+      case Call(_, _, rator, _):
           return base_name(rator_name(rator)) # TODO: remove base_name -Jeremy
       case _:
           return 'no_name'
     
 def auto_rewrites(term, env):
-    orig_term = term
     # Iterate until we can't rewrite anymore (to a fixed point)
     while True:
         current = get_num_rewrites()

--- a/compiler/emit_c.py
+++ b/compiler/emit_c.py
@@ -201,7 +201,7 @@ def emit_program(p: ir.Program) -> str:
         )
     for d in p.decls:
         if isinstance(d, ir.Global):
-            tmp = ctx.fresh_tmp()
+            ctx.fresh_tmp()
             stmts, expr = _emit_term(d.body, ctx, locals_in_scope=set())
             for s in stmts:
                 out.append("    " + s)

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -3795,7 +3795,6 @@ def _find_top_level(s: str, needle: str) -> Optional[int]:
     """Return the offset of ``needle`` at paren-depth 0 in ``s``, or
     ``None``.  Used to strip top-level binders from rendered goals."""
     depth = 0
-    n = len(needle)
     for i, ch in enumerate(s):
         if ch == "(":
             depth += 1

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -286,7 +286,7 @@ def check_implies(loc, frm1, frm2):
               + '\t' + str(frm2)
           raise wrap_user_error(e, context) from e
 
-    case(Or(loc1, tyof1, args1), _):
+    case(Or(_, _, args1), _):
       for arg1 in args1:
         try:
           check_implies(loc, arg1, frm2)
@@ -304,10 +304,10 @@ def check_implies(loc, frm1, frm2):
         try:
           check_implies(loc, arg1, frm2)
           return
-        except UserError as e:
+        except UserError:
           # implicit modus ponens
           match arg1:
-            case IfThen(loc3, tyof3, prem, conc):
+            case IfThen(_, _, prem, conc):
               try:
                   check_implies(loc, conc, frm2)
                   remaining = [arg for arg in args1 if arg != arg1]
@@ -319,7 +319,7 @@ def check_implies(loc, frm1, frm2):
                     rest = And(loc2, tyof2, remaining)
                   check_implies(loc, rest, prem)
                   return
-              except UserError as e2:
+              except UserError:
                   pass
             case _:
               pass
@@ -335,7 +335,7 @@ def check_implies(loc, frm1, frm2):
         try:
           check_implies(loc, frm1, arg2)
           return
-        except UserError as e:
+        except UserError:
           continue
       user_error(loc, '\nCould not prove that\n\t' + str(frm1) + '\n' \
                  + 'implies\n\t' + str(frm2) + '\n' \
@@ -343,7 +343,7 @@ def check_implies(loc, frm1, frm2):
                  + '\n'.join(['\t' + str(frm1) + '   implies   ' + str(arg2)\
                               for arg2 in args2]))
       
-    case (IfThen(loc1, tyof1, prem1, conc1), IfThen(loc2, tyof2, prem2, conc2)):
+    case (IfThen(_, _, prem1, conc1), IfThen(loc2, tyof2, prem2, conc2)):
       try:
         check_implies(loc, prem2, prem1)
         check_implies(loc, conc1, conc2)
@@ -353,7 +353,7 @@ def check_implies(loc, frm1, frm2):
             + '\t' + str(frm2)
         raise wrap_user_error(e, context) from e
 
-    case (All(loc1, tyof1, var1, _, body1), All(loc2, tyof2, var2, _, body2)):
+    case (All(_, _, var1, _, body1), All(loc2, tyof2, var2, _, body2)):
       try:
           sub = { var2[0]: OverloadedVar(loc2, var1[1], [var1[0]]) }
           body2a = body2.substitute(sub)
@@ -364,7 +364,7 @@ def check_implies(loc, frm1, frm2):
             + '\t' + str(frm2)
         raise wrap_user_error(e, context) from e
 
-    case (All(loc1, tyof1, vars1, _, body1), _):
+    case (All(_, _, _, _, body1), _):
        matching = {}
        try:
          vars, body = collect_all(frm1)
@@ -395,7 +395,7 @@ def check_implies(loc, frm1, frm2):
                     
 def instantiate(loc, allfrm, arg):
   match allfrm:
-    case All(loc2, tyof, (var, ty), (s, e), frm):
+    case All(_, _, (var, _), (s, _), frm):
       sub = { var : arg }
       ret = frm.substitute(sub)
       if s != 0:
@@ -459,10 +459,10 @@ def isolate_difference(term1, term2):
     return None
   else:
     match (term1, term2):
-      case (Lambda(l1, tyof1, vs1, body1), Lambda(l2, tyof2, vs2, body2)):
+      case (Lambda(l1, _, vs1, body1), Lambda(_, _, vs2, body2)):
         ren = {x: ResolvedVar(l1, t2, y) for ((x,t1),(y,t2)) in zip(vs1, vs2)}
         return isolate_difference(body1.substitute(ren), body2)
-      case (Call(l1, tyof1, fun1, args1), Call(l2, tyof2, fun2, args2)):
+      case (Call(l1, _, fun1, args1), Call(_, _, fun2, args2)):
         if fun1 == fun2:
           if len(args1) == len(args2):
               return isolate_difference_list(args1, args2)
@@ -470,19 +470,19 @@ def isolate_difference(term1, term2):
               return (term1, term2)
         else:
           return isolate_difference(fun1, fun2)
-      case (SwitchCase(l1, p1, body1), SwitchCase(l2, p2, body2)):
+      case (SwitchCase(l1, p1, body1), SwitchCase(_, p2, body2)):
         if p1 == p2:
           return isolate_difference(body1, body2)
         else:
           return (p1, p2)
-      case (Switch(l1, tyof1, s1, cs1), Switch(l2, tyof2, s2, cs2)):
+      case (Switch(l1, _, s1, cs1), Switch(_, _, s2, cs2)):
         if s1 == s2:
           return isolate_difference_list(cs1, cs2)
         else:
           return (s1, s2)
-      case(And(l1, tyof1, args1), And(l2, tyof2, args2)):
+      case(And(l1, _, args1), And(_, _, args2)):
         return isolate_difference_list(args1, args2)
-      case (All(l1, tyof1, var1, _, body1), All(l2, tyof2, var2, _, body2)):
+      case (All(l1, _, _, _, body1), All(_, _, _, _, body2)):
         return (term1, term2)
       case _:
         return (term1, term2)
@@ -494,13 +494,13 @@ def collect_all_if_then(loc, frm, env):
       frm = frm.reduceLets(env)
 
     match frm:
-      case All(loc2, tyof, var, _, frm):
+      case All(loc2, _, var, _, frm):
         (rest_vars, mps) = collect_all_if_then(loc, frm, env)
         x, t = var
         return ([ResolvedVar(loc2, t, x)] + rest_vars, mps)
-      case IfThen(loc2, tyof, prem, conc):
+      case IfThen(loc2, _, prem, conc):
         return ([], [(prem, conc)])
-      case And(loc2, tyof, args):
+      case And(loc2, _, args):
         mps1 = []
         for arg in args:
           try:
@@ -518,7 +518,7 @@ def collect_all_if_then(loc, frm, env):
 
 def collect_all(frm):
     match frm:
-      case All(loc2, tyof, var, _, frm):
+      case All(loc2, _, var, _, frm):
         (rest_vars, body) = collect_all(frm)
         x, t = var
         return ([ResolvedVar(loc2, t, x)] + rest_vars, body)
@@ -737,7 +737,7 @@ def check_proof(proof, env):
               with speculative_probe():
                 check_proof_of(arg, prem, env)
               rets.append(conc)
-            except UserError as e:
+            except UserError:
               pass
           if len(rets) == 1: ret = rets[0]
           elif len(rets) > 1: ret = And(loc2, tyof, rets)
@@ -792,8 +792,8 @@ def check_proof(proof, env):
       formula = check_proof(eq_pf, env)
       (a,b) = split_equation(loc, formula, env)
       match (a,b):
-        case (Call(loc2, tyof2, rator1, args1),
-              Call(loc4, tyof4, rator2, args2)) if len(args1) == len(args2):
+        case (Call(loc2, _, rator1, args1),
+              Call(_, _, rator2, args2)) if len(args1) == len(args2):
           f1 = base_name(rator_name(rator1))
           f2 = base_name(rator_name(rator2))
           if f1 != f2:
@@ -879,7 +879,7 @@ def get_type_args(ty):
   if isinstance(ty, VarRef):
     return []
   match ty:
-    case TypeInst(l1, ty, type_args):
+    case TypeInst(_, ty, type_args):
       return type_args
     case _:
       raise InternalError('unhandled case in get_type_args: ' + repr(ty))
@@ -887,7 +887,7 @@ def get_type_args(ty):
 label_count = 0
 
 def reset_label():
-    label_count = 1
+    pass
 
 def generate_label():
     global label_count
@@ -899,23 +899,23 @@ def proof_use_advice(proof, formula, env):
     prefix = style.dark_green('Advice about using fact:') + '\n' \
         + '\t' + str(formula) + '\n\n'
     match formula:
-      case Bool(loc, tyof, True):
+      case Bool(loc, _, True):
         return prefix + '\tThe "true" fact is useless.\n'
-      case Bool(loc, tyof, False):
+      case Bool(loc, _, False):
         return prefix \
             + '\tUse this "false" fact to implicitly prove anything!\n'
-      case And(loc, tyof, args):
+      case And(loc, _, args):
         return prefix \
             + '\tUse this logical-and to implicitly prove any of its parts:\n' \
             + '\n'.join('\t\t' + str(arg) for arg in args)
-      case Or(loc, tyof, args):
+      case Or(loc, _, args):
         reset_label()
         return prefix \
             + '\tUse this logical-or by proceeding with a "cases" statement:\n'\
             + '\t\tcases ' + str(proof) + '\n' \
             + '\n'.join(['\t\tcase ' + generate_label() + ' : ' + str(arg) \
                          + ' { ? }' for arg in args])
-      case IfThen(loc, tyof, prem, conc):
+      case IfThen(loc, _, prem, conc):
         return prefix \
             + '\tApply this if-then formula to a proof of its premise:\n' \
             + '\t\t' + str(prem) + '\n' \
@@ -923,11 +923,11 @@ def proof_use_advice(proof, formula, env):
             + '\t\t' + str(conc) + '\n' \
             + '\tby using an apply-to statement:\n' \
             + '\t\tapply ' + str(proof) + ' to ?'
-      case All(loc, tyof, var, (s, e), body):
+      case All(loc, _, var, (s, _), body):
         vars = [var]
         while s != 0:
           match body:
-            case All(loc2, tyof2, var2, (s, e2), body):
+            case All(_, _, var2, (s, _), body):
               vars.append(var2)
 
         letters = []
@@ -956,7 +956,7 @@ def proof_use_advice(proof, formula, env):
             + '\tby writing ' + pronoun + how \
             + '\tto obtain a proof of:\n' \
             + '\t\t' + str(body.substitute(new_vars))
-      case Some(loc, tyof, vars, body):
+      case Some(loc, _, vars, body):
         letters = []
         new_vars = {}
         i = 65
@@ -974,7 +974,7 @@ def proof_use_advice(proof, formula, env):
                else ' is a new name of your choice' ) + ',\n' \
             + 'followed by a proof of the goal.'
 
-      case Call(loc2, tyof2, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+      case Call(_, _, rator, [_, _]) if isinstance(rator, VarRef) and rator.get_name() == '=':
         return prefix \
             + '\tYou can use this equality in a replace statement:\n' \
             + '\t\treplace ' + str(proof) + '\n'
@@ -989,9 +989,9 @@ def make_unique(name, env):
 
 def is_recursive(name, typ):
     match typ:
-      case OverloadedVar(l1, tyof, rs):
+      case OverloadedVar(_, _, rs):
         return name == rs[0]
-      case TypeInst(l1, ty, type_args):
+      case TypeInst(_, ty, _):
         return is_recursive(name, ty)
       case _:
         return False
@@ -1008,7 +1008,7 @@ def update_all_head(r):
 
 def gen_conjunct_advice(conjunct, arbs, ihs):
   match conjunct:
-    case All(_, _, (n, t), _, b):
+    case All(_, _, (n, _), _, b):
       return gen_conjunct_advice(b, arbs + [base_name(n)], ihs)
     case IfThen(_, _, _, b):
       return gen_conjunct_advice(b, arbs, ihs + [f"IH{len(ihs)}"])
@@ -1034,29 +1034,29 @@ def proof_advice(formula, env):
             + '\tConsider using\n\t\tsimplify\n\n'
     
     match formula:
-      case Bool(loc, tyof, True):
+      case Bool(loc, _, True):
         return prefix + '\tYou can prove "true" with a period.\n'
-      case Bool(loc, tyof, False):
+      case Bool(loc, _, False):
         return prefix \
             + '\tProve "false" by proving a contradiction:\n' \
             + '\tif you prove both "P" and "not P", \n' \
             + '\tthen "contradict (recall not P), (recall P)" proves "false".\n'
-      case And(loc, tyof, args):
+      case And(loc, _, args):
         return prefix \
             + '\tProve this logical-and formula by proving each of its'\
             + ' parts,\n\tshown below, then combine the proofs with commas.\n' \
             + '\n'.join('\t\t' + str(arg) for arg in args)
-      case Or(loc, tyof, args):
+      case Or(loc, _, args):
         return prefix \
             + '\tProve this logical-or formula by proving one of its parts:\n' \
             + '\n'.join('\t\t' + str(arg) for arg in args)
-      case IfThen(loc, tyof, prem, conc):
+      case IfThen(loc, _, prem, conc):
         return prefix \
             + '\tProve this if-then formula with:\n' \
             + '\t\tassume label: ' + str(prem) + '\n' \
             + '\tfollowed by a proof of:\n' \
             + '\t\t' + str(conc)
-      case All(loc, tyof, var, (s, e), body):
+      case All(loc, _, var, (s, _), body):
         pf = "arbitrary "
         cur = formula
         prev_s = s + 1 # This variable stops spillover into other alls
@@ -1095,7 +1095,7 @@ def proof_advice(formula, env):
           pass
 
         match ty:
-          case Union(loc2, name, typarams, alts):
+          case Union(_, name, _, alts):
             has_custom_ind = env.get_inductive(var_ty)
 
             if ty.visibility == 'opaque':
@@ -1140,7 +1140,7 @@ def proof_advice(formula, env):
             return arb_advice
 
 
-      case Some(loc, tyof, vars, body):
+      case Some(loc, _, vars, body):
         letters = []
         new_vars = {}
         i = 65
@@ -1155,13 +1155,13 @@ def proof_advice(formula, env):
             + ' with your choice(s),\n' \
             + '\tthen prove:\n' \
             + '\t\t' + str(body.substitute(new_vars))
-      case Call(loc2, tyof2, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+      case Call(_, _, rator, [_, _]) if isinstance(rator, VarRef) and rator.get_name() == '=':
         return prefix \
             + '\tTo prove this equality, one of these statements might help:\n'\
             + '\t\texpand\n' \
             + '\t\treplace\n' \
             + '\t\tequations\n'
-      case TLet(loc2, _, var, rhs, body):
+      case TLet(_, _, var, _, body):
         return proof_advice(body, env)
       case _:
         for (name, b) in env.dict.items():
@@ -1186,7 +1186,7 @@ def givens_str(env):
 
 def pred_to_equality(meta, pred):
     match pred:
-      case IfThen(meta1, ty1, p, Bool(meta2, ty2, False)):
+      case IfThen(_, _, p, Bool(_, _, False)):
           return Call(meta, None, ResolvedVar(meta, None, '='),
                       [p , Bool(meta, None, False)])
       case _:
@@ -1331,7 +1331,7 @@ def check_proof_of(proof, formula, env):
       
     case PReflexive(loc):
       match formula:
-        case Call(loc2, tyof2, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+        case Call(loc2, _, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
           lhsNF = lhs.reduce(env)
           rhsNF = rhs.reduce(env)
           if lhsNF != rhsNF:
@@ -1376,7 +1376,7 @@ def check_proof_of(proof, formula, env):
     case PExtensionality(loc, proof):
       (lhs,rhs) = split_equation(loc, formula, env)
       match lhs.typeof:
-        case FunctionType(loc2, [], typs, ret_ty):
+        case FunctionType(loc2, [], typs, _):
           names = [generate_proof_name('x') for ty in typs]
           args = [ResolvedVar(loc, None, x) for x in names]
           call_lhs = Call(loc, None, lhs, args)
@@ -1385,7 +1385,7 @@ def check_proof_of(proof, formula, env):
           for i, v in enumerate(reversed(list(zip(names, typs)))):
             formula = All(loc, None, v, (i, len(names)), formula)
           _try_check_proof_of(proof, formula, env)
-        case FunctionType(loc2, ty_params, params, ret_ty):
+        case FunctionType(loc2, ty_params, params, _):
           add_diagnostic(loc, 'extensionality expects function without any type parameters, not ' + str(len(ty_params))
                 + givens_str(env))
         case _:
@@ -1400,7 +1400,7 @@ def check_proof_of(proof, formula, env):
         formula = formula.reduceLets(env)
 
       match formula:
-        case All(loc2, tyof, var2, (s, e), formula2):
+        case All(loc2, _, var2, (s, e), formula2):
           x2, ty2 = var2
           if ty != ty2:
             add_diagnostic(loc, "arbitrary expects " + base_name(x)
@@ -1430,7 +1430,7 @@ def check_proof_of(proof, formula, env):
         formula = formula.reduceLets(env)
       
       match formula:
-        case Some(loc2, tyof, vars, formula2):
+        case Some(loc2, _, vars, formula2):
           sub = {var[0]: trm for (var,trm) in zip(vars, witnesses) }
           body_frm = formula2.substitute(sub)
           _try_check_proof_of(body, body_frm, env)
@@ -1445,7 +1445,7 @@ def check_proof_of(proof, formula, env):
         someFormula = someFormula.reduceLets(env)
       
       match someFormula:
-        case Some(loc2, tyof, vars, formula2):
+        case Some(loc2, _, vars, formula2):
           sub = {var[0]: ResolvedVar(loc2, None, x) for (var,x) in zip(vars,witnesses)}
           witnessFormula = formula2.substitute(sub)
           
@@ -1468,7 +1468,7 @@ def check_proof_of(proof, formula, env):
         formula = formula.reduceLets(env)
 
       match formula:
-        case IfThen(loc2, tyof, prem, conc):
+        case IfThen(loc2, _, prem, conc):
           body_env = env.declare_local_proof_var(loc, label, prem)
           _try_check_proof_of(body, conc, body_env)
         case _:
@@ -1479,7 +1479,7 @@ def check_proof_of(proof, formula, env):
     case ImpIntro(loc, label, prem1, body):
       new_prem1 = check_formula(prem1, env)
       match formula:
-        case IfThen(loc2, tyof, prem2, conc):
+        case IfThen(loc2, _, prem2, conc):
           prem1_red = new_prem1.reduce(env)
           prem2_red = prem2.reduce(env)
           if prem1_red != prem2_red:
@@ -1515,7 +1515,7 @@ def check_proof_of(proof, formula, env):
     case PLet(loc, label, frm, reason, rest):
       new_frm = check_formula(frm, env)
       match new_frm:
-        case Hole(loc2, tyof):
+        case Hole(loc2, _):
           proved_formula = check_proof(reason, env)
           warning(loc, "\nhave " + base_name(label) + ':\n\t' + str(proved_formula))
           body_env = env.declare_local_proof_var(loc, label, proved_formula)
@@ -1527,7 +1527,7 @@ def check_proof_of(proof, formula, env):
     case PAnnot(loc, claim, reason):
       new_claim = check_formula(claim, env)
       match new_claim:
-        case Hole(loc2, tyof):
+        case Hole(loc2, _):
           _try_check_proof_of(reason, formula, env)
           add_diagnostic(loc, '\nneed to show:\n\t' + str(formula)
                 + givens_str(env))
@@ -1555,7 +1555,6 @@ def check_proof_of(proof, formula, env):
     case Suffices(loc, claim, reason, rest):
       evaluate = False
 
-      definitions = []
       match reason:
         case EvaluateGoal(loc2):
            evaluate = True
@@ -1570,9 +1569,9 @@ def check_proof_of(proof, formula, env):
         set_dont_reduce_opaque(False)
 
         match red_claim:
-          case Omitted(loc2, tyof):
+          case Omitted(loc2, _):
             _try_check_proof_of(rest, new_formula, env)
-          case Hole(loc2, tyof):
+          case Hole(loc2, _):
             newer_formula = check_formula(new_formula, env)
             warning(loc, '\nsuffices to prove:\n\t' + str(newer_formula))
             check_proof_of(rest, newer_formula, env)
@@ -1587,20 +1586,20 @@ def check_proof_of(proof, formula, env):
         claim_red = new_claim.reduce(env)
 
         match claim_red:
-          case Hole(loc2, tyof):
+          case Hole(loc2, _):
             proved_formula = check_proof(reason, env)
             match proved_formula:
-              case IfThen(loc3, _, prem, conc):
+              case IfThen(_, _, prem, conc):
                 check_implies(loc, conc, formula)
                 warning(loc2, '\nsuffices to prove:\n\t' + str(prem))
                 _try_check_proof_of(rest, prem, env)
               case _:
                 add_diagnostic(loc, 'expected a proof of an "if"-"then" formula, not ' + str(proved_formula)
                       + givens_str(env))
-          case Omitted(loc2, tyof):
+          case Omitted(loc2, _):
             proved_formula = check_proof(reason, env)
             match proved_formula:
-              case IfThen(loc3, _, prem, conc):
+              case IfThen(_, _, prem, conc):
                 check_implies(loc, conc, formula)
                 _try_check_proof_of(rest, prem, env)
               case _:
@@ -1616,7 +1615,7 @@ def check_proof_of(proof, formula, env):
         with speculative_probe():
           red_formula = formula.reduce(env)
           match red_formula:
-            case And(loc2, tyof2, frms):
+            case And(loc2, _, frms):
               for (frm,pf) in zip(frms, pfs):
                 check_proof_of(pf, frm, env)
               if len(pfs) < len(frms):
@@ -1650,7 +1649,7 @@ def check_proof_of(proof, formula, env):
         sub_red = sub_frm.reduceLets(env)
 
       match sub_red:
-        case Or(loc1, tyof, frms):
+        case Or(_, _, frms):
           if len(cases) < len(frms):
               add_diagnostic(loc, "expected " + str(len(frms)) + " cases, not " + str(len(cases))
                     + givens_str(env))
@@ -1666,10 +1665,10 @@ def check_proof_of(proof, formula, env):
           add_diagnostic(proof.location, "expected 'or', not " + str(sub_red)
                 + givens_str(env))
           
-    case RuleInduction(loc, hyp_name, ri_cases):
+    case RuleInduction(loc, _, _):
       _check_rule_induction(proof, formula, env)
 
-    case RuleInversion(loc, hyp_name, ri_cases):
+    case RuleInversion(loc, _, _):
       _check_rule_inversion(proof, formula, env)
 
     case Induction(loc, typ, cases):
@@ -1678,7 +1677,7 @@ def check_proof_of(proof, formula, env):
       if isinstance(formula, TLet):
         formula = formula.reduceLets(env)
       match formula:
-        case All(loc2, tyof, (var,ty), _, frm):
+        case All(loc2, _, (var,ty), _, frm):
           if typ != ty:
             add_diagnostic(loc, "type of induction: " + str(typ) \
                   + "\ndoes not match the all-formula's type: " + str(ty)
@@ -1703,7 +1702,7 @@ def check_proof_of(proof, formula, env):
 
         if type_vars != []:
           match typ:
-            case TypeInst(loc, t, params):
+            case TypeInst(loc, _, params):
               assert len(type_vars) == len(params) # Enforced by match_induction_fun
               for k, v in zip(type_vars, params):
                 type_subst[k] = v
@@ -1812,9 +1811,9 @@ def check_proof_of(proof, formula, env):
           has_false_case = False
           for scase in cases:
             match scase.pattern:
-              case PatternBool(l1, True):
+              case PatternBool(_, True):
                 has_true_case = True
-              case PatternBool(l1, False):
+              case PatternBool(_, False):
                 has_false_case = True
               case _:
                 internal_error(loc, 'unhandled case in switch proof')
@@ -2311,7 +2310,7 @@ def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
     if ret_ty:
       try:
           type_match(loc, type_params, return_type, ret_ty, matching)
-      except MatchFailed as e:
+      except MatchFailed:
         new_msg = 'expected type ' + str(ret_ty) + '\n' \
             + '\tbut the call ' + str(call) + '\n' \
             + '\thas return type ' + str(return_type) + '\n\n' \
@@ -2407,11 +2406,11 @@ def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, 
       print('tc_call_helper(' + str(call) + ') rator type: ' + str(new_rator.typeof))
   funty = new_rator.typeof
   match funty:
-    case OverloadType(loc2, overloads):
+    case OverloadType(_, overloads):
       num_matches = 0
       for (x, funty) in overloads:
           match funty:
-            case FunctionType(loc2, typarams, param_types, return_type):
+            case FunctionType(_, typarams, param_types, return_type):
               # Preserve the rator's use-site location (e.g. the `+'
               # token in `x + y') on the resolved variable.  Using
               # `loc2' (the FunctionType's declaration site) here
@@ -2426,7 +2425,7 @@ def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, 
                                                  subterms, ret_ty, call,
                                                  typarams, param_types, return_type)
                 num_matches += 1
-              except (UserError, MatchFailed) as e:
+              except (UserError, MatchFailed):
                 pass
       if num_matches == 0:
           arg_types = [type_synth_term(arg, env, None, []).typeof for arg in args]
@@ -2448,7 +2447,7 @@ def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, 
                 + '\n'.join([error_header(ty.location) + str(ty) for (x,ty) in overloads]))
       else:
           return new_call
-    case FunctionType(loc2, typarams, param_types, return_type):
+    case FunctionType(_, typarams, param_types, return_type):
       return type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty, call,
                                    typarams, param_types, return_type)
     case _:
@@ -2524,51 +2523,51 @@ def check_no_recfun_escape(term, recfun):
       _escape_error(term.location, recfun)
     return
   match term:
-    case Call(loc, ty, rator, args):
+    case Call(_, _, rator, args):
       _check_rator_no_escape(rator, recfun)
       for a in args:
         check_no_recfun_escape(a, recfun)
-    case TermInst(loc, ty, subject, type_args, inferred):
+    case TermInst(_, _, subject, _, _):
       check_no_recfun_escape(subject, recfun)
-    case Generic(loc, ty, typarams, body):
+    case Generic(_, _, _, body):
       check_no_recfun_escape(body, recfun)
-    case Conditional(loc, ty, cond, thn, els):
+    case Conditional(_, _, cond, thn, els):
       check_no_recfun_escape(cond, recfun)
       check_no_recfun_escape(thn, recfun)
       check_no_recfun_escape(els, recfun)
-    case TAnnote(loc, ty, subject, typ):
+    case TAnnote(_, _, subject, _):
       check_no_recfun_escape(subject, recfun)
-    case Lambda(loc, ty, vars, body):
+    case Lambda(_, _, _, body):
       check_no_recfun_escape(body, recfun)
-    case Switch(loc, ty, subject, cases):
+    case Switch(_, _, subject, cases):
       check_no_recfun_escape(subject, recfun)
       for c in cases:
         check_no_recfun_escape(c.body, recfun)
-    case Array(loc, ty, elements):
+    case Array(_, _, elements):
       for e in elements:
         check_no_recfun_escape(e, recfun)
-    case MakeArray(loc, ty, subject):
+    case MakeArray(_, _, subject):
       check_no_recfun_escape(subject, recfun)
-    case ArrayGet(loc, ty, subject, position):
+    case ArrayGet(_, _, subject, position):
       check_no_recfun_escape(subject, recfun)
       check_no_recfun_escape(position, recfun)
-    case TLet(loc, ty, var, rhs, body):
+    case TLet(_, _, _, rhs, body):
       check_no_recfun_escape(rhs, recfun)
       check_no_recfun_escape(body, recfun)
-    case Mark(loc, ty, subject):
+    case Mark(_, _, subject):
       check_no_recfun_escape(subject, recfun)
-    case And(loc, ty, args):
+    case And(_, _, args):
       for a in args:
         check_no_recfun_escape(a, recfun)
-    case Or(loc, ty, args):
+    case Or(_, _, args):
       for a in args:
         check_no_recfun_escape(a, recfun)
-    case IfThen(loc, ty, premise, conclusion):
+    case IfThen(_, _, premise, conclusion):
       check_no_recfun_escape(premise, recfun)
       check_no_recfun_escape(conclusion, recfun)
-    case All(loc, ty, var, pos, body):
+    case All(_, _, _, _, body):
       check_no_recfun_escape(body, recfun)
-    case Some(loc, ty, vars, body):
+    case Some(_, _, _, body):
       check_no_recfun_escape(body, recfun)
     case Int() | Bool() | Hole() | Omitted():
       pass
@@ -2587,7 +2586,7 @@ def _check_rator_no_escape(rator, recfun):
   if isinstance(rator, VarRef):
     return
   match rator:
-    case TermInst(loc, ty, subject, type_args, inferred):
+    case TermInst(_, _, subject, _, _):
       _check_rator_no_escape(subject, recfun)
     case _:
       check_no_recfun_escape(rator, recfun)
@@ -2630,7 +2629,7 @@ def check_type(typ, env, arity_required=True):
         _check_union_arity(typ, 0, env)
       # len(rs) == 1: this is a non-overloaded type reference. Promote.
       return ResolvedVar(loc, tyof, rs[0])
-    case ResolvedVar(loc, tyof, name):
+    case ResolvedVar(loc, tyof, _):
       if not env.type_var_is_defined(typ):
         user_error(loc, 'undefined type variable ' + str(typ))
       if arity_required:
@@ -2664,17 +2663,17 @@ def type_first_letter(typ):
   if isinstance(typ, VarRef):
     return typ.get_name()[0]
   match typ:
-    case IntType(loc):
+    case IntType(_):
       return 'i'
-    case BoolType(loc):
+    case BoolType(_):
       return 'b'
-    case TypeType(loc):
+    case TypeType(_):
       return 't'
-    case FunctionType(loc, typarams, param_types, return_type):
+    case FunctionType(_, _, _, _):
       return 'f'
-    case TypeInst(loc, typ, arg_types):
+    case TypeInst(_, typ, _):
       return type_first_letter(typ)
-    case GenericUnknownInst(loc, typ):
+    case GenericUnknownInst(_, typ):
       return type_first_letter(typ)
     case _:
       print('error in type_first_letter: unhandled type ' + repr(typ))
@@ -2730,7 +2729,7 @@ def type_synth_term(term, env, recfun, subterms):
     print('type_synth_term: ' + str(term) + '\n' \
           + '\tin ' + str(recfun))
   match term:
-    case Mark(loc, tyof, subject):
+    case Mark(loc, _, subject):
       new_subject = type_synth_term(subject, env, recfun, subterms)
       ret = Mark(loc, new_subject.typeof, new_subject)
   
@@ -2743,7 +2742,7 @@ def type_synth_term(term, env, recfun, subterms):
       except Exception as e:
         user_error(loc, str(e))
       match ty:
-        case GenericUnknownInst(loc2, union_type):
+        case GenericUnknownInst(loc2, _):
           user_error(loc, 'Cannot infer type arguments for\n' \
                 + '\t' + base_name(rs[0]) + '\nPlease make them explicit.')
 
@@ -2761,7 +2760,7 @@ def type_synth_term(term, env, recfun, subterms):
       if ty is None:
         user_error(loc, 'while type checking, undefined variable ' + str(term))
       match ty:
-        case GenericUnknownInst(loc2, union_type):
+        case GenericUnknownInst(loc2, _):
           user_error(loc, 'Cannot infer type arguments for\n' \
                 + '\t' + base_name(name) + '\nPlease make them explicit.')
       ret = ResolvedVar(loc, ty, name)
@@ -2921,9 +2920,9 @@ def type_synth_term(term, env, recfun, subterms):
           has_false_case = False
           for scase in cases:
             match scase.pattern:
-              case PatternBool(l1, True):
+              case PatternBool(_, True):
                 has_true_case = True
-              case PatternBool(l1, False):
+              case PatternBool(_, False):
                 has_false_case = True
               case _:
                 user_error(c.location, 'not an appropriate case for bool\n\t' \
@@ -2949,7 +2948,7 @@ def type_synth_term(term, env, recfun, subterms):
     case TermInst(loc, _, subject, tyargs, inferred):
       ret = type_check_term_inst(loc, subject, tyargs, inferred, recfun, subterms, env)
 
-    case TAnnote(loc, tyof, subject, typ):
+    case TAnnote(loc, _, subject, typ):
       check_type(typ, env)
       ret = type_check_term(subject, typ, env, recfun, subterms)
 
@@ -2958,8 +2957,8 @@ def type_synth_term(term, env, recfun, subterms):
       ret = term
       term.typeof = fun_type
       
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty,
-                   body, terminates):
+    case GenRecFun(loc, name, typarams, params, returns, _, _,
+                   body, _):
       param_types = [t for (p,t) in params]
       fun_type = FunctionType(loc, typarams, param_types, returns)
       ret = term
@@ -2982,12 +2981,12 @@ def type_check_term(term, typ, env, recfun, subterms):
   if get_verbose():
     print('\ntype_check_term: ' + str(term) + ' : ' + str(typ) + '?\n')
   match term:
-    case Mark(loc, tyof, subject):
+    case Mark(loc, _, subject):
       new_subject = type_check_term(subject, typ, env, recfun, subterms)
       return Mark(loc, new_subject.typeof, new_subject)
-    case Hole(loc, tyof):
+    case Hole(loc, _):
       return Hole(loc, typ)
-    case Omitted(loc, tyof):
+    case Omitted(loc, _):
       return Omitted(loc, typ)
     case Generic(loc, _, type_params, body):
       match typ:
@@ -3008,11 +3007,11 @@ def type_check_term(term, typ, env, recfun, subterms):
       if var_typ is None:
         user_error(loc, 'variable ' + str(term) + ' is not defined')
       match (var_typ, typ):
-        case (GenericUnknownInst(loc2, union1), TypeInst(loc3, union2, tyargs)):
+        case (GenericUnknownInst(loc2, union1), TypeInst(_, union2, tyargs)):
           if union1 == union2:
             return TermInst(loc, typ, ResolvedVar(loc, typ, name),
                             tyargs, True)
-        case (FunctionType(loc1, typarams, param_types1, ret_type1),
+        case (FunctionType(_, typarams, param_types1, ret_type1),
               FunctionType(loc2, [], param_types2, ret_type2)):
           if len(typarams) > 0:
             matching = {}
@@ -3048,11 +3047,11 @@ def type_check_term(term, typ, env, recfun, subterms):
                   return ResolvedVar(loc, typ, x)
           user_error(loc, 'could not find an overload of ' + base_name(rs[0]) \
                 + ' of type ' + str(typ) + '\nin: ' + str(var_typ))
-        case (GenericUnknownInst(loc2, union1), TypeInst(loc3, union2, tyargs)):
+        case (GenericUnknownInst(loc2, union1), TypeInst(_, union2, tyargs)):
           if union1 == union2:
               return TermInst(loc, typ, ResolvedVar(loc, typ, rs[0]),
                               tyargs, True)
-        case (FunctionType(loc1, typarams, param_types1, ret_type1),
+        case (FunctionType(_, typarams, param_types1, ret_type1),
               FunctionType(loc2, [], param_types2, ret_type2)):
           if len(typarams) > 0:
             matching = {}
@@ -3064,7 +3063,7 @@ def type_check_term(term, typ, env, recfun, subterms):
               type_args = [matching[x] for x in type_params]
               return TermInst(ResolvedVar(loc, var_typ, rs[0]),
                               type_args, True)
-            except UserError as e:
+            except UserError:
               pass
       if var_typ != typ:
         user_error(loc, 'expected a term of type ' + str(typ) \
@@ -3097,8 +3096,8 @@ def type_check_term(term, typ, env, recfun, subterms):
       new_body = type_check_term(body, typ, body_env, recfun, subterms)
       return TLet(loc, typ, var, new_rhs, new_body)
       
-    case Call(loc, _, (OverloadedVar(loc2, vt, [op_name, *_])
-                       | ResolvedVar(loc2, vt, op_name)), args) \
+    case Call(loc, _, (OverloadedVar(loc2, _, [op_name, *_])
+                       | ResolvedVar(loc2, _, op_name)), args) \
         if op_name == '=' or op_name == '≠':
       new_term = type_synth_term(term, env, recfun, subterms)
       ty = new_term.typeof
@@ -3178,7 +3177,7 @@ def lookup_union(loc, typ, env):
   if isinstance(typ, VarRef):
     return env.get_def_of_type_var(typ)
   match typ:
-    case TypeInst(loc2, inst_typ, tyargs):
+    case TypeInst(_, inst_typ, _):
       return env.get_def_of_type_var(inst_typ)
     case _:
       user_error(loc, 'expected a union type but instead got ' + str(typ))
@@ -3190,7 +3189,7 @@ def check_constructor_pattern(loc, pat_constr, params, typ, env, cases_present):
   if get_verbose():
     print('for union: ' + str(defn))
   match defn:
-    case Union(loc2, name, typarams, alts):
+    case Union(_, _, typarams, alts):
       # example:
       # typ is List<E>
       # union List<T> { empty; node(T, List<T>); }
@@ -3237,7 +3236,7 @@ def check_pattern(pattern, typ, env, cases_present):
   match pattern:
     case PatternBool(loc, value):
       match typ:
-        case BoolType(loc2):
+        case BoolType(_):
           cases_present[str(value)] = True
           return env
         case _:
@@ -3314,7 +3313,7 @@ def check_strict_positivity(ty, union_name, env, forbidden=False):
             f"inconsistent (Russell's paradox)")
     return
   match ty:
-    case TypeInst(loc, head, type_args):
+    case TypeInst(_, head, type_args):
       check_strict_positivity(head, union_name, env, forbidden)
       head_pols = _lookup_param_polarities(head, env)
       for i, t in enumerate(type_args):
@@ -3325,11 +3324,11 @@ def check_strict_positivity(ty, union_name, env, forbidden=False):
         else:
           eff_forbidden = forbidden
         check_strict_positivity(t, union_name, env, eff_forbidden)
-    case FunctionType(loc, ty_params, param_types, return_type):
+    case FunctionType(_, _, param_types, return_type):
       for t in param_types:
         check_strict_positivity(t, union_name, env, forbidden=True)
       check_strict_positivity(return_type, union_name, env, forbidden)
-    case ArrayType(loc, elt_ty):
+    case ArrayType(_, elt_ty):
       check_strict_positivity(elt_ty, union_name, env, forbidden)
     case _:
       pass
@@ -3358,7 +3357,7 @@ def infer_param_polarities(union_decl, env):
           polarities[idx] = '-'
       return
     match ty:
-      case TypeInst(loc, head, type_args):
+      case TypeInst(_, head, type_args):
         walk(head, current)
         head_pols = _lookup_param_polarities(head, env)
         for i, arg in enumerate(type_args):
@@ -3370,11 +3369,11 @@ def infer_param_polarities(union_decl, env):
           else:
             eff = current
           walk(arg, eff)
-      case FunctionType(loc, ty_params, param_types, return_type):
+      case FunctionType(_, _, param_types, return_type):
         for t in param_types:
           walk(t, '-')
         walk(return_type, current)
-      case ArrayType(loc, elt_ty):
+      case ArrayType(_, elt_ty):
         walk(elt_ty, current)
       case _:
         pass
@@ -3907,7 +3906,7 @@ def _build_rule_induction_theorem(decl, param_types, rule_translations,
   derivation `union` (we just don't use the induction hypotheses)."""
   loc = decl.location
   pred_name = decl.name
-  base_pred = base_name(pred_name)
+  base_name(pred_name)
   arity = len(param_types)
 
   # The theorem's uniquified name was pre-registered in env during
@@ -4306,7 +4305,7 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
       orig_name = base_name(name)
       if orig_name in unique_name.keys():
           match new_ty:
-            case FunctionType(loc2, ty_params, params, ret_ty):
+            case FunctionType(_, _, params, _):
               pass
             case _:
               binding = env.dict[unique_name[orig_name]]
@@ -4320,7 +4319,7 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
               env.declare_term_var(loc, name, new_ty,
                                    visibility=decl.visibility)
   
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(loc, name, typarams, params, returns, _):
       body_env = env.declare_type_vars(loc, typarams)
       check_type(returns, body_env)
       for t in params:
@@ -4331,14 +4330,14 @@ def process_declaration_visibility(decl : Declaration, env: Env, module_chain, d
       return decl, env.declare_term_var(loc, name, fun_type,
                                         visibility=decl.visibility)
 
-    case GenRecFun(loc, name, typarams, param_pairs, returns, measure, measure_ty,
-                   body, terminates):
+    case GenRecFun(loc, name, typarams, param_pairs, returns, _, measure_ty,
+                   body, _):
       body_env = env.declare_type_vars(loc, typarams)
       check_type(returns, body_env)
       for (p,t) in param_pairs:
           if t:
               check_type(t, body_env)
-      vars = [p for (p,t) in param_pairs]
+      [p for (p,t) in param_pairs]
       param_types = [t for (p,t) in param_pairs]
       if any([t == None for t in param_types]):
           user_error(loc, 'Add type annotations to the parameters.')
@@ -4544,22 +4543,22 @@ def process_declaration(stmt : Statement, env : Env, module_chain, downstream_ne
     case Declaration():
       return process_declaration_visibility(stmt, env, module_chain, downstream_needs_checking)
           
-    case Theorem(loc, name, frm, pf):
+    case Theorem(loc, name, _, _):
       return stmt, env
   
-    case Postulate(loc, name, frm):
+    case Postulate(loc, name, _):
       return stmt, env
   
-    case Assert(loc, frm):
+    case Assert(loc, _):
       return stmt, env
   
-    case Print(loc, trm):
+    case Print(loc, _):
       return stmt, env
 
     case Auto(loc, name):
       return stmt, env
   
-    case Associative(loc, typarams, op, typeof):
+    case Associative(loc, typarams, _, typeof):
       body_env = env.declare_type_vars(loc, typarams)
       check_type(typeof, body_env)
       return stmt, env
@@ -4593,9 +4592,9 @@ def type_check_fun_case(fun_case, name, params, returns, body_env, cases_present
     body_env = body_env.declare_term_vars(fun_case.location,
                                           zip(fun_case.parameters, params[1:]))
     match fun_case.pattern:
-      case PatternCons(loc, cons, parameters):
+      case PatternCons(_, _, parameters):
         pat_params = parameters
-      case PatternBool(loc, val):
+      case PatternBool(_, _):
         pat_params = []
     new_body = type_check_term(fun_case.body, returns, body_env, name, pat_params)
     check_no_recfun_escape(new_body, name)
@@ -4692,19 +4691,19 @@ def type_check_stmt(stmt, env, error_on_next_import : dict[str, bool]):
     case Trace(loc, var):
       var_ty = env.get_type_of_term_var(var)
       match var_ty:
-        case FunctionType(loc2, args, typs, ret_ty):
+        case FunctionType(_, _, _, _):
           pass
         case _:
           user_error(var.location, 'trace expects an identifer of type function, but instead got type ' + str(var_ty))
       return stmt
   
-    case Union(loc, name, typarams, alts):
+    case Union(loc, name, typarams, _):
       return stmt
   
     case Export(loc, name):
         return stmt
     
-    case Import(loc, name, ast):
+    case Import(loc, name, _):
       if name in error_on_next_import:
         if error_on_next_import[name]:
           # The first import was from the prelude
@@ -4747,7 +4746,7 @@ def type_check_stmt(stmt, env, error_on_next_import : dict[str, bool]):
 
 def validate_conjunct(loc, conj, fun):
   match conj:
-    case All(loc1, _, (name, ty), pos, body):
+    case All(loc1, _, (_, ty), _, body):
       # Make sure that  body is valid
       # Am I checking that all parameters are used? No.
       if validate_conjunct(loc, body, fun):
@@ -4768,7 +4767,7 @@ def validate_conjunct(loc, conj, fun):
 
 def extract_conjuncts(prem, fun):
   match prem:
-    case And(loc, ty, args):
+    case And(loc, _, args):
       return [validate_conjunct(loc, c, fun) for c in args]
     case _:
       return [validate_conjunct(prem.location, prem, fun)]
@@ -4777,7 +4776,7 @@ def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0
   if get_verbose():
     print("generate_conjunct_body", conjunct)
   match conjunct:
-    case All(loc1, _, (name, ty), _, body):
+    case All(_, _, (name, ty), _, body):
       if len(case.pattern.parameters) <= param_i:
         user_error(loc, "Parameters in induction case didn't match parameters in conjunct")
       # TODO: This is really slapdash, it would be nice to know for the error message, for example, how many parameters the conjunct expects
@@ -4786,7 +4785,7 @@ def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0
       env = env.declare_term_var(loc, inst_name, ty)
       return AllIntro(loc, (inst_name, ty), (0, 1), 
                       generate_conjunct_body(loc, body, case, fun_var, subst, env, param_i + 1))
-    case IfThen(loc, ty, prem, conc):
+    case IfThen(loc, ty, _, conc):
       ind_hyp = generate_proof_name("_")
       if len(case.induction_hypotheses) > 0:
         ind_hyp = case.induction_hypotheses[0][0]
@@ -4794,7 +4793,7 @@ def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0
       return ImpIntro(loc, ind_hyp, None, generate_conjunct_body(loc, conc, case, fun_var, subst, env, param_i))
     case Call(loc, ty, rator, [arg]):
       match case.pattern:
-        case PatternTerm(loc, term, params):
+        case PatternTerm(loc, _, _):
           try:
             case.pattern.term = type_check_term(case.pattern.term, arg.typeof.substitute(subst), env, None, [])
           except UserError as e:
@@ -4843,7 +4842,7 @@ def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0
 
 def match_induction_generics(frm):
   match frm:
-    case All(loc, _, (name, ty), _, body) if isinstance(ty, TypeType):
+    case All(_, _, (name, ty), _, body) if isinstance(ty, TypeType):
       new_frm, tys = match_induction_generics(body)
       return new_frm, [name] + tys
     case _:
@@ -4851,10 +4850,10 @@ def match_induction_generics(frm):
 
 def match_induction_fun(frm, ty_tys, ind_ty):
   match frm:
-    case All(loc, _, (name, FunctionType(loc1, tps, [param_ty], BoolType())), _, body):
+    case All(loc, _, (_, FunctionType(_, _, [param_ty], BoolType())), _, body):
       type_mismatch = False
       match param_ty:
-        case TypeInst(loc1, typ, ps):
+        case TypeInst(_, typ, ps):
           if len(ps) != len(ty_tys):
             user_error(loc, "Theorem and predicate should have the same number of type parameters")
           # TODO: Name should be defined for the parameters all the time?
@@ -4884,7 +4883,7 @@ def match_induction_conjuncts(frm, fun, fun_ty, ind_ty):
                        Call(loc, fun_ty, ResolvedVar(loc, None, fun), [ResolvedVar(loc, None, 'x')]))
 
       match conc:
-        case All(_, typeof, (name, ty), pos, Call(loc, tyof, rator, [arg])) \
+        case All(_, _, (name, _), _, Call(loc, _, rator, [arg])) \
           if rator.name == fun and arg.name == name:
             pass
         case _:
@@ -4910,21 +4909,21 @@ def collect_env(stmt, env : Env):
     case Define(loc, name, ty, body):
       return env.define_term_var(loc, name, ty, body, stmt.visibility)
       
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(loc, name, typarams, params, returns, _):
       fun_type = FunctionType(loc, typarams, params, returns)
       return env.define_term_var(loc, name, fun_type, stmt,
                                  stmt.visibility)
 
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty,
-                  body, terminates):
+    case GenRecFun(loc, name, typarams, params, returns, _, _,
+                  body, _):
       fun_type = FunctionType(loc, typarams, [t for (x,t) in params], returns)
       return env.define_term_var(loc, name, fun_type, stmt,
                                  stmt.visibility)
       
-    case Union(loc, name, typarams, alts):
+    case Union(loc, name, typarams, _):
       return env
           
-    case Theorem(loc, name, frm, pf, isLemma):
+    case Theorem(loc, name, frm, _, _):
       return env.declare_proof_var(loc, name, frm)
 
     case Postulate(loc, name, frm):
@@ -4934,16 +4933,16 @@ def collect_env(stmt, env : Env):
       # Already collected inline during process_declaration.
       return env
 
-    case Export(loc, name, ast):
+    case Export(loc, name, _):
       return env
 
-    case Import(loc, name, ast):
+    case Import(loc, name, _):
       return env
   
     case Assert(loc, frm):
       return env
   
-    case Print(loc, trm):
+    case Print(loc, _):
       return env
 
     case Module(loc, name):
@@ -4992,18 +4991,18 @@ def collect_env(stmt, env : Env):
       resolved_op = None
       op_ty = env.get_type_of_term_var(op)
       match op_ty:
-          case OverloadType(loc2, overloads):
+          case OverloadType(_, overloads):
               for (x, funty) in overloads:
                   match funty:
-                      case FunctionType(loc3, typarams2, param_types, return_type):
+                      case FunctionType(_, typarams2, param_types, _):
                           try:
                               matching: dict = {}
                               type_match(loc, typarams2, param_types[0], typ, matching)
                               resolved_op = x
                               break
-                          except MatchFailed as ex:
+                          except MatchFailed:
                               continue
-          case FunctionType(loc2, typarams2, param_types, return_type):
+          case FunctionType(_, typarams2, param_types, _):
               assert isinstance(op, VarRef)
               resolved_op = op.get_name()
       if assoc_formula in env.proofs():
@@ -5032,30 +5031,30 @@ def add_vars(vars, call):
 
 def find_rec_calls(name, term, env):
   match term:
-    case TermInst(loc2, tyof, subject, tyargs, inferred):
+    case TermInst(loc2, _, subject, _, _):
       return find_rec_calls(name, subject, env)
     case Var() | OverloadedVar() | ResolvedVar():
       return []
-    case Bool(loc2, tyof, val):
+    case Bool(loc2, _, _):
       return []
-    case And(loc2, tyof, args):
+    case And(loc2, _, args):
       return sum([find_rec_calls(name, arg, env) for arg in args], [])
-    case Or(loc2, tyof, args):
+    case Or(loc2, _, args):
       return sum([find_rec_calls(name, arg, env) for arg in args], [])
-    case IfThen(loc2, tyof, prem, conc):
+    case IfThen(loc2, _, prem, conc):
       return find_rec_calls(name, prem, env) + find_rec_calls(name, conc, env)
-    case All(loc2, tyof, var, pos, frm2):
+    case All(loc2, _, _, _, frm2):
       return find_rec_calls(name, frm2, env)
-    case Some(loc2, tyof, vars, frm2):
+    case Some(loc2, _, _, frm2):
       return find_rec_calls(name, frm2, env)
-    case Call(loc2, tyof, rator, args):
+    case Call(loc2, _, rator, args):
       calls = find_rec_calls(name, rator, env) + \
           sum([find_rec_calls(name, arg, env) for arg in args], [])
       if rator_name(rator) == name:
           return [RecCall([], [], args)] + calls
       else:
           return calls
-    case Switch(loc2, tyof, subject, cases):
+    case Switch(loc2, _, subject, cases):
       calls = []
       for c in cases:
         c_body_calls = find_rec_calls(name, c.body, env)
@@ -5074,37 +5073,37 @@ def find_rec_calls(name, term, env):
         calls += new_c_body_calls
       return calls
   
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(_, name, _, params, _, cases):
       return []
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty,
-                   body, terminates):
+    case GenRecFun(_, name, _, params, _, _, _,
+                   body, _):
       return []
-    case Conditional(loc2, tyof, cond, thn, els):
+    case Conditional(loc2, _, cond, thn, els):
       thn_calls = find_rec_calls(name, thn, env)
       els_calls = find_rec_calls(name, els, env)
       new_thn_calls = [add_condition(cond, call) for call in thn_calls]
       not_cond = IfThen(loc2, None, cond, Bool(loc2, None, False))
       new_els_calls = [add_condition(not_cond, call) for call in els_calls]
       return find_rec_calls(name, cond, env) + new_thn_calls + new_els_calls
-    case Lambda(loc2, tyof, vars, body):
+    case Lambda(loc2, _, _, body):
       return find_rec_calls(name, body, env)
-    case Generic(loc2, tyof, typarams, body):
+    case Generic(loc2, _, _, body):
       return find_rec_calls(name, body, env)
-    case TAnnote(loc2, tyof, subject, typ):
+    case TAnnote(loc2, _, subject, _):
       return find_rec_calls(name, subject, env)
-    case ArrayGet(loc2, tyof, arr, ind):
+    case ArrayGet(loc2, _, arr, ind):
       return find_rec_calls(name, arr, env) \
           + find_rec_calls(name, ind, env)
-    case Array(loc2, tyof, elements):
+    case Array(loc2, _, elements):
       return sum([find_rec_calls(name, elt, env) for elt in elements], [])
-    case MakeArray(loc2, tyof, subject):
+    case MakeArray(loc2, _, subject):
       return find_rec_calls(name, subject, env)
-    case TLet(loc2, tyof, var, rhs, body):
+    case TLet(loc2, _, _, rhs, body):
       return find_rec_calls(name, rhs, env) \
           + find_rec_calls(name, body, env)
-    case Hole(loc2, tyof):
+    case Hole(loc2, _):
       return []
-    case Omitted(loc2, tyof):
+    case Omitted(loc2, _):
       return []
     case _:
       internal_error(getattr(term, 'location', None),
@@ -5125,9 +5124,9 @@ def check_proofs(stmt, env: Env):
   if _dbg is not None:
     _dbg.on_statement(stmt, env)
   match stmt:
-    case Define(loc, name, ty, body):
+    case Define(loc, name, _, body):
       pass
-    case Theorem(loc, name, frm, pf, isLemma):
+    case Theorem(loc, name, frm, pf, _):
       if get_verbose():
         print('checking proof of theorem ' + base_name(name))
       _try_check_proof_of(pf, frm, env)
@@ -5138,10 +5137,10 @@ def check_proofs(stmt, env: Env):
     case Predicate():
       pass
 
-    case RecFun(loc, name, typarams, params, returns, cases):
+    case RecFun(loc, name, typarams, params, _, _):
       pass
 
-    case GenRecFun(loc, name, typarams, params, returns, measure, measure_ty,
+    case GenRecFun(loc, name, typarams, params, _, measure, _,
                    body, terminates):
       body_env = env.declare_type_vars(loc, typarams)
       
@@ -5185,13 +5184,13 @@ def check_proofs(stmt, env: Env):
       # check that the terminates proof proves the above formula
       _try_check_proof_of(terminates, formula, body_env)
   
-    case Union(loc, name, typarams, alts):
+    case Union(loc, name, typarams, _):
       pass
   
     case Export(loc, name):
       pass
   
-    case Import(loc, name, ast):
+    case Import(loc, name, _):
       pass
   
     case Print(loc, trm):
@@ -5204,7 +5203,7 @@ def check_proofs(stmt, env: Env):
       
     case Assert(loc, frm):
       match frm:
-        case Call(loc2, tyof2, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
+        case Call(_, _, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
           set_reduce_all(True)
           set_eval_all(True)
           L = lhs.reduce(env)
@@ -5216,7 +5215,7 @@ def check_proofs(stmt, env: Env):
           else:
               user_error(loc, 'assertion failed:\n' +
                     '\t' + str(L) + ' ≠ ' + str(R) + '\n')
-        case IfThen(loc2, tyof2,
+        case IfThen(_, _,
                     Call(_, _, rator, [lhs, rhs]),
                     Bool(_, _, False)) if isinstance(rator, VarRef) and rator.get_name() == '=':
           set_reduce_all(True)
@@ -5237,18 +5236,18 @@ def check_proofs(stmt, env: Env):
           set_eval_all(False)
           set_reduce_all(False)
           match result:
-            case Bool(loc2, tyof, True):
+            case Bool(_, _, True):
               pass
-            case Bool(loc2, tyof, False):
+            case Bool(_, _, False):
               user_error(loc, 'assertion failed: ' + str(frm))
             case result:
               user_error(loc, 'assertion expected Boolean result, not ' \
                     + str(result))
 
-    case Auto(loc, pvar):
+    case Auto(loc, _):
       pass
   
-    case Associative(loc, typarams, op, typ):
+    case Associative(loc, typarams, _, _):
       pass
   
     case Inductive():
@@ -5257,7 +5256,7 @@ def check_proofs(stmt, env: Env):
     case Module(loc, name):
       pass
 
-    case Trace(loc, function_name):
+    case Trace(loc, _):
       pass
 
     case _:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ exclude = [
 
 [tool.ruff.lint]
 # Pyflakes rules enabled incrementally as the codebase is cleaned up
-# (see issue #481). F403/F405 (star-import side-effects) and F841
-# (unused-locals) are still deferred.
-select = ["F401", "F541", "F601", "F811", "F821"]
+# (see issue #481). F403/F405 (star-import side-effects) are still
+# deferred.
+select = ["F401", "F541", "F601", "F811", "F821", "F841"]
 
 [tool.mypy]
 # Starter config (#479) + first tightening pass toward --strict. The

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -78,7 +78,7 @@ def previous_token():
 def advance():
     global current_position
     current_position = current_position + 1
-    
+
 def end_of_file():
     return current_position >= len(token_list)
 
@@ -91,7 +91,7 @@ def consume_token(expected, display, context = "", advice=""):
                      f'expected {expect_msg} {context}, not\n\t{current_token().value}{advice}')
   else:
     advance()
-  
+
 check_closest_kwd = False
 
 def parse(program_text: str,
@@ -138,7 +138,7 @@ def parse_identifier():
   if end_of_file():
     raise ParseError(meta_from_tokens(previous_token(), previous_token()),
           'expected an identifier, not end of file')
-  token = current_token()      
+  token = current_token()
   if token.type == 'IDENT':
     advance()
     return token.value
@@ -162,10 +162,10 @@ def meta_from_tokens(start_token, end_token):
     meta.end_column = end_token.end_column
     meta.end_pos = end_token.end_pos
     return meta
-      
+
 def parse_term_hi():
   token = current_token()
-  
+
   if token.type == 'ALL':
     advance()
     vars = parse_type_annot_list()
@@ -213,7 +213,7 @@ def parse_term_hi():
       advance()
       return mkIntLit(meta_from_tokens(intToken,intToken),
                       int(intToken.value), token.type)
-    else: 
+    else:
       raise ParseError(meta_from_tokens(current_token(),current_token()),
             'expected an integer not\n\t' + current_token().value)
 
@@ -221,7 +221,7 @@ def parse_term_hi():
     start_token = current_token()
     advance()
     prem = parse_term()
-    try: 
+    try:
       consume_token('THEN', 'keyword "then"', context='after premise of "if" formula')
     except ParseError as e:
       raise e.extend(meta_from_tokens(start_token, current_token()), '\nwhile parsing\n' \
@@ -263,7 +263,7 @@ def parse_term_hi():
     consume_token('RBRACE', '"}"', context='after body of "generic"')
     meta = meta_from_tokens(token, previous_token())
     return Generic(meta, None, params, body)
-    
+
   elif token.type == 'LESSTHAN':
     advance()
     type_params = parse_ident_list()
@@ -274,7 +274,7 @@ def parse_term_hi():
     for j, ty in enumerate(reversed(type_params)):
       result = All(meta, None, (ty, TypeType(meta)), (j, len(type_params)), result)
     return result
-    
+
   elif token.type == 'LPAR':
     start_token = current_token()
     advance()
@@ -300,7 +300,7 @@ def parse_term_hi():
     advance()
     meta = meta_from_tokens(token,token)
     return Omitted(meta, None)
-    
+
   elif token.type == 'MINUS':
     advance()
     subject = parse_call()
@@ -318,7 +318,7 @@ def parse_term_hi():
     subject = parse_term_equal()
     meta = meta_from_tokens(token, previous_token())
     return IfThen(meta, None, subject, Bool(meta, None, False))
-    
+
   elif token.type == 'QMARK':
     advance()
     meta = meta_from_tokens(token,token)
@@ -364,17 +364,17 @@ def parse_term_hi():
       token = current_token()
     consume_token('RSQB', 'closing bracket "]"', context='at end of list literal')
     return listToNodeList(meta_from_tokens(token,token), lst_terms)
-  
+
   elif token.type == 'DEFINE':
     return parse_define_term()
-  
+
   else:
     try:
       name = parse_identifier()
       meta = meta_from_tokens(token, token)
       var = Var(meta, None, name)
       return var
-    except ParseError as e:  
+    except ParseError:
       raise ParseError(meta_from_tokens(token, current_token()),
             'expected a term, not\n\t' + quote(current_token().value))
     except Exception as e:
@@ -401,7 +401,7 @@ def parse_array_get():
         + str(e))
 
   return term
-    
+
 def parse_call():
   while_parsing = 'while parsing function call\n' \
       + '\tterm ::= term "(" term_list ")"\n'
@@ -456,9 +456,9 @@ def parse_term_expt():
     right = parse_make_array()
     term = Call(meta_from_tokens(start_token, previous_token()), None,
                 rator, [term,right])
-    
+
   return term
-    
+
 def parse_term_mult():
   term = parse_term_expt()
 
@@ -471,7 +471,7 @@ def parse_term_mult():
     right = parse_term_expt()
     term = Call(meta_from_tokens(start_token, previous_token()), None,
                 rator, [term,right])
-    
+
   return term
 
 def parse_term_add():
@@ -485,7 +485,7 @@ def parse_term_add():
     right = parse_term_mult()
     term = Call(meta_from_tokens(token, previous_token()), None,
                 rator, [term,right])
-    
+
   return term
 
 def parse_term_compare():
@@ -499,7 +499,7 @@ def parse_term_compare():
     right = parse_term_compare()
     term = Call(meta_from_tokens(token, previous_token()), None,
                 rator, [term,right])
-    
+
   return term
 
 def parse_term_equal():
@@ -512,14 +512,14 @@ def parse_term_equal():
     right = parse_term_equal()
     call_meta = meta_from_tokens(token, previous_token())
     if opr == '≠' or opr == '/=':
-      term = IfThen(call_meta, None, 
+      term = IfThen(call_meta, None,
                     Call(call_meta, None, Var(meta, None, '='), [term,right]),
                     Bool(call_meta, None, False))
     else:
       term = Call(call_meta, None,
                   Var(meta, None, opr), [term,right])
   return term
-    
+
 def parse_term_logic():
   token = current_token()
   term = parse_term_equal()
@@ -533,41 +533,40 @@ def parse_term_logic():
                  extract_and(term) + extract_and(right))
     elif opr == 'OR':
       term = Or(meta_from_tokens(token, previous_token()), None,
-                 extract_or(term) + extract_or(right))        
+                 extract_or(term) + extract_or(right))
 
   if (not end_of_file()) and current_token().type == 'COLON':
     advance()
     typ = parse_type()
     term = TAnnote(meta_from_tokens(token, previous_token()), None,
                    term, typ)
-      
+
   return term
 
 def parse_term_iff():
   token = current_token()
   term = parse_term_logic()
   while (not end_of_file()) and (current_token().value in iff_operators):
-    opr = current_token().type
     advance()
     right = parse_term_logic()
     loc = meta_from_tokens(token, previous_token())
     left_right = IfThen(loc, None, term.copy(), right.copy())
     right_left = IfThen(loc, None, right.copy(), term.copy())
-    term = And(loc, None, [left_right, right_left])  
+    term = And(loc, None, [left_right, right_left])
 
   if (not end_of_file()) and current_token().type == 'COLON':
     advance()
     typ = parse_type()
     term = TAnnote(meta_from_tokens(token, previous_token()), None,
                    term, typ)
-      
+
   return term
 
 def parse_term():
   if end_of_file():
       raise ParseError(meta_from_tokens(previous_token(),previous_token()),
             'expected a term, not end of file')
-      
+
   token = current_token()
   term = parse_term_iff()
 
@@ -596,7 +595,7 @@ def parse_define_term():
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
-      
+
 def parse_assumption():
   if current_token().type == 'COLON':
     label = '_'
@@ -617,7 +616,7 @@ proof_keywords = {'apply', 'arbitrary', 'assume',
                   'recall', 'reflexive', 'replace',
                   'suffices', 'suppose', 'switch', 'symmetric',
                   'transitive'}
-      
+
 def parse_recall():
   start_token = current_token()
   advance()
@@ -672,7 +671,7 @@ def parse_proof_hi():
     except Exception as e:
       raise ParseError(meta_from_tokens(token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
-  
+
   elif token.type == 'CASES':
     while_parsing = 'while parsing cases (use a logical or)\n' \
         + '\tconclusion ::= "cases" proof case_clause*\n' \
@@ -687,11 +686,11 @@ def parse_proof_hi():
       meta = meta_from_tokens(token, previous_token())
       return Cases(meta, subject, cases)
     except ParseError as e:
-      raise e.extend(meta_from_tokens(token, previous_token()), while_parsing)        
+      raise e.extend(meta_from_tokens(token, previous_token()), while_parsing)
     except Exception as e:
       raise ParseError(meta_from_tokens(token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
-    
+
   elif token.type == 'CONCLUDE':
     while_parsing = 'while parsing\n' \
         + '\tconclusion ::= "conclude" formula "by" proof\n'
@@ -705,7 +704,7 @@ def parse_proof_hi():
     except Exception as e:
       raise ParseError(meta_from_tokens(token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
-        
+
   elif token.type == 'CONJUNCT':
     advance()
     meta = meta_from_tokens(current_token(),current_token())
@@ -713,19 +712,19 @@ def parse_proof_hi():
     if current_token().type != 'INT' and current_token().value != '0':
       raise ParseError(meta, 'expected an int literal after "conjunct", not\n\t' \
             + current_token().value)
-      
+
     index = int(current_token().value)
     advance()
     consume_token('OF', 'keyword "of"', context='after index of "conjunct"')
-    
+
     subject = parse_proof()
     meta = meta_from_tokens(token,previous_token())
     return PAndElim(meta, index, subject)
-      
+
   elif token.type == 'DOT':
     advance()
     return PTrue(meta_from_tokens(token, token))
-  
+
   elif token.type == 'EQUATIONS':
     advance()
     first = parse_equation()
@@ -755,10 +754,10 @@ def parse_proof_hi():
         else:
             result = PTransitive(meta, eq_proof, result)
     return result
-    
+
   elif token.type == 'RECALL':
     return parse_recall()
-    
+
   elif token.type == 'INDUCTION':
     return parse_induction()
 
@@ -818,7 +817,7 @@ def parse_proof_hi():
     else:
         return ApplyDefsGoal(meta, [Var(meta, None, t) for t in defs],
                               SwitchProof(meta, subject, cases))
-    
+
   elif token.type == 'SYMMETRIC':
     advance()
     eq = parse_proof()
@@ -841,7 +840,7 @@ def parse_proof_hi():
                              subject)
     else:
         return EvaluateGoal(meta_from_tokens(token, previous_token()))
-    
+
   else:
     if check_closest_kwd:
       close_keyword = closest_keyword(token.value, proof_keywords)
@@ -849,10 +848,10 @@ def parse_proof_hi():
         raise ParseError(meta_from_tokens(token, token),
                          'expected a proof.\nDid you mean "' + close_keyword \
                          + '" instead of "' + token.value + '"?')
-  
+
     try:
       name = parse_identifier()
-    except ParseError as e:
+    except ParseError:
       raise ParseError(meta_from_tokens(token, current_token()),
                        'expected a proof, not\n\t' + quote(current_token().value),
                        missing=True)
@@ -882,7 +881,7 @@ def parse_case():
     consume_token('RBRACE', '"}"', context='after body of "case"')
     return (label,premise,body)
   except ParseError as e:
-    raise e.extend(meta_from_tokens(start_token, current_token()), 
+    raise e.extend(meta_from_tokens(start_token, current_token()),
                    'while parsing:\n\t"case" label ":" formula "{" proof "}"')
 
 def parse_proof_switch_case():
@@ -911,11 +910,11 @@ def parse_proof_switch_case():
     return SwitchProofCase(meta, pat, assumptions, body)
   except ParseError as e:
     raise e.extend(meta_from_tokens(start_token, current_token()), while_parsing)
-    
+
 def parse_proof_med():
     start_token = current_token()
     proof = parse_proof_hi()
-    
+
     while (not end_of_file()) and current_token().type == 'LESSTHAN':
       while_parsing= 'while trying to parse type arguments for instantiation of an "all" formula:\n\t'\
               + 'proof ::= proof "<" type_list ">"'
@@ -928,7 +927,7 @@ def parse_proof_med():
           proof = AllElimTypes(meta, proof, ty, (j, len(type_list)))
       except ParseError as e:
         raise e.extend(meta_from_tokens(start_token, current_token()), while_parsing)
-      
+
     while (not end_of_file()) and current_token().type == 'LSQB':
       advance()
       term_list = parse_nonempty_term_list()
@@ -943,9 +942,9 @@ def parse_proof_statement():
   if end_of_file():
     raise ParseError(meta_from_tokens(previous_token(),previous_token()),
           'expected a proof, not end of file')
-      
+
   token = current_token()
-    
+
   if token.type == 'SUFFICES':
     advance()
     formula = parse_term()
@@ -958,8 +957,6 @@ def parse_proof_statement():
     advance()
     defs = parse_ident_list_bar()
     if current_token().type == 'IN':
-        while_parsing = 'while parsing definition:\n' \
-            + '\tconclusion ::= "definition" identifier_list_bar "in" proof\n'
         advance()
         subject = parse_proof()
         meta = meta_from_tokens(token, previous_token())
@@ -1000,7 +997,7 @@ def parse_proof_statement():
     else:
       meta = meta_from_tokens(token, previous_token())
       return SimplifyGoal(meta, None, givens), False
-  
+
   elif token.type == 'SUPPOSE' or token.type == 'ASSUME':
     start_token = current_token()
     advance()
@@ -1013,7 +1010,7 @@ def parse_proof_statement():
     except Exception as e:
       raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
-      
+
     meta = meta_from_tokens(token,previous_token())
     return ImpIntro(meta, label, premise, None), False
 
@@ -1025,13 +1022,13 @@ def parse_proof_statement():
     for j, var in enumerate(reversed(vars)):
         result = AllIntro(meta, var, (j, len(vars)), result)
     return result, False
-    
+
   elif token.type == 'CHOOSE':
     advance()
     witnesses = parse_nonempty_term_list()
     meta = meta_from_tokens(token, previous_token())
     return SomeIntro(meta, witnesses, None), False
-    
+
   elif token.type == 'OBTAIN':
     advance()
     witnesses = parse_ident_list()
@@ -1041,13 +1038,13 @@ def parse_proof_statement():
     some = parse_proof()
     meta = meta_from_tokens(token, previous_token())
     return SomeElim(meta, witnesses, label, premise, some, None), False
-    
+
   elif token.type == 'HAVE':
     return parse_have(), False
 
   elif token.type == 'DEFINE':
     return parse_define_proof_stmt(), False
-      
+
   elif token.type == 'INJECTIVE':
     advance()
     constr = parse_term()
@@ -1060,8 +1057,6 @@ def parse_proof_statement():
     return PExtensionality(meta, None), False
 
   elif token.type == 'SHOW':
-    while_parsing = 'while parsing\n' \
-        + '\tproof_stmt ::= "show" formula\n'
     advance()
     claim = parse_term()
     return PAnnot(meta_from_tokens(token, previous_token()),
@@ -1087,13 +1082,13 @@ def parse_define_proof_stmt():
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
-    
+
 
 def parse_have():
   while_parsing = 'while parsing\n' \
       + '\tproof_stmt ::= "have" identifier ":" formula "by" proof\n' \
       + '\tproof_stmt ::= "have" ":" formula "by" proof\n'
-  try:  
+  try:
     start_token = current_token()
     token = start_token
     advance()
@@ -1105,7 +1100,7 @@ def parse_have():
     if current_token().type != 'COLON':
       try:
         label = parse_identifier()
-      except ParseError as e:
+      except ParseError:
         raise ParseError(meta_from_tokens(current_token(), current_token()),
             'expected an identifier or colon after "have", not\n\t' \
             + current_token().value)
@@ -1133,7 +1128,6 @@ def parse_have():
       + str(e))
 
 def parse_proof(allow_missing=True):
-    start_token = previous_token()
     proof_stmt, concluded = parse_proof_statement()
     if concluded:
         return proof_stmt
@@ -1149,7 +1143,7 @@ def parse_proof(allow_missing=True):
             raise ParseError(meta_from_tokens(current_token(), previous_token()),
                              "Unexpected error while parsing:\n\t" \
               + str(e))
-              
+
         if isinstance(proof_stmt, AllIntro):
             proof_stmt.set_body(body)
         else:
@@ -1175,14 +1169,14 @@ def parse_finishing_proof():
     while not end_of_file() and current_token().type == 'COMMA':
       advance()
       right = parse_proof()
-      proof = PTuple(meta_from_tokens(start_token, previous_token()), 
+      proof = PTuple(meta_from_tokens(start_token, previous_token()),
                      extract_tuple(proof) + extract_tuple(right))
     return proof
 
 def parse_induction():
   while_parsing = 'while parsing\n' \
       + '\tconclusion ::= "induction" type ind_case*\n'
-  try:    
+  try:
     start_token = current_token()
     token = start_token
     advance()
@@ -1330,7 +1324,7 @@ def parse_theorem(visibility):
 
     try:
       name = parse_identifier()
-    except ParseError as e:
+    except ParseError:
       if end_of_file():
 
         raise ParseError(meta_from_tokens(start_token, start_token),
@@ -1343,9 +1337,9 @@ def parse_theorem(visibility):
           + str(e))
 
     consume_token('COLON', 'a colon', context='after theorem name')
-      
+
     what = parse_term()
-    
+
     if is_postulate:
         return Postulate(meta_from_tokens(start_token, previous_token()),
                          name, what)
@@ -1438,7 +1432,7 @@ def parse_function(visibility):
     advance()
     name = parse_identifier()
     typarams = parse_type_parameters()
-    
+
     if current_token().type == 'LPAR':
       advance()
       params = parse_var_list()
@@ -1454,13 +1448,13 @@ def parse_function(visibility):
     else:
       fun = lam
     return Define(meta, name, None, fun, visibility=visibility)
-    
+
   except ParseError as e:
     raise e.extend(meta_from_tokens(start_token, previous_token()), while_parsing)
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
-      
+
 def parse_gen_rec_function(visibility):
   while_parsing = 'while parsing\n' \
       + '\tstatement ::= "recfun" identifier type_params_opt "(" variable_list ")" "->" type "measure" term ":" type "{" term "}" "terminates" proof\n'
@@ -1469,7 +1463,7 @@ def parse_gen_rec_function(visibility):
     advance()
     name = parse_identifier()
     typarams = parse_type_parameters()
-    
+
     if current_token().type == 'LPAR':
       advance()
       params = parse_var_list()
@@ -1487,19 +1481,19 @@ def parse_gen_rec_function(visibility):
 
     consume_token('TERMINATES', '"terminates"', context='after "}" in "recfun"')
     terminates = parse_proof()
-    
+
     meta = meta_from_tokens(start_token, previous_token())
     return GenRecFun(meta, name,
                      typarams, params, return_type,
                      measure, measure_ty, body, terminates, visibility=visibility)
-    
+
   except ParseError as e:
     raise e.extend(meta_from_tokens(start_token, previous_token()),
                    while_parsing)
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()),
                      "Unexpected error while parsing:\n\t" + str(e))
-    
+
 def parse_recursive_function(visibility):
   while_parsing = 'while parsing\n' \
       + '\tstatement ::= "recursive" identifier type_params_opt' \
@@ -1511,7 +1505,6 @@ def parse_recursive_function(visibility):
     type_params = parse_type_parameters()
 
     if current_token().type == 'LPAR':
-      paren_start_token = current_token()
       advance()
       param_types = parse_type_list()
       consume_token('RPAR', 'a closing parenthesis ")"')
@@ -1533,7 +1526,7 @@ def parse_recursive_function(visibility):
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
-    
+
 def parse_define(visibility):
   while_parsing = 'while parsing\n' \
       + '\tproof_stmt ::= "define" identifier "=" term\n'
@@ -1576,7 +1569,7 @@ def parse_statement():
     visibility = 'default'
 
   token = current_token()
-    
+
   if token.type == 'DEFINE':
     return parse_define(visibility)
 
@@ -1625,7 +1618,7 @@ def parse_statement():
     except Exception as e:
       raise ParseError(meta_from_tokens(token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
-      
+
   elif token.type == 'IMPORT':
     while_parsing = 'while parsing import\n' \
         + '\tstatement ::= "import" identifier ["using" | "hiding" name ("|" name)*]\n'
@@ -1667,19 +1660,19 @@ def parse_statement():
     except Exception as e:
         raise ParseError(meta_from_tokens(token, previous_token()), "Unexpected error while parsing:\n\t" \
           + str(e))
-  
+
   elif token.type == 'AUTO':
     advance()
     pvar = parse_proof_hi()
     meta = meta_from_tokens(token, previous_token())
     return Auto(meta, pvar)
-      
+
   elif token.type == 'ASSOCIATIVE':
     advance()
     name = parse_identifier()
     typarams = parse_type_parameters()
     advance()
-    
+
     typ = parse_type()
     meta = meta_from_tokens(token, previous_token())
     return Associative(meta, typarams, Var(meta, None, name), typ)
@@ -1713,7 +1706,7 @@ def parse_statement():
             raise ParseError(meta_from_tokens(token, token),
                   'did you mean "' + kw \
                   + '" instead of "' + token.value + '"?')
-      
+
     if token.value == '/' and current_position + 1 < len(token_list) and next_token().value == '*':
       raise ParseError(meta_from_tokens(token, token),
         "expected a statement, not '/*', did you forget to close a comment?")
@@ -1728,12 +1721,12 @@ def parse_type_parameters():
       return ident_list
   else:
       return []
-    
+
 def parse_type():
   if end_of_file():
       raise ParseError(meta_from_tokens(previous_token(),previous_token()),
             'expected a type, not end of file')
-      
+
   token = current_token()
   if token.type == 'BOOL':
     advance()
@@ -1758,16 +1751,16 @@ def parse_type():
   else:
     try:
       name = parse_identifier()
-    except ParseError as e:
+    except ParseError:
       raise ParseError(meta_from_tokens(token, current_token()),
             'expected a type, not\n\t' + quote(current_token().value))
     except Exception as e:
       raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
-    
+
     var = Var(meta_from_tokens(token,token), None, name)
     inst = False
-    
+
     if not end_of_file() and current_token().type == 'LESSTHAN':
       inst = True
       start_token = current_token()
@@ -1797,8 +1790,8 @@ def parse_function_type():
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
-    
-    
+
+
 def parse_type_list():
   typ = parse_type()
   type_list = [typ]
@@ -1828,11 +1821,11 @@ def parse_nonempty_term_list():
     trm = parse_term()
     trm_list.append(trm)
   return trm_list
-    
+
 def parse_constructor():
   while_parsing = 'while parsing\n' \
       + '\tconstructor ::= identifier | identifier "(" type_list ")"'
-  try:  
+  try:
     start_token = current_token()
     name = parse_identifier()
 
@@ -1849,7 +1842,7 @@ def parse_constructor():
   except Exception as e:
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
-    
+
 
 def parse_constructor_pattern():
   start_token = current_token()
@@ -1864,7 +1857,7 @@ def parse_constructor_pattern():
                                           start_token),
                          None, constr_name),
                      ident_list)
-    
+
 
 def parse_pattern():
   if current_token().value == '0':
@@ -1895,7 +1888,7 @@ def parse_pattern():
     start_token = current_token()
     try:
       return parse_constructor_pattern()
-    except ParseError as e:
+    except ParseError:
       raise ParseError(meta_from_tokens(start_token, current_token()),
             'expected a pattern, not\n\t' + quote(current_token().value))
     except Exception as e:
@@ -1910,7 +1903,7 @@ def parse_pattern_list():
     return [pat] + ident_list
   else:
     return [pat]
-      
+
 def parse_ident_list():
   ident = parse_identifier()
   ident_list = [ident]
@@ -1931,7 +1924,7 @@ def parse_single_or_repeat():
       ident = parse_identifier()
       ident_list = [ident]
   return ident_list
-      
+
 def parse_ident_list_bar():
   ident_list = parse_single_or_repeat()
   while current_token().value == '|':
@@ -1951,7 +1944,7 @@ def parse_type_annot_list():
           + 'while parsing\n\ttype_annot_list ::= identifier ":" type' \
           + '\n\ttype_annot_list ::= identifier ":" type "," type_annot_list')
   type_annot_list = [(ident,ty)]
-  
+
   while current_token().type == 'COMMA':
     advance()
     ident = parse_identifier()
@@ -1969,7 +1962,7 @@ def parse_type_annot_list():
 def parse_var_list():
   if current_token().type == 'RPAR':
       return []
-      
+
   ident = parse_identifier()
   if current_token().type == 'COLON':
     advance()
@@ -1977,7 +1970,7 @@ def parse_var_list():
   else:
     ty = None
   var_list = [(ident,ty)]
-  
+
   while current_token().type == 'COMMA':
     advance()
     ident = parse_identifier()
@@ -1988,17 +1981,16 @@ def parse_var_list():
       ty = None
     var_list.append((ident, ty))
   return var_list
-  
+
 def parse_fun_case():
   while_parsing = 'while parsing\n' \
       + '\tfun_case ::= identifier "(" param_list ")" "=" term\n'
-  try:    
+  try:
     start_token = current_token()
     rator = parse_identifier()
     rator_meta = meta_from_tokens(start_token, previous_token())
-    
+
     if current_token().type == 'LPAR':
-      lpar_token = current_token()
       advance()
       pat_list = parse_pattern_list()
       consume_token('RPAR', 'closing parenthesis ")"')
@@ -2031,6 +2023,6 @@ def parse_switch_case():
     except Exception as e:
         raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
           + str(e))
-    
+
     return SwitchCase(meta_from_tokens(start_token, previous_token()),
                       pattern, body)

--- a/test/claude_fill_hole/test_main.py
+++ b/test/claude_fill_hole/test_main.py
@@ -196,7 +196,6 @@ def test_stray_print_does_not_corrupt_response(monkeypatch, tmp_path):
     source = "theorem t: bool = true\n"
     file_path = tmp_path / "proof.pf"
     file_path.write_text(source)
-    request = _build_request(str(file_path), "?")  # placeholder; we use --dry-run
 
     request_json = json.dumps(
         {

--- a/test/lsp/test_dap_server.py
+++ b/test/lsp/test_dap_server.py
@@ -299,7 +299,7 @@ def test_stack_trace_inside_function(dap_session, tmp_path):
     client.request("continue")
     while True:
         try:
-            evt = client.wait_for_event("stopped", timeout=2.0)
+            client.wait_for_event("stopped", timeout=2.0)
         except TimeoutError:
             break
         client.request("continue")

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -874,7 +874,7 @@ def test_chained_refine_after_workspace_update(server, open_doc):
         f"first codeAction should return one refine action; got {actions1!r}"
     )
     assert actions1[0].title == "Refine hole"
-    edit1 = actions1[0].edit.changes[uri][0]
+    assert actions1[0].edit.changes[uri]
     # Eglot would apply this edit locally and then send didChange.
     # Simulate the post-edit content here.
     new_text = "arbitrary P:bool\n  ?"


### PR DESCRIPTION
## Summary
- complete the F841 unused-local cleanup stage from #481
- convert unused match captures and exception bindings to wildcards or direct calls
- enable F841 in Ruff's selected Pyflakes rules

## Validation
- `ruff check .`
- `python3 -m py_compile abstract_syntax.py proof_checker.py rec_desc_parser.py compiler/emit_c.py lsp/query.py`
- `git diff --check`
- `make tests`
- `make tests-lib`

## Note
- Targeted command `pytest test/claude_fill_hole/test_main.py test/lsp/test_lsp_server.py::test_chained_refine_after_workspace_update test/lsp/test_dap_server.py::test_stack_trace_inside_function` passed the fill-hole and LSP cases, but the DAP case failed before the edited line because its fixture reported `undefined variable: Nat`.
