### PR TITLE
Clarify TacticsCheatSheet tip #9: replace needs an equation

### DIFF
--- a/gh_pages/doc/TacticsCheatSheet.md
+++ b/gh_pages/doc/TacticsCheatSheet.md
@@ -108,7 +108,7 @@ Use these when `apply lemma to p` doesn't typecheck because `p` is a wider conju
 
 8. **Views need their law before use.** A `view` declaration checks the supplied `roundtrip` theorem exactly. For a target type `T`, prove `all v:T. into(out(v)) = v` before the `view` declaration; for generic views, quantify type parameters first.
 
-9. **`switch P` on a boolean introduces asymmetric assumptions.** `case true assume h { ... }` makes `h : P` available — an equation usable in `replace`. `case false assume h { ... }` makes `h : not P` available — a *negation*, not an equation — so `replace h` fails with "expected an equation". Use `simplify with h` in the false branch (it substitutes `P` with `false` and reduces). Also: the introduced formula is `P` (resp. `not P`), not `P = true` (resp. `P = false`) — annotating `assume h: P = true` will fail to match the expected assumption.
+9. **`switch P` on a boolean introduces asymmetric assumptions.** `case true assume h { ... }` makes `h : P` available; `case false assume h { ... }` makes `h : not P` available. `simplify with h` works in both branches (it substitutes `P` with `true` or `false` and reduces). If `P` is itself an equation `a = b`, you may also use `replace h` in the `case true` branch; for any other boolean (a predicate call, `≤`, etc.), `replace h` fails with "expected an equation" and you should use `simplify with h`. Also: the introduced formula is `P` (resp. `not P`), not `P = true` (resp. `P = false`) — annotating `assume h: P = true` will fail to match the expected assumption.
 
 ## Working tips
 


### PR DESCRIPTION
## Summary
- Tip #9 in [`gh_pages/doc/TacticsCheatSheet.md`](gh_pages/doc/TacticsCheatSheet.md) implied that `case true assume h` always produces "an equation usable in `replace`". That's only true when `P` is itself an equation `a = b`; for other booleans (predicate calls, `≤`, etc.), `replace h` fails with "expected an equation" — the same as in the `case false` branch.
- Rewrite the tip so `simplify with h` is presented as the move that works in *both* branches, with `replace h` called out as the equation-only specialization for `case true`.

Wording follows the suggestion in the issue.

Fixes #646

## Test plan
- [x] No code changes; pure docs edit.
- [x] Markdown still renders as a single bullet under "Pitfalls".

🤖 Generated with [Claude Code](https://claude.com/claude-code)