### PR TITLE
[codex] Rename grammar nonterminals for clarity

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -71,20 +71,20 @@ ARROW: "->"
 ?switch_list: switch_case                           -> single
     | switch_case switch_list                       -> push
 
-ident: IDENT              -> ident
-    | "operator" OPERATOR -> ident
-    | "operator" "++"     -> ident_append
-    | "operator" "/"      -> ident_div
-    | "operator" "|"      -> ident_union
-    | "operator" "&"      -> ident_intersect
-    | "operator" "in"      -> ident_member
-    | "operator" ".+."      -> ident_multiset_sum
-    | "operator" ".-."      -> ident_nat_sub
-    | "operator" ".o."      -> ident_circ
-    | "operator" "(="      -> ident_subset_equal
-    | "operator" "<="      -> ident_less_equal
-    | "operator" ">="      -> ident_greater_equal
-    | "operator" "/="      -> ident_not_equal
+identifier: IDENT              -> identifier
+    | "operator" OPERATOR -> identifier
+    | "operator" "++"     -> identifier_append
+    | "operator" "/"      -> identifier_div
+    | "operator" "|"      -> identifier_union
+    | "operator" "&"      -> identifier_intersect
+    | "operator" "in"      -> identifier_member
+    | "operator" ".+."      -> identifier_multiset_sum
+    | "operator" ".-."      -> identifier_nat_sub
+    | "operator" ".o."      -> identifier_circ
+    | "operator" "(="      -> identifier_subset_equal
+    | "operator" "<="      -> identifier_less_equal
+    | "operator" ">="      -> identifier_greater_equal
+    | "operator" "/="      -> identifier_not_equal
 
 ?term_hi: INT                                      -> int
     | NAT                                          -> nat
@@ -100,13 +100,13 @@ ident: IDENT              -> ident
     | "array" "(" term ")"                         -> make_array
     | term_hi "(" term_list ")"                    -> call
     | term_hi "[" term "]"                         -> array_get
-    | "λ" type_params_opt var_list "{" term "}"    -> lambda
-    | "fun" type_params_opt var_list "{" term "}"  -> lambda
-    | "generic" ident_list "{" term "}"            -> generic
+    | "λ" type_params_opt variable_list "{" term "}"    -> lambda
+    | "fun" type_params_opt variable_list "{" term "}"  -> lambda
+    | "generic" identifier_list "{" term "}"            -> generic
     | "switch" term "{" switch_list "}"            -> switch
-    | "all" type_annot_list "." term               -> all_formula
-    | "<" ident_list ">" term                      -> alltype_formula
-    | "some" type_annot_list "." term              -> some_formula
+    | "all" type_annotation_list "." term               -> all_formula
+    | "<" identifier_list ">" term                      -> alltype_formula
+    | "some" type_annotation_list "." term              -> some_formula
     | "define" IDENT "=" term ";" term             -> define_term
     | "?"                                          -> hole_term
     | "─"                                          -> omitted_term
@@ -122,51 +122,51 @@ ident: IDENT              -> ident
     | term                                         -> single
     | term "," term_list                           -> push
     
-?ident_list:                                       -> empty
-    | ident                                        -> single
-    | ident "," ident_list                         -> push
+?identifier_list:                                       -> empty
+    | identifier                                        -> single
+    | identifier "," identifier_list                         -> push
 
-?ident_list_bar:                                   -> empty
-    | ident                                        -> single
-    | INT "*" ident                                -> repeat
-    | ident "|" ident_list_bar                     -> push
-    | INT "*" ident "|" ident_list_bar             -> push_repeat
+?identifier_list_bar:                                   -> empty
+    | identifier                                        -> single
+    | INT "*" identifier                                -> repeat
+    | identifier "|" identifier_list_bar                     -> push
+    | INT "*" identifier "|" identifier_list_bar             -> push_repeat
 
-?type_annot_list:                                  -> empty_binding
-    | ident ":" type                               -> single_binding
-    | ident ":" type "," type_annot_list           -> push_binding
+?type_annotation_list:                                  -> empty_binding
+    | identifier ":" type                               -> single_binding
+    | identifier ":" type "," type_annotation_list           -> push_binding
 
