### PR TITLE
Add per-theorem comments to sparse stdlib files (Refs #99)

### DIFF
--- a/lib/NatEvenOdd.pf
+++ b/lib/NatEvenOdd.pf
@@ -16,27 +16,34 @@ import NatMult
  Odd and Even Numbers
  */
 
+// Parity counted by flipping `b` once per `suc`: `parity(n, b)` is
+// `b` xor (n is odd).
 recursive parity(Nat, bool) -> bool {
   parity(zero, b) = b
   parity(suc(n'), b) = parity(n', not b)
 }
 
+// Computable test for even.
 fun is_even(n : Nat) {
   parity(n, true)
 }
 
+// Computable test for odd.
 fun is_odd(n : Nat) {
   parity(n, false)
 }
 
+// Propositional even: `n` equals `2 * m` for some `m`.
 fun EvenNat(n : Nat) {
   some m:Nat. n = suc(suc(zero)) * m
 }
 
+// Propositional odd: `n` equals `1 + 2 * m` for some `m`.
 fun OddNat(n : Nat) {
   some m:Nat. n = suc (suc(suc(zero)) * m)
 }
 
+// Any multiple of two is even.
 lemma two_even: all n:Nat. EvenNat(suc(suc(zero)) * n)
 proof
   arbitrary n:Nat
@@ -44,6 +51,7 @@ proof
   choose n.
 end
 
+// `1 + 2*n` is odd for every `n`.
 lemma one_two_odd: all n:Nat. OddNat(suc(zero) + suc(suc(zero)) * n)
 proof
   arbitrary n:Nat
@@ -52,6 +60,7 @@ proof
   evaluate
 end
 
+// Every natural is either computably even or computably odd.
 theorem even_or_odd: all n:Nat. is_even(n) or is_odd(n)
 proof
   induction Nat
@@ -74,6 +83,7 @@ proof
 end
 
 
+// Sum of two even numbers is even.
 theorem addition_of_evens:
   all x:Nat, y:Nat.
   if EvenNat(x) and EvenNat(y) then EvenNat(x + y)
@@ -92,6 +102,7 @@ proof
   ... = #suc(suc(zero)) * (a + b)#   by replace dist_mult_add.
 end
 
+// Computable parity implies propositional parity in each direction.
 theorem is_even_odd:
   all n:Nat.
   (if is_even(n) then EvenNat(n))
@@ -142,6 +153,7 @@ proof
   }
 end
 
+// Every natural is either propositionally even or propositionally odd.
 theorem Even_or_Odd: all n:Nat. EvenNat(n) or OddNat(n)
 proof
   arbitrary n:Nat
@@ -154,6 +166,7 @@ proof
   }
 end
 
+// Subtracting one from an odd successor leaves an even number.
 lemma odd_one_even: all n:Nat. if OddNat(suc(zero) + n) then EvenNat(n)
 proof
   arbitrary n:Nat
@@ -166,6 +179,7 @@ proof
   n2k
 end
 
+// Subtracting one from a positive even number leaves an odd number.
 lemma even_one_odd: all n:Nat. if EvenNat(suc(zero) + n) then OddNat(n)
 proof
   arbitrary n:Nat
@@ -189,6 +203,7 @@ proof
   }
 end
 
+// Even and not-odd are equivalent: a number is even iff it is not odd.
 theorem Even_not_Odd: all n:Nat. EvenNat(n) ⇔ not OddNat(n)
 proof
   induction Nat

--- a/lib/NatMonus.pf
+++ b/lib/NatMonus.pf
@@ -17,11 +17,13 @@ import NatAdd
  Properties of Subtraction
  */
  
+// Zero minus anything is zero.
 lemma zero_monus: all x:Nat. zero ∸ x = zero
 proof
   evaluate
 end
 
+// Subtraction cancels itself.
 lemma monus_cancel: all n:Nat. n ∸ n = zero
 proof
   induction Nat
@@ -35,6 +37,7 @@ proof
   }
 end
 
+// Subtracting zero is the identity.
 lemma monus_zero: all n:Nat.
   n ∸ zero = n
 proof
@@ -47,6 +50,7 @@ proof
   }
 end
 
+// Adding the same prefix to both sides cancels in `∸`.
 theorem add_both_monus: all z:Nat, y:Nat, x:Nat.
   (z + y) ∸ (z + x) = y ∸ x
 proof
@@ -66,16 +70,19 @@ end
  Properties of pred
 */
 
+// Predecessor of one is zero.
 lemma pred_one: pred(suc(zero)) = zero
 proof
  expand pred.
 end
 
