### PR TITLE
[codex] Run static checks before regressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,11 @@ python deduce.py path/to/file.pf
 python deduce.py --recursive-descent file.pf
 python deduce.py --lalr file.pf
 
-# Make targets run BOTH parsers across the test/lib tree
-make tests        # should-validate + should-error
+# Make targets run static checks and BOTH parsers across the test/lib tree
+make static       # ruff + mypy
+make tests        # static + should-validate + should-error
 make tests-lib    # checks the stdlib itself
-make              # tests + tests-lib (default)
+make              # static + token checks + tests (default)
 ```
 
 `test-deduce.py` is the higher-level harness used in CI:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ TEST_ERROR_DIR = ./test/should-error
 TEST_IMPORT_DIR = ./test/test-imports
 EXAMPLES_DIR = ./examples
 
-default: tests-tokens tests
+default: static tests-tokens tests
+
+static:
+	$(PYTHON) -m ruff check .
+	$(PYTHON) -m mypy .
 
 tests-tokens:
 	$(PYTHON) ./gh_pages/scripts/keywords.py
@@ -18,7 +22,7 @@ tests-tokens:
 # once in the parent and forks worker processes that inherit the
 # populated AST cache via copy-on-write -- ~10x faster than the
 # previous subprocess-per-file harness.
-tests:
+tests: static
 	$(PYTHON) test-deduce.py
 
 # Per-category targets kept for granular debugging; ``make tests``


### PR DESCRIPTION
## Summary

- Add a `make static` target that runs ruff and mypy through the repo-selected Python.
- Make `make tests` depend on `static`, so the usual local regression command matches the CI static gate before running `test-deduce.py`.
- Update `CLAUDE.md` testing guidance to document the new local check path.

## Root Cause

The normal local regression path only ran the Deduce harness, while GitHub Actions ran `ruff check .` and `mypy .` separately before the harness. That let automation commit after a green local `make tests` run while CI still caught static-check failures.

## Validation

- `make static`
- `make -n tests`
- `make tests`