-?var_list:                                         -> empty_binding
-    | ident ":" type                               -> single_binding
-    | ident ":" type "," var_list                  -> push_binding
-    | ident "," var_list                           -> push_var
-    | ident                                        -> single_var
+?variable_list:                                         -> empty_binding
+    | identifier ":" type                               -> single_binding
+    | identifier ":" type "," variable_list                  -> push_binding
+    | identifier "," variable_list                           -> push_var
+    | identifier                                        -> single_var
 
 ?assumption_list:                                  -> empty_binding
-    | ident ":" term                               -> single_binding
+    | identifier ":" term                               -> single_binding
     | ":" term                                     -> single_anon_binding
-    | ident                                        -> single_var
-    | ident ":" term "," assumption_list           -> push_binding
+    | identifier                                        -> single_var
+    | identifier ":" term "," assumption_list           -> push_binding
     | ":" term "," assumption_list                 -> push_anon_binding
-    | ident "," assumption_list                    -> push_var
+    | identifier "," assumption_list                    -> push_var
 
-?ind_case: "case" pattern "{" proof "}"            -> ind_case
-    | "case" pattern "suppose" assumption_list "{" proof "}" -> ind_case_assume
-    | "case" pattern "assume" assumption_list "{" proof "}" -> ind_case_assume
+?induction_case: "case" pattern "{" proof "}"            -> induction_case
+    | "case" pattern "suppose" assumption_list "{" proof "}" -> induction_case_assume
+    | "case" pattern "assume" assumption_list "{" proof "}" -> induction_case_assume
 
-?ind_case_list: ind_case                           -> single
-    | ind_case ind_case_list                       -> push
+?induction_case_list: induction_case                           -> single
+    | induction_case induction_case_list                       -> push
 
-?rule_ind_case: "case" IDENT "{" proof "}"         -> rule_ind_case
-?rule_ind_case_list: rule_ind_case                 -> single
-    | rule_ind_case rule_ind_case_list             -> push
+?rule_induction_case: "case" IDENT "{" proof "}"         -> rule_induction_case
+?rule_induction_case_list: rule_induction_case                 -> single
+    | rule_induction_case rule_induction_case_list             -> push
 
-?switch_pf_case: "case" pattern "{" proof "}"      -> switch_pf_case
-    | "case" pattern "suppose" assumption_list "{" proof "}"      -> switch_pf_case_assume
-    | "case" pattern "assume" assumption_list "{" proof "}"      -> switch_pf_case_assume    
+?switch_proof_case: "case" pattern "{" proof "}"      -> switch_proof_case
+    | "case" pattern "suppose" assumption_list "{" proof "}"      -> switch_proof_case_assume
+    | "case" pattern "assume" assumption_list "{" proof "}"      -> switch_proof_case_assume
 
-?switch_pf_case_list: switch_pf_case               -> single
-    | switch_pf_case switch_pf_case_list           -> push
+?switch_proof_case_list: switch_proof_case               -> single
+    | switch_proof_case switch_proof_case_list           -> push
 
 ?equation: term_compare "=" term_add reason    -> equation
 
@@ -191,16 +191,16 @@ ident: IDENT              -> ident
     | "contradict" proof                                 -> contradict
     | "conjunct" INT "of" proof                          -> conjunct
     | "cases" proof case_list                            -> cases
-    | "induction" type ind_case_list                     -> induction
-    | "rule" "induction" IDENT rule_ind_case_list        -> rule_induction
-    | "rule" "inversion" IDENT rule_ind_case_list        -> rule_inversion
-    | "expand" ident_list_bar "in" proof                 -> apply_defs_fact
+    | "induction" type induction_case_list                     -> induction
+    | "rule" "induction" IDENT rule_induction_case_list        -> rule_induction
+    | "rule" "inversion" IDENT rule_induction_case_list        -> rule_inversion
+    | "expand" identifier_list_bar "in" proof                 -> apply_defs_fact
     | "replace" proof_list "in" proof                    -> rewrite_fact
     | "evaluate"                                         -> eval_goal
     | "evaluate" "in" proof                              -> eval_fact
