### PR TITLE
Reduce duplicate LSP regression coverage

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -11,8 +11,9 @@ Modes
 Default (no flags): runs ``--cli + --lib + --passable + --errors``.
 
 Per-category flags (combinable):
-    --cli          One subprocess invocation of ``deduce.py example.pf``
-                   to sanity-check the CLI entry point itself.
+    --cli          One subprocess invocation of ``deduce.py`` on a tiny
+                   no-stdlib proof to sanity-check the CLI entry point
+                   itself.
     --lib          ``lib/`` with both parsers, no shared cache.
     --passable     ``test/should-validate``, ``example.pf``,
                    ``test/prelude`` with both parsers.
@@ -417,29 +418,29 @@ def run_parser_equivalence() -> list[tuple[str, str, str]]:
 
 
 def run_cli_test() -> list[tuple[str, str, str]]:
-    """Sanity-check that ``python deduce.py example.pf`` works end-to-end.
+    """Sanity-check that ``python deduce.py`` works end-to-end.
 
     The in-process runner exercises ``lsp.library.check_file``; this
     one subprocess invocation makes sure the ``deduce.py`` CLI wrapper
-    itself (arg parsing, ``init_import_directories``,
-    ``print_theorems``, exit codes) hasn't drifted. One file is
-    enough -- we're not re-checking ``example.pf``'s contents (the
-    in-process sweep already does that), we're testing the CLI shape.
+    itself (arg parsing, no-stdlib mode, exit codes, success output)
+    hasn't drifted. A tiny no-stdlib file is enough -- we're testing
+    the CLI shape without paying for a full stdlib bootstrap.
     """
+    cli_path = "./test/should-validate/theorem_true.pf"
     cp = subprocess.run(
-        [sys.executable, "deduce.py", "./example.pf"],
+        [sys.executable, "deduce.py", "--no-stdlib", cli_path],
         capture_output=True, text=True,
     )
     failures: list[tuple[str, str, str]] = []
     if cp.returncode != 0:
         failures.append((
-            "./example.pf", "cli",
+            cli_path, "cli",
             f"exit {cp.returncode}\nstderr: {cp.stderr[:500]}\n"
             f"stdout: {cp.stdout[:500]}",
         ))
-    elif "example.pf is valid" not in cp.stdout:
+    elif "theorem_true.pf is valid" not in cp.stdout:
         failures.append((
-            "./example.pf", "cli",
+            cli_path, "cli",
             f"unexpected stdout:\n{cp.stdout[:500]}",
         ))
     return failures
@@ -619,7 +620,9 @@ def main(argv: list[str]) -> int:
 
     if flags["cli"]:
         print("\n=== --cli: deduce.py CLI sanity check ===")
-        _, fails = time_section("deduce.py ./example.pf", run_cli_test)
+        _, fails = time_section(
+            "deduce.py --no-stdlib theorem_true.pf", run_cli_test
+        )
         total_failures.extend(fails)
 
     # Lib pool: clean state (no shared cache).

--- a/test/lsp/conftest.py
+++ b/test/lsp/conftest.py
@@ -11,11 +11,8 @@ adding ``lib/`` and ``test/test-imports/`` to the import path,
 bumping the recursion limit). All test modules in this directory
 inherit it automatically.
 
-The ``_reset_prelude_per_test`` fixture drops the prelude cache
-between tests so each test starts from a clean slate. Strictly
-optional now that ``check_file`` is self-contained, but it makes
-test failures less puzzling -- a leak in the new state machinery
-shows up as a single failing test rather than as a cascade.
+Tests that need to force a fresh bootstrap call ``reset_prelude_cache``
+explicitly; ordinary tests rely on ``check_file`` to restore state.
 """
 
 import sys
@@ -36,7 +33,6 @@ from abstract_syntax import (  # noqa: E402
     init_import_directories,
 )
 from flags import set_quiet_mode  # noqa: E402
-from lsp.library import reset_prelude_cache  # noqa: E402
 
 
 LIB_DIR = REPO_ROOT / "lib"
@@ -51,16 +47,4 @@ def _set_up_globals():
     add_import_directory(str(LIB_DIR))
     add_import_directory(str(TEST_IMPORTS_DIR))
     sys.setrecursionlimit(10000)
-    yield
-
-
-@pytest.fixture(autouse=True)
-def _reset_prelude_per_test():
-    """Drop the prelude snapshot between tests for tidier isolation.
-
-    ``check_file``'s automatic state restore is enough for correctness,
-    but starting each test from a fresh bootstrap keeps test ordering
-    invisible.
-    """
-    reset_prelude_cache()
     yield

