### PR TITLE
Enable parser.py disallow-untyped-defs ratchet

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -385,7 +385,7 @@ def parse_tree_to_ast(e: Any, parent: Any) -> Any:
     elif e.data == 'push_proof':
         proof_stmt = parse_tree_to_ast(e.children[0], e)
         if len(e.children) == 1:
-            meta: Any = Meta()  # type: ignore[no-untyped-call]
+            meta: Any = Meta()  # type: ignore[no-untyped-call,unused-ignore]
             meta.empty = False
             meta.filename = e.meta.filename
             meta.line = e.meta.end_line+1

--- a/parser.py
+++ b/parser.py
@@ -62,7 +62,7 @@ def init_parser() -> None:
 # Parsing Concrete to Abstract Syntax
 ##################################################
 
-def parse_tree_to_str_list(e):
+def parse_tree_to_str_list(e: Any) -> list[str]:
     if e.data == 'empty':
         return []
     elif e.data == 'single':
@@ -73,7 +73,7 @@ def parse_tree_to_str_list(e):
     else:
         raise Exception('parse_tree_to_str_list, unexpected ' + str(e))
 
-def parse_tree_to_list(e, parent):
+def parse_tree_to_list(e: Any, parent: Any) -> list[Any]:
     # Returns a list to match the recursive-descent parser's convention.
     # The inner 2-tuples like (identifier, typ) are paired data, not collections,
     # and stay as tuples.
@@ -118,12 +118,12 @@ def parse_tree_to_list(e, parent):
     else:
         raise Exception('parse_tree_to_str_list, unexpected ' + str(e))
 
-def parse_tree_to_case(e):
+def parse_tree_to_case(e: Any) -> tuple[str, Any]:
     tag = str(e.children[0].value)
     body = parse_tree_to_ast(e.children[1], e)
     return (tag, body)
 
-def parse_tree_to_case_list(e):
+def parse_tree_to_case_list(e: Any) -> list[tuple[str, Any]]:
     if e.data == 'single':
         return [parse_tree_to_case(e.children[0])]
     elif e.data == 'push':
@@ -156,13 +156,13 @@ operator_symbol = {'add': '+', 'sub': '-', 'mul': '*', 'div': '/', 'circ': '∘'
                    'membership': '∈', 'multiset_sum': '⨄', 'append': '++'}
 
 impl_num = 0
-def next_impl_num():
+def next_impl_num() -> int:
     global impl_num
     ret = impl_num
     impl_num += 1
     return ret
 
-def set_visibility(statement, visibility):
+def set_visibility(statement: Any, visibility: str) -> None:
     if visibility == 'private':
         statement.visibility = 'private'
     elif visibility == 'opaque':
@@ -173,7 +173,7 @@ def set_visibility(statement, visibility):
     else:
         statement.visibility = 'public'
         
-def build_equations_proof(loc, eqs):
+def build_equations_proof(loc: Meta, eqs: list[Any]) -> Any:
     result = None
     for (lhs, rhs, reason) in reversed(eqs):
         num_marks = count_marks(lhs) + count_marks(rhs)
@@ -189,7 +189,7 @@ def build_equations_proof(loc, eqs):
             result = PTransitive(loc, eq_proof, result)
     return result
         
-def parse_tree_to_ast(e, parent):
+def parse_tree_to_ast(e: Any, parent: Any) -> Any:
     if isinstance(e, Token):
         return e
     
@@ -247,7 +247,7 @@ def parse_tree_to_ast(e, parent):
     elif e.data == 'bool_type':
       return BoolType(e.meta)
     elif e.data == 'array_type':
-      elt_type = parse_tree_to_ast(e.children[0])
+      elt_type = parse_tree_to_ast(e.children[0], e)
       return ArrayType(e.meta, elt_type)
     elif e.data == 'type_type':
       return TypeType(e.meta)
@@ -385,7 +385,7 @@ def parse_tree_to_ast(e, parent):
     elif e.data == 'push_proof':
         proof_stmt = parse_tree_to_ast(e.children[0], e)
         if len(e.children) == 1:
-            meta = Meta() # Put the location of the 'Hole' at the start of the next line
+            meta: Any = Meta()  # type: ignore[no-untyped-call]
             meta.empty = False
             meta.filename = e.meta.filename
             meta.line = e.meta.end_line+1