-    | "simplify" opt_proof_list "in" proof               -> simplify_fact
-    | "switch" term "{" switch_pf_case_list "}"          -> switch_proof
-    | "switch" term "for" ident_list "{" switch_pf_case_list "}" -> switch_proof_for
+    | "simplify" optional_proof_list "in" proof               -> simplify_fact
+    | "switch" term "{" switch_proof_case_list "}"          -> switch_proof
+    | "switch" term "for" identifier_list "{" switch_proof_case_list "}" -> switch_proof_for
     | "equations" equation                               -> equation_proof
     | "equations" equation equation_list                 -> equations_proof
     | "recall" term_list                                 -> recall_proof
@@ -219,25 +219,25 @@ ident: IDENT              -> ident
     | "sorry"                                            -> sorry_proof
     | "{" proof "}"
 
-?opt_proof_list:                                    -> empty
+?optional_proof_list:                                    -> empty
     | "with" proof_list
 
-?proof_stmt: "arbitrary" type_annot_list            -> all_intro
+?proof_stmt: "arbitrary" type_annotation_list            -> all_intro
     | "assume" IDENT                                -> imp_intro
     | "assume" IDENT ":" term                       -> imp_intro_explicit
     | "assume" ":" term                             -> imp_intro_anon
     | "choose" term_list                            -> some_intro
     | "define" IDENT "=" term                       -> define_term_proof
-    | "expand" ident_list_bar                       -> expand
+    | "expand" identifier_list_bar                       -> expand
     | "replace" proof_list                          -> rewrite_goal
     | "show" term                                   -> annot_stmt
-    | "simplify" opt_proof_list                     -> simplify_goal
+    | "simplify" optional_proof_list                     -> simplify_goal
     | "extensionality"                              -> extensionality_proof
     | "have" IDENT ":" term reason              -> let
     | "have" ":" term reason                    -> let_anon
     | "injective" term                              -> injective_proof
-    | "obtain" ident_list "where" IDENT "from" proof          -> some_elim
-    | "obtain" ident_list "where" IDENT ":" term "from" proof -> some_elim_explicit
+    | "obtain" identifier_list "where" IDENT "from" proof          -> some_elim
+    | "obtain" identifier_list "where" IDENT ":" term "from" proof -> some_elim_explicit
     | "stop" "?"                                     -> hole_in_middle_proof
     | "suffices" term reason                    -> suffices
     | "suppose" IDENT                               -> imp_intro
@@ -270,7 +270,7 @@ ident: IDENT              -> ident
     | type "," type_list                         -> push
 
 ?type_params_opt:                                -> empty
-   | "<" ident_list ">"
+   | "<" identifier_list ">"
 
 ?constructor: IDENT                                   -> constructor_id
     | IDENT "(" type_list ")"                    -> constructor_apply
@@ -285,78 +285,78 @@ ident: IDENT              -> ident
 
 ?union: visibility "union" IDENT type_params_opt "{" constructor_list "}" -> union
 
-?pred_rule: IDENT ":" term                                 -> pred_rule
+?predicate_rule: IDENT ":" term                                 -> predicate_rule
 
-?pred_rule_list:                                           -> empty
-    | pred_rule pred_rule_list                             -> push
+?predicate_rule_list:                                           -> empty
+    | predicate_rule predicate_rule_list                             -> push
 
-?predicate_decl: visibility "predicate" ident type_params_opt ":" type "{" pred_rule_list "}" -> predicate_decl
-?relation_decl:  visibility "relation"  ident type_params_opt ":" type "{" pred_rule_list "}" -> relation_decl
+?predicate_declaration: visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}" -> predicate_declaration
+?relation_declaration:  visibility "relation"  identifier type_params_opt ":" type "{" predicate_rule_list "}" -> relation_declaration
 
-?pattern: ident                                  -> pattern_id
+?pattern: identifier                                  -> pattern_id
     | "0"                                        -> pattern_zero
     | "true"                                     -> pattern_true
     | "false"                                    -> pattern_false
     | "[" "]"                                    -> pattern_empty_list