+// `pred` undoes `suc`.
 lemma pred_suc_n: all n:Nat. pred(suc(n)) = n
 proof
   evaluate
 end
 
+// Subtracting one is the same as taking the predecessor.
 lemma monus_one_pred : all x : Nat. x ∸ suc(zero) = pred(x)
 proof
  induction Nat
@@ -92,7 +99,8 @@ end
  Properties of Addition and Subtraction
  */
 
-theorem add_monus_identity: all m:Nat. all n:Nat. 
+// Adding then subtracting `m` is the identity.
+theorem add_monus_identity: all m:Nat. all n:Nat.
   (m + n) ∸ m = n
 proof
   induction Nat
@@ -110,6 +118,7 @@ proof
   }
 end
 
+// Chained subtractions combine into a single subtraction.
 theorem monus_monus_eq_monus_add : all x : Nat. all y:Nat. all z:Nat.
   (x ∸ y) ∸ z = x ∸ (y + z)
 proof
@@ -139,6 +148,7 @@ proof
   }
 end
 
+// The order of two consecutive subtractions does not matter.
 theorem monus_order : all x : Nat, y : Nat, z : Nat.
   (x ∸ y) ∸ z = (x ∸ z) ∸ y
 proof

--- a/lib/NatMult.pf
+++ b/lib/NatMult.pf
@@ -17,6 +17,7 @@ import NatMonus
  Properties of Multiplication
 */
 
+// Left zero of multiplication. Folded into auto rewrites.
 lemma zero_mult: all n:Nat.
   zero * n = zero
 proof
@@ -26,6 +27,7 @@ end
 
 auto zero_mult
 
+// Literal-form left zero, so `lit(0) * lit(y)` rewrites under auto.
 theorem nat_zero_mult: all y:Nat.
   lit(zero) * lit(y) = lit(zero)
 proof
@@ -35,6 +37,7 @@ end
 
 auto nat_zero_mult
 
+// Right zero of multiplication.
 lemma mult_zero: all n:Nat.
   n * zero = zero
 proof
@@ -50,6 +53,7 @@ end
 
 auto mult_zero
 
+// Unfold `suc(m) * n` to `n + m * n` (the recursive definition).
 lemma suc_mult: all m:Nat, n:Nat.
   suc(m) * n = n + m * n
 proof
@@ -57,6 +61,7 @@ proof
   expand operator*.
 end
 
+// Literal-form of `suc_mult`, registered as an auto rewrite.
 theorem lit_suc_mult: all m:Nat, n:Nat.
   lit(suc(m)) * lit(n) = lit(n) + lit(m) * lit(n)
 proof
@@ -66,6 +71,7 @@ end
 
 auto lit_suc_mult
 
+// Step the right operand of `*` through `suc`.
 lemma mult_suc: all m:Nat. all n:Nat.
   m * suc(n) = m + m * n
 proof
@@ -84,6 +90,7 @@ proof
   }
 end
 
+// Literal-form of `mult_suc` for both sides.
 theorem lit_mult_lit_suc: all m:Nat, n:Nat.
   lit(m) * lit(suc(n)) = lit(m) + lit(m) * lit(n)
 proof
@@ -94,6 +101,7 @@ end
 
 auto lit_mult_lit_suc
 
+// Variant of `lit_mult_lit_suc` without `lit` around the right `suc`.
 theorem lit_mult_suc: all m:Nat, n:Nat.
   lit(m) * suc(n) = lit(m) + lit(m) * n
 proof
@@ -104,6 +112,7 @@ end
 
 auto lit_mult_suc
 
+// Multiplication is commutative.
 theorem mult_commute: all m:Nat. all n:Nat.
   m * n = n * m
 proof
@@ -122,6 +131,7 @@ proof
   }
 end
 
+// Left identity (using the `suc(zero)` form of one).
 theorem one_mult: all n:Nat.
   suc(zero) * n = n
 proof
@@ -133,6 +143,7 @@ end
 
 auto one_mult
 
+// Literal-form left identity.
 theorem nat_one_mult: all n:Nat.
   lit(suc(zero)) * n = n
 proof
@@ -142,6 +153,7 @@ end
 
 auto nat_one_mult
 
+// Right identity.
 lemma mult_one: all n:Nat.
   n * suc(zero) = n
 proof
@@ -152,6 +164,7 @@ end
 
 auto mult_one
 
+// Literal-form right identity.
 theorem nat_mult_one: all n:Nat.
   n * lit(suc(zero)) = n
 proof
@@ -161,6 +174,7 @@ end
 
 auto nat_mult_one
 
+// Nat has no zero divisors: a product is zero only if one factor is.
 theorem mult_to_zero : all n :Nat, m : Nat.
   if m * n = zero then m = zero or n = zero
 proof
