### PR TITLE
Adopt mypy --strict on checker_logic

### DIFF
--- a/checker_logic.py
+++ b/checker_logic.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """Formula/proof utility logic independent of whole-file orchestration.
 
 File charter:
@@ -12,7 +11,51 @@ File charter:
   ``checker_types.py``.
 """
 
+from typing import TYPE_CHECKING, Any, cast
+
+from lark.tree import Meta
+
+from abstract_syntax import (
+    All,
+    And,
+    Bool,
+    Call,
+    Env,
+    Formula,
+    IfThen,
+    Lambda,
+    MarkException,
+    Or,
+    OverloadedVar,
+    PatternCons,
+    ResolvedVar,
+    Switch,
+    SwitchCase,
+    TLet,
+    Term,
+    VarRef,
+    base_name,
+    count_marks,
+    find_mark,
+    formula_match,
+    formulas_equal_modulo_numeric_literals,
+    get_num_rewrites,
+    get_reduced_defs,
+    is_equation,
+    is_true,
+    name2str,
+    replace_mark,
+    reset_num_rewrites,
+    reset_reduced_defs,
+    rewrite_aux,
+    split_equation,
+)
 from checker_common import *
+if TYPE_CHECKING:
+    from checker_proofs import update_all_head
+from checker_types import check_formula
+from error import MatchFailed, UserError, internal_error, user_error, wrap_user_error
+from flags import get_verbose, print_verbose
 
 def check_implies(loc: Meta, frm1: Formula, frm2: Formula) -> None:
   if get_verbose():
@@ -150,7 +193,7 @@ def instantiate(loc: Meta, allfrm: Any, arg: Any) -> Any:
     case _:
       internal_error(loc, 'expected all formula to instantiate, not ' + str(allfrm))
   
-def str_of_env(env):
+def str_of_env(env: Any) -> str:
   return '{' + ', '.join([k + ": " + str(e) for (k,e) in env.items()]) + '}'
 
 def pattern_to_term(pat: Any) -> Any:
@@ -166,8 +209,6 @@ def pattern_to_term(pat: Any) -> Any:
       internal_error(pat.location, "expected a pattern, not " + str(pat))
 
 def rewrite(loc: Meta, formula: Any, equation: Any, env: Env) -> Any:
-    if False and get_verbose():
-        print('rewriting ' + str(formula) + '\n\twith ' + str(equation))
     num_marks = count_marks(formula)
     if num_marks == 0:
         ret = rewrite_aux(loc, formula, equation, env)
@@ -184,14 +225,14 @@ def rewrite(loc: Meta, formula: Any, equation: Any, env: Env) -> Any:
     else:
         internal_error(loc, 'in replace, formula contains more than one mark:\n\t' + str(formula))
 
-def facts_to_str(env):
+def facts_to_str(env: Any) -> str:
   result = ''
   for (x,p) in env.items():
     if isinstance(p, Formula) or isinstance(p, Term):
       result += x + ': ' + str(p) + '\n'
   return result
 
-def isolate_difference_list(list1, list2):
+def isolate_difference_list(list1: Any, list2: Any) -> Any:
   for (t1, t2) in zip(list1, list2):
     diff = isolate_difference(t1, t2)
     if diff:
@@ -233,7 +274,7 @@ def isolate_difference(term1: Any, term2: Any) -> Any:
       case _:
         return (term1, term2)
 
-def collect_all_if_then(loc: Meta, frm: Any, env: Env) -> Any:
+def collect_all_if_then(loc: Meta, frm: Any, env: Env) -> tuple[list[Any], list[Any]]:
     """Returns a list of all variables that need be instantiated, and anythings that need applied"""
 
     if isinstance(frm, TLet):
@@ -262,7 +303,7 @@ def collect_all_if_then(loc: Meta, frm: Any, env: Env) -> Any:
       case _:
         user_error(loc, "in 'apply', expected an if-then formula, not " + str(frm))
 
-def collect_all(frm):
+def collect_all(frm: Any) -> tuple[list[Any], Any]:
     match frm:
       case All(loc2, _, var, _, frm):
         (rest_vars, body) = collect_all(frm)
@@ -271,14 +312,14 @@ def collect_all(frm):
       case _:
         return ([], frm)
 
-def auto_simplified_hint(new_formula):
+def auto_simplified_hint(new_formula: Any) -> str:
   if is_true(new_formula):
     return '\nThe goal has been simplified to `true`, possibly by an `auto` rewrite rule.\n' \
            'Finish the proof with `.` (which closes any goal of the form `true`).'
   return ''
 
 
-def _ast_mentions_any(node, target_names):
+def _ast_mentions_any(node: Any, target_names: Any) -> bool:
   # AST traversal: does `node` reference any name in `target_names`?
   # No general `free_vars` is defined across all Term subclasses, so we
   # walk the dataclass fields directly.
@@ -309,7 +350,7 @@ def _ast_mentions_any(node, target_names):
   return False
 
 
-def _expand_would_progress(residual, defs, env):
+def _expand_would_progress(residual: Any, defs: Any, env: Any) -> bool:
   # Would running `expand_definitions` on `residual` with the same `defs`
   # actually change the formula? Used to gate the "unfold further" hint
   # so it doesn't fire when more expand wouldn't help -- e.g. when the
@@ -353,7 +394,7 @@ def _expand_would_progress(residual, defs, env):
   return False
 
 
