### PR TITLE
[codex] Add recursive child call diagnostics tests

### DIFF
--- a/test/should-error/nested_child_recursive_call.pf
+++ b/test/should-error/nested_child_recursive_call.pf
@@ -1,0 +1,16 @@
+import Nat
+import List
+
+recursive all_elements<T>(List<T>, fn T->bool) -> bool {
+  all_elements(empty, P) = true
+  all_elements(node(x, xs), P) = P(x) and all_elements(xs, P)
+}
+
+union BinTree {
+  tr_node(Nat, Nat, List<BinTree>)
+}
+
+recursive is_valid(BinTree) -> bool {
+  is_valid(tr_node(n, h, kids)) =
+    all_elements(kids, λx:BinTree{ is_valid(x) })
+}

--- a/test/should-error/nested_child_recursive_call.pf.err
+++ b/test/should-error/nested_child_recursive_call.pf.err
@@ -1,0 +1,6 @@
+./test/should-error/nested_child_recursive_call.pf:15.36-15.47: ill-formed recursive call
+expected first argument to be n or h or kids, not x
+
+	in context of call all_elements(kids, fun x:BinTree { is_valid(x) })
+	function type: (fn <T> List<T>, (fn T -> bool) -> bool)
+	inferred type arguments: T := BinTree

--- a/test/should-error/recursive_function_higher_order_escape.pf
+++ b/test/should-error/recursive_function_higher_order_escape.pf
@@ -1,0 +1,15 @@
+import Nat
+import List
+
+recursive all_elements<T>(List<T>, fn T->bool) -> bool {
+  all_elements(empty, P) = true
+  all_elements(node(x, xs), P) = P(x) and all_elements(xs, P)
+}
+
+union BinTree {
+  tr_node(Nat, Nat, List<BinTree>)
+}
+
+recursive is_valid(BinTree) -> bool {
+  is_valid(tr_node(n, h, kids)) = all_elements(kids, is_valid)
+}

--- a/test/should-error/recursive_function_higher_order_escape.pf.err
+++ b/test/should-error/recursive_function_higher_order_escape.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/recursive_function_higher_order_escape.pf:14.54-14.62: the name 'is_valid' of a recursive function may only appear as the operator of a function call within its own body


### PR DESCRIPTION
## Summary

- Add regression coverage for recursive calls through nested list children in a lambda, matching the BinTree shape from #174.
- Add regression coverage for passing the recursive function itself as a higher-order value.
- Lock in the current diagnostics so this old issue does not regress to “no recursive calls” again.

## Validation

- make tests