@@ -178,6 +192,7 @@ proof
   }
 end
 
+// A product equals one only if both factors are one.
 lemma one_mult_one : all x : Nat, y : Nat.
   if x * y = suc(zero) then x = suc(zero) and y = suc(zero)
 proof
@@ -213,6 +228,7 @@ proof
   }
 end
 
+// Doubling: `2 * n` is `n + n`.
 lemma two_mult: all n:Nat.
   suc(suc(zero)) * n = n + n
 proof
@@ -221,6 +237,7 @@ proof
                 ... = n + n           by .
 end
 
+// Literal-form doubling.
 theorem lit_two_mult: all n:Nat.
   ℕ2 * n = n + n
 proof
@@ -229,6 +246,7 @@ proof
   replace two_mult.
 end
 
+// Left distributivity of `*` over `+`.
 theorem dist_mult_add:
   all a:Nat, x:Nat, y:Nat.
   a * (x + y) = a * x + a * y
@@ -252,6 +270,7 @@ proof
   }
 end
 
+// Right distributivity of `*` over `+`.
 theorem dist_mult_add_right:
   all x:Nat, y:Nat, a:Nat.
   (x + y) * a = x * a + y * a
@@ -263,6 +282,7 @@ proof
           ... = x * a + y * a       by replace mult_commute.
 end
   
+// Multiplication is associative.
 theorem mult_assoc: all m:Nat. all n:Nat, o:Nat.
   (m * n) * o = m * (n * o)
 proof
@@ -286,6 +306,7 @@ end
 
 associative operator* in Nat
 
+// Right cancellation when the right factor is positive.
 lemma mult_right_cancel : all m : Nat, n : Nat, o : Nat.
   if m * suc(o) = n * suc(o) then m = n
 proof
@@ -320,6 +341,7 @@ proof
   }
 end
 
+// Left cancellation when the left factor is positive.
 lemma mult_left_cancel : all m : Nat, a : Nat, b : Nat.
   if suc(m) * a = suc(m) * b then a = b
 proof

--- a/lib/NatSum.pf
+++ b/lib/NatSum.pf
@@ -17,7 +17,8 @@ import NatLess
  Properties of Summation
  */
 
-theorem summation_cong: all k : Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s : Nat, t : Nat. 
+// Pointwise-equal summands over shifted ranges yield equal sums.
+theorem summation_cong: all k : Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s : Nat, t : Nat.
   if (all i:Nat. if i < k then f(s + i) = g(t + i))
   then summation(k, s, f) = summation(k, t, g)
 proof
@@ -47,7 +48,9 @@ proof
   }
 end
 
-lemma summation_cong4: all k:Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s :Nat. 
+// Like `summation_cong`, but the hypothesis is phrased in terms of
+// the absolute index `i` rather than a shift.
+lemma summation_cong4: all k:Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s :Nat.
   if (all i:Nat. if s ≤ i and i < s + k then f(i) = g(i))
   then summation(k, s, f) = summation(k, s, g)
 proof
@@ -100,8 +103,10 @@ proof
   }
 end
 
+// Re-indexing: summing `f` from `s` equals summing `g(suc(·))` from
+// `suc(s)` when `f(i) = g(suc(i))` pointwise.
 lemma summation_suc:
-  all k:Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s :Nat. 
+  all k:Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s :Nat.
   if (all i:Nat. f(i) = g(suc(i)))
   then summation(k, s, f) = summation(k, suc(s), g)
 proof
@@ -116,7 +121,9 @@ proof
   apply summation_cong[k][f, g, s, suc(s)] to sum_prem
 end
 
-lemma summation_cong3: all k:Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s :Nat, t :Nat. 
+// Variant of `summation_cong` without the `i < k` guard on the
+// hypothesis — useful when the equation holds for all shifts.
+lemma summation_cong3: all k:Nat. all f : fn Nat->Nat, g : fn Nat->Nat, s :Nat, t :Nat.
   if (all i:Nat. f(s + i) = g(t + i))
   then summation(k, s, f) = summation(k, t, g)
 proof
@@ -144,6 +151,9 @@ proof
   }
 end
 
+// Split a summation of length `a + b` into a `g`-prefix of length
+// `a` and an `h`-suffix of length `b`, when each piece agrees
+// pointwise with `f` on its segment.
 theorem summation_add:
   all a:Nat. all b:Nat, s:Nat, t:Nat, f:fn Nat->Nat, g:fn Nat->Nat, h:fn Nat->Nat.
   if (all i:Nat. if i < a then g(s + i) = f(s + i))
@@ -189,6 +199,7 @@ proof
   }
 end
 
