### PR TITLE
Adopt mypy --strict on checker_types

### DIFF
--- a/checker_types.py
+++ b/checker_types.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """Type checking for Deduce types, terms, calls, patterns, and unions.
 
 File charter:
@@ -14,10 +13,73 @@ File charter:
   ``checker_pipeline.py``.
 """
 
-from checker_common import *
+from pathlib import Path
+from typing import Any
 
-def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
-                          call, typarams, param_types, return_type):
+from lark.tree import Meta
+
+from abstract_syntax import (
+    All,
+    And,
+    Array,
+    ArrayGet,
+    ArrayType,
+    Bool,
+    BoolType,
+    Call,
+    Conditional,
+    Env,
+    Formula,
+    FunctionType,
+    GenRecFun,
+    Generic,
+    GenericUnknownInst,
+    Hole,
+    IfThen,
+    Int,
+    IntType,
+    Lambda,
+    MakeArray,
+    Mark,
+    Omitted,
+    Or,
+    OverloadType,
+    OverloadedVar,
+    PatternBool,
+    PatternCons,
+    RecFun,
+    ResolvedVar,
+    Some,
+    Switch,
+    SwitchCase,
+    TAnnote,
+    TLet,
+    Term,
+    TermInst,
+    Type,
+    TypeInst,
+    TypeType,
+    Union,
+    Var,
+    VarRef,
+    base_name,
+    callable_name,
+    is_associative,
+    type_match,
+    type_names,
+)
+from checker_common import *
+import checker_pipeline as _checker_pipeline
+from error import MatchFailed, UserError, internal_error, user_error, wrap_user_error, error_header
+from flags import get_verbose
+
+# Re-export under a typed signature so callers don't trip
+# ``disallow_untyped_calls`` (checker_pipeline is still on
+# ``# mypy: ignore-errors``).
+_instantiate_view_type: Any = _checker_pipeline._instantiate_view_type
+
+def type_check_call_funty(loc: Meta, new_rator: Any, args: list[Any], env: Env, recfun: Any, subterms: Any, ret_ty: Any,
+                          call: Any, typarams: list[Any], param_types: list[Any], return_type: Any) -> Any:
   assoc_name = callable_name(new_rator)
   is_assoc = assoc_name is not None and is_associative(loc, assoc_name,
                                                        return_type, env)
@@ -43,7 +105,7 @@ def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
     return Call(loc, return_type, new_rator, new_args)
   else:
     #print('type check call to generic: ' + str(call))
-    matching = {}
+    matching: dict[Any, Any] = {}
     # If there is an expected return type, match that first.
     type_params = type_names(loc, typarams)
     if ret_ty:
