### PR TITLE
Replace boolean-switch assume-mismatch trace with construct-aware advice

### DIFF
--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -1541,10 +1541,13 @@ def _check_proof_of_switch(proof: Any, formula: Any, env: Env) -> None:
         assumptions = [(label, check_formula(asm, body_env) if asm else None) for (label,asm) in scase.assumptions]
         if len(assumptions) == 1:
           if assumptions[0][1] != None and assumptions[0][1] != predicate:
-            (small_case_asm, small_eqn) = isolate_difference(assumptions[0][1], predicate)
+            subject_str = str(new_subject)
             msg = 'expected assumption\n' + str(predicate) \
-                + '\nnot\n' + str(assumptions[0][1]) \
-                + '\nbecause\n\t' + str(small_case_asm) + ' ≠ ' + str(small_eqn)
+                + '\nbut got\n' + str(assumptions[0][1]) \
+                + '\n\nIn a `switch <expr>` where `<expr>` is a boolean,' \
+                + ' `case true` introduces\nan assumption of formula `<expr>`' \
+                + ' directly (here: `' + subject_str + '`), not' \
+                + ' `<expr> = true`.\n`case false` introduces `not <expr>`.'
             add_diagnostic(scase.location, msg
                   + givens_str(env))
           body_env = body_env.declare_local_proof_var(loc, assumptions[0][0], predicate)

--- a/test/should-error/givens_switch_bool_wrong_assume_false.pf
+++ b/test/should-error/givens_switch_bool_wrong_assume_false.pf
@@ -1,0 +1,8 @@
+theorem T: all b:bool. b = b
+proof
+  arbitrary b:bool
+  switch b {
+    case true { . }
+    case false assume h: b = false { . }
+  }
+end

--- a/test/should-error/givens_switch_bool_wrong_assume_false.pf.err
+++ b/test/should-error/givens_switch_bool_wrong_assume_false.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/givens_switch_bool_wrong_assume_false.pf:6.5-6.41: expected assumption
+not b
+but got
+b = false
+
+In a `switch <expr>` where `<expr>` is a boolean, `case true` introduces
+an assumption of formula `<expr>` directly (here: `b`), not `<expr> = true`.
+`case false` introduces `not <expr>`.

--- a/test/should-error/givens_switch_bool_wrong_assume_true.pf
+++ b/test/should-error/givens_switch_bool_wrong_assume_true.pf
@@ -1,0 +1,8 @@
+theorem T: all b:bool. b = b
+proof
+  arbitrary b:bool
+  switch b {
+    case true assume h: b = true { . }
+    case false { . }
+  }
+end

--- a/test/should-error/givens_switch_bool_wrong_assume_true.pf.err
+++ b/test/should-error/givens_switch_bool_wrong_assume_true.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/givens_switch_bool_wrong_assume_true.pf:5.5-5.39: expected assumption
+b
+but got
+b = true
+
+In a `switch <expr>` where `<expr>` is a boolean, `case true` introduces
+an assumption of formula `<expr>` directly (here: `b`), not `<expr> = true`.
+`case false` introduces `not <expr>`.


### PR DESCRIPTION
## Summary
- Special-case the diagnostic in `_check_proof_of_switch` so a wrong `assume h: ...` on a `case true` / `case false` arm prints construct-aware advice instead of the cryptic `because X ≠ Y` unification trace.
- Add two should-error fixtures: one for `case true assume h: b = true`, one for `case false assume h: b = false`.

## Before / after

Repro from the issue:

```deduce
switch y = x {
  case true assume h: (y = x) = true { . }
  case false assume h: not (y = x) { . }
}
```

**Before:**
```
expected assumption
y = x
not
(y = x) = true
because
	y = x ≠ y
```

**After:**
```
expected assumption
y = x
but got
(y = x) = true

In a `switch <expr>` where `<expr>` is a boolean, `case true` introduces
an assumption of formula `<expr>` directly (here: `y = x`), not `<expr> = true`.
`case false` introduces `not <expr>`.
```

Addresses #610.

## Test plan
- [x] `python3.13 test-deduce.py --errors` (recursive-descent should-error suite, includes both new fixtures)
- [ ] Full `python test-deduce.py` (lib + should-validate + should-error + prelude + parser equivalence) under both parsers via CI