+// Append a final term to a summation: `Σ_{i<n+1} f(s+i) = Σ_{i<n} + f(s+n)`.
 lemma summation_suc_add: all n:Nat, s:Nat, f:fn Nat->Nat.
   summation(suc(zero) + n, s, f) = summation(n, s, f) + f(s + n)
 proof

--- a/lib/UIntEvenOdd.pf
+++ b/lib/UIntEvenOdd.pf
@@ -12,14 +12,17 @@ import UIntMult
   is one plus twice another UInt.
 */
 
+// `Even(n)` iff `n` equals `2 * m` for some `m`.
 fun Even(n : UInt) {
   some m:UInt. n = 2 * m
 }
 
+// `Odd(n)` iff `n` equals `1 + 2 * m` for some `m`.
 fun Odd(n : UInt) {
   some m:UInt. n = 1 + (2 * m)
 }
 
+// Any multiple of two is even.
 theorem uint_two_even: all n:UInt. Even(2 * n)
 proof
   arbitrary n:UInt
@@ -27,6 +30,7 @@ proof
   choose n.
 end
 
+// `1 + 2*n` is odd for every `n`.
 theorem uint_one_two_odd: all n:UInt. Odd(1 + 2 * n)
 proof
   arbitrary n:UInt
@@ -34,6 +38,7 @@ proof
   choose n.
 end
 
+// even + even = even
 theorem uint_even_add_even: all x:UInt, y:UInt.
   if Even(x) and Even(y) then Even(x + y)
 proof
@@ -49,6 +54,7 @@ proof
   ... = #2 * (a + b)# by replace uint_dist_mult_add.
 end
 
+// even + odd = odd
 theorem uint_even_add_odd: all x:UInt, y:UInt.
   if Even(x) and Odd(y) then Odd(x + y)
 proof
@@ -67,6 +73,7 @@ proof
   ... = 1 + #2 * (a + b)# by replace uint_dist_mult_add.
 end
 
+// odd + even = odd
 theorem uint_odd_add_even: all x:UInt, y:UInt.
   if Odd(x) and Even(y) then Odd(x + y)
 proof
@@ -79,6 +86,7 @@ proof
   odd_yx
 end
 
+// odd + odd = even
 theorem uint_odd_add_odd: all x:UInt, y:UInt.
   if Odd(x) and Odd(y) then Even(x + y)
 proof
@@ -100,6 +108,7 @@ proof
   ... = #2 * (1 + (a + b))# by replace uint_dist_mult_add.
 end
 
+// A product is even if the left factor is.
 theorem uint_even_mult_left: all x:UInt, y:UInt.
   if Even(x) then Even(x * y)
 proof
@@ -114,6 +123,7 @@ proof
   ... = 2 * (a * y) by .
 end
 
+// A product is even if the right factor is.
 theorem uint_even_mult_right: all x:UInt, y:UInt.
   if Even(y) then Even(x * y)
 proof
@@ -124,6 +134,7 @@ proof
   even_yx
 end
 
+// odd * odd = odd
 theorem uint_odd_mult_odd: all x:UInt, y:UInt.
   if Odd(x) and Odd(y) then Odd(x * y)
 proof
@@ -144,6 +155,7 @@ proof
   ... = 1 + #2 * (b + a * (1 + 2 * b))# by replace uint_dist_mult_add.
 end
 
+// Every UInt is either even or odd.
 theorem uint_Even_or_Odd: all n:UInt. Even(n) or Odd(n)
 proof
   induction UInt
@@ -173,6 +185,7 @@ proof
   }
 end
 
+// Subtracting one from an odd successor leaves an even number.
 theorem uint_odd_one_even: all n:UInt. if Odd(1 + n) then Even(n)
 proof
   arbitrary n:UInt
@@ -184,6 +197,7 @@ proof
   n_eq
 end
 
+// Subtracting one from a positive even number leaves an odd number.
 theorem uint_even_one_odd: all n:UInt. if Even(1 + n) then Odd(n)
 proof
   arbitrary n:UInt
@@ -209,6 +223,7 @@ proof
   }
 end
 
+// Even and not-odd are equivalent.
 theorem uint_Even_not_Odd: all n:UInt. Even(n) ⇔ not Odd(n)
 proof
   arbitrary n:UInt

--- a/lib/UIntMonus.pf
+++ b/lib/UIntMonus.pf
@@ -16,6 +16,8 @@ import UIntMult
   addition and order.
 */
 
+// Internal helper: when `x < y`, the binary-form subtraction
+// `inc_dub(x) ∸ dub_inc(y)` is zero.
 lemma inc_dub_monus_dub_inc_less: all x:UInt, y:UInt.
   if x < y
   then inc_dub(x) ∸ dub_inc(y) = bzero
