### PR TITLE
Add file charters to abstract_syntax/ modules

### DIFF
--- a/abstract_syntax/__init__.py
+++ b/abstract_syntax/__init__.py
@@ -1,9 +1,28 @@
-from __future__ import annotations
+"""Compatibility facade for the split ``abstract_syntax`` package.
 
-# Compatibility facade for the split abstract_syntax package.  Existing
-# callers can keep using `import abstract_syntax as ast` or
-# `from abstract_syntax import Var, Env, uniquify_deduce` while the
-# implementation lives in cohesive submodules.
+Scope: re-export every public name from the cohesive submodules so that
+callers can keep writing ``import abstract_syntax as ast`` or
+``from abstract_syntax import Var, Env, uniquify_deduce`` even though the
+implementation is spread across ``core``, ``terms``, ``proofs``,
+``declarations``, ``env``, ``literals``, ``rewrite``, ``ops``, and
+``theorems``.
+
+Also seeds each submodule's ``globals()`` with the union of public names,
+matching the lookup behaviour of the previous single-file module so that
+methods migrated unchanged can still resolve peer classes/helpers as
+module globals.
+
+Goes here:
+  * additions to ``_MODULE_NAMES`` when a new submodule joins the package
+  * additions to ``_DYNAMIC_NAMES`` / ``_DYNAMIC_OWNERS`` for new
+    module-level mutable globals whose canonical home is one submodule
+
+Does NOT go here:
+  * any AST node, helper, or pass — pick the submodule whose charter
+    matches and add it there
+"""
+
+from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType

