### PR TITLE
Check more Reference.md grammar fragments (Function, View, Import, Predicate, ...)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -1078,8 +1078,8 @@ To add type parameters to a function (to make it generic), see
 
 ## Function (Statement)
 
-```
-statement ::= visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}"
+```deduce-grammar
+function ::= visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}"
 ```
 
 The `fun` statement is for defining a function (non-recursive).
@@ -1342,10 +1342,11 @@ end
 
 ## Import (Statement)
 
-```
-statement ::= "import" identifier
-            | "import" identifier "using"  identifier ("|" identifier)*
-            | "import" identifier "hiding" identifier ("|" identifier)*
+```deduce-grammar
+import ::= visibility "import" IDENT
+import ::= visibility "import" IDENT "using" import_filter_list
+import ::= visibility "import" IDENT "hiding" import_filter_list
+import_filter_list ::= identifier ("|" identifier)*
 ```
 
 Import all of the definitions and theorems from the specified file
@@ -1426,8 +1427,8 @@ For induction over an inductively-defined predicate (rather than a
 union type), see [`rule induction`](#rule-induction-proof).
 
 ## Inductive (Statement)
-```
-inductive_decl: "inductive" type "by" proof
+```deduce-grammar
+inductive_decl ::= "inductive" type "by" proof_hi
 ```
 
 The `inductive` statement allows you to declare custom inductive structure
@@ -1900,8 +1901,8 @@ that finishes with a [conclusion](#conclusion-proof).
 
 ## Proof List
 
-```
-proof_list :: proof 
+```deduce-grammar
+proof_list ::= proof
 proof_list ::= proof "|" proof_list
 ```
 
@@ -1930,9 +1931,11 @@ with a [Conclusion](#conclusion-proof) (not a proof statement).
 
 ## Predicate (Statement)
 
-```
-statement ::= visibility "predicate" identifier type_params_opt ":" type "{" rule* "}"
-rule ::= identifier ":" formula
+```deduce-grammar
+predicate_declaration ::= visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}"
+predicate_rule ::= IDENT ":" term
+predicate_rule_list ::= ε
+predicate_rule_list ::= predicate_rule predicate_rule_list
 ```
 
 The `predicate` statement defines an inductively-defined set: the
@@ -2035,9 +2038,9 @@ well as some advice about how to prove it.
 
 ## Reason
 
-```
+```deduce-grammar
 reason ::= "by" proof
-reason ::= "begin" proof "end"
+reason ::= "proof" proof "end"
 ```
 
 ## Recall (Proof)
@@ -2102,8 +2105,8 @@ can use a `switch` statement.
 
 ## Relation (Statement)
 
-```
-statement ::= visibility "relation" identifier type_params_opt ":" type "{" rule* "}"
+```deduce-grammar
+relation_declaration ::= visibility "relation" identifier type_params_opt ":" type "{" predicate_rule_list "}"
 ```
 
 `relation` is an exact synonym for [`predicate`](#predicate-statement).
@@ -2831,17 +2834,8 @@ optionally be annotated with its type.
 
 ## View (Statement)
 
-```
-statement ::= visibility "view" identifier type_params_opt "{"
-                "source" type
-                "target" type
-                "into" identifier
-                "out" identifier
-                "roundtrip" identifier
-              "}"
-
-statement ::= visibility "recursive" identifier type_params_opt "(" type_list ")"
-                "->" type "{" fun_case+ "}"
+```deduce-grammar
+view_declaration ::= visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}"
 ```
 
 A `view` declaration describes how to pattern match on a value through


### PR DESCRIPTION
## Summary

Another slice of the [#473](https://github.com/jsiek/deduce/issues/473) Reference.md / Deduce.lark sync work. Migrates the grammar snippets for **Function (Statement)**, **Inductive**, **Reason**, **Proof List**, **Predicate**, **Relation**, **View**, and **Import** from plain ` ``` ` blocks to strict ` ```deduce-grammar ` blocks, so `gh_pages/scripts/reference_grammar.py` now catches drift on those rules.

The Reference grammar checker now covers **23** rules against `Deduce.lark` (up from 12).

### Doc bugs surfaced and fixed by the strict check

- **Reason**: documented `reason ::= "begin" proof "end"`, but the parser uses `"proof" proof "end"`.
- **Proof List**: first alternative was written `proof_list :: proof` (typo, missing `=`).
- **Inductive**: documented `proof` on the RHS, but the parser uses `proof_hi` (a higher-precedence proof form).

### Realigned nonterminal names

- **Predicate** → `predicate_declaration`, `predicate_rule`, `predicate_rule_list`
- **Relation** → `relation_declaration`
- **View** → `view_declaration` (also dropped an unrelated stray `recursive` alternative)
- **Import** → `import`, `import_filter_list` (also adds the missing `visibility` keyword that the parser accepts)
- **Function (Statement)** → `function`
- **Inductive** → `inductive_decl`
- **Reason** → `reason`
- **Proof List** → `proof_list`

## Sub-tasks from #473

This PR addresses one slice of the **Reference.md ↔ LALR sync** task in #473.

Completed by this PR:
- Migrate another batch of `Reference.md` grammar fragments to strict `deduce-grammar` blocks (now 23 rules checked, up from 12).

Remaining work for #473 (not covered here):
- Decide whether and how much of `test/should-error/` should participate in parser equivalence checks.
- Migrate the remaining `Reference.md` grammar fragments to strict `deduce-grammar` blocks (many sections still use plain `\`\`\`` blocks — e.g. Assert, Print, Trace, Theorem, Define, Auto, etc.).
- Expand round-trip coverage after improving the pretty-printer for currently non-parse-preserving proof/declaration forms.

## Test plan
- [x] `python3 gh_pages/scripts/reference_grammar.py` reports `Checked 23 ...`
- [x] `python3 gh_pages/scripts/keywords.py` passes
- [x] `make static` passes (ruff + mypy)
- [ ] `make tests` / `python3 test-deduce.py --site`

Refs [#473](https://github.com/jsiek/deduce/issues/473).

🤖 Generated with [Claude Code](https://claude.com/claude-code)