### PR TITLE
Add abstract_syntax annotations group 9

### DIFF
--- a/abstract_syntax.py
+++ b/abstract_syntax.py
@@ -4332,19 +4332,19 @@ def formulas_equal_modulo_numeric_literals(frm1: Any, frm2: Any) -> bool:
     case _:
       return False
 
-def mkUIntLit(loc, num):
+def mkUIntLit(loc: Meta, num: int) -> Term:
     return Call(loc, None, Var(loc, None, 'fromNat'),
                 [Call(loc, None, Var(loc, None, 'lit'),
                       [intToNat(loc, num)])])
   
-def mkPos(loc, arg):
+def mkPos(loc: Meta, arg: Term) -> Term:
   return Call(loc, None, Var(loc, None, 'pos'), [arg])
 
-def mkNeg(loc, arg):
+def mkNeg(loc: Meta, arg: Term) -> Term:
   return Call(loc, None, Var(loc, None, 'negsuc'), [arg])
 
 # The following is used in the parser.
-def mkIntLit(loc, n, sign):
+def mkIntLit(loc: Meta, n: int, sign: str) -> Term:
   if sign == 'PLUS':
     return mkPos(loc, mkUIntLit(loc, n))
   else:
@@ -4449,27 +4449,30 @@ def nodeListToList(t: Term) -> list[Term]:
     case _:
       raise InternalError('nodeListToList: not a node list: ' + str(t))
 
-def nodeListToString(t):
+def nodeListToString(t: Term) -> str | None:
   match t:
     case TermInst(_, _, ctor, _, _) if _is_named(ctor, 'empty'):
       return ''
     case Call(_, _, TermInst(_, _, ctor, _, _),
               [arg, ls]) if _is_named(ctor, 'node'):
-      return str(arg) + ', ' + nodeListToString(ls)
+      rest = nodeListToString(ls)
+      return str(arg) + ', ' + rest if rest is not None else None
+    case _:
+      return None
 
-def mkEmpty(loc):
+def mkEmpty(loc: Meta) -> Term:
   return Var(loc, None, 'empty')
 
-def mkNode(loc, arg, ls):
+def mkNode(loc: Meta, arg: Term, ls: Term) -> Term:
   return Call(loc, None, Var(loc, None, 'node'), [arg, ls])
 
-def listToNodeList(loc, lst):
+def listToNodeList(loc: Meta, lst: Sequence[Term]) -> Term:
   if len(lst) == 0:
     return mkEmpty(loc)
   else:
     return mkNode(loc, lst[0], listToNodeList(loc, lst[1:]))
 
-def isEmptySet(t):
+def isEmptySet(t: Term) -> bool:
   match t:
     case Call(_, _, fun,
               [Lambda(_, _, _, Bool(_, _, False))]) \
@@ -4525,7 +4528,7 @@ class ViewBinding(Binding):
     return str(self.view)
 
 
-def type_params_str(type_params):
+def type_params_str(type_params: Sequence[str]) -> str:
   if len(type_params) > 0:
     return '<' + ','.join(type_params) + '>'
   else:
@@ -4549,13 +4552,13 @@ class Env:
       self.dict = {}
 
   # This is a hack. Not reliable. Added for GenRecFun.
-  def base_to_unique(self, name):
+  def base_to_unique(self, name: str) -> str | None:
     for k in self.dict.keys():
       if base_name(k) == name:
         return k
     return None
 
-  def base_to_overloads(self, name):
+  def base_to_overloads(self, name: str) -> list[str]:
     overloads = []
     for k in self.dict.keys():
       if base_name(k) == name:
@@ -4566,7 +4569,7 @@ class Env:
     return ',\n'.join(['\t' + name2str(k) + ': ' + str(v) \
                        for (k,v) in reversed(self.dict.items())])
 
-  def __contains__(self, item):
+  def __contains__(self, item: str) -> bool:
     return item in self.dict.keys()
     
   def proofs_str(self):
@@ -4579,12 +4582,12 @@ class Env:
                        for (k,v) in reversed(self.dict.items()) \
                        if isinstance(v,TermBinding) and v.local])
   
-  def declare_type(self, loc, name, vis = 'public'):
+  def declare_type(self, loc: Meta, name: str, vis: str = 'public') -> Env:
     new_env = Env(self.dict)
     new_env.dict[name] = TypeBinding(loc, module=self.get_current_module(), visibility=vis)
     return new_env
 
-  def declare_type_vars(self, loc, type_vars):
+  def declare_type_vars(self, loc: Meta, type_vars: Sequence[str]) -> Env:
     new_env = self
     for x in type_vars:
       new_env = new_env.declare_type(loc, x)
@@ -4598,14 +4601,16 @@ class Env:
     new_env.dict[name] = TypeBinding(loc, defn, module=self.get_current_module(), visibility=visibility)
     return new_env
 
-  def declare_view(self, loc, view, visibility='public'):
+  def declare_view(self, loc: Meta, view: ViewDecl,
+                   visibility: str = 'public') -> Env:
     new_env = Env(self.dict)
     new_env.dict[view.name] = ViewBinding(loc, view,
                                           module=self.get_current_module(),
                                           visibility=visibility)
     return new_env
   