--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -1,3 +1,22 @@
+"""AST foundation for the abstract_syntax package.
+
+Scope: the abstract base classes that every concrete AST node inherits from
+(``AST``, ``Type``, ``Term``, ``Formula``, ``Proof``, ``Statement``), the
+shared dataclass plumbing they rely on (generic ``copy``/``_ast_map``), and
+the uniquify-time bookkeeping (``UniquifyContext``, ``generate_name``,
+``name2str``, ``current_module``) that downstream modules consume.
+
+Goes here:
+  * a new top-level AST supertype (a new sibling of ``Term``/``Proof``/...)
+  * dataclass machinery or naming helpers that every node uses
+  * the ``UniquifyContext`` and module-name globals
+
+Does NOT go here:
+  * concrete node dataclasses — those live in ``terms``, ``proofs``,
+    ``declarations``, or ``env`` depending on category
+  * passes over whole AST trees (those live in ``ops``)
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields as dc_fields

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1,3 +1,31 @@
+"""Concrete top-level ``Statement`` nodes — the declarations of a module.
+
+Scope: every dataclass node that can appear at the top level of a ``.pf``
+file, together with the bookkeeping that supports them across imports.
+This covers the ``Declaration`` family (``Theorem``, ``Postulate``,
+``Predicate``, ``Union``, ``RecFun``, ``GenRecFun``, ``ViewRecFun``,
+``ViewDecl``, ``Define``, ``Import``) and the non-``Declaration``
+statements (``Auto``, ``Inductive``, ``Module``, ``Export``,
+``Associative``, ``Trace``, ``Assert``, ``Print``). Their AST helpers
+(``Constructor``, ``Rule``, ``FunCase``) also live here because they only
+make sense as parts of these declarations.
+
+Module-level state for cross-module bookkeeping lives here too:
+``uniquified_modules`` (the registry of already-checked modules consulted
+by ``Import``), ``find_private_lemma_definers``, ``find_file`` (the
+import-path resolver), ``get_predicate_decl``, and helpers like
+``extend``/``overwrite`` for inserting into name environments.
+
+Goes here:
+  * a new top-level statement form
+  * helpers/registries scoped to one declaration kind, or to whole-module
+    import bookkeeping
+
+Does NOT go here:
+  * the immutable proof-checker ``Env`` and ``Binding`` types (``env``)
+  * proof-checking logic — that lives in ``proof_checker`` / ``checker_*``
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/abstract_syntax/env.py
+++ b/abstract_syntax/env.py
@@ -1,3 +1,22 @@
+"""The proof-checker environment ``Env`` and its ``Binding`` nodes.
+
+Scope: the immutable, functionally-updated name environment that the type
+checker and proof checker thread through their recursive walks, plus the
+``Binding`` variants it stores: ``TypeBinding``, ``TermBinding``,
+``ProofBinding``, ``AutoEquationBinding``, ``ViewBinding``,
+``AssociativeBinding``. Also includes small environment-shape helpers
+such as ``type_params_str``.
+
+Goes here:
+  * a new kind of static binding the checker needs to track
+  * methods on ``Env`` for adding/looking up bindings
+
+Does NOT go here:
+  * the runtime *value* environment used by the interpreter (lives in
+    ``proof_checker`` / interpreter code)
+  * concrete AST nodes for declarations (``declarations``)
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -1,3 +1,32 @@
+"""Recognizers, builders, and conversions for built-in literal shapes.
+
+Scope: the helpers that bridge between Python-level values and the
+constructor stacks the language uses for its literals. Covers:
+  * ``Nat`` (``zero``/``suc``): ``mkZero``, ``mkSuc``, ``intToNat``,
+    ``isNat``/``isLitNat``, ``natToInt``, ``getZero``/``getSuc``.
+  * ``UInt`` (``bzero``/``inc_dub``/``dub_inc``): ``mkBZero``,
+    ``mkIncDub``, ``mkDubInc``, ``intToUInt``, ``isUInt``/``isLitUInt``,
+    ``uintToInt``, ``uint_inc``.
+  * ``Int`` (``pos``/``neg`` over ``UInt``): ``mkPos``/``mkNeg``,
+    ``mkIntLit``, ``isDeduceInt``, ``deduceIntToInt``.
+  * Lists (``empty``/``node``): ``mkEmpty``/``mkNode``,
+    ``listToNodeList``, ``isNodeList``, ``nodeListToList``,
+    ``nodeListToString``.
+  * Empty set, equation shape (``mkEqual``, ``split_equation``,
+    ``is_equation``, ``equation_vars``), and small constructor-name
+    predicates (``is_constructor``, ``constr_name``,
+    ``constructor_conflict``).
+
+Goes here:
+  * a new literal form whose surface syntax desugars to a constructor
+    stack (e.g. a new numeric encoding, a new collection literal)
+  * an equality/literal-shape recognizer used by checker passes
+
+Does NOT go here:
+  * generic term/formula AST nodes (``terms``)
+  * rewriting/marking machinery (``rewrite``)
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/abstract_syntax/ops.py
+++ b/abstract_syntax/ops.py
@@ -1,3 +1,27 @@
+"""Cross-cutting whole-AST operations and dispatcher helpers.
+
+Scope: passes and predicates that traverse arbitrary AST shapes —
+operations that have to know about every node category and therefore
+sit at the top of the import order. Includes the driver
+``uniquify_deduce``, the invariant audits ``check_post_uniquify_invariants``
+and ``check_post_typecheck_invariants``, ``alpha_equiv`` (with its
+private ``_alpha_equiv_*`` helpers), ``explicit_term_inst``, ``type_match``,
+``flatten_assoc``/``flatten_assoc_list``, ``make_switch_for``, and the
+small symbol/name helpers that bridge categories
+(``callable_name``, ``named_callable_name``, ``is_associative``,
+``type_names``).
+
+Goes here:
+  * a new AST-wide pass / consistency check
+  * a helper that has to dispatch on more than one node category
+    (Term + Proof + Statement, etc.)
+
+Does NOT go here:
+  * the proof-checker proper — that lives in ``proof_checker`` /
+    ``checker_*`` and consumes these helpers
+  * single-category helpers; put those next to their node definitions
+"""
+
 from __future__ import annotations
 
 from .core import *

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -1,3 +1,28 @@
+"""Concrete ``Proof`` AST nodes — every syntactic form usable in a proof.
+
+Scope: dataclass nodes for every tactic and proof-term constructor parsed
+out of a ``proof: ... end`` block. Examples: ``PVar``, ``PLet``, ``PRecall``,
+``ModusPonens``, ``ImpIntro``, ``AllIntro``/``AllElim``, ``SomeIntro``/
+``SomeElim``, ``PTuple``/``PAndElim``, ``Induction``/``RuleInduction``/
+``RuleInversion``, ``SwitchProof``, ``EvaluateGoal``/``EvaluateFact``,
+``SimplifyGoal``/``SimplifyFact``, ``ApplyDefsGoal``/``ApplyDefsFact``,
+``RewriteGoal``/``RewriteFact``, ``PReflexive``/``PSymmetric``/
+``PTransitive``, ``PInjective``/``PExtensionality``, ``PHole``/``PSorry``/
+``PHelpUse``, ``Suffices``, ``Cases``.
+
+Also houses the small AST helpers that exist only to support proof
+structure: ``IndCase``, ``RuleInductionCase``, ``SwitchProofCase``, and
+``extract_tuple``.
+
+Goes here:
+  * a new proof / tactic syntactic form (a new ``Proof`` subclass)
+  * an auxiliary AST node that appears only inside a proof
+
+Does NOT go here:
+  * proof-checking logic — that lives in ``proof_checker`` / ``checker_*``
+  * term/formula nodes (``terms``) or declarations (``declarations``)
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/abstract_syntax/rewrite.py
+++ b/abstract_syntax/rewrite.py
@@ -1,3 +1,26 @@
+"""``Mark``-driven rewriting machinery used by ``replace``/``rewrite``.
+
+Scope: the primitives that locate ``Mark`` nodes inside a formula, swap
+them out for a replacement, and drive the formula-matching used by
+``rewrite`` proofs. Includes ``count_marks``/``find_mark``/``MarkException``,
+the overloaded ``replace_mark`` family, ``remove_mark``, the equation
+``rewrite_aux``/``try_rewrite``/``formula_match`` engine, conjunction and
+disjunction flatteners (``extract_and``/``extract_or``), ``auto_rewrites``,
+and the small module-level state (``default_mark_LHS`` toggle,
+``num_rewrites`` counter, ``call_arity``/``call_head_name`` helpers used
+to drive the matcher).
+
+Goes here:
+  * a new rewriting heuristic or matching primitive
+  * any helper that operates over the ``Mark`` placeholder, the auto-rewrite
+    cache, or the rewrite counter
+
+Does NOT go here:
+  * the ``Mark`` AST node itself (``terms``)
+  * the proof rules that invoke rewriting (``proofs``); their checker
+    logic lives in ``proof_checker`` / ``checker_*``
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1,3 +1,32 @@
+"""Concrete ``Term``, ``Formula``, ``Type``, and ``Pattern`` AST nodes.
+
+Scope: every dataclass node whose category is a value-level expression, a
+type expression, a formula (logical connective/quantifier), or a pattern.
+This includes the variable family (``Var``, ``OverloadedVar``,
+``ResolvedVar``), ``Lambda``, ``Call``, ``Switch``/``SwitchCase``,
+``TermInst``, ``MakeArray``/``ArrayGet``, ``TLet``, ``Mark``, ``Hole``,
+``Omitted``; the ``Type`` nodes (``BoolType``, ``TypeType``,
+``FunctionType``, ``ArrayType``, ``TypeInst``, ``GenericUnknownInst``,
+...); the patterns (``PatternBool``, ``PatternCons``, ``PatternTerm``);
+and the formula nodes (``Bool``, ``And``, ``Or``, ``IfThen``, ``All``,
+``Some``).
+
+Also houses the module-level mutable reduction flags
+(``reduce_only``/``reduce_all``/``dont_reduce_opaque``/``eval_all``/
+``reduced_defs``) and small helpers tied to term shape (``is_match``,
+operator-name predicates).
+
+Goes here:
+  * a new concrete ``Term``/``Formula``/``Type``/``Pattern`` dataclass
+  * helpers whose signature is purely over term-level shapes
+
+Does NOT go here:
+  * proof nodes (``proofs``), top-level statements (``declarations``)
+  * literal recognizers/builders for ``zero``/``suc``/``bzero``/lists
+    (``literals``)
+  * whole-AST passes (``ops``) or rewrite-mark machinery (``rewrite``)
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/abstract_syntax/theorems.py
+++ b/abstract_syntax/theorems.py
@@ -1,3 +1,22 @@
+"""``.thm`` artifact generation for checked modules.
+
+Scope: walking a checked module's statement list and emitting the public
+theorem signatures into a sibling ``.thm`` file. Owns ``collect_public``
+(the visibility walk that follows public re-exported imports through the
+``collected_imports`` set) and ``print_theorems`` (the driver that writes
+the artifact alongside the source).
+
+Goes here:
+  * any logic for deciding what shows up in a generated ``.thm`` file
+  * the format / header / sort order of the generated file
+
+Does NOT go here:
+  * the per-statement ``print_theorems_statement`` methods themselves —
+    those live on each ``Declaration`` subclass in ``declarations``
+  * the consumer side (``.thm`` files are read by ``Import`` resolution
+    in ``declarations``)
+"""
+
 from __future__ import annotations
 
 from .core import *


### PR DESCRIPTION
## Summary
- Adds a module-level docstring to every file under `abstract_syntax/` that states (a) the file's scope (what kinds of nodes/helpers/passes live there) and (b) what should NOT live there.
- Goal: give future contributors a fast answer to "where should I put this new node / helper / pass?" without having to skim every file in the package.
- Pure documentation change — no behavioural edits.

Charters added to:
- `__init__.py` — the compatibility facade
- `core.py` — AST base classes + dataclass/uniquify plumbing
- `terms.py` — concrete `Term`/`Formula`/`Type`/`Pattern` nodes
- `proofs.py` — concrete `Proof` nodes
- `declarations.py` — top-level `Statement` nodes + cross-module bookkeeping
- `env.py` — proof-checker `Env` and `Binding` types
- `literals.py` — recognizers/builders for nat/uint/int/list/equation literals
- `rewrite.py` — `Mark`-driven rewriting machinery
- `ops.py` — cross-cutting whole-AST passes (uniquify, alpha-equiv, type-match, invariants)
- `theorems.py` — `.thm` artifact generation

Closes #608

## Test plan
- [x] `make static` (ruff + mypy)
- [x] Sample stdlib file (`lib/Nat.pf`) still validates
- [ ] `python test-deduce.py` (running)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)