### PR TITLE
[codex] Add type aliases

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -285,6 +285,8 @@ identifier: IDENT              -> identifier
 
 ?union: visibility "union" IDENT type_params_opt "{" constructor_list "}" -> union
 
+?type_alias: visibility "type" IDENT type_params_opt "=" type -> type_alias
+
 ?predicate_rule: IDENT ":" term                                 -> predicate_rule
 
 ?predicate_rule_list:                                           -> empty
@@ -342,6 +344,7 @@ identifier: IDENT              -> identifier
 ?inductive_decl: "inductive" type "by" proof_hi
 
 ?statement: union
+ | type_alias
  | predicate_declaration
  | relation_declaration
  | recursive_function

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -3,7 +3,7 @@
 Scope: every dataclass node that can appear at the top level of a ``.pf``
 file, together with the bookkeeping that supports them across imports.
 This covers the ``Declaration`` family (``Theorem``, ``Postulate``,
-``Predicate``, ``Union``, ``RecFun``, ``GenRecFun``, ``ViewRecFun``,
+``Predicate``, ``Union``, ``TypeAlias``, ``RecFun``, ``GenRecFun``, ``ViewRecFun``,
 ``ViewDecl``, ``Define``, ``Import``) and the non-``Declaration``
 statements (``Auto``, ``Inductive``, ``Module``, ``Export``,
 ``Associative``, ``Trace``, ``Assert``, ``Print``). Their AST helpers
@@ -383,6 +383,57 @@ class Union(Declaration):
         + ' '.join([str(c) for c in self.alternatives]) + '}'
     else:
       return base_name(self.name)
+
+
+@dataclass
+class TypeAlias(Declaration):
+  type_params: List[str]
+  body: Type
+
+  def reduce(self, env: object) -> Self:
+    return self
+
+  def uniquify(self, env: object, ctx: object) -> TypeAlias:
+    env_map = cast(dict[str, Any], env)
+    uniq_ctx = cast(UniquifyContext, ctx)
+    if self.name in env_map.keys():
+      user_error(self.location, "type names may not be overloaded")
+    new_name = generate_name(self.name, uniq_ctx)
+    env_map[self.name] = [new_name]
+    env_map['no overload'][self.name] = 'type alias'
+
+    body_env = copy_dict(env_map)
+    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
+    for old, new in zip(self.type_params, new_type_params):
+      extend(body_env, old, new, self.location)
+
+    return TypeAlias(self.location, new_name, new_type_params,
+                     self.body.uniquify(body_env, uniq_ctx),
+                     visibility=self.visibility)
+
+  def collect_exports(
+      self,
+      export_env: dict[str, Any],
+      importing_module: str,
+  ) -> None:
+    if self.visibility == 'private' and importing_module != get_current_module():
+      return
+    export_env[base_name(self.name)] = [self.name]
+
+  def substitute(self, sub: object) -> Self:
+    return self
+
+  def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
+    header = 'type ' + base_name(self.name) \
+        + ('<' + ','.join([base_name(t) for t in self.type_params]) + '>' if self.type_params else '')
+    return indent*' ' + header + ' = ' + str(self.body) + '\n'
+
+  def __str__(self) -> str:
+    if get_verbose():
+      shown_name = self.name
+      params = '<' + ','.join(self.type_params) + '>' if self.type_params else ''
+      return 'type ' + shown_name + params + ' = ' + str(self.body)
+    return base_name(self.name)
   
   
 @dataclass

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -26,7 +26,7 @@ from abstract_syntax import (
     Or, OverloadType, OverloadedVar, PSorry, PVar, PatternBool, PatternCons,
     Postulate, Predicate, Print, RecFun, ResolvedVar, Rule, Some,
     Statement, Switch, SwitchCase, TAnnote, TLet, Term, TermInst, Theorem,
-    Trace, Type, TypeInst, TypeType, Union, Var, VarRef, VerboseLevel,
+    Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, VarRef, VerboseLevel,
     ViewDecl, ViewRecFun, alpha_equiv, base_name, callable_name,
     check_post_typecheck_invariants, find_file, mkEqual, print_theorems,
     set_eval_all, set_reduce_all, type_match, type_names,
@@ -214,6 +214,14 @@ def process_declaration_visibility(decl: Declaration, env: Env,
                                              [checked_target], checked_source),
                                 env, "out")
       return checked_decl, env.declare_view(loc, checked_decl,
+                                            decl.visibility)
+
+    case TypeAlias(loc, name, typarams, body):
+      body_env = env.declare_type_vars(loc, typarams)
+      checked_body = check_type(body, body_env)
+      checked_alias = TypeAlias(loc, name, typarams, checked_body,
+                                visibility=decl.visibility)
+      return checked_alias, env.define_type(loc, name, checked_alias,
                                             decl.visibility)
   
     case Union(loc, name, typarams, alts):
