### PR TITLE
[codex] Check more proof Reference grammar fragments

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -939,8 +939,11 @@ Deduce.)
 
 ```
 conclusion ::= "equations" equation equation_list
-equation ::= term "=" term reason
-half_equation ::= "..." "=" term reason
+```
+
+```deduce-grammar
+equation ::= term_compare "=" term_add reason
+half_equation ::= "..." "=" term_add reason
 equation_list ::= half_equation
 equation_list ::= half_equation equation_list
 equation_list ::= "$" equation equation_list
@@ -1904,9 +1907,9 @@ See [Visibility](#visibility).
 
 ## Proof
 
-```
-proof ::= proof_stmt proof
+```deduce-grammar
 proof ::= conclusion
+proof ::= proof_stmt proof?
 ```
 
 A proof is a sequence of zero or more [proof statements](#proof-statement)
@@ -2318,9 +2321,9 @@ analogous case body assumes `even(k) and even(k)`.
 
 ## Simplify (Proof)
 
-```
-proof_stmt :: "simplify"
-proof_stmt :: "simplify" "with" identifier_list_bar
+```deduce-grammar
+optional_proof_list ::= ε
+optional_proof_list ::= "with" proof_list
 ```
 
 Simplify the current goal formula using all of the built-in automatic


### PR DESCRIPTION
## Summary
- migrate the Equations helper grammar to a strict checked `deduce-grammar` block
- migrate the top-level `proof` grammar snippet to a strict checked block
- document and check `optional_proof_list`, used by simplify proof forms

## Validation
- `python3 gh_pages/scripts/reference_grammar.py`
- `git diff --check`
- `make tests`

Issue #473 remains open for additional Reference.md grammar-fragment migration, should-error parser-equivalence policy, and future round-trip expansion.