--- a/test/lsp/test_check.py
+++ b/test/lsp/test_check.py
@@ -1,8 +1,8 @@
 """Acceptance test for ``lsp.query.check`` (Phase 1 / Step 3).
 
-For every ``test/should-error/*.pf`` fixture, verifies that ``check``
-returns a single ``Diagnostic`` with ``Severity.ERROR`` whose start
-line and column match the location reported in the sibling ``.err``
+For representative ``test/should-error/*.pf`` fixtures, verifies that
+``check`` returns ``Diagnostic`` values with ``Severity.ERROR`` whose
+start line and column match a location reported in the sibling ``.err``
 fixture. For a sample of ``test/should-validate/`` files, verifies
 ``check`` returns an empty list.
 
@@ -55,24 +55,33 @@ def _expected_positions(err_path: Path) -> list[Position]:
     ]
 
 
-def _error_pf_files() -> list[Path]:
-    return sorted(p for p in ERROR_DIR.glob("*.pf"))
-
-
-# A handful of should-validate files; the full corpus is already
-# covered by test_library.py at the CheckResult level. These confirm
-# the query API's empty-list contract.
-_SAMPLE_VALID = [
-    "after.pf",
-    "all-elim-tlet.pf",
-    "ImportTests.pf",
-    "ListTests.pf",
-    "NatTests.pf",
+_SAMPLE_ERRORS = [
+    # Normal proof error.
+    "conclude.pf",
+    # Parser error with multiple location headers.
+    "define_missing_semi.pf",
+    # Reference-style error with primary and related locations.
+    "overload6.pf",
+    # Import-related error.
+    "import_using_unknown.pf",
+    # Givens/proof-context diagnostic.
+    "givens_conclude_hole.pf",
 ]
 
 
-@pytest.mark.parametrize("pf_path", _error_pf_files(), ids=lambda p: p.name)
-def test_check_reports_error_at_expected_location(pf_path: Path) -> None:
+# A handful of should-validate files; the full corpus is covered by
+# test-deduce.py. These confirm the query API's empty-list contract.
+_SAMPLE_VALID = [
+    "empty_file.pf",
+    "ImportTests.pf",
+    "ListTests.pf",
+    "uint_replicate.pf",
+]
+
+
+@pytest.mark.parametrize("name", _SAMPLE_ERRORS)
+def test_check_reports_error_at_expected_location(name: str) -> None:
+    pf_path = ERROR_DIR / name
     err_path = pf_path.with_suffix(pf_path.suffix + ".err")
     expected_positions = _expected_positions(err_path)
     if not expected_positions:

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -1,8 +1,9 @@
 """Acceptance test for ``lsp.library.check_file`` (Phase 1 / Step 1).
 
-For every file in ``test/should-validate`` and ``test/should-error``,
-verifies that the library API returns the same outcome (ok vs. error)
-that ``test-deduce.py`` produces by shelling out to ``deduce.py``.
+For representative files in ``test/should-validate`` and
+``test/should-error``, verifies that the library API returns the same
+outcome (ok vs. error) that ``test-deduce.py`` produces in the full
+corpus sweep.
 
 The session/state fixtures live in ``conftest.py`` so the Step 3
 acceptance test can share them.
@@ -26,11 +27,37 @@ ERROR_DIR = REPO_ROOT / "test" / "should-error"
 LIB_DIR = REPO_ROOT / "lib"
 
 
-def _pf_files(d: Path) -> list[Path]:
-    return sorted(p for p in d.glob("*.pf"))
+_SAMPLE_VALID = [
+    "empty_file.pf",
+    "ImportTests.pf",
+    "ListTests.pf",
+    "uint_replicate.pf",
+]
+
+_SAMPLE_ERRORS = [
+    "conclude.pf",
+    "define_missing_semi.pf",
+    "overload6.pf",
+    "import_using_unknown.pf",
+    "givens_conclude_hole.pf",
+]
+
+_SAMPLE_LIB_COLLECT_ERRORS = [
+    "Base.pf",
+    "Nat.pf",
+    "List.pf",
+    "IntMult.pf",
+    "UIntDiv.pf",
+]
 
 
-@pytest.mark.parametrize("path", _pf_files(PASS_DIR), ids=lambda p: p.name)
+def _paths(directory: Path, names: list[str]) -> list[Path]:
+    return [directory / name for name in names]
+
+
+@pytest.mark.parametrize(
+    "path", _paths(PASS_DIR, _SAMPLE_VALID), ids=lambda p: p.name
+)
 def test_should_validate(path: Path) -> None:
     result = check_file(str(path), prelude=())
     assert isinstance(result, CheckResult)