@@ -26,6 +28,8 @@ proof
   simplify with prem.
 end
 
+// Internal helper: when `not (x < y)`, that subtraction is
+// `pred(dub(x ∸ y))`.
 lemma inc_dub_monus_dub_inc_greater: all x:UInt, y:UInt.
   if not (x < y)
   then inc_dub(x) ∸ dub_inc(y) = pred(dub(x ∸ y))
@@ -36,6 +40,7 @@ proof
   replace apply eq_false to prem.
 end
 
+// Specification: UInt subtraction agrees with Nat subtraction under `toNat`.
 theorem toNat_monus: all x:UInt, y:UInt.
   toNat(x ∸ y) = toNat(x) ∸ toNat(y)
 proof
@@ -162,12 +167,14 @@ proof
   }
 end
 
+// Zero (as `bzero`) minus anything is zero.
 lemma uint_bzero_monus: all x:UInt. bzero ∸ x = bzero
 proof
   arbitrary x:UInt
   expand operator∸.
 end
 
+// Subtracting `bzero` is the identity.
 lemma uint_monus_bzero: all n:UInt. n ∸ bzero = n
 proof
   arbitrary n:UInt
@@ -179,6 +186,7 @@ proof
   conclude n ∸ bzero = n by apply uint_toNat_injective to X
 end
 
+// Subtraction cancels itself.
 lemma uint_monus_cancel_bzero: all n:UInt. n ∸ n = bzero
 proof
   arbitrary n:UInt
@@ -190,7 +198,8 @@ proof
   conclude n ∸ n = bzero by apply uint_toNat_injective to X
 end
 
-theorem uint_add_monus_identity: all m:UInt, n:UInt. 
+// Adding then subtracting `m` is the identity.
+theorem uint_add_monus_identity: all m:UInt, n:UInt.
   (m + n) ∸ m = n
 proof
   arbitrary m:UInt, n:UInt
@@ -203,6 +212,7 @@ end
 
 auto uint_add_monus_identity
 
+// Chained subtractions combine into one.
 theorem uint_monus_monus_eq_monus_add : all x:UInt, y:UInt, z:UInt.
   (x ∸ y) ∸ z = x ∸ (y + z)
 proof
@@ -214,6 +224,7 @@ proof
   conclude (x ∸ y) ∸ z = x ∸ (y + z) by apply uint_toNat_injective to X
 end
 
+// Two consecutive subtractions can be swapped.
 theorem uint_monus_order : all x : UInt, y : UInt, z : UInt.
   (x ∸ y) ∸ z = (x ∸ z) ∸ y
 proof
@@ -227,6 +238,7 @@ proof
   conclude (x ∸ y) ∸ z = (x ∸ z) ∸ y by apply uint_toNat_injective to X
 end
 
+// Adding the same prefix to both sides cancels in `∸`.
 theorem uint_add_both_monus: all z:UInt, y:UInt, x:UInt.
   (z + y) ∸ (z + x) = y ∸ x
 proof
@@ -236,6 +248,7 @@ proof
   add_both_monus
 end
 
+// Multiplication distributes over (truncated) subtraction.
 theorem uint_dist_mult_monus: all x:UInt. all y:UInt, z:UInt.
   x * (y ∸ z) = x * y ∸ x * z
 proof
@@ -245,6 +258,7 @@ proof
   dist_mult_monus
 end
 
+// Literal `fromNat` distributes over `∸`.
 theorem lit_monus_fromNat: all x:Nat, y:Nat. fromNat(lit(x)) ∸ fromNat(lit(y)) = fromNat(lit(x) ∸ lit(y))
 proof
   arbitrary x:Nat, y:Nat
@@ -254,6 +268,7 @@ end
 
 auto lit_monus_fromNat
 
+// If `m ≤ n`, then `m + (n ∸ m) = n` (no truncation happens).
 theorem uint_monus_add_identity: all n:UInt. all m:UInt.
   if m ≤ n
   then m + (n ∸ m) = n
@@ -268,6 +283,7 @@ proof
     by apply monus_add_identity to A
 end
 
+// `n ≤ m` witnesses the existence of a difference `x` with `m = n + x`.
 theorem uint_le_exists_monus : all n : UInt, m : UInt.
   if n <= m then some x : UInt. m = n + x
 proof
@@ -277,6 +293,7 @@ proof
   symmetric apply uint_monus_add_identity[m, n] to prem
 end
 
+// `x ∸ y = 0` characterises `x ≤ y` and vice versa.
 theorem uint_monus_zero_iff_less_eq : all x : UInt, y : UInt.
   x ≤ y ⇔ x ∸ y = 0
 proof
