### PR TITLE
[codex] Reduce MCP lemma lookup cache misses

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -292,8 +292,11 @@ def _check_file_impl(
         cached = get_uniquified_modules()
         # The cache is keyed by module name and corresponds to a
         # specific on-disk state. When the caller passes in-memory
-        # content, the cache may be stale, so we bypass it and re-parse.
-        use_cache = content is None
+        # content, it is usually an unsaved editor buffer, so the cache
+        # may be stale. MCP tools, however, read the file from disk and
+        # pass that exact text through this same API; those calls are
+        # cacheable because they match the cache's on-disk contract.
+        use_cache = content is None or _content_matches_file(filename, content)
         if use_cache and module_name in cached:
             ast = cached[module_name]
         else:
@@ -397,6 +400,19 @@ def _check_file_impl(
             module_name=module_name,
             ast=ast,
         )
+
+
+def _content_matches_file(filename: str, content: str) -> bool:
+    """Return true when ``content`` exactly matches ``filename`` on disk.
+
+    A missing or unreadable file means the caller's text is necessarily
+    an in-memory buffer, so it must bypass the module cache.
+    """
+    try:
+        with open(filename, "r", encoding="utf-8") as f:
+            return f.read() == content
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -4008,16 +4008,6 @@ def _rank_lemmas(
 
     raw_scores: list = []
     for info, formula, module in candidates:
-        head = _formula_head_symbol(formula)
-        symbols = _formula_symbols(formula)
-
-        head_score = 1.0 if (goal_head is not None and head == goal_head) else 0.0
-
-        if goal_syms:
-            overlap = len(goal_syms & symbols) / len(goal_syms)
-        else:
-            overlap = 0.0
-
         proximity = 1.0 if module == user_module else 0.0
 
         sig_lower = info.signature.lower()
@@ -4034,17 +4024,10 @@ def _rank_lemmas(
         if pattern is not None and pattern.search(info.signature):
             pattern_score = 1.0
 
-        raw = (
-            4.0 * head_score
-            + 2.0 * overlap
-            + 1.0 * proximity
-            + 2.0 * substring_score
-            + 3.0 * pattern_score
-        )
-
         # When the user typed a goal-shape pattern or substring, only
-        # surface lemmas that match it -- other signals shouldn't
-        # promote unrelated lemmas above a query-only baseline.
+        # surface lemmas that match it. Run this cheap filter before
+        # walking formula ASTs; query-only MCP calls otherwise pay the
+        # recursive symbol extraction cost for every in-scope theorem.
         if has_substring_query and substring_score == 0.0:
             continue
         if pattern is not None and pattern_score == 0.0:
@@ -4056,6 +4039,26 @@ def _rank_lemmas(
             # dropped by the ``raw <= 0`` filter below.
             raw_scores.append((1.0 + proximity, info, module))
             continue
+
+        if goal_head is not None:
+            head = _formula_head_symbol(formula)
+            head_score = 1.0 if head == goal_head else 0.0
+        else:
+            head_score = 0.0
+
+        if goal_syms:
+            symbols = _formula_symbols(formula)
+            overlap = len(goal_syms & symbols) / len(goal_syms)
+        else:
+            overlap = 0.0
+
+        raw = (
+            4.0 * head_score
+            + 2.0 * overlap
+            + 1.0 * proximity
+            + 2.0 * substring_score
+            + 3.0 * pattern_score
+        )
 
         # No goal AND no query that this lemma matched -> nothing to
         # score on.  Skip.

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -18,6 +18,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+from abstract_syntax import get_uniquified_modules  # noqa: E402
 from lsp.library import CheckResult, check_file  # noqa: E402
 
 PASS_DIR = REPO_ROOT / "test" / "should-validate"
@@ -64,8 +65,35 @@ def test_lib_collect_errors_no_false_positives(path: Path) -> None:
     used to leak failed-probe errors into the sink even when the
     enclosing rule recovered."""
     result = check_file(str(path), collect_errors=True, prelude=())
+    assert result.errors is not None
     assert result.ok, (
         f"{path.name} should validate but collect_errors mode reported "
         f"{len(result.errors)} error(s); first:\n{result.error_message}"
     )
     assert result.errors == []
+
+
+def test_matching_disk_content_populates_module_cache(tmp_path: Path) -> None:
+    """MCP tools pass disk-backed content into ``check_file``; that
+    content should still use the on-disk module cache."""
+    path = tmp_path / "Cacheable.pf"
+    source = "theorem cached: true\nproof\n  .\nend\n"
+    path.write_text(source, encoding="utf-8")
+
+    result = check_file(str(path), content=source, prelude=())
+
+    assert result.ok
+    assert path.stem in get_uniquified_modules()
+
+
+def test_unsaved_content_bypasses_module_cache(tmp_path: Path) -> None:
+    """Content that differs from disk is an editor buffer snapshot and
+    must not be cached as the file's module."""
+    path = tmp_path / "Unsaved.pf"
+    path.write_text("theorem disk: true\nproof\n  .\nend\n", encoding="utf-8")
+    unsaved = "theorem buffer: true\nproof\n  .\nend\n"
+
+    result = check_file(str(path), content=unsaved, prelude=())
+
+    assert result.ok
+    assert path.stem not in get_uniquified_modules()


### PR DESCRIPTION
## Summary

- Cache `check_file(..., content=...)` calls when the supplied content exactly matches the file on disk, preserving unsaved-buffer cache bypasses while letting MCP disk-backed calls reuse module cache entries.
- Avoid formula AST walks in `available_lemmas_at` ranking until after cheap query filters and browse-mode handling.
- Add library tests for disk-matching content cache behavior and unsaved content bypass behavior.

## Validation

- `python3 -m pytest test/lsp/test_library.py -q`
- `python3 -m pytest test/lsp/test_available_lemmas.py test/lsp/test_library.py -q`
- `python3 -m ruff check lsp/library.py lsp/query.py test/lsp/test_library.py`
- `python3 -m mypy lsp/library.py lsp/query.py test/lsp/test_library.py`
- `make tests`
