### PR TITLE
[codex] Dedupe MCP lemma recommendations

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -3652,6 +3652,7 @@ def _collect_lemma_candidates(
     )
 
     out = []
+    seen_names: set[str] = set()
     user_module = _module_for_path(path)
     prelude_set = set(prelude)
     seen_modules: set = set()
@@ -3666,7 +3667,8 @@ def _collect_lemma_candidates(
                 continue
             if isinstance(stmt, (Theorem, Postulate)):
                 info = _lemma_info_for(stmt, public_only=True)
-                if info is not None:
+                if info is not None and info.name not in seen_names:
+                    seen_names.add(info.name)
                     out.append((info, stmt.what, module_name))
             elif isinstance(stmt, _ImportNode) and stmt.visibility == "public":
                 if stmt.name in seen_modules or stmt.name == user_module:
@@ -3692,6 +3694,9 @@ def _collect_lemma_candidates(
             info = _lemma_info_for(stmt, public_only=False)
             if info is None:
                 continue
+            if info.name in seen_names:
+                continue
+            seen_names.add(info.name)
             out.append((info, stmt.what, user_module))
 
     if prelude:
@@ -4068,7 +4073,11 @@ def _rank_lemmas(
 
     raw_scores.sort(key=lambda t: (-t[0], t[1].name))
     matches = []
+    seen_names: set[str] = set()
     for raw, info, module in raw_scores:
+        if info.name in seen_names:
+            continue
+        seen_names.add(info.name)
         matches.append(
             LemmaMatch(
                 name=info.name,

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -24,10 +24,14 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from lsp.query import (  # noqa: E402
     LemmaMatch,
+    LemmaInfo,
     Position,
     SymbolKind,
+    _rank_lemmas,
     available_lemmas_at,
 )
+from lsp.library import check_file  # noqa: E402
+from abstract_syntax import Theorem, base_name  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -369,6 +373,27 @@ def test_limit_caps_result_count() -> None:
         limit=2,
     )
     assert len(matches) == 2
+
+
+def test_rank_lemmas_dedupes_same_declaration_name() -> None:
+    """Different import/prelude walks can reach the same declaration;
+    only one recommendation should be returned for a theorem name."""
+    source = "theorem helper: true\nproof\n  .\nend\n"
+    result = check_file("lemmas.pf", content=source)
+    assert result.ok
+    helper = next(
+        stmt
+        for stmt in result.ast
+        if isinstance(stmt, Theorem) and base_name(stmt.name) == "helper"
+    )
+    info = LemmaInfo("helper", SymbolKind.THEOREM, "helper: true")
+    matches = _rank_lemmas(
+        ((info, helper.what, "lemmas"), (info, helper.what, "lemmas")),
+        goal_text=None,
+        query=None,
+        user_module="lemmas",
+    )
+    assert [m.name for m in matches] == ["helper"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Deduplicate `available_lemmas_at` candidates by theorem/postulate name during collection.
- Defensively dedupe ranked lemma matches before returning recommendations.
- Add focused regression coverage for duplicate candidate ranking.

## Validation

- `python3 -m pytest test/lsp/test_available_lemmas.py -q`
- `python3 -m pytest test/lsp/test_mcp_server.py -q`
- `python3 -m ruff check lsp/query.py test/lsp/test_available_lemmas.py`
- `python3 -m py_compile lsp/query.py test/lsp/test_available_lemmas.py`
- `git diff --check`