@@ -306,6 +323,7 @@ proof
   fwd, bkwd
 end
 
+// When the subtraction does not truncate, `+` can be reassociated with `∸`.
 theorem uint_monus_add_assoc: all n:UInt, l:UInt,m:UInt.
   if m ≤ n
   then l + (n ∸ m) = (l + n) ∸ m
@@ -320,6 +338,7 @@ proof
   lnm
 end
 
+// Literal-form of `uint_monus_bzero`.
 theorem uint_monus_zero: all n:UInt. n ∸ 0 = n
 proof
   expand lit | fromNat
@@ -328,6 +347,7 @@ end
 
 auto uint_monus_zero
 
+// Literal-form of `uint_monus_cancel_bzero`.
 theorem uint_monus_cancel: all n:UInt. n ∸ n = 0
 proof
   expand lit | fromNat
@@ -336,6 +356,7 @@ end
 
 auto uint_monus_cancel
 
+// `pred` is the same as subtracting one.
 lemma uint_pred_monus: all n:UInt. pred(n) = n ∸ 1
 proof
   arbitrary n:UInt
@@ -343,6 +364,7 @@ proof
   replace toNat_pred | toNat_monus | uint_toNat_fromNat | nat_monus_one_pred.
 end
 
+// Subtracting one from a positive UInt strictly decreases it.
 theorem uint_monus_one_less: all n:UInt.
   if not (n = 0) then n ∸ 1 < n
 proof

--- a/lib/UIntMult.pf
+++ b/lib/UIntMult.pf
@@ -15,6 +15,8 @@ import UIntAdd
   rest of the file builds the usual algebraic and order facts.
 */
 
+// Specification: UInt multiplication agrees with Nat multiplication
+// under `toNat`. Most theorems below pivot through this lemma.
 theorem toNat_mult: all x:UInt, y:UInt.
   toNat(x * y) = toNat(x) * toNat(y)
 proof
@@ -83,6 +85,7 @@ proof
   }
 end
 
+// Multiplication is commutative.
 theorem uint_mult_commute: all m:UInt, n:UInt.
   m * n = n * m
 proof
@@ -92,6 +95,7 @@ proof
   mult_commute
 end
 
+// Multiplication is associative.
 theorem uint_mult_assoc: all m:UInt, n:UInt, o:UInt.
   (m * n) * o = m * (n * o)
 proof
@@ -102,6 +106,7 @@ end
 
 associative operator* in UInt
 
+// `fromNat` is a multiplicative homomorphism.
 theorem fromNat_mult: all x:Nat, y:Nat. (fromNat(x * y) = fromNat(x) * fromNat(y))
 proof
   arbitrary x:Nat, y:Nat
@@ -110,6 +115,7 @@ proof
   replace toNat_mult | uint_toNat_fromNat.
 end
   
+// Auto rewrite: combine literal `fromNat` factors before multiplying.
 theorem lit_mult_fromNat: all x:Nat, y:Nat.
   fromNat(lit(x)) * fromNat(lit(y)) = fromNat(lit(x) * lit(y))
 proof
@@ -120,6 +126,7 @@ end
 
 auto lit_mult_fromNat
 
+// Left zero of multiplication.
 theorem uint_zero_mult: all n:UInt. 0 * n = 0
 proof
   arbitrary n:UInt
@@ -128,6 +135,7 @@ end
 
 auto uint_zero_mult
 
+// Right zero of multiplication.
 theorem uint_mult_zero: all n:UInt. n * 0 = 0
 proof
   arbitrary n:UInt
@@ -138,6 +146,7 @@ end
 
 auto uint_mult_zero
 
+// Left identity for multiplication.
 theorem uint_one_mult: all n:UInt.
   1 * n = n
 proof
@@ -149,6 +158,7 @@ end
 
 auto uint_one_mult
 
+// Right identity for multiplication.
 theorem uint_mult_one: all n:UInt.
   n * 1 = n
 proof
@@ -160,6 +170,7 @@ end
 
 auto uint_mult_one
 
+// Left distributivity of `*` over `+`.
 theorem uint_dist_mult_add:
   all a:UInt, x:UInt, y:UInt.
   a * (x + y) = a * x + a * y
@@ -170,6 +181,7 @@ proof
   replace dist_mult_add.
 end
 
+// Right distributivity of `*` over `+`.
 theorem uint_dist_mult_add_right:
   all x:UInt, y:UInt, a:UInt.
   (x + y) * a = x * a + y * a
@@ -181,6 +193,7 @@ proof
   uint_dist_mult_add[a, x, y]
 end
 