-    | IDENT "(" ident_list ")"                   -> pattern_apply
-    | "with" ident_list "." term                 -> pattern_term
+    | IDENT "(" identifier_list ")"                   -> pattern_apply
+    | "with" identifier_list "." term                 -> pattern_term
 
-?param_list:                                      -> empty
+?pattern_list:                                      -> empty
     | pattern                                       -> single
-    | pattern "," ident_list                        -> push
+    | pattern "," identifier_list                        -> push
     
-?fun_case: ident "(" param_list ")" "=" term      -> fun_case
+?fun_case: identifier "(" pattern_list ")" "=" term      -> fun_case
 
 ?fun_case_list: fun_case                               -> single
     | fun_case fun_case_list                           -> push
 
-?rec_function: visibility "recursive" ident type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}" -> rec_fun
+?recursive_function: visibility "recursive" identifier type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}" -> recursive_function
 
-?function: visibility "fun" ident type_params_opt "(" var_list ")" "{" term "}" -> fun
+?function: visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}" -> fun
 
-?gen_rec_fun: visibility "recfun" ident type_params_opt "(" var_list ")" "->" type "measure" term "of" type "{" term "}" "terminates" proof -> gen_rec_fun
+?general_recursive_function: visibility "recfun" identifier type_params_opt "(" variable_list ")" "->" type "measure" term "of" type "{" term "}" "terminates" proof -> general_recursive_function
 
-?view_decl: visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" ident "out" ident "roundtrip" ident "}" -> view_decl
+?view_declaration: visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}" -> view_declaration
 
-?definition: visibility "define" ident "=" term        -> define
- | visibility "define" ident ":" type "=" term         -> define_annot
+?definition: visibility "define" identifier "=" term        -> define
+ | visibility "define" identifier ":" type "=" term         -> define_annot
 
 ?import: visibility "import" IDENT                 -> import
        | visibility "import" IDENT "using" import_filter_list  -> import_using
        | visibility "import" IDENT "hiding" import_filter_list -> import_hiding
-?import_filter_list: ident ("|" ident)*            -> import_filter_list
+?import_filter_list: identifier ("|" identifier)*            -> import_filter_list
 ?export: "export" IDENT                            -> export
 
 ?assert: "assert" term                             -> assert
 
 ?print: "print" term                               -> print
 
-?assoc_decl: "associative" ident type_params_opt "in" type -> assoc_decl
+?associative_declaration: "associative" identifier type_params_opt "in" type -> associative_declaration
 
-?auto_decl: "auto" proof_hi -> auto_decl
+?auto_declaration: "auto" proof_hi -> auto_declaration
 
-?module_decl: "module" ident  -> module_decl
+?module_declaration: "module" identifier  -> module_declaration
 
-?trace: "trace" ident -> trace
+?trace: "trace" identifier -> trace
 
 ?inductive_decl: "inductive" type "by" proof_hi
 
 ?statement: union
- | predicate_decl
- | relation_decl
- | rec_function
+ | predicate_declaration
+ | relation_declaration
+ | recursive_function
  | function
- | gen_rec_fun
- | view_decl
+ | general_recursive_function
+ | view_declaration
  | definition
- | assoc_decl
- | auto_decl
+ | associative_declaration
+ | auto_declaration
  | import
  | export
  | assert
  | print
  | theorem
- | module_decl
+ | module_declaration
  | trace
  | inductive_decl
 

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -190,7 +190,7 @@ assert cnt(X)(7) = 0
 ## All (Universal Quantifier)
 
 ```
-formula ::= "all" var_list "." formula
+formula ::= "all" variable_list "." formula
 ```
 
 A formula of the form `all x1:T1,...,xn:Tn. P` is true
@@ -337,7 +337,7 @@ end
 ## Arbitrary (Forall Introduction)
 
 ```
-proof_stmt ::= "arbitrary" var_list
+proof_stmt ::= "arbitrary" variable_list
 ```
 
 A proof of the form
