### PR TITLE
Refactor callable name helpers

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -313,27 +313,25 @@ def is_associative(loc: Meta, opname: str, typ: Type | None, env: Env) -> bool:
       pass
   return False
 
-def rator_name(rator: Term | RecFun | GenRecFun) -> str:
-  if isinstance(rator, VarRef):
-    return rator.get_name()
-  match rator:
-    case RecFun(_, name, _, _, _, _):
-      return name
-    case GenRecFun(_, name, _, _, _, _, _, _, _):
-      return name
-    case Lambda(_, _, _, _):
-      return 'no_name'
-    case TermInst(_, _, arg2, _):
-      return rator_name(arg2)
-    case Generic(_, _, _, _):
-      return 'no_name'
+def named_callable_name(t: VarRef | RecFun | GenRecFun) -> str:
+  if isinstance(t, VarRef):
+    return t.get_name()
+  return t.name
+
+
+def callable_name(t: Term | RecFun | GenRecFun) -> str | None:
+  if isinstance(t, VarRef | RecFun | GenRecFun):
+    return named_callable_name(t)
+  match t:
+    case TermInst(_, _, subject, _, _):
+      return callable_name(subject)
     case _:
-      return 'no_name'
+      return None
 
 
 def flatten_assoc(op_name: str, trm: Term) -> list[Term]:
   match trm:
-    case Call(_, _, rator, args) if rator_name(rator) == op_name:
+    case Call(_, _, rator, args) if callable_name(rator) == op_name:
       return sum([flatten_assoc(op_name, arg) for arg in args], [])
     case _:
       return [trm]
@@ -1173,46 +1171,38 @@ def is_operator_name(name: str) -> bool:
     
 def is_var_operator(trm: Term) -> bool:
   # `Var.__str__` / `OverloadedVar.__str__` use this without recursing
-  # through `is_operator`, which would loop on TermInst(Var(...)).
+  # through `is_operator_callable`, which would loop on TermInst(Var(...)).
   return isinstance(trm, VarRef) and is_operator_name(trm.get_name())
 
-def is_operator(trm: Term | RecFun | GenRecFun) -> bool:
-  if isinstance(trm, VarRef):
-    return is_operator_name(trm.get_name())
-  match trm:
-    case RecFun(_, name, _, _, _, _):
-      return is_operator_name(name)
-    case GenRecFun(_, name, _, _, _, _, _, _, _):
-      return is_operator_name(name)
-    case TermInst(_, _, subject, _, _):
-      return is_operator(subject)
-    case _:
-      return False
+def is_operator_callable(trm: Term | RecFun | GenRecFun) -> bool:
+  name = callable_name(trm)
+  return name is not None and is_operator_name(name)
 
-def operator_name(trm: Term | RecFun | GenRecFun) -> str:
-  if isinstance(trm, VarRef):
-    nm = trm.get_name()
-    return nm if get_unique_names() else base_name(nm)
-  match trm:
-    case RecFun(_, name, _, _, _, _):
-      return base_name(name)
-    case GenRecFun(_, name, _, _, _, _, _, _, _):
-      return base_name(name)
-    case TermInst(_, _, subject, _):
-      return operator_name(subject)
-    case _:
-      raise InternalError('operator_name, unexpected term ' + str(trm))
+def _callable_display_subject(trm: Term | RecFun | GenRecFun) -> Term | RecFun | GenRecFun:
+  while isinstance(trm, TermInst):
+    trm = trm.subject
+  return trm
+
+def operator_display_name(trm: Term | RecFun | GenRecFun) -> str:
+  name = callable_name(trm)
+  if name is None:
+    raise InternalError('operator_display_name, unexpected term ' + str(trm))
+  if isinstance(_callable_display_subject(trm), VarRef) and get_unique_names():
+    return name
+  return base_name(name)
 
 def is_infix_operator(trm: Term | RecFun | GenRecFun) -> bool:
-  return is_operator(trm) and operator_name(trm) in infix_precedence.keys()
+  name = callable_name(trm)
+  return name is not None and base_name(name) in infix_precedence.keys()
 
