### PR TITLE
Improve UInt custom induction followups

### DIFF
--- a/docs/uint-view-recursion-plan.md
+++ b/docs/uint-view-recursion-plan.md
@@ -1,0 +1,72 @@
+# UInt view-based structural recursion plan
+
+## Background
+
+`UInt` is implemented with private binary constructors, but the public
+library presents users with the familiar zero/successor view:
+
+```deduce
+theorem uint_induction: all P:fn UInt -> bool.
+  if P(0) and (all m:UInt. if P(m) then P(1 + m))
+  then all n : UInt. P(n)
+```
+
+Today, proofs can use that view directly with `induction UInt`:
+
+```deduce
+induction UInt
+case 0 { ... }
+case with n. 1 + n assume IH { ... }
+```
+
+Recursive functions over `UInt` are still written with general recursion
+and an explicit measure, usually counting down from `n` to `n ∸ 1` and
+using `uint_monus_one_less` as the termination fact.
+
+## Goal
+
+Add a structural-recursion surface for `UInt` that lets beginners define
+functions over the same public view used by `uint_induction`, without
+mentioning `Nat`, `fromNat`, `toNat`, or the private binary constructors.
+
+For example, a future surface could allow a definition shaped like:
+
+```deduce
+viewrec replicate<T>(n : UInt, x : T) -> List<T>
+case 0 {
+  []
+}
+case with n'. 1 + n' {
+  node(x, replicate(n', x))
+}
+```
+
+The exact keyword and clause syntax are open design choices. The important
+property is that the recursive call is visibly on the predecessor exposed
+by the `1 + n'` view.
+
+## Desugaring direction
+
+A first implementation can share the existing custom-induction machinery:
+
+- Use a view theorem with the same zero/successor cases as `uint_induction`.
+- Check that each view-recursive clause matches one public view case.
+- Desugar the successor clause to a `recfun` with `measure n of UInt`.
+- Generate or require the existing termination proof obligation
+  `n ∸ 1 < n`, discharged by `uint_monus_one_less` under `not (n = 0)`.
+
+This keeps the runtime representation private and avoids changing `UInt`
+constructors. It also gives diagnostics a single source of truth: a bad
+case pattern can be explained by showing the expected public view case.
+
+## Acceptance sketch
+
+- `UInt` view recursion accepts base and successor clauses using `0` and
+  `with n. 1 + n`.
+- Recursive calls in the successor clause are accepted only on the exposed
+  predecessor, or on expressions justified by a generated measure proof.
+- Error messages name the expected public view cases rather than
+  `bzero`, `dub_inc`, or `inc_dub`.
+- Existing `recfun ... measure ...` programs continue to work unchanged.
+- Existing `induction UInt` behavior remains compatible with the
+  zero/successor cases documented in the Reference.

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -1281,6 +1281,19 @@ instantiate them. For example:
 case with x. 1 + x assume IH { ... }
 ```
 
+For `UInt`, this means `induction UInt` uses the public zero/successor
+view from `uint_induction`, not the private binary constructors. The two
+cases are:
+
+```
+case 0 { ... }
+case with n. 1 + n assume IH { ... }
+```
+
+If a custom induction proof has the wrong number of cases, or if a
+`with` pattern does not match the custom induction theorem, Deduce reports
+the expected case shape in the error message.
+
 ## Injective (Proof)
 
 ```

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -1025,6 +1025,12 @@ def gen_conjunct_advice(conjunct, arbs, ihs):
 def gen_custom_induction_advice(conjuncts):
   return "\n".join([gen_conjunct_advice(c, [], []) for c in conjuncts])
 
+def _custom_induction_expected_cases(conjuncts):
+  return gen_custom_induction_advice(conjuncts).replace('\t\t', '\t')
+
+def _custom_induction_case_hint(conjunct):
+  return gen_conjunct_advice(conjunct, [], []).replace('\t\t', '\t')
+
 def proof_advice(formula, env):
     prefix = style.dark_green('Advice:') + '\n'
 
@@ -1750,6 +1756,15 @@ def check_proof_of(proof, formula, env):
         type_subst = {}
 
         types_elimmed = custom_ind["thm"]
+
+        if len(cases) != len(conjuncts):
+          plural = '' if len(conjuncts) == 1 else 's'
+          add_diagnostic(loc, 'expected ' + str(len(conjuncts)) \
+                + ' case' + plural + ' for custom induction on ' + str(typ) \
+                + ', but have ' + str(len(cases)) \
+                + '\nExpected cases:\n' + _custom_induction_expected_cases(conjuncts) \
+                + givens_str(env))
+          return
 
         if type_vars != []:
           match typ:
@@ -4796,40 +4811,47 @@ def extract_conjuncts(prem, fun):
     case _:
       return [validate_conjunct(prem.location, prem, fun)]
 
-def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0):
+def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0, case_hint = None):
   if get_verbose():
     print("generate_conjunct_body", conjunct)
+  if case_hint is None:
+    case_hint = _custom_induction_case_hint(conjunct)
   match conjunct:
     case All(_, _, (name, ty), _, body):
       if len(case.pattern.parameters) <= param_i:
-        user_error(loc, "Parameters in induction case didn't match parameters in conjunct")
-      # TODO: This is really slapdash, it would be nice to know for the error message, for example, how many parameters the conjunct expects
+        user_error(case.pattern.location, "custom induction case pattern is missing a bound variable"
+              + "\nExpected a case shaped like:\n" + case_hint)
       inst_name = case.pattern.parameters[param_i]
       subst[inst_name]= ResolvedVar(loc, ty, name)
       env = env.declare_term_var(loc, inst_name, ty)
       return AllIntro(loc, (inst_name, ty), (0, 1), 
-                      generate_conjunct_body(loc, body, case, fun_var, subst, env, param_i + 1))
+                      generate_conjunct_body(loc, body, case, fun_var, subst, env, param_i + 1, case_hint))
     case IfThen(loc, ty, _, conc):
       ind_hyp = generate_proof_name("_")
       if len(case.induction_hypotheses) > 0:
         ind_hyp = case.induction_hypotheses[0][0]
         case.induction_hypotheses = case.induction_hypotheses[1:]