-def expand_residual_hint(residual: Any, defs: Any, env: Env) -> Any:
+def expand_residual_hint(residual: Any, defs: Any, env: Env) -> str:
   # When `expand f.` fails and `f` still appears in the residual goal,
   # tell the user the unfolding depth was too shallow. The common case
   # is a recursive function whose body re-introduces its own name; one
@@ -361,7 +402,7 @@ def expand_residual_hint(residual: Any, defs: Any, env: Env) -> Any:
   # Only fire when another expand pass would actually change the
   # residual -- otherwise the suggestion is misdirection (e.g. the
   # function is stuck on a variable arg and the real fix is `switch`).
-  still_present = []
+  still_present: list[str] = []
   for d in defs:
     if not isinstance(d, VarRef):
       continue
@@ -389,7 +430,7 @@ def expand_residual_hint(residual: Any, defs: Any, env: Env) -> Any:
           'Chain another expand with `|` (e.g. `expand f | f.`) or use `N*f` to unfold further.')
 
 
-def expand_backward_mark_hint(formula, var, env):
+def expand_backward_mark_hint(formula: Any, var: Any, env: Any) -> str:
   # When `expand X` fails inside a marked equation `# L # = R` (or the
   # mirrored form), expand only saw the marked side. If unfolding X on
   # the *other* side would succeed, suggest wrapping that side in
@@ -426,7 +467,7 @@ def expand_backward_mark_hint(formula, var, env):
       return ''
 
 
-def replace_backward_mark_hint(formula, eq, env):
+def replace_backward_mark_hint(formula: Any, eq: Any, env: Any) -> str:
   # Mirror of `expand_backward_mark_hint` for the `replace` tactic: when
   # `replace eq` fails inside a marked equation `# L # = R` because the
   # eq's LHS doesn't appear on the marked side, but it *would* match on

--- a/checker_types.py
+++ b/checker_types.py
@@ -69,14 +69,18 @@ from abstract_syntax import (
     type_names,
 )
 from checker_common import *
-import checker_pipeline as _checker_pipeline
 from error import MatchFailed, UserError, internal_error, user_error, wrap_user_error, error_header
 from flags import get_verbose
 
-# Re-export under a typed signature so callers don't trip
-# ``disallow_untyped_calls`` (checker_pipeline is still on
-# ``# mypy: ignore-errors``).
-_instantiate_view_type: Any = _checker_pipeline._instantiate_view_type
+# Lazy adapter for checker_pipeline._instantiate_view_type: a module-level
+# import would close the cycle
+# checker_types -> checker_pipeline -> checker_induction -> checker_proofs
+# -> checker_types and crash at import time. The Any return tag also keeps
+# strict callers off ``disallow_untyped_calls`` while checker_pipeline is
+# still on ``# mypy: ignore-errors``.
+def _instantiate_view_type(loc: Any, typ: Any, env: Any) -> Any:
+  import checker_pipeline
+  return checker_pipeline._instantiate_view_type(loc, typ, env)
 
 def type_check_call_funty(loc: Meta, new_rator: Any, args: list[Any], env: Env, recfun: Any, subterms: Any, ret_ty: Any,
                           call: Any, typarams: list[Any], param_types: list[Any], return_type: Any) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ module = [
     "checker_cache",
     "checker_common",
     "checker_induction",
+    "checker_logic",
     "checker_pipeline",
     "checker_proofs",
     "checker_types",


### PR DESCRIPTION
## Summary

- Drop `# mypy: ignore-errors` from `checker_logic.py`; add explicit imports for the `abstract_syntax` / `error` / `flags` / `lark.tree` names the wildcard `from checker_common import *` no longer re-exports under `no_implicit_reexport = true`.
- Cross-module imports: `update_all_head` from `checker_proofs` (guarded by `TYPE_CHECKING:` to avoid the runtime cycle `checker_logic → checker_proofs → checker_logic`; the facade injection makes it available at call time) and `check_formula` from `checker_types`.
- Annotate all 17 function signatures (`Any` for AST parameters, `Meta` for `loc`, concrete returns where obvious). Drive-by: remove the long-dead `if False and get_verbose():` guard in `rewrite` (which would trip `warn_unreachable` once this module enters the strict block).
- Add `"checker_logic"` to the unified strict override block in `pyproject.toml`.

**Hotfix folded in:** main is currently broken — PR #617 + PR #618 each introduced a module-level cross-checker import (`checker_pipeline` → `checker_induction`, and `checker_types` → `checker_pipeline`), and together they closed a cycle:

```
checker_induction → checker_proofs → checker_types → checker_pipeline → checker_induction
```

`python3.13 -c "import proof_checker"` and the full `Run Tests` CI job both fail on `origin/main` at 315feaf. This PR converts the `checker_types` end of the cycle (the `_instantiate_view_type` re-export) to a lazy import inside a tiny adapter function, so the import is only resolved at call time after every module is loaded. Tests pass locally on this rebased branch.

Refs #506.

## Test plan

- [x] `python3.13 -c "import proof_checker"` succeeds (regression for cycle)
- [x] `python3.13 -m mypy .` clean
- [x] `python3.13 -m ruff check .` clean
- [x] `python3.13 -m pytest test/unit/ -x` (539 tests pass)
- [x] `python3.13 test-deduce.py` (full suite, ~103s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)