-def is_prefix_operator(trm):
-  return is_operator(trm) and operator_name(trm) in prefix_precedence.keys()
+def is_prefix_operator(trm: Term | RecFun | GenRecFun) -> bool:
+  name = callable_name(trm)
+  return name is not None and base_name(name) in prefix_precedence.keys()
 
 def precedence(trm: Term) -> int | None:
   match trm:
-    case Call(_, _, rator, args) if is_operator(rator):
-      op_name = operator_name(rator)
+    case Call(_, _, rator, args) if is_operator_callable(rator):
+      op_name = base_name(operator_display_name(rator))
       if len(args) >= 2:
         return infix_precedence.get(op_name, None)
       elif len(args) == 1:
@@ -1369,10 +1359,10 @@ class Call(Term):
 
   def __str__(self):
     if is_infix_operator(self.rator) and len(self.args) >= 2:
-      op_str = ' ' + operator_name(self.rator) + ' '
+      op_str = ' ' + operator_display_name(self.rator) + ' '
       return op_str.join([op_arg_str(self, arg) for arg in self.args])
     elif is_prefix_operator(self.rator) and len(self.args) == 1:
-      return operator_name(self.rator) + " " + op_arg_str(self, self.args[0])
+      return operator_display_name(self.rator) + " " + op_arg_str(self, self.args[0])
     elif isDeduceInt(self):
       return deduceIntToInt(self)
     elif isLitNat(self): # and not get_verbose():
@@ -1409,11 +1399,14 @@ class Call(Term):
     fun = self.rator.reduce(env)
     if get_eval_all():
       is_assoc = False
+      assoc_name = None
     else:
-      is_assoc = is_associative(self.location, rator_name(self.rator),
-                                self.typeof, env)
+      assoc_name = callable_name(self.rator)
+      is_assoc = assoc_name is not None and is_associative(self.location,
+                                assoc_name, self.typeof, env)
     if is_assoc:
-      flat_args = flatten_assoc_list(rator_name(self.rator), self.args)
+      assert assoc_name is not None
+      flat_args = flatten_assoc_list(assoc_name, self.args)
     else:
       flat_args = self.args
     args = [arg.reduce(env) for arg in flat_args]
@@ -1428,7 +1421,7 @@ class Call(Term):
           ret = Call(self.location, self.typeof, fun, args)
       case (OverloadedVar() | ResolvedVar()) if is_assoc:
         ret = Call(self.location, self.typeof, fun,
-                   flatten_assoc_list(rator_name(self.rator), args))
+                   flatten_assoc_list(assoc_name, args))
 
       case Lambda(loc, _, vars, body):
         # Note (Phase 5 / Step 22): no debugger hook here.
@@ -1441,11 +1434,7 @@ class Call(Term):
         # ``anonymous``; literal lambdas with no name fall back to
         # ``<lambda>``.
         call_env = fun.env if fun.env is not None else env
-        rn = rator_name(self.rator)
-        if rn == 'no_name':
-          display_name = '<lambda>'
-        else:
-          display_name = rn
+        display_name = callable_name(self.rator) or '<lambda>'
         ret = self.do_call(loc, vars, body, args, call_env, name=display_name)
     
       case GenRecFun(loc, name, [], params, returns, _, _,
@@ -1491,7 +1480,7 @@ class Call(Term):
   def do_call(self, loc, vars, body, args, env, name="anonymous"):
     # because of associativity, args can be longer than vars.
     # ``name`` is the source-visible name of the function being
-    # called -- caller passes the result of ``rator_name(self.rator)``
+    # called -- caller passes the result of ``callable_name(self.rator)``
     # so debugger traps and trace output see ``foo`` rather than
     # ``anonymous`` when the lambda came from a named binding.
     subst = {k: v for ((k,t),v) in zip(vars, args)}
@@ -1536,7 +1525,7 @@ class Call(Term):
       if get_verbose():
         print('not reducing recursive call to associative ' + str(fun))
       return Call(self.location, self.typeof, fun,
-                 flatten_assoc_list(rator_name(fun), args))
+                 flatten_assoc_list(name, args))
     else:
       if get_verbose():
         print('not reducing recursive call to ' + str(fun))
@@ -1590,7 +1579,7 @@ class Call(Term):
     set_reduce_only(old_reduce_only)
 
     new_args += worklist
