### PR TITLE
Add Int absolute value stdlib slice (Refs #660)

### DIFF
--- a/lib/Int.pf
+++ b/lib/Int.pf
@@ -17,6 +17,7 @@ public import IntAddSub
 public import IntMult
 public import IntLess
 public import IntEvenOdd
+public import IntAbs
 
 // Need the following for integer literals.
 

--- a/lib/IntAbs.pf
+++ b/lib/IntAbs.pf
@@ -1,0 +1,106 @@
+module Int
+
+import UInt
+import Base
+import IntDefs
+import IntAddSub
+import IntMult
+
+/*
+  Theorems about Int absolute value.
+
+  Lifts the structural identities `abs(pos(n)) = n` and
+  `abs(negsuc(n)) = 1 + n` to public theorems, gives the
+  `abs(x) = 0 ⇔ x = +0` characterization, and shows that absolute value
+  distributes over multiplication.
+*/
+
+theorem int_abs_pos: all n:UInt. abs(pos(n)) = n
+proof
+  arbitrary n:UInt
+  expand abs.
+end
+
+auto int_abs_pos
+
+theorem int_abs_negsuc: all n:UInt. abs(negsuc(n)) = 1 + n
+proof
+  arbitrary n:UInt
+  expand abs.
+end
+
+auto int_abs_negsuc
+
+theorem int_abs_zero: abs(+0) = 0
+proof
+  evaluate
+end
+
+auto int_abs_zero
+
+theorem int_abs_eq_zero_implies_zero: all x:Int.
+  if abs(x) = 0 then x = +0
+proof
+  arbitrary x:Int
+  switch x {
+    case pos(n) {
+      assume n_eq_0
+      replace n_eq_0
+      evaluate
+    }
+    case negsuc(n) {
+      .
+    }
+  }
+end
+
+theorem int_zero_implies_abs_eq_zero: all x:Int.
+  if x = +0 then abs(x) = 0
+proof
+  arbitrary x:Int
+  assume prem
+  replace prem
+  int_abs_zero
+end
+
+theorem int_abs_eq_zero_iff_zero: all x:Int.
+  abs(x) = 0 ⇔ x = +0
+proof
+  arbitrary x:Int
+  int_abs_eq_zero_implies_zero[x], int_zero_implies_abs_eq_zero[x]
+end
+
+theorem int_abs_mult: all x:Int, y:Int.
+  abs(x * y) = abs(x) * abs(y)
+proof
+  arbitrary x:Int, y:Int
+  switch x {
+    case pos(x') {
+      switch y {
+        case pos(y') {
+          replace mult_pos_pos.
+        }
+        case negsuc(y') {
+          replace mult_pos_negsuc
+          replace abs_neg
+          replace uint_dist_mult_add.
+        }
+      }
+    }
+    case negsuc(x') {
+      switch y {
+        case pos(y') {
+          replace int_mult_commute[negsuc(x'), pos(y')]
+          replace mult_pos_negsuc
+          replace abs_neg
+          replace uint_dist_mult_add_right
+          replace uint_mult_commute[y', x'].
+        }
+        case negsuc(y') {
+          expand operator*
+          replace sign_negsuc | mult_neg_neg | mult_pos_uint.
+        }
+      }
+    }
+  }
+end

--- a/test/should-validate/IntTests.pf
+++ b/test/should-validate/IntTests.pf
@@ -6,3 +6,22 @@ assert -1 ≤ -1
 assert -2 ≤ -1
 assert +0 ≤ +1
 assert -1 ≤ +0
+
+// abs spec smoke checks
+assert abs(+0) = 0
+assert abs(+5) = 5
+assert abs(-5) = 5
+assert abs(pos(7)) = 7
+assert abs(negsuc(6)) = 7
+
+theorem abs_distributes_over_mult_sample:
+  abs(-3 * +4) = abs(-3) * abs(+4)
+proof
+  int_abs_mult[-3, +4]
+end
+
+theorem abs_zero_iff_int_zero_sample: all x:Int.
+  abs(x) = 0 ⇔ x = +0
+proof
+  int_abs_eq_zero_iff_zero
+end


### PR DESCRIPTION
## Summary

Adds `lib/IntAbs.pf` with the missing public Int absolute-value theorems from the slice 5 / conversion-and-spec-cleanup portion of #660:

- `int_abs_pos`, `int_abs_negsuc` — public lifts of the structural identities (previously only available as private lemmas inside `IntAddSub.pf`), both registered as auto rules so `abs(pos(n))` / `abs(negsuc(n))` simplify automatically.
- `int_abs_zero` — `abs(+0) = 0`, auto.
- `int_abs_eq_zero_implies_zero`, `int_zero_implies_abs_eq_zero`, `int_abs_eq_zero_iff_zero` — the `abs(x) = 0 ⇔ x = +0` characterization.
- `int_abs_mult` — `abs(x * y) = abs(x) * abs(y)`, by case analysis on the `pos`/`negsuc` representations.

Wires `IntAbs` through `lib/Int.pf` and extends `test/should-validate/IntTests.pf` with abs smoke asserts plus sample theorems that exercise `int_abs_mult` and `int_abs_eq_zero_iff_zero`.

Addresses #660 (conversion / spec cleanup portion); the remaining slices (multiplication monotonicity/cancellation, division/modulo, divisibility/gcd/lcm, powers, summation) stay open as follow-ups.

## Test plan

- [x] `python3.13 deduce.py lib/IntAbs.pf` validates
- [x] `python3.13 deduce.py test/should-validate/IntTests.pf` validates (RD and `--lalr`)
- [x] `python3.13 test-deduce.py --lib` passes (lib × 2 parsers, 35 modules)
- [x] `make tests` passes (static + token + should-validate × 2 parsers + should-error + parser equivalence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)