### PR TITLE
Hide Binary internals from UInt.thm

### DIFF
--- a/lib/UIntAdd.pf
+++ b/lib/UIntAdd.pf
@@ -159,7 +159,7 @@ end
 
 auto uint_add_bzero
 
-theorem uint_bzero_less_one_add: all n:UInt.
+lemma uint_bzero_less_one_add: all n:UInt.
   bzero < inc_dub(bzero) + n
 proof
   arbitrary n:UInt
@@ -191,7 +191,7 @@ proof
   fwd, bkwd
 end
 
-theorem uint_add_to_bzero: all n:UInt, m:UInt.
+lemma uint_add_to_bzero: all n:UInt, m:UInt.
   if n + m = bzero
   then n = bzero and m = bzero
 proof
@@ -223,7 +223,7 @@ proof
   uint_less_equal_add
 end
 
-theorem uint_less_add_pos: all x:UInt, y:UInt.
+lemma uint_less_add_pos: all x:UInt, y:UInt.
   if bzero < y
   then x < x + y
 proof

--- a/lib/UIntDefs.pf
+++ b/lib/UIntDefs.pf
@@ -98,7 +98,7 @@ private fun pred(x:Binary) {
   }
 }
 
-fun uint_view(x:Binary) {
+private fun uint_view(x:Binary) {
   if x = bzero then UIntZero else UIntSucc(pred(x))
 }
 
@@ -176,7 +176,7 @@ private recursive cnt_dubs(Binary) -> Binary {
   cnt_dubs(inc_dub(x)) = inc(cnt_dubs(x))
 }
 
-fun log(b : UInt) {
+opaque fun log(b : UInt) {
   cnt_dubs(pred(b))
 }
 

--- a/lib/UIntLess.pf
+++ b/lib/UIntLess.pf
@@ -422,7 +422,7 @@ proof
   }
 end
 
-theorem uint_bzero_le: all x:UInt.
+lemma uint_bzero_le: all x:UInt.
   bzero ≤ x
 proof
   arbitrary x:UInt

--- a/lib/UIntMonus.pf
+++ b/lib/UIntMonus.pf
@@ -162,13 +162,13 @@ proof
   }
 end
 
-theorem uint_bzero_monus: all x:UInt. bzero ∸ x = bzero
+lemma uint_bzero_monus: all x:UInt. bzero ∸ x = bzero
 proof
   arbitrary x:UInt
   expand operator∸.
 end
 
-theorem uint_monus_bzero: all n:UInt. n ∸ bzero = n
+lemma uint_monus_bzero: all n:UInt. n ∸ bzero = n
 proof
   arbitrary n:UInt
   have X: toNat(n ∸ bzero) = toNat(n) by {
@@ -179,7 +179,7 @@ proof
   conclude n ∸ bzero = n by apply uint_toNat_injective to X
 end
 
-theorem uint_monus_cancel_bzero: all n:UInt. n ∸ n = bzero
+lemma uint_monus_cancel_bzero: all n:UInt. n ∸ n = bzero
 proof
   arbitrary n:UInt
   have X: toNat(n ∸ n) = toNat(bzero) by {
@@ -336,7 +336,7 @@ end
 
 auto uint_monus_cancel
 
-theorem uint_pred_monus: all n:UInt. pred(n) = n ∸ 1
+lemma uint_pred_monus: all n:UInt. pred(n) = n ∸ 1
 proof
   arbitrary n:UInt
   suffices toNat(pred(n)) = toNat(n ∸ 1) by uint_toNat_injective

--- a/lib/UIntSum.pf
+++ b/lib/UIntSum.pf
@@ -34,7 +34,7 @@ proof
   uint_toNat_fromNat
 end
 
-theorem uint_summation_bzero:
+lemma uint_summation_bzero:
   all begin:UInt, f:fn UInt->UInt.
   uint_summation(bzero, begin, f) = bzero
 proof


### PR DESCRIPTION
## Summary

Private union `Binary` is the underlying representation for `UInt`, but several
public theorems referenced its private constructors (`bzero`, `inc_dub`) or
private functions (`pred`) in their statements, leaking those names into the
generated `UInt.thm` files. Two public function definitions (`uint_view`, `log`)
also exposed `Binary` internals via their bodies.

- Demote 9 theorems whose statements lexically reference `bzero`/`inc_dub`/`pred`
  to `lemma` (private theorem):
  `uint_bzero_less_one_add`, `uint_add_to_bzero`, `uint_less_add_pos`,
  `uint_bzero_monus`, `uint_monus_bzero`, `uint_monus_cancel_bzero`,
  `uint_pred_monus`, `uint_bzero_le`, `uint_summation_bzero`. They remain
  accessible to other `UInt` module files (e.g. `UIntDiv`, `UIntPowLog`) but no
  longer appear in the public `.thm` summaries.
- Mark `uint_view` private (matches its sibling `uint_unview`).
- Mark `log` opaque so its body `cnt_dubs(pred(b))` is hidden in `.thm`.

After this change, `lib/UInt.thm` no longer contains `bzero`, `inc_dub`,
`dub_inc`, `pred`, or `cnt_dubs` anywhere except in two residual `auto
uint_add_bzero` / `auto uint_bzero_add` lines. Those autos register private
lemmas with the rewrite engine; the registrations are inert outside `module
UInt` (the lemmas themselves aren't accessible), but the `auto` statement is
still printed in `.thm`. Suppressing that would require teaching
`theorems.collect_public` to filter `Auto` by visibility of its target, which is
a Python change and out of scope for this issue.

Addresses #619.

## Test plan

- [x] `make tests-lib` — all lib `.pf` files validate
- [x] `python test-deduce.py` — full suite (lib + should-validate + should-error + prelude + parser equivalence)
- [x] `make static` — ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)