### PR TITLE
Add UInt countdown recursion support example

### DIFF
--- a/gh_pages/doc/FunctionalProgramming.md
+++ b/gh_pages/doc/FunctionalProgramming.md
@@ -271,6 +271,28 @@ recursive zip<T,U>(List<T>, List<U>) -> List< Pair<T, U> > {
 }
 ```
 
+Unsigned integers are not exposed as an ordinary recursive union, so
+functions that count down over `UInt` should currently use `recfun`
+with an explicit measure. The recursive call below is accepted because
+the `terminates` proof shows that `n ∸ 1` is smaller than `n` whenever
+the nonzero branch is taken.
+
+```{.deduce^#replicate_uint}
+recfun replicate<T>(n : UInt, x : T) -> List<T>
+  measure n of UInt
+{
+  if n = 0 then []
+  else node(x, replicate(n ∸ 1, x))
+}
+terminates {
+  arbitrary n:UInt, x:T
+  uint_monus_one_less[n]
+}
+```
+
+The usual zero/successor-style induction rule for `UInt` is still
+available for proofs about these functions.
+
 
 ## Generic Functions
 

--- a/lib/UIntMonus.pf
+++ b/lib/UIntMonus.pf
@@ -343,4 +343,16 @@ proof
   replace toNat_pred | toNat_monus | uint_toNat_fromNat | nat_monus_one_pred.
 end
 
+theorem uint_monus_one_less: all n:UInt.
+  if not (n = 0) then n ∸ 1 < n
+proof
+  arbitrary n:UInt
+  assume n_nz
+  have n_pos: 0 < n by apply uint_not_zero_pos to n_nz
+  have one_le_n: 1 ≤ n by apply uint_pos_implies_one_le to n_pos
+  suffices 1 + (n ∸ 1) < 1 + n by uint_add_both_sides_of_less[1, n ∸ 1, n]
+  suffices n < 1 + n by replace (apply uint_monus_add_identity[n, 1] to one_le_n).
+  uint_less_plus1[n]
+end
+
   

--- a/test/should-validate/uint_replicate.pf
+++ b/test/should-validate/uint_replicate.pf
@@ -1,15 +1,3 @@
-// replicate.pf
-//
-// The classic Haskell intro-FP function:
-//
-//     replicate :: Int -> a -> [a]
-//     replicate n x = [x, x, ..., x]   -- n copies
-//
-// Below we define replicate over UInt and prove two correctness theorems:
-//
-//   1. replicate_add:      replicate(m + n, x) = replicate(m, x) ++ replicate(n, x)
-//   2. length_replicate:   length(replicate(n, x)) = n
-
 import UInt
 import List
 
@@ -26,7 +14,6 @@ terminates {
 
 assert replicate(3, 7) = [7, 7, 7]
 
-// replicate distributes over UInt addition into list concatenation.
 theorem replicate_add: all T:type. all m:UInt. all n:UInt, x:T.
   replicate(m + n, x) = replicate(m, x) ++ replicate(n, x)
 proof
@@ -52,7 +39,6 @@ proof
   }
 end
 
-// The length of replicate(n, x) is n.
 theorem length_replicate: all T:type. all n:UInt. all x:T.
   length(replicate(n, x)) = n
 proof


### PR DESCRIPTION
## Summary

- add public `uint_monus_one_less` for `UInt` countdown recursion on `n ∸ 1`
- update `examples/replicate.pf` to define `replicate` over `UInt` with `recfun` and prove `replicate_add` / `length_replicate`
- add a focused `should-validate` regression test and document the current `recfun` approach for `UInt`

Closes #539

## Validation

- `python3 deduce.py lib/UIntMonus.pf`
- `python3 deduce.py examples/replicate.pf`
- `python3 deduce.py test/should-validate/uint_replicate.pf`
- `python3 test-deduce.py`