@@ -44,7 +71,9 @@ def test_should_validate(path: Path) -> None:
     assert result.module_name == path.stem
 
 
-@pytest.mark.parametrize("path", _pf_files(ERROR_DIR), ids=lambda p: p.name)
+@pytest.mark.parametrize(
+    "path", _paths(ERROR_DIR, _SAMPLE_ERRORS), ids=lambda p: p.name
+)
 def test_should_error(path: Path) -> None:
     result = check_file(str(path), prelude=())
     assert isinstance(result, CheckResult)
@@ -57,7 +86,10 @@ def test_should_error(path: Path) -> None:
     assert result.module_name == path.stem
 
 
-@pytest.mark.parametrize("path", _pf_files(LIB_DIR), ids=lambda p: p.name)
+@pytest.mark.parametrize(
+    "path", _paths(LIB_DIR, _SAMPLE_LIB_COLLECT_ERRORS),
+    ids=lambda p: p.name,
+)
 def test_lib_collect_errors_no_false_positives(path: Path) -> None:
     """Regression test for issue #400: ``check_file(..., collect_errors=True)``
     on a stdlib file must agree with ``deduce.py`` -- speculative

--- a/test/lsp/test_symbols.py
+++ b/test/lsp/test_symbols.py
@@ -26,6 +26,13 @@ from lsp.query import (  # noqa: E402
 )
 
 
+def _line_starting_with(path: Path, prefix: str) -> int:
+    for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if line.startswith(prefix):
+            return index
+    raise AssertionError(f"{path} has no line starting with {prefix!r}")
+
+
 # --------------------------------------------------------------------------
 # list_symbols
 # --------------------------------------------------------------------------
@@ -283,9 +290,10 @@ def test_definition_of_cross_file_constructor() -> None:
     assert loc.path.endswith("lib/NatDefs.pf"), (
         f"expected lib/NatDefs.pf, got {loc.path!r}"
     )
-    # The ``suc(Nat)`` constructor sits inside ``union Nat { ... }`` on
-    # line 5 of NatDefs.pf.
-    assert loc.range.start.line == 5
+    # The ``suc(Nat)`` constructor sits inside ``union Nat { ... }``.
+    assert loc.range.start.line == _line_starting_with(
+        REPO_ROOT / "lib" / "NatDefs.pf", "  suc(Nat)"
+    )
 
 
 def test_definition_of_cross_file_operator() -> None:
@@ -306,8 +314,10 @@ def test_definition_of_cross_file_operator() -> None:
     assert loc.path.endswith("lib/NatDefs.pf"), (
         f"expected lib/NatDefs.pf, got {loc.path!r}"
     )
-    # ``recursive operator +(Nat,Nat) -> Nat { ... }'' starts on line 8.
-    assert loc.range.start.line == 8
+    assert loc.range.start.line == _line_starting_with(
+        REPO_ROOT / "lib" / "NatDefs.pf",
+        "recursive operator +(Nat,Nat) -> Nat {",
+    )
 
 
 def test_definition_of_overloaded_operator_preserves_use_site() -> None:
@@ -341,12 +351,13 @@ def test_definition_of_overloaded_operator_preserves_use_site() -> None:
         "type checker is leaking the operator declaration's location "
         "onto the ResolvedVar, masking the use site"
     )
-    # ``recursive operator +(Nat,Nat) -> Nat { ... }'' starts on line 8
-    # of lib/NatDefs.pf.
     assert loc.path.endswith("lib/NatDefs.pf"), (
         f"expected lib/NatDefs.pf, got {loc.path!r}"
     )
-    assert loc.range.start.line == 8
+    assert loc.range.start.line == _line_starting_with(
+        REPO_ROOT / "lib" / "NatDefs.pf",
+        "recursive operator +(Nat,Nat) -> Nat {",
+    )
 
 
 def test_definition_of_ignores_imported_node_locations() -> None:


### PR DESCRIPTION
Summary:
- Prune duplicate LSP corpus sweeps in test_library.py and test_check.py to representative fixtures while keeping full corpus coverage in test-deduce.py.
- Remove the autouse LSP prelude cache reset so ordinary tests rely on check_file isolation.
- Speed the CLI sanity check with a tiny --no-stdlib proof.
- Fix brittle NatDefs line assertions in test_symbols.py.

Validation:
- python3 -m pytest test/lsp/test_library.py -q
- python3 -m pytest test/lsp/test_check.py -q
- python3 -m pytest test/lsp/test_symbols.py -q
- python3 -m pytest test/lsp/ -q --durations=20
- python3 test-deduce.py --cli
- python3 test-deduce.py
- python3 -m mypy .

Closes #569