-    flat_results = flatten_assoc_list(rator_name(self.rator), new_args)
+    flat_results = flatten_assoc_list(name, new_args)
     if len(flat_results) == 1:
       return explicit_term_inst(flat_results[0])
     else:
@@ -4039,8 +4028,8 @@ def _try_match_one_plus(t):
     """
     if not isinstance(t, Call) or len(t.args) != 2:
       return None
-    name = rator_name(t.rator)
-    if name == 'no_name' or base_name(name) != '+':
+    name = callable_name(t.rator)
+    if name is None or base_name(name) != '+':
       return None
     a, b = t.args
     if (isUInt(a) and uintToInt(a) == 1) \
@@ -4401,7 +4390,8 @@ def isEmptySet(t):
   match t:
     case Call(_, _, fun,
               [Lambda(_, _, _, Bool(_, _, False))]) \
-              if base_name(rator_name(fun)) == 'char_fun':
+              if (name := callable_name(fun)) is not None \
+              and base_name(name) == 'char_fun':
       return True
     case _:
       return False
@@ -4437,10 +4427,12 @@ class ProofBinding(Binding):
 
 @dataclass
 class AutoEquationBinding(Binding):
-  equations : List[Formula]
+  equations : dict[str, list[Formula]]
+  fallback_equations : list[Formula] = field(default_factory=list)
   
   def __str__(self):
-    return ', '.join([str(e) for e in self.equations])
+    head_equations = [e for equations in self.equations.values() for e in equations]
+    return ', '.join([str(e) for e in head_equations + self.fallback_equations])
 
 @dataclass
 class ViewBinding(Binding):
@@ -4554,30 +4546,32 @@ class Env:
     new_env = Env(self.dict)
     full_name = '__auto__'
     (lhs,rhs) = split_equation(loc, equation, new_env)
-    head_lhs = term_head(lhs)
+    head_lhs = call_head_name(lhs)
     #print('declare auto: ' + head_lhs + '\n\t' + str(equation))
     if full_name in self.dict:
-        if head_lhs in new_env.dict[full_name].equations:
-            new_env.dict[full_name].equations[head_lhs].append(equation)
-        else:
-            new_env.dict[full_name].equations[head_lhs] = [equation]
+        old = cast(AutoEquationBinding, self.dict[full_name])
+        new_equations = {head: [*equations]
+                         for (head, equations) in old.equations.items()}
+        new_fallback_equations = [*old.fallback_equations]
     else:
         new_equations = {}
-        new_equations[head_lhs] = [equation]
-        if 'no_name' not in new_equations:
-            new_equations['no_name'] = []
-        new_env.dict[full_name] = AutoEquationBinding(loc, new_equations,
-                                                      module=self.get_current_module())
+        new_fallback_equations = []
+    if head_lhs is None:
+        new_fallback_equations.append(equation)
+    else:
+        new_equations.setdefault(head_lhs, []).append(equation)
+    new_env.dict[full_name] = AutoEquationBinding(loc, new_equations,
+                                                  new_fallback_equations,
+                                                  module=self.get_current_module())
     return new_env
 
-  def get_auto_rewrites(self, head: str) -> list[Formula]:
+  def get_auto_rewrites(self, head: str | None) -> list[Formula]:
     full_name = '__auto__'
     if full_name in self.dict.keys():
-        equations = cast(Any, self.dict[full_name]).equations
-        if head in equations:
-            return cast(list[Formula], equations[head])
-        else:
-            return cast(list[Formula], equations['no_name'])
+        binding = cast(AutoEquationBinding, self.dict[full_name])
+        if head is None:
+            return binding.fallback_equations
+        return binding.equations.get(head, binding.fallback_equations)
     else:
       return []
 
@@ -5320,12 +5314,14 @@ def rewrite_aux(loc: Meta, formula: Term | SwitchCase, equation: Formula,
     case Some(loc2, tyof, vars, frm2):
       return Some(loc2, tyof, vars, rewrite_aux(loc, frm2, equation, env, depth - 1))
     case Call(loc2, tyof, rator, args):
-      is_assoc = is_associative(loc2, rator_name(rator), formula.typeof, env)
+      assoc_name = callable_name(rator)
+      is_assoc = assoc_name is not None \
+          and is_associative(loc2, assoc_name, formula.typeof, env)
       if get_verbose():
           print('is_assoc? ' + str(is_assoc))
       if is_assoc:
-          # args = sum([flatten_assoc(rator_name(rator), arg) for arg in args], [])
-          args = flatten_assoc_list(rator_name(rator), args)
+          assert assoc_name is not None
+          args = flatten_assoc_list(assoc_name, args)
       new_rator = rewrite_aux(loc, rator, equation, env, depth - 1)
       new_args = [rewrite_aux(loc, arg, equation, env, depth - 1) for arg in args]
       if rewrite_debug and get_verbose():
@@ -5355,7 +5351,8 @@ def rewrite_aux(loc: Meta, formula: Term | SwitchCase, equation: Formula,
                 output_terms.append(new_args[i])
                 i = i + 1
             else:
-                flat_tmp = flatten_assoc(rator_name(rator), new_tmp)
+                assert assoc_name is not None
+                flat_tmp = flatten_assoc(assoc_name, new_tmp)
                 if get_verbose():
                     print('rewrote: ' + str(tmp) + '\n\tinto: ' \
                           + ', '.join([str(a) for a in flat_tmp]))
@@ -5556,19 +5553,20 @@ def call_arity(call: Term) -> int:
       case _:
         return 1 #raise Exception('call_arity: not a call ' + str(call))
 
-def term_head(term: Term) -> str:
+def call_head_name(term: Term) -> str | None:
     match term:
       case Call(_, _, rator, _):
-          return base_name(rator_name(rator)) # TODO: remove base_name -Jeremy
+          name = callable_name(rator)
+          return base_name(name) if name is not None else None
       case _:
-          return 'no_name'
+          return None
     
 def auto_rewrites(term: Term, env: Env) -> Term:
     # Iterate until we can't rewrite anymore (to a fixed point)
     while True:
         current = get_num_rewrites()
         # Grab all the equations that are applicable to the head constructor
-        equations = env.get_auto_rewrites(term_head(term))
+        equations = env.get_auto_rewrites(call_head_name(term))
         # Rewrite using the first equation that matches 
         for eq in equations:
             current_eq = get_num_rewrites()
@@ -5667,17 +5665,6 @@ def _alpha_equiv_value(v1: object, v2: object,
   return bool(v1 == v2)
 
 
-def _varref_name(t: Any) -> str:
-  # Var / OverloadedVar / ResolvedVar / RecFun / GenRecFun all expose
-  # a canonical name -- the first three via get_name(), the others
-  # via .name. Unified here so dispatch can stay flat.
-  if isinstance(t, (Var, ResolvedVar)):
-    return t.name
-  if isinstance(t, OverloadedVar):
-    return t.resolved_names[0]
-  return str(t.name)  # RecFun / GenRecFun
-
-
 def _alpha_equiv_varref(
     t1: Var | OverloadedVar | ResolvedVar | RecFun | GenRecFun,
     t2: object,
@@ -5687,8 +5674,8 @@ def _alpha_equiv_varref(
   # Names of comparable kinds. If t2 is not a comparable kind, fail.
   if not isinstance(t2, (Var, OverloadedVar, ResolvedVar, RecFun, GenRecFun)):
     return False
-  n1 = _varref_name(t1)
-  n2 = _varref_name(t2)
+  n1 = named_callable_name(t1)
+  n2 = named_callable_name(t2)
   in1 = n1 in env1
   in2 = n2 in env2
   if in1 != in2:

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -45,10 +45,10 @@ from abstract_syntax import (
     TAnnote, TLet, Term, TermInst, Theorem, Trace, Type, TypeInst, TypeType,
     Union, Var, VarRef, ViewDecl, ViewRecFun, alpha_equiv, base_name,
     check_post_typecheck_invariants, count_marks, find_file, find_mark,
-    formula_match, formulas_equal_modulo_numeric_literals, get_num_rewrites,
+    callable_name, formula_match, formulas_equal_modulo_numeric_literals, get_num_rewrites,
     get_predicate_decl, get_reduced_defs,
     get_type_name, isUInt, is_associative, is_constructor, is_equation,
-    is_true, mkEqual, name2str, print_theorems, rator_name, remove_mark,
+    is_true, mkEqual, name2str, print_theorems, remove_mark,
     replace_mark, reset_num_rewrites, reset_reduced_defs, rewrite_aux,
     set_dont_reduce_opaque, set_eval_all, set_reduce_all, split_equation,
     type_match, type_names, uintToInt, uniquify_deduce as uniquify_deduce,
@@ -889,14 +889,19 @@ def check_proof(proof, env):
       match (a,b):
         case (Call(loc2, _, rator1, args1),
               Call(_, _, rator2, args2)) if len(args1) == len(args2):
-          f1 = base_name(rator_name(rator1))
-          f2 = base_name(rator_name(rator2))
+          name1 = callable_name(rator1)
+          name2 = callable_name(rator2)
+          if name1 is None or name2 is None:
+            user_error(loc, 'in injective, expected constructor calls, not '
+                  + str(formula))
+          f1 = base_name(name1)
+          f2 = base_name(name2)
           if f1 != f2:
             user_error(loc, 'in injective, ' + f1 + ' ≠ ' + f2)
           if str(constr) != f1:
             user_error(loc, 'in injective, ' + str(constr) + ' ≠ ' + f1)
-          if not is_constructor(rator_name(rator1), env):
-            user_error(loc, 'in injective, ' + rator_name(rator1) + ' not a constructor')
+          if not is_constructor(name1, env):
+            user_error(loc, 'in injective, ' + name1 + ' not a constructor')
           boolty = BoolType(loc)
           eqs = [mkEqual(loc, arg1, arg2) for (arg1,arg2) in zip(args1, args2)]
           if len(eqs) > 1:
@@ -1332,16 +1337,14 @@ def _check_rule_induction_or_inversion(proof, goal, env, is_inversion):
           "to the predicate, got '" + str(pred_call) + "'")
 
   rator = pred_call.rator
-  rator_name = None
-  if isinstance(rator, VarRef):
-    rator_name = rator.get_name()
-  if rator_name != pred_name_in:
+  rator_callable_name = callable_name(rator)
+  if rator_callable_name != pred_name_in:
     user_error(loc, keyword_phrase + " over '" + base_name(pred_name_in)
           + "' but the goal's premise is a call to '"
           + str(rator) + "'")
-  pred_decl = get_predicate_decl(rator_name)
+  pred_decl = get_predicate_decl(rator_callable_name)
   if pred_decl is None:
-    user_error(loc, keyword_phrase + ": '" + base_name(rator_name)
+    user_error(loc, keyword_phrase + ": '" + base_name(rator_callable_name)
           + "' is not a predicate or relation declared with the "
           "'predicate' or 'relation' keyword")
 
@@ -1372,7 +1375,7 @@ def _check_rule_induction_or_inversion(proof, goal, env, is_inversion):
       user_error(c.location,
             keyword_phrase + ": '" + base
             + "' is not a rule of predicate '"
-            + base_name(rator_name) + "'")
+            + base_name(rator_callable_name) + "'")
     if c.rule_name in user_cases_by_rule:
       user_error(c.location,
             keyword_phrase + ": duplicate case for rule '"
@@ -2446,9 +2449,12 @@ def apply_rewrites(loc, formula, eqns, env, *, display_formula=None):
     
 def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
                           call, typarams, param_types, return_type):
-  is_assoc = is_associative(loc, rator_name(new_rator), return_type, env)
+  assoc_name = callable_name(new_rator)
+  is_assoc = assoc_name is not None and is_associative(loc, assoc_name,
+                                                       return_type, env)
   if get_verbose():
-      print('is_assoc? ' + rator_name(new_rator) + ' : ' + str(return_type) + ' = ' + str(is_assoc))
+      print('is_assoc? ' + (assoc_name or '<anonymous>') + ' : '
+            + str(return_type) + ' = ' + str(is_assoc))
   if (is_assoc and len(args) < len(param_types)) \
       or ((not is_assoc) and len(args) != len(param_types)):
     user_error(loc, 'incorrect number of arguments in call:\n\t' + str(call) \
@@ -2640,8 +2646,8 @@ def reset_recursive_call_count():
 
 def check_recursive_call(call, recfun, subterms):
   # print('check_recursive_call(' + repr(call) + ') in ' + str(recfun))
-  # print('rator_name = ' + rator_name(call.rator))
-  if rator_name(call.rator) != recfun:
+  # print('callable_name = ' + str(callable_name(call.rator)))
+  if recfun is None or callable_name(call.rator) != recfun:
       return
   increment_recursive_call_count()
 
@@ -3623,13 +3629,11 @@ def _validate_predicate_rule_shape(rule, pred_name, keyword, arity, env):
           + base_name(pred_name) + "': the rule's conclusion must apply '"
           + base_name(pred_name) + "', but found '" + str(concl) + "'")
   rator = concl.rator
-  rator_name = None
-  if isinstance(rator, VarRef):
-    rator_name = rator.get_name()
-  if rator_name != pred_name:
+  rator_callable_name = callable_name(rator)
+  if rator_callable_name != pred_name:
     suggestion = ''
-    if rator_name is not None:
-      base_rator = base_name(rator_name)
+    if rator_callable_name is not None:
+      base_rator = base_name(rator_callable_name)
       base_pred = base_name(pred_name)
       if edit_distance(base_rator, base_pred) <= max(2, len(base_pred) // 5):
         suggestion = " (did you mean '" + base_pred + "'?)"
@@ -5505,7 +5509,7 @@ def find_rec_calls(name, term, env):
     case Call(loc2, _, rator, args):
       calls = find_rec_calls(name, rator, env) + \
           sum([find_rec_calls(name, arg, env) for arg in args], [])
-      if rator_name(rator) == name:
+      if callable_name(rator) == name:
           return [RecCall([], [], args)] + calls
       else:
           return calls

--- a/test/unit/test_ast_invariants.py
+++ b/test/unit/test_ast_invariants.py
@@ -566,7 +566,8 @@ def _spec_AutoEquationBinding() -> ast.AutoEquationBinding:
         module="M",
         visibility="public",
         location=_meta(),
-        equations=[_var("e")],
+        equations={"f": [ast.Bool(_meta(), None, True)]},
+        fallback_equations=[ast.Bool(_meta(), None, False)],
     )
 
 

--- a/test/unit/test_callable_names.py
+++ b/test/unit/test_callable_names.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from lark.tree import Meta
+
+import abstract_syntax as ast
+
+
+def _meta() -> Meta:
+    return Meta()
+
+
+def test_callable_name_distinguishes_anonymous_callable() -> None:
+    lam = ast.Lambda(_meta(), None, [("x", ast.IntType(_meta()))],
+                     ast.Var(_meta(), None, "x"))
+
+    assert ast.callable_name(ast.Var(_meta(), None, "f")) == "f"
+    assert ast.callable_name(ast.TermInst(_meta(), None,
+                                          ast.Var(_meta(), None, "f"),
+                                          [ast.IntType(_meta())],
+                                          True)) == "f"
+    assert ast.callable_name(lam) is None
+
+
+def test_auto_rewrite_fallback_bucket_is_explicit() -> None:
+    fallback = ast.Bool(_meta(), None, False)
+    direct = ast.Bool(_meta(), None, True)
+    env = ast.Env({
+        "__auto__": ast.AutoEquationBinding(
+            location=_meta(),
+            module="M",
+            equations={"f": [direct]},
+            fallback_equations=[fallback],
+        )
+    })
+
+    assert env.get_auto_rewrites("f") == [direct]
+    assert env.get_auto_rewrites("missing") == [fallback]
+    assert env.get_auto_rewrites(None) == [fallback]


### PR DESCRIPTION
## Summary
- replace the old rator/operator helper layer with typed callable-name helpers that return None for anonymous callables
- store auto-rewrite fallback equations explicitly instead of using a magic no_name bucket
- update proof-checker identity checks and add unit coverage for callable names and fallback lookup

## Verification
- python3 -m ruff check abstract_syntax.py proof_checker.py
- python3 -m mypy .
- python3 -m mypy . --no-site-packages
- python3 -m pytest test/unit/test_callable_names.py test/unit/test_ast_invariants.py
- python3 ./deduce.py --recursive-descent ./lib/Set.pf --dir ./lib
- python3 ./deduce.py --lalr ./lib/Set.pf --dir ./lib
- python3 ./deduce.py --recursive-descent ./lib/BigO.pf --dir ./lib
- python3 ./deduce.py --lalr ./lib/BigO.pf --dir ./lib
- make tests

Closes #576