### PR TITLE
Prove lit_add_div_zero in lib/Nat.pf

### DIFF
--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -565,7 +565,13 @@ proof
 end
 auto lit_add_div_suc
 
-postulate lit_add_div_zero: all a:Nat, y:Nat. if a < y then add_div(a, zero, y) = lit(zero)
+theorem lit_add_div_zero: all a:Nat, y:Nat. if a < y then add_div(a, zero, y) = lit(zero)
+proof
+  arbitrary a:Nat, y:Nat
+  assume a_y: a < y
+  expand add_div | lit | operator/
+  replace (apply eq_true to a_y).
+end
 auto lit_add_div_zero
 
 theorem lit_less_zero_false: all x:Nat. (x < lit(zero)) = false


### PR DESCRIPTION
## Summary
- Replace the `postulate lit_add_div_zero` in `lib/Nat.pf` with a proper proof.
- The proof expands `add_div`, `lit`, and `operator/`, then rewrites the `a < y` premise to `true` via `eq_true` to close the goal.

## Test plan
- [x] `python3.13 deduce.py lib/Nat.pf` (recursive-descent)
- [x] `python3.13 deduce.py --lalr lib/Nat.pf`
- [x] `python3.13 test-deduce.py --lib` (both parsers across the full stdlib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)