### PR TITLE
Narrow Any in checker_logic.py to Pattern/Formula/Term/set[str]

### DIFF
--- a/checker_logic.py
+++ b/checker_logic.py
@@ -27,6 +27,7 @@ from abstract_syntax import (
     MarkException,
     Or,
     OverloadedVar,
+    Pattern,
     PatternCons,
     ResolvedVar,
     Switch,
@@ -196,7 +197,7 @@ def instantiate(loc: Meta, allfrm: Any, arg: Any) -> Any:
 def str_of_env(env: Any) -> str:
   return '{' + ', '.join([k + ": " + str(e) for (k,e) in env.items()]) + '}'
 
-def pattern_to_term(pat: Any) -> Any:
+def pattern_to_term(pat: Pattern) -> Term:
   match pat:
     case PatternCons(loc, constr, params):
       if len(params) > 0:
@@ -303,23 +304,24 @@ def collect_all_if_then(loc: Meta, frm: Any, env: Env) -> tuple[list[Any], list[
       case _:
         user_error(loc, "in 'apply', expected an if-then formula, not " + str(frm))
 
-def collect_all(frm: Any) -> tuple[list[Any], Any]:
+def collect_all(frm: Formula) -> tuple[list[Term], Formula]:
     match frm:
       case All(loc2, _, var, _, frm):
         (rest_vars, body) = collect_all(frm)
         x, t = var
-        return ([ResolvedVar(loc2, t, x)] + rest_vars, body)
+        prefix: list[Term] = [ResolvedVar(loc2, t, x)]
+        return (prefix + rest_vars, body)
       case _:
         return ([], frm)
 
-def auto_simplified_hint(new_formula: Any) -> str:
+def auto_simplified_hint(new_formula: Formula) -> str:
   if is_true(new_formula):
     return '\nThe goal has been simplified to `true`, possibly by an `auto` rewrite rule.\n' \
            'Finish the proof with `.` (which closes any goal of the form `true`).'
   return ''
 
 
-def _ast_mentions_any(node: Any, target_names: Any) -> bool:
+def _ast_mentions_any(node: Any, target_names: set[str]) -> bool:
   # AST traversal: does `node` reference any name in `target_names`?
   # No general `free_vars` is defined across all Term subclasses, so we
   # walk the dataclass fields directly.


### PR DESCRIPTION
## Summary

Small slice of the "Reduce `Any` usage in `checker_*.py`" follow-up tracked in #506. Continues the pattern from #630 (`checker_cache.py`), this time for `checker_logic.py`.

Four signatures had `Any` for AST nodes whose precise type is already determined by the body and every call site:

- `pattern_to_term(pat: Any) -> Any` → `pattern_to_term(pat: Pattern) -> Term`. The body matches `PatternCons` and returns either a `Call` or the constructor; `PatternCons.constructor: Term` already promises the constructor is a `Term`. Direct callers (`checker_proofs.py:1471, 1581`) pass `indcase.pattern` / `scase.pattern`, both typed `Pattern`. The pipeline call site (`checker_pipeline.py:1060`) routes through the `pattern_to_term: Any = pattern_to_term_raw` cross-checker re-export, so it is unaffected.
- `collect_all(frm: Any) -> tuple[list[Any], Any]` → `collect_all(frm: Formula) -> tuple[list[Term], Formula]`. The matched cases each yield a `Formula` body and a `list[ResolvedVar]` prefix; the prefix gets an explicit `list[Term]` annotation so the `+ rest_vars` concatenation type-checks under invariant `list`. The internal caller in `check_implies` passes the result to `formula_match`, whose `vars: list[Term]` parameter already matched.
- `auto_simplified_hint(new_formula: Any) -> str` → `auto_simplified_hint(new_formula: Formula) -> str`. The body only calls `is_true`, whose `abstract_syntax.terms.is_true` signature is `Formula -> bool`. Both internal call sites in `expand_definitions` / `apply_rewrites` already operate on the new/rewritten formula.
- `_ast_mentions_any(node: Any, target_names: Any) -> bool` → `_ast_mentions_any(node: Any, target_names: set[str]) -> bool`. The walker legitimately keeps `Any` for `node` (it traverses arbitrary dataclass-or-primitive subtrees via `vars(n).values()`), but every call site builds `target_names` as a `set[str]` (`set(d.resolved_names)` or `{d.get_name()}`).

`Any` token count in `checker_logic.py` drops from 44 → 37 (lines with `Any` drop from 18 → 15).

The remaining `Any`-typed parameters in this file are the cross-cutting AST walkers / hint builders (`isolate_difference`, `instantiate`, `expand_definitions`, `apply_rewrites`, `rewrite`, `collect_all_if_then`, `_expand_would_progress`, `expand_residual_hint`, `expand_backward_mark_hint`, `replace_backward_mark_hint`) plus the unused `str_of_env` / `facts_to_str`. Those need a wider pass and would not have been mechanical here.

Refs #506.

## Test plan
- [x] `mypy --strict checker_logic.py --follow-imports=silent` clean
- [x] `python3.13 -m mypy .` clean — no regressions in callers (50 files)
- [x] `python3.13 -m ruff check .` clean
- [x] `python3.13 -m pytest test/unit/` — 539 passed
- [x] `python3.13 test-deduce.py` — full suite green (lib, should-validate × 2 parsers, should-error, equiv, round-trip; 123s wall time)
- [x] CI green: static checks, regression (lib), regression (passable), regression (errors), regression (parser), regression (equiv), regression (site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)