@@ -107,7 +169,7 @@ def type_check_call_funty(loc, new_rator, args, env, recfun, subterms, ret_ty,
     # print('}}}')
     return ret
 
-def overload_mismatch_annotation(loc, overload_funty, arg_types, ret_ty):
+def overload_mismatch_annotation(loc: Meta, overload_funty: Any, arg_types: list[Any], ret_ty: Any) -> Any:
   """Return a short annotation explaining why this overload doesn't fit, or
   ``None`` if neither side matches (in which case the bare overload type is
   already informative on its own). The annotation distinguishes the two
@@ -118,7 +180,7 @@ def overload_mismatch_annotation(loc, overload_funty, arg_types, ret_ty):
       type_params = type_names(loc, typarams)
       args_match = (len(param_types) == len(arg_types))
       if args_match:
-        m = {}
+        m: dict[Any, Any] = {}
         try:
           for (pt, at) in zip(param_types, arg_types):
             type_match(loc, type_params, pt, at, m)
@@ -140,7 +202,7 @@ def overload_mismatch_annotation(loc, overload_funty, arg_types, ret_ty):
     case _:
       return None
 
-def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, call):
+def type_check_call_helper(loc: Meta, new_rator: Any, args: list[Any], env: Env, recfun: Any, subterms: Any, ret_ty: Any, call: Any) -> Any:
   if get_verbose():
       print('tc_call_helper(' + str(call) + ') rator type: ' + str(new_rator.typeof))
   funty = new_rator.typeof
@@ -192,7 +254,7 @@ def type_check_call_helper(loc, new_rator, args, env, recfun, subterms, ret_ty, 
     case _:
       user_error(loc, 'expected operator to have function type, not ' + str(funty))
       
-def type_check_call(loc, rator, args, env, recfun, subterms, ret_ty, call):
+def type_check_call(loc: Meta, rator: Any, args: list[Any], env: Env, recfun: Any, subterms: Any, ret_ty: Any, call: Any) -> Any:
   if get_verbose():
       print('tc_check_call(' + str(call) + ')')
       print('rator: ' + str(rator))
@@ -201,19 +263,19 @@ def type_check_call(loc, rator, args, env, recfun, subterms, ret_ty, call):
 
 recursive_call_count = 0
 
-def get_recursive_call_count():
+def get_recursive_call_count() -> int:
     global recursive_call_count
     return recursive_call_count
 
-def increment_recursive_call_count():
+def increment_recursive_call_count() -> None:
     global recursive_call_count
     recursive_call_count += 1
 
-def reset_recursive_call_count():
+def reset_recursive_call_count() -> None:
     global recursive_call_count
     recursive_call_count = 0
 
-def check_recursive_call(call, recfun, subterms):
+def check_recursive_call(call: Any, recfun: Any, subterms: Any) -> None:
   # print('check_recursive_call(' + repr(call) + ') in ' + str(recfun))
   # print('callable_name = ' + str(callable_name(call.rator)))
   if recfun is None or callable_name(call.rator) != recfun:
@@ -232,22 +294,22 @@ def check_recursive_call(call, recfun, subterms):
           + " or ".join([base_name(x) for x in subterms]) \
           + ", not " + str(call.args[0]))
 
-def _is_recfun_ref(node, recfun):
+def _is_recfun_ref(node: Any, recfun: Any) -> bool:
   if isinstance(node, ResolvedVar):
-    return node.name == recfun
+    return bool(node.name == recfun)
   if isinstance(node, OverloadedVar):
-    return recfun in node.resolved_names
+    return bool(recfun in node.resolved_names)
   if isinstance(node, Var):
-    return node.name == recfun
+    return bool(node.name == recfun)
   return False
 
-def _escape_error(loc, recfun):
+def _escape_error(loc: Meta, recfun: Any) -> None:
   user_error(loc,
         "the name '" + base_name(recfun) + "'"
         + " of a recursive function may only appear as the operator"
         + " of a function call within its own body")
 
-def check_no_recfun_escape(term, recfun):
+def check_no_recfun_escape(term: Any, recfun: Any) -> None:
   # Walk ``term`` and raise an error if ``recfun`` (the uniquified
   # name of the enclosing recursive function) appears anywhere other
   # than as the (optionally type-instantiated) operator of a Call.
@@ -317,7 +379,7 @@ def check_no_recfun_escape(term, recfun):
       if _is_recfun_ref(term, recfun):
         _escape_error(term.location, recfun)
 
-def _check_rator_no_escape(rator, recfun):
+def _check_rator_no_escape(rator: Any, recfun: Any) -> None:
   # At a Call rator position, a direct VarRef to ``recfun`` is the
   # only place the name is legal; TermInst wrapping such a VarRef
   # (the ``@foo<T>(...)`` syntax) is the same shape. Anything else
@@ -336,7 +398,7 @@ def _check_rator_no_escape(rator, recfun):
 # (issue #257); folding it into `check_type` makes every site that accepts a
 # user-written type — postulate/define/recursive/theorem signatures, etc. —
 # reject `Foo` when it should be `Foo<...>`.
-def _check_union_arity(head, given, env):
+def _check_union_arity(head: Any, given: int, env: Env) -> None:
   if not env.type_var_is_defined(head):
     return
   type_def = env.get_def_of_type_var(head)
@@ -412,7 +474,7 @@ def check_type(typ: Any, env: Env, arity_required: bool = True) -> Any:
 
 def type_first_letter(typ: Any) -> str:
   if isinstance(typ, VarRef):
-    return typ.get_name()[0]
+    return str(typ.get_name()[0])
   match typ:
     case IntType(_):
       return 'i'
@@ -430,7 +492,7 @@ def type_first_letter(typ: Any) -> str:
       print('error in type_first_letter: unhandled type ' + repr(typ))
       exit(-1)
 
-def type_check_term_inst(loc, subject, tyargs, inferred, recfun, subterms, env):
+def type_check_term_inst(loc: Meta, subject: Any, tyargs: list[Any], inferred: bool, recfun: Any, subterms: Any, env: Env) -> Any:
   tyargs = [check_type(ty, env) for ty in tyargs]
   new_subject = type_synth_term(subject, env, recfun, subterms)
   ty = new_subject.typeof
@@ -449,7 +511,7 @@ def type_check_term_inst(loc, subject, tyargs, inferred, recfun, subterms, env):
         user_error(loc, 'expected a type name, not ' + str(ty))
   return TermInst(loc, retty, new_subject, tyargs, inferred)
 
-def type_check_term_inst_var(loc, subject_var, tyargs, inferred, env):
+def type_check_term_inst_var(loc: Meta, subject_var: Any, tyargs: list[Any], inferred: bool, env: Env) -> Any:
   if isinstance(subject_var, VarRef):
       tyargs = [check_type(ty, env) for ty in tyargs]
       ty = env.get_type_of_term_var(subject_var)
@@ -578,19 +640,8 @@ def type_synth_term(term: Term, env: Env, recfun: Any, subterms: Any) -> Term:
       ret = IfThen(loc, ty, new_prem, new_conc)
       
     case All(loc, _, var, pos, body):
-      all_types = None
       x, ty = var
       new_ty = check_type(ty, env)
-      if isinstance(new_ty, TypeType):
-        if all_types == None or all_types == True:
-          all_types = True
-        else:
-          user_error(loc, 'cannot mix type and term variables in an all formula')
-      else:
-        if all_types == None or all_types == False:
-          all_types = False
-        else:
-          user_error(loc, 'cannot mix type and term variables in an all formula')
       new_var = (x, new_ty)
       body_env = env.declare_term_vars(loc, [new_var])
       new_body = check_formula(body, body_env, recfun, subterms)
@@ -643,10 +694,10 @@ def type_synth_term(term: Term, env: Env, recfun: Any, subterms: Any) -> Term:
       new_subject = type_synth_term(subject, env, recfun, subterms)
       ty = new_subject.typeof
 
-      cases_present = {}
-      result_type = [None] # boxed to allow mutable update in process_case
+      cases_present: dict[Any, Any] = {}
+      result_type: list[Any] = [None] # boxed to allow mutable update in process_case
 
-      def process_case(c, result_type, cases_present):
+      def process_case(c: Any, result_type: list[Any], cases_present: dict[Any, Any]) -> Any:
         new_env = check_pattern(c.pattern, ty, env, cases_present)
         new_body = type_synth_term(c.body, new_env, recfun, subterms)
         case_type = new_body.typeof
@@ -715,14 +766,13 @@ def type_synth_term(term: Term, env: Env, recfun: Any, subterms: Any) -> Term:
     case _:
       if isinstance(term, Type):
         internal_error(term.location, 'type_synth_term called on type ' + str(term))
-        ret = TypeType(term.location)
       else:
         user_error(term.location, 'cannot synthesize a type for ' + str(term))
   if get_verbose():
     print('\ttype synth: ' + str(term) + '\n\t=> ' + str(ret) + ' : ' + str(ret.typeof))
   return ret
 
-def type_check_formula(term, env):
+def type_check_formula(term: Term, env: Env) -> Term:
   return type_check_term(term, BoolType(term.location), env, None, [])
 
 def type_check_term(term: Term, typ: Type, env: Env, recfun: Any, subterms: Any) -> Term:
@@ -762,7 +812,7 @@ def type_check_term(term: Term, typ: Type, env: Env, recfun: Any, subterms: Any)
         case (FunctionType(_, typarams, param_types1, ret_type1),
               FunctionType(loc2, [], param_types2, ret_type2)):
           if len(typarams) > 0:
-            matching = {}
+            matching: dict[Any, Any] = {}
             type_params = type_names(loc, typarams)
             try:
               type_match(loc, type_params, ret_type1, ret_type2, matching)
@@ -862,10 +912,10 @@ def type_check_term(term: Term, typ: Type, env: Env, recfun: Any, subterms: Any)
     case Switch(loc, _, subject, cases):
       new_subject = type_synth_term(subject, env, recfun, subterms)
       ty = new_subject.typeof
-      cases_present = {}
-      result_type = [None] # boxed to allow mutable update in process_case
-      
-      def process_case(c, result_type, cases_present):
+      cases_present: dict[Any, Any] = {}
+      result_type: list[Any] = [None] # boxed to allow mutable update in process_case
+
+      def process_case(c: Any, result_type: list[Any], cases_present: dict[Any, Any]) -> Any:
         new_env = check_pattern(c.pattern, ty, env, cases_present)
         #print('\n$\n' + str(c) + '\nnew env:\n' + str(new_env))
         new_body = type_check_term(c.body, typ, new_env, recfun, subterms)
@@ -921,7 +971,7 @@ def type_check_term(term: Term, typ: Type, env: Env, recfun: Any, subterms: Any)
               + ' but got ' + str(ty))
       return new_term
   
-def lookup_union(loc, typ, env):
+def lookup_union(loc: Meta, typ: Any, env: Env) -> Any:
   if isinstance(typ, VarRef):
     return env.get_def_of_type_var(typ)
   match typ:
@@ -930,7 +980,7 @@ def lookup_union(loc, typ, env):
     case _:
       user_error(loc, 'expected a union type but instead got ' + str(typ))
 
-def check_constructor_pattern(loc, pat_constr, params, typ, env, cases_present):
+def check_constructor_pattern(loc: Meta, pat_constr: Any, params: list[Any], typ: Any, env: Env, cases_present: dict[Any, Any]) -> Any:
   if get_verbose():
     print('check_constructor_pattern: ' + str(pat_constr))
   defn = lookup_union(loc, typ, env)
@@ -975,7 +1025,7 @@ def check_constructor_pattern(loc, pat_constr, params, typ, env, cases_present):
     case _:
       user_error(loc, str(typ) + ' is not a union type')
         
-def check_pattern(pattern: Any, typ: Any, env: Env, cases_present: Any) -> Any:
+def check_pattern(pattern: Any, typ: Any, env: Env, cases_present: dict[Any, Any]) -> Env:
   if get_verbose():
     print('check pattern: ' + str(pattern))
     print('against type: ' + str(typ))
@@ -999,14 +1049,14 @@ def check_pattern(pattern: Any, typ: Any, env: Env, cases_present: Any) -> Any:
       user_error(pattern.location, 'expected a pattern, not\n\t' \
             + str(pattern))
 
-def check_formula(frm: Any, env: Env, recfun: Any = None, subterms: Any = []) -> Any:
+def check_formula(frm: Term, env: Env, recfun: Any = None, subterms: Any = []) -> Term:
   return type_check_term(frm, BoolType(frm.location), env, recfun, subterms)
 
-modules: set = set()
+modules: set[Any] = set()
 
-dirty_files: set = set()
+dirty_files: set[Any] = set()
 
-def is_modified(filename):
+def is_modified(filename: str) -> bool:
     path = Path(filename)
     last_mod = path.stat().st_mtime
     thm_path = path.with_suffix('.thm')
@@ -1034,10 +1084,10 @@ def is_modified(filename):
 #
 # Deduce does not allow forward references between unions, so polarities can be
 # computed in source order.
-def _flip_polarity(pol):
+def _flip_polarity(pol: str) -> str:
   return '-' if pol == '+' else '+'
 
-def _lookup_param_polarities(head, env):
+def _lookup_param_polarities(head: Any, env: Env) -> Any:
   """If `head` resolves to a Union, return its inferred per-parameter polarities
   (or None if not yet inferred)."""
   if not isinstance(head, VarRef):
@@ -1050,7 +1100,7 @@ def _lookup_param_polarities(head, env):
     return getattr(head_def, 'param_polarities', None)
   return None
 
-def check_strict_positivity(ty, union_name, env, forbidden=False):
+def check_strict_positivity(ty: Any, union_name: Any, env: Env, forbidden: bool = False) -> None:
   if isinstance(ty, VarRef):
     ref_name = ty.get_name()
     if forbidden and ref_name == union_name:
@@ -1086,7 +1136,7 @@ def check_strict_positivity(ty, union_name, env, forbidden=False):
 # fixpoint iteration so self-references read the in-progress polarities. This
 # converges in at most |type_params| iterations because polarity is monotone
 # (only goes '+' -> '-').
-def infer_param_polarities(union_decl, env):
+def infer_param_polarities(union_decl: Any, env: Env) -> None:
   if not union_decl.type_params:
     union_decl.param_polarities = []
     return
@@ -1096,7 +1146,7 @@ def infer_param_polarities(union_decl, env):
 
   type_param_names = set(union_decl.type_params)
 
-  def walk(ty, current):
+  def walk(ty: Any, current: str) -> None:
     if isinstance(ty, VarRef):
       ref_name = ty.get_name()
       if ref_name in type_param_names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ module = [
     "checker_common",
     "checker_induction",
     "checker_proofs",
+    "checker_types",
     "compiler.closure",
     "compiler.compile_prelude",
     "compiler.emit_c",


### PR DESCRIPTION
## Summary

- Removes the ``# mypy: ignore-errors`` directive from ``checker_types.py`` (~1135 LOC, the second-largest remaining target) and adds it to the unified ``[[tool.mypy.overrides]]`` strict block in ``pyproject.toml``.
- Replaces the invisible re-exports from the ``from checker_common import *`` wildcard with explicit ``abstract_syntax`` / ``error`` / ``flags`` / ``lark.tree`` imports for every symbol the file actually uses. The wildcard line stays for runtime compatibility (ruff ignores F401/F403/F405 on ``checker_*.py``).
- Annotates every function parameter and return type. ``Any`` is used freely for AST nodes whose precise type is not obvious, matching the brevity of PR #614.
- Re-exports the cross-checker helper ``_instantiate_view_type`` (which lives in ``checker_pipeline``, still on ``# mypy: ignore-errors``) under an ``Any``-typed module attribute so call sites don't trip ``disallow_untyped_calls``.
- Drops two small bits of dead code that the unreachable check surfaced: the ``all_types = None`` single-iteration legacy in the ``All`` arm of ``type_synth_term``, and the unreachable assignment after ``internal_error`` in its catch-all case.

Refs #506

## Test plan

- [x] ``python3.13 -m mypy .`` succeeds
- [x] ``python3.13 -m ruff check .`` succeeds
- [x] ``python3.13 -m pytest test/unit/ -x`` -- 539 tests pass
- [x] ``python3.13 test-deduce.py`` -- lib + should-validate × 2 parsers + should-error + parser equivalence + pretty-print round trip all pass (~129s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)