@@ -412,11 +412,11 @@ end
 
 ```deduce-grammar
 assumption_list ::= ε
-assumption_list ::= ident
-assumption_list ::= ident ":" term
+assumption_list ::= identifier
+assumption_list ::= identifier ":" term
 assumption_list ::= ":" term
-assumption_list ::= ident "," assumption_list
-assumption_list ::= ident ":" term "," assumption_list
+assumption_list ::= identifier "," assumption_list
+assumption_list ::= identifier ":" term "," assumption_list
 assumption_list ::= ":" term "," assumption_list
 ```
 
@@ -752,8 +752,8 @@ end
 ## Define (Statement)
 
 ```
-statement ::= visibility "define" ident ":" type "=" term
-            | visibility "define" ident "=" term
+statement ::= visibility "define" identifier ":" type "=" term
+            | visibility "define" identifier "=" term
 ```
 
 The `define` feature of Deduce associates a name with a value.  For
@@ -1051,8 +1051,8 @@ formula ::= term
 ## Function (Term)
 
 ```
-term ::= "fun" var_list "{" term "}"
-term ::= "λ" var_list "{" term "}"
+term ::= "fun" variable_list "{" term "}"
+term ::= "λ" variable_list "{" term "}"
 ```
 
 Functions are created with a `fun` expression.  Their syntax starts with
@@ -1079,7 +1079,7 @@ To add type parameters to a function (to make it generic), see
 ## Function (Statement)
 
 ```
-statement ::= visibility "fun" ident type_params_opt "(" var_list ")" "{" term "}"
+statement ::= visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}"
 ```
 
 The `fun` statement is for defining a function (non-recursive).