@@ -836,6 +844,9 @@ def type_check_stmt(stmt: Statement, env: Env,
   
     case Union(loc, name, typarams, _):
       return stmt
+
+    case TypeAlias():
+      return stmt
   
     case Export(loc, name):
         return stmt
@@ -912,6 +923,9 @@ def collect_env(stmt: Statement, env: Env) -> Env:
       return env.declare_view(loc, stmt, stmt.visibility)
       
     case Union(loc, name, typarams, _):
+      return env
+
+    case TypeAlias():
       return env
           
     case Theorem(loc, name, frm, _, _):
@@ -1181,6 +1195,9 @@ def check_proofs(stmt: Statement, env: Env) -> None:
       _try_check_proof_of(terminates, formula, body_env)
   
     case Union(loc, name, typarams, _):
+      pass
+
+    case TypeAlias():
       pass
 
     case ViewDecl():

--- a/checker_types.py
+++ b/checker_types.py
@@ -57,6 +57,7 @@ from abstract_syntax import (
     Term,
     TermInst,
     Type,
+    TypeAlias,
     TypeInst,
     TypeType,
     Union,
@@ -435,6 +436,27 @@ def _check_union_arity(head: Any, given: int, env: Env) -> None:
           f"Expected union type '{head}' to have "
           f"{len(type_def.type_params)} type arguments, not {given}")
 
+def _lookup_type_alias(loc: Meta, typ: Any, env: Env) -> TypeAlias | None:
+  match typ:
+    case OverloadedVar(_, _, resolved_names):
+      if not env.type_var_is_defined(typ):
+        user_error(loc, 'undefined type variable ' + str(typ))
+      if len(resolved_names) > 1:
+        user_error(loc, 'type names may not be overloaded ' + str(typ))
+      defn = env.get_def_of_type_var(typ)
+    case ResolvedVar():
+      if not env.type_var_is_defined(typ):
+        user_error(loc, 'undefined type variable ' + str(typ))
+      defn = env.get_def_of_type_var(typ)
+    case _:
+      return None
+  return defn if isinstance(defn, TypeAlias) else None
+
+def _type_alias_arity_error(loc: Meta, name: str, expected: int, got: int) -> None:
+  user_error(loc,
+        f"Expected type alias '{base_name(name)}' to have "
+        f"{expected} type arguments, not {got}")
+
 # Validate that ``typ`` is well-formed in ``env`` and return the type
 # with every single-candidate ``OverloadedVar`` narrowed to
 # ``ResolvedVar``. The returned type may share structure with ``typ``
@@ -458,6 +480,13 @@ def check_type(typ: Any, env: Env, arity_required: bool = True) -> Any:
       if view_info is not None:
         _, source_ty, _ = view_info
         return source_ty
+      alias = _lookup_type_alias(loc, typ, env)
+      if alias is not None:
+        if len(alias.type_params) != 0:
+          if arity_required:
+            _type_alias_arity_error(loc, alias.name, len(alias.type_params), 0)
+          return ResolvedVar(loc, tyof, rs[0])
+        return alias.body
       if arity_required:
         _check_union_arity(typ, 0, env)
       # len(rs) == 1: this is a non-overloaded type reference. Promote.
@@ -469,6 +498,13 @@ def check_type(typ: Any, env: Env, arity_required: bool = True) -> Any:
       if view_info is not None:
         _, source_ty, _ = view_info
         return source_ty
+      alias = _lookup_type_alias(loc, typ, env)
+      if alias is not None:
+        if len(alias.type_params) != 0:
+          if arity_required:
+            _type_alias_arity_error(loc, alias.name, len(alias.type_params), 0)
+          return typ
+        return alias.body
       if arity_required:
         _check_union_arity(typ, 0, env)
       return typ
@@ -484,6 +520,15 @@ def check_type(typ: Any, env: Env, arity_required: bool = True) -> Any:
       if view_info is not None:
         _, source_ty, _ = view_info
         return source_ty
+      alias = _lookup_type_alias(loc, inner_typ, env)
+      if alias is not None:
+        new_args = [check_type(ty, env) for ty in arg_types]
+        if len(alias.type_params) != len(new_args):
+          _type_alias_arity_error(loc, alias.name,
+                                  len(alias.type_params), len(new_args))
+        subst = dict(zip(alias.type_params, new_args))
+        expanded = alias.body.substitute(subst)
+        return check_type(expanded, env)
       # The head is a generic-union reference applied to ``arg_types``;
       # suppress the bare-head arity check and validate against the
       # actual arg count instead.

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -137,6 +137,7 @@ presentation while they are migrated to the strict check.
 - [Transitive (Proof)](#transitive-proof)
 - [True (Formula)](#true-formula)
 - [Type](#type)
+- [Type Alias (Statement)](#type-alias-statement)
 - [Type List](#type-list)
 - [Type Parameters](#type-parameters)
 - [Union (Statement)](#union-statement)
@@ -2748,11 +2749,35 @@ end
 ```deduce-grammar
 type ::= "bool"                                        // type of a Boolean
 type ::= "type"                                        // the universe of types
-type ::= identifier                                    // type of a union
-type ::= identifier "<" type_list ">"                  // type of a generic union
+type ::= identifier                                    // type of a union or type alias
+type ::= identifier "<" type_list ">"                  // type of a generic union or type alias
 type ::= "[" type "]"                                  // type of an array
 type ::= "fn" type_params_opt type_list "->" type      // type of a function 
 type ::= "(" type ")"
+```
+
+## Type Alias (Statement)
+
+```deduce-grammar
+type_alias ::= visibility "type" IDENT type_params_opt "=" type
+```
+
+The `type` statement defines a type alias. A type alias may be
+parameterized, so aliases can also be used as type operators.
+
+```{.deduce^#type_alias_example}
+type Truth = bool
+
+define id_truth : fn Truth -> Truth = fun x { x }
+
+union Box<T> {
+  box(T)
+}
+
+type Id<T> = T
+type BoxOf<T> = Box<Id<T>>
+
+define boxed_true : BoxOf<Truth> = box(true)
 ```
 
 ## Type List
@@ -2773,7 +2798,8 @@ type_params_opt ::= ε
 type_params_opt ::= "<" identifier_list ">"
 ```
 
-Specifies the type parameters of a generic union or generic function.
+Specifies the type parameters of a generic union, type alias, or generic
+function.
 
 
 ## Union (Statement)

--- a/parser.py
+++ b/parser.py
@@ -13,7 +13,7 @@ from abstract_syntax import (
     Rule, RuleInduction, RuleInductionCase, RuleInversion, SimplifyFact,
     SimplifyGoal, Some, SomeElim, SomeIntro, Statement, Suffices, Switch,
     SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, TermInst,
-    Theorem, Trace, TypeInst, TypeType, Union, Var,
+    Theorem, Trace, TypeAlias, TypeInst, TypeType, Union, Var,
     ViewDecl, count_marks, extract_and, extract_or, extract_tuple,
     get_default_mark_LHS, intToNat, listToNodeList, mkEqual, mkIntLit,
     mkUIntLit, remove_mark,
@@ -661,6 +661,14 @@ def parse_tree_to_ast(e, parent):
         statement = Union(e.meta, str(e.children[1].value),
                           parse_tree_to_list(e.children[2], e),
                           parse_tree_to_list(e.children[3], e))
+        set_visibility(statement, visibility)
+        return statement
+
+    elif e.data == 'type_alias':
+        visibility = parse_tree_to_ast(e.children[0], e)
+        statement = TypeAlias(e.meta, str(e.children[1].value),
+                              parse_tree_to_list(e.children[2], e),
+                              parse_tree_to_ast(e.children[3], e))
         set_visibility(statement, visibility)
         return statement
 

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -18,7 +18,7 @@ from abstract_syntax import (
     RuleInduction, RuleInductionCase, RuleInversion, SimplifyFact,
     SimplifyGoal, Some, SomeElim, SomeIntro, Statement, Suffices, Switch,
     SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, TermInst,
-    Theorem, Trace, TypeInst, TypeType, Union, Var, ViewDecl,
+    Theorem, Trace, TypeAlias, TypeInst, TypeType, Union, Var, ViewDecl,
     count_marks, extract_and, extract_or, extract_tuple, get_default_mark_LHS,
     intToNat, listToNodeList, mkEqual, mkIntLit, mkUIntLit, remove_mark,
 )
@@ -1398,6 +1398,24 @@ def parse_union(visibility):
     raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
       + str(e))
 
+def parse_type_alias(visibility):
+  while_parsing = 'while parsing\n' \
+      + '\tstatement ::= "type" identifier type_params_opt "=" type\n'
+  try:
+    start_token = current_token()
+    advance()
+    name = parse_identifier()
+    type_params = parse_type_parameters()
+    consume_token('EQUAL', '"="', context='after type alias name')
+    body = parse_type()
+    return TypeAlias(meta_from_tokens(start_token, previous_token()),
+                     name, type_params, body, visibility=visibility)
+  except ParseError as e:
+    raise e.extend(meta_from_tokens(start_token, previous_token()), while_parsing)
+  except Exception as e:
+    raise ParseError(meta_from_tokens(start_token, previous_token()), "Unexpected error while parsing:\n\t" \
+      + str(e))
+
 def parse_predicate(visibility, keyword):
   # Parses both `predicate` and `relation`. They produce the same AST;
   # `keyword` ('predicate' | 'relation') is preserved on the AST node so
@@ -1607,7 +1625,7 @@ def parse_define(visibility):
 
 statement_keywords = {'assert', 'define', 'import', 'inductive', 'print',
                       'theorem', 'lemma', 'postulate', 'predicate', 'recursive',
-                      'relation', 'fun', 'trace', 'union', 'view' }
+                      'relation', 'fun', 'trace', 'type', 'union', 'view' }
 
 def parse_statement():
   if end_of_file():
@@ -1634,6 +1652,9 @@ def parse_statement():
 
   elif token.type == 'UNION':
     return parse_union(visibility)
+
+  elif token.type == 'TYPE':
+    return parse_type_alias(visibility)
 
   elif token.type == 'PREDICATE':
     return parse_predicate(visibility, 'predicate')

--- a/test/should-validate/type_alias.pf
+++ b/test/should-validate/type_alias.pf
@@ -1,0 +1,21 @@
+type Truth = bool
+
+define id_truth : fn Truth -> Truth = fun x { x }
+
+assert id_truth(true) = true
+
+union Box<T> {
+  box(T)
+}
+
+type Id<T> = T
+type BoxOf<T> = Box<Id<T>>
+type TruthBox = BoxOf<Truth>
+
+define boxed_true : TruthBox = box(true)
+
+type BoolEndo = fn Truth -> Truth
+
+define apply_endo : fn BoolEndo, Truth -> Truth = fun f, x { f(x) }
+
+assert apply_endo(id_truth, true) = true


### PR DESCRIPTION
## Summary
- Adds top-level `type` aliases, including parameterized aliases that act as type operators.
- Expands aliases during type checking for annotations, constructor signatures, and function types.
- Updates Reference.md and adds a should-validate regression covering aliases and type operators.

## Validation
- make tests
