### PR TITLE
Suggest similarly-named theorems for undefined proof variables

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -65,8 +65,15 @@ class PVar(Proof):
                + " from other modules. To make it accessible here, change"
                + " `lemma` to `theorem` there.")
         user_error(self.location, msg)
+      from edit_distance import edit_distance
+      from math import ceil
+      close = [v for v in env.keys()
+               if edit_distance(self.name, v)
+                  <= ceil(len(self.name) / 5)]
+      hint = '\n\tdid you intend: ' + ', '.join(close) if close else ''
       env_str = ('\n' + ', '.join(env.keys())) if get_verbose() else ''
-      user_error(self.location, "undefined proof variable " + self.name + env_str)
+      user_error(self.location,
+                 "undefined proof variable " + self.name + hint + env_str)
     if not isinstance(env[self.name], list):
       user_error(self.location, "proof variable not bound to list " + self.name)
     return PVar(self.location, env[self.name][0])

--- a/test/should-error/undefined_pvar_did_you_intend.pf
+++ b/test/should-error/undefined_pvar_did_you_intend.pf
@@ -1,0 +1,13 @@
+import NatDefs
+import NatAdd
+
+// A typo on a theorem name should produce a `did you intend: ...` hint
+// listing close edit-distance matches from the proof environment, the
+// same way `no such rule` / `rule induction: no such predicate` already
+// do for their respective error sites.
+
+theorem T: all x:Nat, y:Nat. x + y = y + x
+proof
+  arbitrary x:Nat, y:Nat
+  add_commut[x, y]
+end

--- a/test/should-error/undefined_pvar_did_you_intend.pf.err
+++ b/test/should-error/undefined_pvar_did_you_intend.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/undefined_pvar_did_you_intend.pf:12.3-12.13: undefined proof variable add_commut
+	did you intend: add_commute


### PR DESCRIPTION
## Summary

- When a proof variable doesn't resolve, append a `did you intend: ...` hint listing close edit-distance matches from the proof environment, mirroring the existing pattern for `no such rule` (`abstract_syntax/proofs.py:560-568`) and `rule induction / inversion: no such predicate` (lines 596-605, 633-642).
- Adds `test/should-error/undefined_pvar_did_you_intend.pf` exercising the new hint on a `add_commut` typo (suggests `add_commute`).

Before:
```
tmp/mistake1.pf:4.3-4.14: undefined proof variable max_commute
```
After:
```
tmp/mistake1.pf:4.3-4.14: undefined proof variable max_commute
	did you intend: xor_commute, add_commute, mult_commute
```

Closes #633.

## Test plan
- [x] `python3.13 test-deduce.py --errors` passes (new fixture matches)
- [x] `python3.13 -m ruff check abstract_syntax/proofs.py`
- [x] `python3.13 -m mypy abstract_syntax/proofs.py`
- [ ] CI green on full `test-deduce.py` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)