@@ -1154,8 +1154,8 @@ statement (see [Recursive Function](#recursive-function-statement)).
 ## Generic Function (Term)
 
 ```
-term ::= "fun" type_params_opt var_list "{" term "}"
-term ::= "λ" type_params_opt var_list "{" term "}"
+term ::= "fun" type_params_opt variable_list "{" term "}"
+term ::= "λ" type_params_opt variable_list "{" term "}"
 ```
 
 To make a [Function](#function-term) generic, add type parameters surrounded
@@ -1278,9 +1278,9 @@ can also be an operator, which starts with the keyword
 A comma-separated sequence of identifiers.
 
 ```deduce-grammar
-ident_list ::= ε
-ident_list ::= ident
-ident_list ::= ident "," ident_list
+identifier_list ::= ε
+identifier_list ::= identifier
+identifier_list ::= identifier "," identifier_list
 ```
 
 ## Identifier List Bar
@@ -1292,11 +1292,11 @@ multiple times (e.g. for a recursive function), preceed the identifier
 by a number and the multiplication sign.
 
 ```deduce-grammar
-ident_list_bar ::= ε
-ident_list_bar ::= ident
-ident_list_bar ::= number "*" ident
-ident_list_bar ::= ident "|" ident_list_bar
-ident_list_bar ::= number "*" ident "|" ident_list_bar
+identifier_list_bar ::= ε
+identifier_list_bar ::= identifier
+identifier_list_bar ::= number "*" identifier
+identifier_list_bar ::= identifier "|" identifier_list_bar
+identifier_list_bar ::= number "*" identifier "|" identifier_list_bar
 ```
 
 ## If and only if (iff)
@@ -1382,9 +1382,9 @@ assert 1 ∈ S and 2 ∈ S and 3 ∈ S and not (4 ∈ S)
 ## Induction
 
 ```
-conclusion ::= "induction" type ind_case*
-ind_case ::= "case" pattern "{" proof "}"
-ind_case ::= "case" pattern "assume" assumption_list "{" proof "}"
+conclusion ::= "induction" type induction_case*
+induction_case ::= "case" pattern "{" proof "}"
+induction_case ::= "case" pattern "assume" assumption_list "{" proof "}"
 ```
 
 A proof of the form
@@ -1852,9 +1852,9 @@ and [Recursive Function (Statement)](#function-statement) via a Parameter List.
 ## Parameter List
 
 ```
-param_list ::= ε
-param_list ::= pattern
-param_list ::= pattern "," identifier_list
+pattern_list ::= ε
+pattern_list ::= pattern
+pattern_list ::= pattern "," identifier_list
 ```
 
 A parameter list begins with a pattern (for the first function
@@ -2191,8 +2191,8 @@ end
 ## Rule Induction (Proof)
 
 ```
-conclusion ::= "rule" "induction" identifier rule_ind_case+
-rule_ind_case ::= "case" identifier "{" proof "}"
+conclusion ::= "rule" "induction" identifier rule_induction_case+
+rule_induction_case ::= "case" identifier "{" proof "}"
 ```
 
 A proof of the form
@@ -2265,8 +2265,8 @@ induction hypothesis.
 ## Rule Inversion (Proof)
 
 ```
-conclusion ::= "rule" "inversion" identifier rule_ind_case+
-rule_ind_case ::= "case" identifier "{" proof "}"
+conclusion ::= "rule" "inversion" identifier rule_induction_case+
+rule_induction_case ::= "case" identifier "{" proof "}"
 ```
 
 The structurally-identical companion to
@@ -2379,7 +2379,7 @@ sure that the given formula matches the current goal.
 ## Some (Formula)
 
 ```
-formula ::= "some" var_list "." formula
+formula ::= "some" variable_list "." formula
 ```
 
 The formula `some x1:T1,...,xn:Tn. P` is true when there exists
@@ -2819,11 +2819,11 @@ An unsigned integer literal is a sequence of one or more digits.
 ## Variable List
 
 ```deduce-grammar
-var_list ::= ε
-var_list ::= ident
-var_list ::= ident "," var_list
-var_list ::= ident ":" type
-var_list ::= ident ":" type "," var_list
+variable_list ::= ε
+variable_list ::= identifier
+variable_list ::= identifier "," variable_list
+variable_list ::= identifier ":" type
+variable_list ::= identifier ":" type "," variable_list
 ```
 
 A comma-separated list of variable declarations. Each variable may

--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -8,7 +8,7 @@ from lark import Lark
 ## Other types:
 ##      comment
 ##      whitespace
-##      ident
+##      identifier
 known_tokens = {
     'ALL' : 'keyword', 
     'AMPERSAND': 'operator', 
@@ -56,7 +56,7 @@ known_tokens = {
     'HASH': 'operator',
     'HAVE': 'keyword',
     'HELP': 'keyword',
-    'IDENT': 'ident',
+    'IDENT': 'identifier',
     'IF': 'keyword',
     'IFF': 'operator',
     'IMPORT': 'keyword',

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -26,7 +26,7 @@ FENCE_RE = re.compile(r"^```(?P<info>.*)$")
 
 TOKEN_ALIASES = {
     "identifier": "IDENT",
-    "identifier_list": "ident_list",
+    "identifier_list": "identifier_list",
     "natural_number": "NAT",
     "number": "INT",
     "unsigned_integer": "INT",

--- a/parser.py
+++ b/parser.py
@@ -75,7 +75,7 @@ def parse_tree_to_str_list(e):
 
 def parse_tree_to_list(e, parent):
     # Returns a list to match the recursive-descent parser's convention.
-    # The inner 2-tuples like (ident, typ) are paired data, not collections,
+    # The inner 2-tuples like (identifier, typ) are paired data, not collections,
     # and stay as tuples.
     if e.data == 'empty':
         return []
@@ -96,25 +96,25 @@ def parse_tree_to_list(e, parent):
     elif e.data == 'empty_binding':
         return []
     elif e.data == 'single_binding':
-        ident = parse_tree_to_ast(e.children[0], parent)
+        identifier = parse_tree_to_ast(e.children[0], parent)
         typ = parse_tree_to_ast(e.children[1], parent)
-        return [(ident,typ)]
+        return [(identifier,typ)]
     elif e.data == 'single_anon_binding':
         typ = parse_tree_to_ast(e.children[0], parent)
         return [('_',typ)]
     elif e.data == 'single_var':
-        ident = parse_tree_to_ast(e.children[0], parent)
-        return [(ident,None)]
+        identifier = parse_tree_to_ast(e.children[0], parent)
+        return [(identifier,None)]
     elif e.data == 'push_binding':
-        ident = parse_tree_to_ast(e.children[0], parent)
+        identifier = parse_tree_to_ast(e.children[0], parent)
         typ = parse_tree_to_ast(e.children[1], parent)
-        return [(ident,typ)] + parse_tree_to_list(e.children[2], parent)
+        return [(identifier,typ)] + parse_tree_to_list(e.children[2], parent)
     elif e.data == 'push_anon_binding':
         typ = parse_tree_to_ast(e.children[0], parent)
         return [('_',typ)] + parse_tree_to_list(e.children[1], parent)
     elif e.data == 'push_var':
-        ident = parse_tree_to_ast(e.children[0], parent)
-        return [(ident,None)] + parse_tree_to_list(e.children[1], parent)
+        identifier = parse_tree_to_ast(e.children[0], parent)
+        return [(identifier,None)] + parse_tree_to_list(e.children[1], parent)
     else:
         raise Exception('parse_tree_to_str_list, unexpected ' + str(e))
 
@@ -305,31 +305,31 @@ def parse_tree_to_ast(e, parent):
         return Hole(e.meta, None)
     elif e.data == 'omitted_term':
         return Omitted(e.meta, None)
-    elif e.data == 'ident':
+    elif e.data == 'identifier':
         return str(e.children[0].value)
-    elif e.data == 'ident_div':
+    elif e.data == 'identifier_div':
         return '/'
-    elif e.data == 'ident_append':
+    elif e.data == 'identifier_append':
         return '++'
-    elif e.data == 'ident_union':
+    elif e.data == 'identifier_union':
         return '∪'
-    elif e.data == 'ident_intersect':
+    elif e.data == 'identifier_intersect':
         return '∩'
-    elif e.data == 'ident_member':
+    elif e.data == 'identifier_member':
         return '∈'
-    elif e.data == 'ident_multiset_sum':
+    elif e.data == 'identifier_multiset_sum':
         return '⨄'
-    elif e.data == 'ident_nat_sub':
+    elif e.data == 'identifier_nat_sub':
         return '∸'
-    elif e.data == 'ident_subset_equal':
+    elif e.data == 'identifier_subset_equal':
         return '⊆'
-    elif e.data == 'ident_less_equal':
+    elif e.data == 'identifier_less_equal':
         return '≤'
-    elif e.data == 'ident_greater_equal':
+    elif e.data == 'identifier_greater_equal':
         return '≥'
-    elif e.data == 'ident_not_equal':
+    elif e.data == 'identifier_not_equal':
         return '≠'
-    elif e.data == 'ident_circ':
+    elif e.data == 'identifier_circ':
         return '∘'
     elif e.data == 'true_literal':
         return Bool(e.meta, None, True)
@@ -549,15 +549,15 @@ def parse_tree_to_ast(e, parent):
         hyp = str(e.children[0].value)
         cases = parse_tree_to_list(e.children[1], e)
         return RuleInversion(e.meta, hyp, cases)
-    elif e.data == 'rule_ind_case':
+    elif e.data == 'rule_induction_case':
         rule_name = str(e.children[0].value)
         body = parse_tree_to_ast(e.children[1], e)
         return RuleInductionCase(e.meta, rule_name, body)
-    elif e.data == 'switch_pf_case':
+    elif e.data == 'switch_proof_case':
         pat = parse_tree_to_ast(e.children[0], e)
         body = parse_tree_to_ast(e.children[1], e)
         return SwitchProofCase(e.meta, pat, [], body)
-    elif e.data == 'switch_pf_case_assume':
+    elif e.data == 'switch_proof_case_assume':
         pat = parse_tree_to_ast(e.children[0], e)
         assms = parse_tree_to_list(e.children[1], e)
         body = parse_tree_to_ast(e.children[2], e)
@@ -573,11 +573,11 @@ def parse_tree_to_ast(e, parent):
         return ApplyDefsGoal(e.meta, [Var(e.meta, None, t) \
                                       for t in definitions],
                              SwitchProof(e.meta, subject, cases))
-    elif e.data == 'ind_case':
+    elif e.data == 'induction_case':
         pat = parse_tree_to_ast(e.children[0], e)
         body = parse_tree_to_ast(e.children[1], e)
         return IndCase(e.meta, pat, [], body)
-    elif e.data == 'ind_case_assume':
+    elif e.data == 'induction_case_assume':
         pat = parse_tree_to_ast(e.children[0], e)
         ind_hyps = parse_tree_to_list(e.children[1], e)
         body = parse_tree_to_ast(e.children[2], e)
@@ -665,8 +665,8 @@ def parse_tree_to_ast(e, parent):
         return statement
 
     # predicate / relation definitions
-    elif e.data == 'predicate_decl' or e.data == 'relation_decl':
-        keyword = 'predicate' if e.data == 'predicate_decl' else 'relation'
+    elif e.data == 'predicate_declaration' or e.data == 'relation_declaration':
+        keyword = 'predicate' if e.data == 'predicate_declaration' else 'relation'
         visibility = parse_tree_to_ast(e.children[0], e)
         name = parse_tree_to_ast(e.children[1], e)
         typarams = parse_tree_to_list(e.children[2], e)
@@ -675,7 +675,7 @@ def parse_tree_to_ast(e, parent):
         statement = Predicate(e.meta, name, typarams, signature, rules, keyword)
         set_visibility(statement, visibility)
         return statement
-    elif e.data == 'pred_rule':
+    elif e.data == 'predicate_rule':
         return Rule(e.meta, str(e.children[0].value),
                     parse_tree_to_ast(e.children[1], e))
     
@@ -705,13 +705,13 @@ def parse_tree_to_ast(e, parent):
                               parse_tree_to_ast(e.children[2], e))
         set_visibility(statement, visibility)
         return statement
-    elif e.data == 'assoc_decl':
+    elif e.data == 'associative_declaration':
         op_var = parse_tree_to_ast(e.children[0], e)
         typarams = parse_tree_to_list(e.children[1], e)
         typ = parse_tree_to_ast(e.children[2], e)
         return Associative(e.meta, typarams, Var(e.meta, None, op_var), typ)
 
-    elif e.data == 'auto_decl':
+    elif e.data == 'auto_declaration':
         pvar = parse_tree_to_ast(e.children[0], e)
         return Auto(e.meta, pvar)
     
@@ -721,7 +721,7 @@ def parse_tree_to_ast(e, parent):
         return Inductive(e.meta, ty, thm)
     
     
-    elif e.data == 'module_decl':
+    elif e.data == 'module_declaration':
         return Module(e.meta, parse_tree_to_ast(e.children[0], e))
     
     # patterns in function definitions
@@ -770,7 +770,7 @@ def parse_tree_to_ast(e, parent):
         return statement
     
     # structurally recursive functions
-    elif e.data == 'rec_fun':
+    elif e.data == 'recursive_function':
         visibility = parse_tree_to_ast(e.children[0], e)
         statement = RecFun(e.meta, parse_tree_to_ast(e.children[1], e),
                            parse_tree_to_list(e.children[2], e),
@@ -781,7 +781,7 @@ def parse_tree_to_ast(e, parent):
         return statement
 
     # general recursion
-    elif e.data == 'gen_rec_fun':
+    elif e.data == 'general_recursive_function':
         visibility = parse_tree_to_ast(e.children[0], e)
         statement = GenRecFun(e.meta,
                               parse_tree_to_ast(e.children[1], e),
@@ -795,7 +795,7 @@ def parse_tree_to_ast(e, parent):
         set_visibility(statement, visibility)
         return statement
 
-    elif e.data == 'view_decl':
+    elif e.data == 'view_declaration':
         visibility = parse_tree_to_ast(e.children[0], e)
         statement = ViewDecl(e.meta,
                              str(e.children[1]),


### PR DESCRIPTION
## Summary
- Renames abbreviated Deduce.lark nonterminals and parser aliases to user-friendly names like `identifier`, `identifier_list`, `variable_list`, and `predicate_declaration`.
- Updates the Lark parse-tree dispatch in `parser.py` to match the renamed aliases.
- Syncs Reference.md grammar snippets and grammar-checking keyword aliases with the new names.

## Validation
- `python3 ./gh_pages/scripts/reference_grammar.py`
- `python3 deduce.py test/should-validate/fib.pf`
- `make tests`

Addresses #642.
