### PR TITLE
[codex] Add Int min/max order laws

### DIFF
--- a/lib/IntDefs.pf
+++ b/lib/IntDefs.pf
@@ -181,3 +181,13 @@ fun operator >(x : Int, y : Int) {
 fun operator ≥(x : Int, y : Int) {
   y ≤ x
 }
+
+fun max(x : Int, y : Int) {
+  if x < y then y
+  else x
+}
+
+fun min(x : Int, y : Int) {
+  if x < y then x
+  else y
+}

--- a/lib/IntLess.pf
+++ b/lib/IntLess.pf
@@ -532,3 +532,317 @@ proof
     y_l_z
   }
 end
+
+// Properties of maximum and minimum.
+
+theorem int_max_symmetric: all x:Int, y:Int. max(x, y) = max(y, x)
+proof
+  arbitrary x:Int, y:Int
+  expand max
+  have tri: x < y or x = y or y < x by int_trichotomy[x, y]
+  cases tri
+  case x_l_y: x < y {
+    have not_y_l_x: not (y < x) by apply int_less_implies_not_greater to x_l_y
+    simplify with x_l_y | not_y_l_x.
+  }
+  case x_eq_y: x = y {
+    replace x_eq_y.
+  }
+  case y_l_x: y < x {
+    have not_x_l_y: not (x < y) by apply int_less_implies_not_greater to y_l_x
+    simplify with y_l_x | not_x_l_y.
+  }
+end
+
+theorem int_max_equal_greater_right: all x:Int, y:Int.
+  if x ≤ y then max(x, y) = y
+proof
+  arbitrary x:Int, y:Int
+  assume prem
+  expand max
+  have x_l_y_or_eq: x < y or x = y
+    by apply int_less_equal_iff_less_or_equal[x, y] to prem
+  cases x_l_y_or_eq
+  case x_l_y: x < y {
+    simplify with x_l_y.
+  }
+  case x_eq_y: x = y {
+    have not_x_l_y: not (x < y) by {
+      replace x_eq_y
+      int_less_irreflexive[y]
+    }
+    simplify with not_x_l_y
+    x_eq_y
+  }
+end
+
+theorem int_max_equal_greater_left: all x:Int, y:Int.
+  if y ≤ x then max(x, y) = x
+proof
+  arbitrary x:Int, y:Int
+  assume prem
+  expand max
+  have y_l_x_or_eq: y < x or y = x
+    by apply int_less_equal_iff_less_or_equal[y, x] to prem
+  cases y_l_x_or_eq
+  case y_l_x: y < x {
+    have not_x_l_y: not (x < y) by apply int_less_implies_not_greater to y_l_x
+    simplify with not_x_l_y.
+  }
+  case y_eq_x: y = x {
+    have not_x_l_y: not (x < y) by {
+      replace y_eq_x
+      int_less_irreflexive[x]
+    }
+    simplify with not_x_l_y.
+  }
+end
+
+theorem int_max_less_equal: all x:Int, y:Int, z:Int.
+  if x ≤ z and y ≤ z then max(x, y) ≤ z
+proof
+  arbitrary x:Int, y:Int, z:Int
+  assume prem
+  expand max
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y
+    show y ≤ z
+    prem
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y
+    show x ≤ z
+    prem
+  }
+end
+
+theorem int_max_greater_left: all x:Int, y:Int.
+  x ≤ max(x, y)
+proof
+  arbitrary x:Int, y:Int
+  expand max
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y
+    apply int_less_implies_less_equal to x_l_y
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y
+    int_less_equal_refl[x]
+  }
+end
+
+theorem int_max_greater_right: all x:Int, y:Int.
+  y ≤ max(x, y)
+proof
+  arbitrary x:Int, y:Int
+  expand max
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y
+    int_less_equal_refl[y]
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y
+    apply int_not_less_implies_less_equal to not_x_l_y
+  }
+end
+
+theorem int_max_is_left_or_right: all x:Int, y:Int.
+  max(x, y) = x or max(x, y) = y
+proof
+  arbitrary x:Int, y:Int
+  expand max
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y.
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y.
+  }
+end
+
+theorem int_max_idempotent: all x:Int.
+  max(x, x) = x
+proof
+  arbitrary x:Int
+  expand max
+  simplify with int_less_irreflexive[x].
+end
+
+theorem int_min_less_equal_left: all x:Int, y:Int.
+  min(x, y) ≤ x
+proof
+  arbitrary x:Int, y:Int
+  expand min
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y
+    int_less_equal_refl[x]
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y
+    apply int_not_less_implies_less_equal to not_x_l_y
+  }
+end
+
+theorem int_min_less_equal_right: all x:Int, y:Int.
+  min(x, y) ≤ y
+proof
+  arbitrary x:Int, y:Int
+  expand min
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y
+    apply int_less_implies_less_equal to x_l_y
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y
+    int_less_equal_refl[y]
+  }
+end
+
+theorem int_min_equal_less_left: all x:Int, y:Int.
+  if x ≤ y then min(x, y) = x
+proof
+  arbitrary x:Int, y:Int
+  assume prem
+  expand min
+  have x_l_y_or_eq: x < y or x = y
+    by apply int_less_equal_iff_less_or_equal[x, y] to prem
+  cases x_l_y_or_eq
+  case x_l_y: x < y {
+    simplify with x_l_y.
+  }
+  case x_eq_y: x = y {
+    have not_x_l_y: not (x < y) by {
+      replace x_eq_y
+      int_less_irreflexive[y]
+    }
+    simplify with not_x_l_y
+    symmetric x_eq_y
+  }
+end
+
+theorem int_min_equal_less_right: all x:Int, y:Int.
+  if y ≤ x then min(x, y) = y
+proof
+  arbitrary x:Int, y:Int
+  assume prem
+  expand min
+  have not_x_l_y: not (x < y) by {
+    assume x_l_y
+    have y_l_x_or_eq: y < x or y = x
+      by apply int_less_equal_iff_less_or_equal[y, x] to prem
+    cases y_l_x_or_eq
+    case y_l_x: y < x {
+      have x_l_x: x < x by apply int_less_trans[x, y, x] to x_l_y, y_l_x
+      apply int_less_irreflexive[x] to x_l_x
+    }
+    case y_eq_x: y = x {
+      have x_l_x: x < x by replace y_eq_x in x_l_y
+      apply int_less_irreflexive[x] to x_l_x
+    }
+  }
+  simplify with not_x_l_y.
+end
+
+theorem int_min_is_left_or_right: all x:Int, y:Int.
+  min(x, y) = x or min(x, y) = y
+proof
+  arbitrary x:Int, y:Int
+  expand min
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y.
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y.
+  }
+end
+
+theorem int_min_idempotent: all x:Int.
+  min(x, x) = x
+proof
+  arbitrary x:Int
+  expand min
+  simplify with int_less_irreflexive[x].
+end
+
+theorem int_min_symmetric: all x:Int, y:Int.
+  min(x, y) = min(y, x)
+proof
+  arbitrary x:Int, y:Int
+  expand min
+  have tri: x < y or x = y or y < x by int_trichotomy[x, y]
+  cases tri
+  case x_l_y: x < y {
+    have not_y_l_x: not (y < x) by apply int_less_implies_not_greater to x_l_y
+    simplify with x_l_y | not_y_l_x.
+  }
+  case x_eq_y: x = y {
+    replace x_eq_y.
+  }
+  case y_l_x: y < x {
+    have not_x_l_y: not (x < y) by apply int_less_implies_not_greater to y_l_x
+    simplify with y_l_x | not_x_l_y.
+  }
+end
+
+theorem int_min_greatest_less_equal: all x:Int, y:Int, z:Int.
+  if z ≤ x and z ≤ y then z ≤ min(x, y)
+proof
+  arbitrary x:Int, y:Int, z:Int
+  assume prem
+  expand min
+  have xy: x < y or not (x < y) by ex_mid[x < y]
+  cases xy
+  case x_l_y: x < y {
+    simplify with x_l_y
+    show z ≤ x
+    prem
+  }
+  case not_x_l_y: not (x < y) {
+    simplify with not_x_l_y
+    show z ≤ y
+    prem
+  }
+end
+
+theorem int_min_max_absorb_left: all x:Int, y:Int.
+  min(x, max(x, y)) = x
+proof
+  arbitrary x:Int, y:Int
+  apply int_min_equal_less_left[x, max(x, y)] to int_max_greater_left[x, y]
+end
+
+theorem int_max_min_absorb_left: all x:Int, y:Int.
+  max(x, min(x, y)) = x
+proof
+  arbitrary x:Int, y:Int
+  apply int_max_equal_greater_left[x, min(x, y)] to int_min_less_equal_left[x, y]
+end
+
+theorem int_min_max_absorb_right: all x:Int, y:Int.
+  min(max(x, y), x) = x
+proof
+  arbitrary x:Int, y:Int
+  replace int_min_symmetric[max(x, y), x]
+  int_min_max_absorb_left[x, y]
+end
+
+theorem int_max_min_absorb_right: all x:Int, y:Int.
+  max(min(x, y), x) = x
+proof
+  arbitrary x:Int, y:Int
+  replace int_max_symmetric[min(x, y), x]
+  int_max_min_absorb_left[x, y]
+end


### PR DESCRIPTION
## Summary
- add overloaded Int min/max definitions matching UInt
- prove Int min/max symmetry, bounds, idempotence, extremal, and absorption laws

## Validation
- make tests

Part of #660.