+// UInt has no zero divisors: a product is zero only if one factor is.
 theorem uint_mult_to_zero: all n:UInt, m:UInt.
   (if n * m = 0 then n = 0 or m = 0)
 proof
@@ -215,6 +228,7 @@ proof
   }
 end
 
+// Doubling: `2 * n` equals `n + n`.
 theorem uint_two_mult: all n:UInt. 2 * n = n + n
 proof
   arbitrary n:UInt
@@ -225,6 +239,7 @@ proof
   replace toNat_two | lit_two_mult.
 end
 
+// Multiplication is monotone on the right under `≤`.
 theorem uint_mult_mono_le: all n:UInt, x:UInt, y:UInt. (if x ≤ y then n * x ≤ n * y)
 proof
   arbitrary n:UInt, x:UInt, y:UInt
@@ -235,6 +250,7 @@ proof
   apply mult_mono_le[toNat(n)] to nxy
 end
 
+// Multiplication is monotone in both arguments under `≤`.
 theorem uint_mult_mono_le2: all n:UInt, x:UInt, m:UInt, y:UInt.
   (if n ≤ m and x ≤ y then n * x ≤ m * y)
 proof
@@ -247,6 +263,7 @@ proof
   apply mult_mono_le2 to nm, xy
 end
 
+// The binary constructor `inc_dub(n)` equals `1 + 2 * n`.
 lemma inc_dub_add_mult2: all n:UInt. inc_dub(n) = 1 + 2 * n
 proof  
   arbitrary n:UInt
@@ -257,6 +274,7 @@ proof
   replace nat_suc_one_add.
 end
 
+// The binary constructor `dub_inc(n)` equals `2 * (1 + n)`.
 lemma dub_inc_mult2_add: all n:UInt. dub_inc(n) = 2 * (1 + n)
 proof
   arbitrary n:UInt
@@ -266,6 +284,7 @@ proof
   replace uint_toNat_fromNat.
 end
 
+// Multiplying both sides by a positive UInt preserves strict order.
 theorem uint_pos_mult_both_sides_of_less: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and x < y then n * x < n * y)
 proof
@@ -280,6 +299,7 @@ proof
   apply pos_mult_both_sides_of_less to zn, xy
 end
 
+// Left cancellation by a positive factor in an equation.
 theorem uint_pos_mult_left_cancel: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and n * x = n * y then x = y)
 proof
@@ -297,6 +317,7 @@ proof
   apply uint_toNat_injective to xy
 end
 
+// Right cancellation by a positive factor in an equation.
 theorem uint_pos_mult_right_cancel: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and x * n = y * n then x = y)
 proof
@@ -305,6 +326,7 @@ proof
   uint_pos_mult_left_cancel
 end
 
+// Strict-inequality counterpart of `uint_pos_mult_left_cancel`.
 theorem uint_pos_mult_left_cancel_less: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and n * x < n * y then x < y)
 proof
@@ -318,6 +340,7 @@ proof
   apply less_toNat to xy
 end
 
+// Strict-inequality counterpart of `uint_pos_mult_right_cancel`.
 theorem uint_pos_mult_right_cancel_less: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and x * n < y * n then x < y)
 proof
@@ -326,6 +349,7 @@ proof
   uint_pos_mult_left_cancel_less
 end
 
+// Non-strict counterpart of `uint_pos_mult_left_cancel_less`.
 theorem uint_pos_mult_left_cancel_less_equal: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and n * x ≤ n * y then x ≤ y)
 proof
@@ -342,6 +366,7 @@ proof
   apply less_equal_toNat to xy
 end
 
+// Non-strict counterpart of `uint_pos_mult_right_cancel_less`.
 theorem uint_pos_mult_right_cancel_less_equal: all n:UInt, x:UInt, y:UInt.
   (if 0 < n and x * n ≤ y * n then x ≤ y)
 proof

--- a/lib/UIntSum.pf
+++ b/lib/UIntSum.pf
@@ -8,13 +8,19 @@ import UIntLess
 import UIntAdd
 
 /*
- Properties of UInt Summation
- */
+  Finite summation over UInt ranges.
 
+  `uint_summation(k, s, f)` sums `f(s), ..., f(s + k - 1)`. It is
+  defined by transporting through `toNat`/`fromNat`, so the theorems
+  below mirror those of the underlying Nat `summation`.
+*/
+
+// Sum `f(s), f(s+1), ..., f(s+k-1)` over UInt.
 fun uint_summation(k:UInt, begin:UInt, f:fn UInt->UInt) {
   fromNat(summation(toNat(k), toNat(begin), λ i { toNat(f(fromNat(i))) }))
 }
 
