### PR TITLE
Narrow Any in checker_cache.py to Statement + concrete cache key

### DIFF
--- a/checker_cache.py
+++ b/checker_cache.py
@@ -17,6 +17,7 @@ from abstract_syntax import (
     Import,
     Predicate,
     PVar,
+    Statement,
     Union,
     VarRef,
     ViewDecl,
@@ -44,7 +45,12 @@ from checker_common import *
 # prelude key changes (different prelude => different baseline =>
 # cache invalid).
 
-_stmt_cache: dict[Any, Any] = {}
+# Key shape is ``("check_proofs", stmt_hash, deps_fingerprint, target,
+# module_name)``; ``target`` is the LSP target hole location (``None`` outside
+# the LSP). The value is always ``True`` -- a sentinel marking "verified
+# under this dependency set"; absent keys mean "must re-check".
+_StmtCacheKey = tuple[str, int, int, tuple[int, int] | None, str]
+_stmt_cache: dict[_StmtCacheKey, bool] = {}
 
 # Hits and misses bucketed by loop, for the test instrumentation
 # the plan requires ("untouched statements were cache hits").
@@ -169,7 +175,7 @@ def _collect_referenced_names(
     return out
 
 
-def _collect_defined_names(stmt: Any) -> set[str]:
+def _collect_defined_names(stmt: Statement) -> set[str]:
     """Return the uniquified names a top-level statement introduces.
 
     Includes the statement's own name plus any auxiliary names it
@@ -200,7 +206,7 @@ def _collect_defined_names(stmt: Any) -> set[str]:
     return names
 
 
-def _is_global_barrier(stmt: Any) -> bool:
+def _is_global_barrier(stmt: Statement) -> bool:
     """Statements with global side-effects on later checking.
 
     ``Import`` brings a module's exports into the environment;


### PR DESCRIPTION
## Summary

Small slice of the "Reduce `Any` usage in `checker_*.py`" follow-up tracked in #506.

- `_collect_defined_names(stmt: Any)` → `_collect_defined_names(stmt: Statement)`. Every caller in `checker_pipeline.py` passes a `Statement` from the `ast3: list[Statement]` walk, and the body only consults `.name`, `.alternatives`, `.rules`, etc., all of which live on `Statement` subclasses.
- `_is_global_barrier(stmt: Any)` → `_is_global_barrier(stmt: Statement)`. Same call-site discipline; body is a single `isinstance(stmt, (Import, Auto))`.
- `_stmt_cache: dict[Any, Any]` → `dict[tuple[str, int, int, tuple[int, int] | None, str], bool]` with a named alias `_StmtCacheKey`. The shape matches the only insertion point in `checker_pipeline.py:1429`:
  ```python
  key = ("check_proofs", sh, deps_fingerprint, target, module_name)
  ```
  where `target = get_target_hole_location()` is typed `Optional[tuple[int, int]]` in `flags.py`, and the stored value is always `True` (a presence sentinel). The new alias is documented with a one-paragraph comment explaining why the value is a bool.

The three remaining `Any` mentions in the file are on `_hash_ast(node: Any)` and `_collect_referenced_names(node: Any, ...)`, which genuinely walk arbitrary AST-or-primitive values (str/int/bool/float/list/tuple/dict/dataclass) and would gain nothing useful from a tighter type.

`Any` count in the file drops from 6 → 3.

Refs #506.

## Test plan
- [x] `mypy --strict checker_cache.py --follow-imports=silent` clean
- [x] `make static` (full project mypy + ruff) clean — no regressions
- [x] `python3.13 test-deduce.py` clean (lib, should-validate, should-error, equiv, round trip)
- [x] `pytest test/lsp/test_check_proofs_cache.py` 11/11 pass
- [x] `pytest test/unit/test_ast_walker_completeness.py` 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)