### PR TITLE
Mark uint_zero_max and uint_max_zero as auto rules (closes #635)

### DIFF
--- a/lib/UIntLess.pf
+++ b/lib/UIntLess.pf
@@ -653,7 +653,9 @@ proof
     replace (apply uint_less_equal_zero to x_le_0).
   }
 end
-  
+
+auto uint_zero_max
+
 theorem uint_max_symmetric: all x:UInt, y:UInt. max(x,y) = max(y,x)
 proof
   arbitrary x:UInt, y:UInt
@@ -679,6 +681,8 @@ proof
   replace uint_max_symmetric[x]
   uint_zero_max
 end
+
+auto uint_max_zero
 
 theorem uint_max_assoc: all x:UInt, y:UInt,z:UInt. max(max(x, y), z) = max(x, max(y, z))
 proof

--- a/test/should-validate/auto_uint_max_zero.pf
+++ b/test/should-validate/auto_uint_max_zero.pf
@@ -1,0 +1,23 @@
+import UInt
+import UIntLess
+
+theorem uint_max_zero_auto: all x:UInt.
+  max(x, 0) = x
+proof
+  arbitrary x:UInt
+  .
+end
+
+theorem uint_zero_max_auto: all x:UInt.
+  max(0, x) = x
+proof
+  arbitrary x:UInt
+  .
+end
+
+theorem uint_max_zero_chain: all x:UInt, y:UInt.
+  max(max(x, 0), max(0, y)) = max(x, y)
+proof
+  arbitrary x:UInt, y:UInt
+  .
+end


### PR DESCRIPTION
## Summary

- Add `auto uint_zero_max` and `auto uint_max_zero` after their respective theorems in [lib/UIntLess.pf](lib/UIntLess.pf), matching the existing `auto uint_zero_add` / `auto uint_add_zero` pattern in [lib/UIntAdd.pf:512](lib/UIntAdd.pf#L512).
- Add [test/should-validate/auto_uint_max_zero.pf](test/should-validate/auto_uint_max_zero.pf) covering the singleton, chained, and mirrored cases that should close in one step now.

Closes #635.

## Why

The two stdlib identities about `UInt` `max` and `0` exist as theorems but were not registered with `auto`. The corresponding `+ 0` lemmas are. As a result, any "fold a commutative monoid (`UInt`, `max`, `0`) over a list" proof (`maximum([x])`, sliding-window maxima, etc.) required an explicit `replace uint_max_zero[...]` / `replace uint_zero_max[...]` step that the `sum` analog does not. With these two `auto` declarations, the singleton-fold base case closes the same way.

## Risk

The auto-rule "silently changes the goal" pitfall ([TacticsCheatSheet.md § Common pitfalls #1](gh_pages/doc/TacticsCheatSheet.md)) applies, but the corresponding `+ 0` reduction is already auto without complaint, so this is symmetric with existing behavior.

## Test plan

- [x] `python3.13 test-deduce.py --lib` — both parsers pass.
- [x] `python3.13 deduce.py test/should-validate/auto_uint_max_zero.pf` — new test validates.
- [ ] Full `python3.13 test-deduce.py` — running locally and on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)