@@ -886,7 +886,7 @@ def token_str(token: Token, program_text: str) -> str:
     return program_text[token.start_pos:token.end_pos]
 
 def parse_program_tree(parse_tree: Any) -> list[Statement]:
-    return cast(list[Statement], parse_tree_to_ast(parse_tree, None))  # type: ignore[no-untyped-call]
+    return cast(list[Statement], parse_tree_to_ast(parse_tree, None))
 
 def parse(program_text: str,
           trace: "bool | VerboseLevel" = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,10 +215,12 @@ module = ["abstract_syntax.*"]
 implicit_reexport = true
 
 # parser.py is also being ratcheted in small strictness slices for #506.
-# These cheap flags are clean; later passes should add check_untyped_defs
-# and disallow_untyped_defs once their larger error sets are fixed.
+# These flags are clean; the remaining strict bit is check_untyped_defs,
+# which currently reports ~255 errors and needs a wider pass.
 [[tool.mypy.overrides]]
 module = ["parser"]
 disallow_any_generics = true
 disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
 warn_return_any = true


### PR DESCRIPTION
## Summary

Another small slice of the [#506](https://github.com/jsiek/deduce/issues/506) `mypy --strict` rollout: ratchet `parser.py` from three strict flags up to five. Adds `disallow_untyped_defs` and `disallow_incomplete_defs` to the parser override block and annotates the eight remaining untyped helpers so the new flags pass.

`parser.py` strict-flag status after this PR:

| Flag | State |
| --- | --- |
| `warn_return_any` | enforced |
| `disallow_any_generics` | enforced |
| `disallow_untyped_calls` | enforced |
| `disallow_untyped_defs` | **enforced (new)** |
| `disallow_incomplete_defs` | **enforced (new)** |
| `check_untyped_defs` | still pending (~255 errors) |
| `disallow_untyped_decorators` | n/a (no decorators) |

`mypy --strict parser.py --follow-imports=silent` now reports 255 errors, all from `check_untyped_defs`. Those are the remaining target for a later slice.

## Approach

AST-shaped parameters and returns get `Any`, per the issue's narrow, monotonic annotation plan — the Lark `Tree` walker `parse_tree_to_ast` fans out to dozens of concrete AST node types and a precise union belongs in a wider pass.

Annotated:

- `parse_tree_to_str_list`, `parse_tree_to_list`, `parse_tree_to_case`, `parse_tree_to_case_list` — Lark `Tree` walkers.
- `next_impl_num` — `() -> int`.
- `set_visibility` — `(Any, str) -> None`.
- `build_equations_proof` — `(Meta, list[Any]) -> Any`.
- `parse_tree_to_ast` — `(Any, Any) -> Any`.

The existing `# type: ignore[no-untyped-call]` on `parse_program_tree` becomes unused once `parse_tree_to_ast` is annotated, so it's dropped.

## Drive-by bug fix

`parse_tree_to_ast` had a buggy call site for the `array_type` LALR branch:

```python
elif e.data == 'array_type':
  elt_type = parse_tree_to_ast(e.children[0])  # missing parent arg
```

The function requires a `parent` argument and every other call site passes one. Now surfaced by `disallow_untyped_defs`; fixed by passing `e` to match the surrounding pattern. This LALR branch was effectively dead under the type-tightened build; the recursive-descent parser is unaffected.

## Sub-tasks from #506

Completed by this PR:
- Ratchet `disallow_untyped_defs` + `disallow_incomplete_defs` for `parser.py`.

Remaining work for #506 (not covered here):
- `parser.py` `check_untyped_defs` (~255 errors).
- `rec_desc_parser.py` strict-mypy adoption.
- Reduce `Any` usage in the larger `checker_*.py` modules.

## Test plan

- [x] `python3.13 -m mypy --strict parser.py --follow-imports=silent` — 255 errors remain, all `check_untyped_defs`.
- [x] `python3.13 -m mypy .` clean.
- [x] `python3.13 -m ruff check .` clean.
- [ ] `make tests`.

Refs [#506](https://github.com/jsiek/deduce/issues/506).