-      return ImpIntro(loc, ind_hyp, None, generate_conjunct_body(loc, conc, case, fun_var, subst, env, param_i))
+      return ImpIntro(loc, ind_hyp, None, generate_conjunct_body(loc, conc, case, fun_var, subst, env, param_i, case_hint))
     case Call(loc, ty, rator, [arg]):
       match case.pattern:
         case PatternTerm(loc, _, _):
           try:
             case.pattern.term = type_check_term(case.pattern.term, arg.typeof.substitute(subst), env, None, [])
           except UserError as e:
-            # TODO: Better way to communicate about parameter order
-            user_error(loc, "Problem type checking induction pattern\n" + str(e))
+            user_error(case.pattern.location, "problem type checking custom induction pattern"
+                  + "\nExpected a case shaped like:\n" + case_hint
+                  + "\n" + str(e))
           new_case = case.pattern.term.copy()
           new_case = new_case.substitute(subst)
           if new_case != arg:
-            user_error(loc, "Induction pattern didn't match\n\t" + str(case.pattern.term) + "\ndid not match with\n\t" + str(arg))
+            user_error(case.pattern.location, "custom induction pattern did not match"
+                  + "\nExpected a case shaped like:\n" + case_hint
+                  + "\nThe pattern\n\t" + str(case.pattern.term)
+                  + "\ndid not match\n\t" + str(arg))
 
         case PatternBool():
-          user_error(loc, "No pattern bool allowed for custom induction")
+          user_error(case.pattern.location, "boolean patterns are not allowed in custom induction"
+                + "\nExpected a case shaped like:\n" + case_hint)
         # TODO: Do I really need to handle constructors without parameters differently?
         case PatternCons(loc, constructor, []):
           if isUInt(arg):
@@ -4837,7 +4859,8 @@ def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0
             if i == 0 and base_name(constructor.name) == 'zero':
               pass
             else:
-              user_error(loc, "UInt Mismatch")
+              user_error(case.pattern.location, "custom induction pattern did not match UInt literal " + str(i)
+                    + "\nExpected a case shaped like:\n" + case_hint)
           else:
             arg = type_synth_term(arg, env, False, [])
             constructor = type_check_term(constructor,  arg.typeof, env, False, [])
@@ -4855,9 +4878,11 @@ def generate_conjunct_body(loc, conjunct, case, fun_var, subst, env, param_i = 0
               args_eq = len(new_args) == len(call_args) and all([arg1 == arg2 for arg1,arg2 in zip(new_args, call_args)])
 
               if not (args_eq and rator_eq):
-                internal_error(loc, "Pattern cons didn't math")
+                user_error(case.pattern.location, "custom induction pattern did not match"
+                      + "\nExpected a case shaped like:\n" + case_hint)
             case _:
-              user_error(loc, "Arg expected to be a call")
+              user_error(case.pattern.location, "custom induction case expected a constructor-like pattern"
+                    + "\nExpected a case shaped like:\n" + case_hint)
         case _:
           internal_error("Unsupported pattern type: " + str(type(case.pattern)))
       return case.body

--- a/test/should-error/induction_custom_missing_case.pf
+++ b/test/should-error/induction_custom_missing_case.pf
@@ -1,0 +1,9 @@
+import UInt
+
+theorem bad_uint_induction_missing_case : all x : UInt. x = x
+proof
+  induction UInt
+  case 0 {
+    .
+  }
+end

--- a/test/should-error/induction_custom_missing_case.pf.err
+++ b/test/should-error/induction_custom_missing_case.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/induction_custom_missing_case.pf:5.3-8.4: expected 2 cases for custom induction on UInt, but have 1
+Expected cases:
+	case 0  {
+		?
+	}
+	case with m. 1 + m assume IH0  {
+		?
+	}

--- a/test/should-error/induction_custom_pattern_mismatch.pf
+++ b/test/should-error/induction_custom_pattern_mismatch.pf
@@ -1,0 +1,12 @@
+import UInt
+
+theorem bad_uint_induction_pattern : all x : UInt. x = x
+proof
+  induction UInt
+  case 0 {
+    .
+  }
+  case with x. x assume IH {
+    .
+  }
+end

--- a/test/should-error/induction_custom_pattern_mismatch.pf.err
+++ b/test/should-error/induction_custom_pattern_mismatch.pf.err
@@ -1,0 +1,9 @@
+./test/should-error/induction_custom_pattern_mismatch.pf:9.8-9.24: custom induction pattern did not match
+Expected a case shaped like:
+	case with m. 1 + m assume IH0  {
+		?
+	}
+The pattern
+	x
+did not match
+	1 + m


### PR DESCRIPTION
## Summary

- add explicit case-count diagnostics for custom induction, including the expected case skeleton
- report custom induction pattern mismatches at the user-written case pattern with the expected shape
- document the public UInt zero/successor induction view and add a design note for future UInt view-based recursion

## Tests

- python3 -m py_compile proof_checker.py
- python3 deduce.py test/should-validate/uint_induction.pf
- python3 test-deduce.py --site
- python3 test-deduce.py --errors
- python3 test-deduce.py --passable

Closes #539