### PR TITLE
Add Makefile check-settings target to validate .claude/settings.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ TEST_ERROR_DIR = ./test/should-error
 TEST_IMPORT_DIR = ./test/test-imports
 EXAMPLES_DIR = ./examples
 
-default: static tests-tokens tests
+default: check-settings static tests-tokens tests
+
+check-settings:
+	$(PYTHON) -c "import json; json.load(open('.claude/settings.json'))"
 
 static:
 	$(PYTHON) -m ruff check .


### PR DESCRIPTION
## Summary
- Adds a `check-settings` Makefile target that runs `json.load` on `.claude/settings.json`.
- Wires it into the `default` chain so `make` (the usual pre-commit run) fails fast if the file is malformed.

Motivation: a broken `.claude/settings.json` (recently seen as commit 76fcb77 "fix settings file") silently disables the project's permission allowlist, causing scheduled tasks / interactive sessions to start prompting on commands that should already be approved. A trivial parse check catches this immediately.

## Test plan
- [x] `make check-settings` passes against the current `.claude/settings.json`.
- [ ] Temporarily break `.claude/settings.json` (e.g. remove a closing `]`) and confirm `make` exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)