### PR TITLE
Suggest `simplify with` when `replace` gets a non-equation hypothesis

### DIFF
--- a/checker_logic.py
+++ b/checker_logic.py
@@ -599,9 +599,18 @@ def apply_rewrites(loc: Meta, formula: Any, eqns: Any, env: Env, *, display_form
     if is_true(eq):
         user_error(loc, 'no need for replace because this equation is handled automatically\n\t' + str(eq))
     if not is_equation(eq):
-        user_error(loc, 'in replace, expected an equation, not:\n\t' + str(eq)
-                   + '\n\twhile replacing '
-                   + ', '.join([str(eq) for eq in eqns]))
+        msg = 'in replace, expected an equation, not:\n\t' + str(eq) \
+              + '\n\twhile replacing ' \
+              + ', '.join([str(e) for e in eqns])
+        match eq:
+            case IfThen(_, _, p, Bool(_, _, False)):
+                msg += '\n\n`replace` only rewrites with equations of the form `a = b`.' \
+                       '\nSince this hypothesis is `not P`, try `simplify with` instead,' \
+                       '\nwhich substitutes\n\t' + str(p) + '\nwith `false` in the goal.'
+            case _:
+                msg += '\n\n`replace` only rewrites with equations of the form `a = b`.' \
+                       '\nFor other boolean hypotheses, use `simplify with` instead.'
+        user_error(loc, msg)
     reset_num_rewrites()
     new_formula = rewrite_aux(loc, new_formula, eq, env)
     if get_num_rewrites() == 0:

--- a/test/should-error/replace_not_p_advice.pf
+++ b/test/should-error/replace_not_p_advice.pf
@@ -1,0 +1,8 @@
+import Nat
+
+theorem T: all x:Nat, y:Nat. if not (x = y) then (if x = y then false else true)
+proof
+  arbitrary x:Nat, y:Nat
+  assume neq: not (x = y)
+  replace neq
+end

--- a/test/should-error/replace_not_p_advice.pf.err
+++ b/test/should-error/replace_not_p_advice.pf.err
@@ -1,0 +1,9 @@
+./test/should-error/replace_not_p_advice.pf:7.3-7.14: in replace, expected an equation, not:
+	not (x = y)
+	while replacing not (x = y)
+
+`replace` only rewrites with equations of the form `a = b`.
+Since this hypothesis is `not P`, try `simplify with` instead,
+which substitutes
+	x = y
+with `false` in the goal.


### PR DESCRIPTION
## Summary

Addresses #611. When `replace H` is given a non-equation hypothesis, the current error says *what's wrong* but not *what to do instead*. This appends an actionable suggestion to use `simplify with` — phrased specially for the common `not P` shape, and generically otherwise.

Before:
```
in replace, expected an equation, not:
	not (y = x)
	while replacing not (y = x)
```

After:
```
in replace, expected an equation, not:
	not (y = x)
	while replacing not (y = x)

`replace` only rewrites with equations of the form `a = b`.
Since this hypothesis is `not P`, try `simplify with` instead,
which substitutes
	y = x
with `false` in the goal.
```

The change is localized to the existing error site in `apply_rewrites` ([checker_logic.py:601-604](checker_logic.py)). New fixture at `test/should-error/replace_not_p_advice.pf` pins the new message.

## Test plan
- [x] `make static` (ruff + mypy)
- [x] `python test-deduce.py` (lib, should-validate × 2 parsers, should-error, parser equivalence — all pass)
- [x] Manually reproduced the issue's example and confirmed the new advice appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)