### PR TITLE
Hide private view-source types behind public view name in printer

### DIFF
--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -41,9 +41,13 @@ from flags import (
     get_unique_names,
     get_verbose,
     init_import_directories as init_import_directories,
+    lookup_view_source_alias,
+    pop_suppress_view_alias,
+    push_suppress_view_alias,
     set_check_imports as set_check_imports,
     set_recursive_descent as set_recursive_descent,
     set_verbose,
+    view_aliasing_suppressed,
 )
 from pathlib import Path
 from edit_distance import edit_distance
@@ -65,8 +69,11 @@ recursion_depth = 0
 def name2str(s: str) -> str:
     if get_unique_names():
         return s
-    else:
-        return base_name(s)
+    if not view_aliasing_suppressed():
+        aliased = lookup_view_source_alias(s)
+        if aliased is not None:
+            return base_name(aliased)
+    return base_name(s)
 
 # current_module is used during uniquify and collect_exports
 current_module = 'none'

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -773,9 +773,18 @@ class ViewDecl(Declaration):
     header = complete_name(self.name) \
       + ('<' + ','.join([name2str(t) for t in self.type_params]) + '>' \
          if len(self.type_params) > 0 else '')
+    # The view's own declaration names its underlying source type
+    # (e.g. `source Binary`); suppress the source→view-name alias so
+    # that line doesn't self-referentially print as `source UInt`.
+    push_suppress_view_alias()
+    try:
+      source_str = str(self.source)
+      target_str = str(self.target)
+    finally:
+      pop_suppress_view_alias()
     ret = 'view ' + header + ' {\n' \
-      + '  source ' + str(self.source) + '\n' \
-      + '  target ' + str(self.target) + '\n' \
+      + '  source ' + source_str + '\n' \
+      + '  target ' + target_str + '\n' \
       + '  into ' + base_name(self.into) + '\n' \
       + '  out ' + base_name(self.out) + '\n' \
       + '  roundtrip ' + base_name(self.roundtrip) + '\n' \

--- a/abstract_syntax/env.py
+++ b/abstract_syntax/env.py
@@ -81,6 +81,13 @@ def type_params_str(type_params: Sequence[str]) -> str:
     return '<' + ','.join(type_params) + '>'
   else:
     return ''
+
+def _view_source_head_name(ty: Type | VarRef) -> Optional[str]:
+  if isinstance(ty, VarRef):
+    return ty.get_name()
+  if isinstance(ty, TypeInst):
+    return _view_source_head_name(ty.typ)
+  return None
   
 @dataclass
 class AssociativeBinding(Binding):
@@ -155,6 +162,10 @@ class Env:
     new_env.dict[view.name] = ViewBinding(loc, view,
                                           module=self.get_current_module(),
                                           visibility=visibility)