-  def declare_term_var(self, loc, name, typ, local = False, visibility='public'):
+  def declare_term_var(self, loc: Meta, name: str, typ: Type,
+                       local: bool = False, visibility: str = 'public') -> Env:
     if typ == None:
       internal_error(loc, 'None not allowed as type of variable in declare_term_var')
     new_env = Env(self.dict)
@@ -4613,7 +4618,8 @@ class Env:
     new_env.dict[name].local = local
     return new_env
 
-  def declare_assoc(self, loc, opname, typarams, typ):
+  def declare_assoc(self, loc: Meta, opname: str, typarams: List[str],
+                    typ: Type) -> Env:
     #print('declaring assoc ' + opname + ' ' + str(typ))
     new_env = Env(self.dict)
     full_name = '__associative_' + opname
@@ -4626,7 +4632,7 @@ class Env:
                                                    module=self.get_current_module())
     return new_env
 
-  def declare_auto_rewrite(self, loc, equation):
+  def declare_auto_rewrite(self, loc: Meta, equation: Formula) -> Env:
     new_env = Env(self.dict)
     full_name = '__auto__'
     (lhs,rhs) = split_equation(loc, equation, new_env)

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -5496,6 +5496,9 @@ def collect_env(stmt, env : Env):
               assert isinstance(op, VarRef)
               resolved_op = op.get_name()
       if assoc_formula in env.proofs():
+          if resolved_op is None:
+              user_error(loc, 'Could not find an overload of ' + str(op)
+                         + ' with type ' + str(typ))
           return env.declare_assoc(loc, resolved_op, typarams, typ)
       else:
           user_error(loc, 'Could not find a proof of\n\t' + str(assoc_formula))

--- a/test/unit/test_abstract_syntax_annotations.py
+++ b/test/unit/test_abstract_syntax_annotations.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+import abstract_syntax as ast
+
+
+def _assert_params_annotated(
+    func: Callable[..., Any],
+    expected_params: set[str],
+) -> None:
+    signature = inspect.signature(func)
+    missing = {
+        name
+        for name in expected_params
+        if signature.parameters[name].annotation is inspect.Parameter.empty
+    }
+    assert missing == set()
+
+
+def test_issue_586_abstract_syntax_function_parameters_are_annotated() -> None:
+    functions: list[tuple[Callable[..., Any], set[str]]] = [
+        (ast.mkUIntLit, {"loc", "num"}),
+        (ast.mkPos, {"loc", "arg"}),
+        (ast.mkNeg, {"loc", "arg"}),
+        (ast.mkIntLit, {"loc", "n", "sign"}),
+        (ast.is_constructor, {"constr_name", "env"}),
+        (ast.is_constr_term, {"term", "env"}),
+        (ast.constr_name, {"term"}),
+        (ast.constructor_conflict, {"term1", "term2", "env"}),
+        (ast._is_named, {"node", "base"}),
+        (ast.isNodeList, {"t"}),
+        (ast.nodeListToList, {"t"}),
+        (ast.nodeListToString, {"t"}),
+        (ast.mkEmpty, {"loc"}),
+        (ast.mkNode, {"loc", "arg", "ls"}),
+        (ast.listToNodeList, {"loc", "lst"}),
+        (ast.isEmptySet, {"t"}),
+        (ast.type_params_str, {"type_params"}),
+    ]
+
+    for func, expected_params in functions:
+        _assert_params_annotated(func, expected_params)
+
+
+def test_issue_586_env_method_parameters_are_annotated() -> None:
+    methods: list[tuple[Callable[..., Any], set[str]]] = [
+        (ast.Env.base_to_unique, {"name"}),
+        (ast.Env.base_to_overloads, {"name"}),
+        (ast.Env.__contains__, {"item"}),
+        (ast.Env.declare_type, {"loc", "name", "vis"}),
+        (ast.Env.declare_type_vars, {"loc", "type_vars"}),
+        (ast.Env.define_type, {"loc", "name", "defn", "visibility"}),
+        (ast.Env.declare_view, {"loc", "view", "visibility"}),
+        (ast.Env.declare_term_var,
+         {"loc", "name", "typ", "local", "visibility"}),
+        (ast.Env.declare_assoc, {"loc", "opname", "typarams", "typ"}),
+        (ast.Env.declare_auto_rewrite, {"loc", "equation"}),
+    ]
+
+    for method, expected_params in methods:
+        _assert_params_annotated(method, expected_params)


### PR DESCRIPTION
## Summary
- Add parameter annotations for the issue #586 abstract_syntax.py group 9 targets.
- Add focused introspection tests that assert the listed parameters remain annotated.

## Validation
- python3.13 -m py_compile abstract_syntax.py
- python3.13 -m pytest test/unit/test_abstract_syntax_annotations.py
- python3.13 -m mypy abstract_syntax.py
- python3.13 -m ruff check abstract_syntax.py test/unit/test_abstract_syntax_annotations.py

Addresses #586.