+// `fromNat` commutes with adding a Nat onto a UInt.
 lemma fromNat_toNat_add:
   all x:UInt, i:Nat. fromNat(toNat(x) + i) = x + fromNat(i)
 proof
@@ -24,6 +30,7 @@ proof
   replace uint_toNat_fromNat | toNat_add | uint_toNat_fromNat.
 end
 
+// Specification: a UInt summation is the corresponding Nat summation.
 theorem toNat_uint_summation:
   all k:UInt, begin:UInt, f:fn UInt->UInt.
   toNat(uint_summation(k, begin, f))
@@ -34,6 +41,7 @@ proof
   uint_toNat_fromNat
 end
 
+// The empty summation is zero.
 lemma uint_summation_bzero:
   all begin:UInt, f:fn UInt->UInt.
   uint_summation(bzero, begin, f) = bzero
@@ -47,6 +55,8 @@ proof
   evaluate
 end
 
+// UInt analogue of `summation_cong`: pointwise-equal summands over
+// shifted ranges yield equal sums.
 theorem uint_summation_cong:
   all k:UInt. all f:fn UInt->UInt, g:fn UInt->UInt, s:UInt, t:UInt.
   if (all i:Nat. if i < toNat(k) then f(s + fromNat(i)) = g(t + fromNat(i)))
@@ -69,6 +79,7 @@ proof
      replace fg.
 end
 
+// Append a final term: `Σ_{i<n+1} f(s+i) = Σ_{i<n} f(s+i) + f(s+n)`.
 theorem uint_summation_next:
   all n:UInt, s:UInt, f:fn UInt->UInt.
   uint_summation(1 + n, s, f) = uint_summation(n, s, f) + f(s + n)
@@ -84,6 +95,9 @@ proof
   replace fromNat_toNat_add[s, toNat(n)] | uint_fromNat_toNat.
 end
 
+// Split a length `a + b` summation into prefix `g` (length `a`) and
+// suffix `h` (length `b`), each agreeing pointwise with `f` on its
+// segment.
 theorem uint_summation_add:
   all a:UInt. all b:UInt, s:UInt, t:UInt,
       f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt.

--- a/test/should-error/private_lemma_hint_stdlib.pf.err
+++ b/test/should-error/private_lemma_hint_stdlib.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/private_lemma_hint_stdlib.pf:13.3-13.12: 'zero_mult' is declared as a `lemma` in module Nat (./lib/NatMult.pf:20); lemmas are module-private and not accessible from other modules. To make it accessible here, change `lemma` to `theorem` there.
+./test/should-error/private_lemma_hint_stdlib.pf:13.3-13.12: 'zero_mult' is declared as a `lemma` in module Nat (./lib/NatMult.pf:21); lemmas are module-private and not accessible from other modules. To make it accessible here, change `lemma` to `theorem` there.


### PR DESCRIPTION
## Summary

Continues the standard-library documentation work in #99 by adding
one-line comments on top-level definitions and theorems in eight
previously sparse modules:

- `lib/NatEvenOdd.pf`
- `lib/NatMonus.pf`
- `lib/NatMult.pf`
- `lib/NatSum.pf`
- `lib/UIntEvenOdd.pf`
- `lib/UIntMonus.pf`
- `lib/UIntMult.pf`
- `lib/UIntSum.pf`

Each comment names the intent of a theorem/lemma/definition rather
than restating its formula, so the role of each item is visible
without reading the proof body. Style follows the established pattern
in `lib/Base.pf` and `lib/NatDefs.pf`. The `UIntSum.pf` module header
is also expanded so it mirrors the descriptive header already on
`NatSum.pf`.

## Relation to #99

Refs #99 — does NOT close the issue.

Progress on the "Left to do" checklist from the issue body:

- [ ] **Continue filling in deeper definition- and theorem-level
  comments where individual stdlib files are still sparse.** —
  partially advanced by this PR (the eight modules above); other
  sparse files remain, e.g. `IntMult`, `NatDiv`, `NatLess`,
  `NatPowLog`, `UIntAdd`, `UIntDiv`, `UIntLess`, `UIntPowLog`,
  `UIntToFrom`.
- [ ] Decide whether Deduce should support Javadoc-style extraction
  from stdlib comments. — not addressed here.
- [ ] Make comments show up in generated theorem/reference files, if
  that remains desirable. — not addressed here.

## Test plan

- [x] `python3.13 test-deduce.py --lib` — all 33 lib modules check
  cleanly under both parsers.
- [x] `python3.13 test-deduce.py --equiv` — RD/LALR ASTs match and
  the pretty-printer round-trips for lib + should-validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)