+    src_head = _view_source_head_name(view.source)
+    if src_head is not None:
+      from flags import register_view_source_alias
+      register_view_source_alias(src_head, view.name)
     return new_env
   
   def declare_term_var(self, loc: Meta, name: str, typ: Type,

--- a/flags.py
+++ b/flags.py
@@ -164,3 +164,36 @@ def get_debugger() -> Optional[Any]:
 def set_debugger(d: Optional[Any]) -> None:
   global debugger
   debugger = d
+
+# Display-only aliases mapping a view's source-type name to the view's
+# public name. Populated when a `view` declaration is processed
+# (`Env.declare_view`). Consulted by `name2str` so a private source
+# type like `Binary` is shown as `UInt` in printed types and goals.
+
+view_source_aliases: dict[str, str] = {}
+
+def register_view_source_alias(source_name: str, view_name: str) -> None:
+  global view_source_aliases
+  view_source_aliases[source_name] = view_name
+
+def lookup_view_source_alias(name: str) -> Optional[str]:
+  global view_source_aliases
+  return view_source_aliases.get(name)
+
+# Nested counter that suppresses view-source aliasing in `name2str`.
+# Bumped by `ViewDecl.pretty_print` so the view's own declaration
+# still names its underlying source type instead of self-referentially
+# rendering as the view name.
+
+_suppress_view_alias_depth: int = 0
+
+def push_suppress_view_alias() -> None:
+  global _suppress_view_alias_depth
+  _suppress_view_alias_depth += 1
+
+def pop_suppress_view_alias() -> None:
+  global _suppress_view_alias_depth
+  _suppress_view_alias_depth -= 1
+
+def view_aliasing_suppressed() -> bool:
+  return _suppress_view_alias_depth > 0

--- a/test/should-error/advice_expand_more.pf.err
+++ b/test/should-error/advice_expand_more.pf.err
@@ -1,8 +1,8 @@
-./test/should-error/advice_expand_more.pf:15.18-15.19:
+./test/should-error/advice_expand_more.pf:15.18-15.19: 
 You provided a proof of:
 	true
 but that is different from what you need to prove:
-	x + sum_test(@[]<Binary>) = x
+	x + sum_test(@[]<UInt>) = x
 The goal still contains `sum_test`. To unfold it again, chain another expand:
 	expand sum_test | sum_test.
 or equivalently

--- a/test/should-error/arbitrary_type_mismatch.pf.err
+++ b/test/should-error/arbitrary_type_mismatch.pf.err
@@ -1,4 +1,4 @@
 ./test/should-error/arbitrary_type_mismatch.pf:7.3-7.18: arbitrary expects x to have type
-	Binary
+	UInt
 but got type
 	Nat

--- a/test/should-error/expand_backward_mark_hint.pf.err
+++ b/test/should-error/expand_backward_mark_hint.pf.err
@@ -1,4 +1,4 @@
 ./test/should-error/expand_backward_mark_hint.pf:14.44-14.61: could not find a place to expand definition of ++ in:
-	node(x, xs ++ @[]<Binary>)
+	node(x, xs ++ @[]<UInt>)
 The right-hand side contains `++`, but `expand` only unfolds inside the marked subterm. Inside an `equations` block, the left-hand side of each step is implicitly marked. To unfold the right-hand side instead, wrap that side in `#...#`:
-	# node(x, xs) ++ @[]<Binary> #
+	# node(x, xs) ++ @[]<UInt> #

--- a/test/should-error/induction_advice_custom.pf.err
+++ b/test/should-error/induction_advice_custom.pf.err
@@ -1,14 +1,14 @@
 ./test/should-error/induction_advice_custom.pf:6.3-6.4: incomplete proof
 Goal:
-	(all o:Binary. (if o + o = 0 then o = 0))
+	(all o:UInt. (if o + o = 0 then o = 0))
 Advice:
 	Prove this "all" formula with:
-		arbitrary o:Binary
+		arbitrary o:UInt
 	followed by a proof of:
 		(if o + o = 0 then o = 0)
 
 	Alternatively, you can try induction with:
-		induction Binary
+		induction UInt
 		case 0  {
 			?
 		}

--- a/test/should-error/induction_custom_missing_case.pf.err
+++ b/test/should-error/induction_custom_missing_case.pf.err
@@ -1,4 +1,4 @@
-./test/should-error/induction_custom_missing_case.pf:5.3-8.4: expected 2 cases for custom induction on Binary, but have 1
+./test/should-error/induction_custom_missing_case.pf:5.3-8.4: expected 2 cases for custom induction on UInt, but have 1
 Expected cases:
 	case 0  {
 		?

--- a/test/should-error/overload_return_type.pf.err
+++ b/test/should-error/overload_return_type.pf.err
@@ -1,7 +1,7 @@
 ./test/should-error/overload_return_type.pf:7.18-7.23: could not find a match for function call:
 	1 + 2
-argument types: Binary, Binary
+argument types: UInt, UInt
 expected return type: Nat
 overloads:
 	(fn Nat, Nat -> Nat)   <-- result type matches, but argument types don't
-	(fn Binary, Binary -> Binary)   <-- argument types match, but result type Binary doesn't match expected Nat
+	(fn UInt, UInt -> UInt)   <-- argument types match, but result type UInt doesn't match expected Nat

--- a/test/should-error/predicate_arg_type_mismatch.pf.err
+++ b/test/should-error/predicate_arg_type_mismatch.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/predicate_arg_type_mismatch.pf:7.14-7.18: expected term of type Binary but got bool
+./test/should-error/predicate_arg_type_mismatch.pf:7.14-7.18: expected term of type UInt but got bool

--- a/test/should-error/predicate_signature_not_bool.pf.err
+++ b/test/should-error/predicate_signature_not_bool.pf.err
@@ -1,1 +1,1 @@
-./lib/UIntDefs.pf:158.10-158.16: the result type of a predicate must be 'bool', not 'Binary'
+./lib/UIntDefs.pf:158.10-158.16: the result type of a predicate must be 'bool', not 'UInt'

--- a/test/should-error/replace_after_auto_simplify.pf.err
+++ b/test/should-error/replace_after_auto_simplify.pf.err
@@ -4,6 +4,6 @@ could not find any matches for
 in
 	true
 while trying to replace using the below equation, left to right
-	(all x:Binary, y:Binary. toNat(x * y) = toNat(x) * toNat(y))
+	(all x:UInt, y:UInt. toNat(x * y) = toNat(x) * toNat(y))
 The goal has been simplified to `true`, possibly by an `auto` rewrite rule.
 Finish the proof with `.` (which closes any goal of the form `true`).

--- a/test/should-error/term_inst_length_node.pf.err
+++ b/test/should-error/term_inst_length_node.pf.err
@@ -1,6 +1,6 @@
 ./test/should-error/term_inst_length_node.pf:7.3-7.4: incomplete proof
 Goal:
-	1 + length(@[]<Binary>) = 1
+	1 + length(@[]<UInt>) = 1
 Advice:
 	To prove this equality, one of these statements might help:
 		expand

--- a/test/should-error/uint_view_no_binary_leak.pf
+++ b/test/should-error/uint_view_no_binary_leak.pf
@@ -1,0 +1,19 @@
+// Issue #634 regression: when a UInt-typed expression is reduced/expanded,
+// the printed goal must show `UInt` (the public view name), not `Binary`
+// (the private source type). The check below leaves a hole so the goal
+// is printed in the error fixture — a `Binary` substring in the fixture
+// would mean the source-type alias is leaking again.
+import UInt
+import List
+
+recursive maximum(List<UInt>) -> UInt {
+  maximum(empty) = 0
+  maximum(node(x, xs)) = max(x, maximum(xs))
+}
+
+theorem uint_view_no_binary_leak: all x:UInt. maximum([x]) = x
+proof
+  arbitrary x:UInt
+  expand maximum
+  ?
+end

--- a/test/should-error/uint_view_no_binary_leak.pf.err
+++ b/test/should-error/uint_view_no_binary_leak.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/uint_view_no_binary_leak.pf:18.3-18.4: incomplete proof
+Goal:
+	max(x, maximum(@[]<UInt>)) = x
+Advice:
+	To prove this equality, one of these statements might help:
+		expand
+		replace
+		equations


### PR DESCRIPTION
## Summary

Fixes the printer leak from issue #634: after the type checker normalizes a view's surface type (`UInt`) to its private source (`Binary`), the source name leaks back into goal displays, advice text, error messages, and the `.thm` files generated for theorems whose statements name the view. The user sees `@[]<Binary>` and `(all x:Binary, y:Binary, z:Binary. ...)` even though they only ever wrote `UInt`, and `Binary` is unreachable from outside the module.

- Process-global view-source → view-name registry in `flags.py`, populated at `Env.declare_view` time. `name2str` (the routine that drives every type-name display) consults the registry and substitutes the view name when the source matches.
- `ViewDecl.pretty_print` pushes a suppression counter so the view's own declaration (`source Binary`) keeps naming the source, not the view — otherwise the `.thm` would print `source UInt`, which is meaningless.
- One new `should-error` fixture (`uint_view_no_binary_leak.pf`) reproducing the original report: `expand maximum` on a `List<UInt>` whose `empty` case lives at the recursion base. The expected stderr asserts `@[]<UInt>` and would fail if the alias ever regresses.
- Nine existing `should-error` fixtures that lexically contained `Binary` in their messages refresh to `UInt`. All are user-facing leaks of the same kind (quantifier types in advice text, parameter types in type-mismatch errors).

### Before

```
$ python3.13 deduce.py tmp/leak.pf
tmp/leak.pf:10.3-10.4: incomplete proof
Goal:
	max(x, maximum(@[]<Binary>)) = x
```

### After

```
$ python3.13 deduce.py tmp/leak.pf
tmp/leak.pf:10.3-10.4: incomplete proof
Goal:
	max(x, maximum(@[]<UInt>)) = x
```

`lib/UInt.thm` and `lib/UIntLess.thm` (gitignored) regenerate with `Binary` gone from every public theorem (e.g. `uint_max_assoc: (all x:UInt, y:UInt, z:UInt. ...)`); the only remaining `Binary` is the legitimate `source Binary` inside the `view UInt { ... }` declaration itself.

## Test plan

- [x] `make static` — ruff + mypy clean
- [x] `python test-deduce.py` — full sweep (lib + should-validate + should-error + parser equivalence + round-trip)
- [x] `python -m pytest test/` — 1126 unit / LSP tests pass
- [x] `make tests-lib` — every stdlib `.pf` validates

Closes #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)