### PR TITLE
[codex] Inline single-use statement grammar rules

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -283,17 +283,10 @@ identifier: IDENT              -> identifier
     | "private"         -> private
     | "opaque"          -> opaque
 
-?union: visibility "union" IDENT type_params_opt "{" constructor_list "}" -> union
-
-?type_alias: visibility "type" IDENT type_params_opt "=" type -> type_alias
-
 ?predicate_rule: IDENT ":" term                                 -> predicate_rule
 
 ?predicate_rule_list:                                           -> empty
     | predicate_rule predicate_rule_list                             -> push
-
-?predicate_declaration: visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}" -> predicate_declaration
-?relation_declaration:  visibility "relation"  identifier type_params_opt ":" type "{" predicate_rule_list "}" -> relation_declaration
 
 ?pattern: identifier                                  -> pattern_id
     | "0"                                        -> pattern_zero
@@ -312,14 +305,6 @@ identifier: IDENT              -> identifier
 ?fun_case_list: fun_case                               -> single
     | fun_case fun_case_list                           -> push
 
-?recursive_function: visibility "recursive" identifier type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}" -> recursive_function
-
-?function: visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}" -> fun
-
-?general_recursive_function: visibility "recfun" identifier type_params_opt "(" variable_list ")" "->" type "measure" term "of" type "{" term "}" "terminates" proof -> general_recursive_function
-
-?view_declaration: visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}" -> view_declaration
-
 ?definition: visibility "define" identifier "=" term        -> define
  | visibility "define" identifier ":" type "=" term         -> define_annot
 
@@ -327,41 +312,26 @@ identifier: IDENT              -> identifier
        | visibility "import" IDENT "using" import_filter_list  -> import_using
        | visibility "import" IDENT "hiding" import_filter_list -> import_hiding
 ?import_filter_list: identifier ("|" identifier)*            -> import_filter_list
-?export: "export" IDENT                            -> export
 
-?assert: "assert" term                             -> assert
-
-?print: "print" term                               -> print
-
-?associative_declaration: "associative" identifier type_params_opt "in" type -> associative_declaration
-
-?auto_declaration: "auto" proof_hi -> auto_declaration
-
-?module_declaration: "module" identifier  -> module_declaration
-
-?trace: "trace" identifier -> trace
-
-?inductive_decl: "inductive" type "by" proof_hi
-
-?statement: union
- | type_alias
- | predicate_declaration
- | relation_declaration
- | recursive_function
- | function
- | general_recursive_function
- | view_declaration
+?statement: visibility "union" IDENT type_params_opt "{" constructor_list "}" -> union
+ | visibility "type" IDENT type_params_opt "=" type -> type_alias
+ | visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}" -> predicate_declaration
+ | visibility "relation"  identifier type_params_opt ":" type "{" predicate_rule_list "}" -> relation_declaration
+ | visibility "recursive" identifier type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}" -> recursive_function
+ | visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}" -> fun
+ | visibility "recfun" identifier type_params_opt "(" variable_list ")" "->" type "measure" term "of" type "{" term "}" "terminates" proof -> general_recursive_function
+ | visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}" -> view_declaration
  | definition
- | associative_declaration
- | auto_declaration
+ | "associative" identifier type_params_opt "in" type -> associative_declaration
+ | "auto" proof_hi -> auto_declaration
  | import
- | export
- | assert
- | print
+ | "export" IDENT -> export
+ | "assert" term -> assert
+ | "print" term -> print
  | theorem
- | module_declaration
- | trace
- | inductive_decl
+ | "module" identifier -> module_declaration
+ | "trace" identifier -> trace
+ | "inductive" type "by" proof_hi -> inductive_decl
 
 ?statement_list: statement                               -> single
     | statement statement_list                           -> push

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -368,7 +368,7 @@ end
 ## Assert (Statement)
 
 ```deduce-grammar
-assert ::= "assert" term
+statement ::= "assert" term
 ```
 
 The `assert` statement evaluates a term and reports an error if the
@@ -430,7 +430,7 @@ See the entry for [Instantiation](#instantiation-term).
 ## Auto `auto` (Automatic Reduction)
 
 ```deduce-grammar
-auto_declaration ::= "auto" proof_hi
+statement ::= "auto" proof_hi
 ```
 
 To tell Deduce to automatically apply an equation, left to right, use
@@ -1088,7 +1088,7 @@ To add type parameters to a function (to make it generic), see
 ## Function (Statement)
 
 ```deduce-grammar
-function ::= visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}"
+statement ::= visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}"
 ```
 
 The `fun` statement is for defining a function (non-recursive).
@@ -1443,7 +1443,7 @@ union type), see [`rule induction`](#rule-induction-proof).
 
 ## Inductive (Statement)
 ```deduce-grammar
-inductive_decl ::= "inductive" type "by" proof_hi
+statement ::= "inductive" type "by" proof_hi
 ```
 
 The `inductive` statement allows you to declare custom inductive structure
@@ -1949,7 +1949,7 @@ with a [Conclusion](#conclusion-proof) (not a proof statement).
 ## Predicate (Statement)
 
 ```deduce-grammar
-predicate_declaration ::= visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}"
+statement ::= visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}"
 predicate_rule ::= IDENT ":" term
 predicate_rule_list ::= ε
 predicate_rule_list ::= predicate_rule predicate_rule_list
@@ -2029,7 +2029,7 @@ suggesting `relation`; the reverse hint fires for an arity-1
 ## Print (Statement)
 
 ```deduce-grammar
-print ::= "print" term
+statement ::= "print" term
 ```
 
 You can ask Deduce to print a value to standard output using the
@@ -2078,7 +2078,7 @@ is a proof of the formula `P1 and ... and Pn`. The formulas
 ## Recursive Function (Statement)
 
 ```deduce-grammar
-recursive_function ::= visibility "recursive" identifier type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}"
+statement ::= visibility "recursive" identifier type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}"
 fun_case ::= identifier "(" pattern_list ")" "=" term
 fun_case_list ::= fun_case
 fun_case_list ::= fun_case fun_case_list
@@ -2125,7 +2125,7 @@ can use a `switch` statement.
 ## Relation (Statement)
 
 ```deduce-grammar
-relation_declaration ::= visibility "relation" identifier type_params_opt ":" type "{" predicate_rule_list "}"
+statement ::= visibility "relation" identifier type_params_opt ":" type "{" predicate_rule_list "}"
 ```
 
 `relation` is an exact synonym for [`predicate`](#predicate-statement).
@@ -2704,7 +2704,7 @@ term_list ::= term "," term_list
 ## Trace (Statement)
 
 ```deduce-grammar
-trace ::= "trace" identifier
+statement ::= "trace" identifier
 ```
 
 You can ask Deduce to print the stack trace of functions as they get called or return a value using the `trace` statement. 
@@ -2773,7 +2773,7 @@ type ::= "(" type ")"
 ## Type Alias (Statement)
 
 ```deduce-grammar
-type_alias ::= visibility "type" IDENT type_params_opt "=" type
+statement ::= visibility "type" IDENT type_params_opt "=" type
 ```
 
 The `type` statement defines a type alias. A type alias may be
@@ -2819,7 +2819,7 @@ function.
 ## Union (Statement)
 
 ```deduce-grammar
-union ::= visibility "union" IDENT type_params_opt "{" constructor_list "}"
+statement ::= visibility "union" IDENT type_params_opt "{" constructor_list "}"
 constructor_list ::= constructor
 constructor_list ::= constructor constructor_list
 constructor ::= IDENT
@@ -2899,7 +2899,7 @@ optionally be annotated with its type.
 ## View (Statement)
 
 ```deduce-grammar
-view_declaration ::= visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}"
+statement ::= visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}"
 ```
 
 A `view` declaration describes how to pattern match on a value through

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -32,6 +32,7 @@ TOKEN_ALIASES = {
     "unsigned_integer": "INT",
 }
 PASSTHROUGH_RULES = {"type_hi"}
+SUBSET_RULES = {"statement"}
 
 
 @dataclass(frozen=True)
@@ -183,11 +184,15 @@ def main() -> int:
                     f"{REFERENCE_MD}:{block.line}: rule {rule!r} is not in Deduce.lark"
                 )
                 continue
-            if documented != expected:
+            if rule in SUBSET_RULES:
+                matches = documented <= expected
+            else:
+                matches = documented == expected
+            if not matches:
                 missing = expected - documented
                 extra = documented - expected
                 parts = [f"{REFERENCE_MD}:{block.line}: rule {rule!r} differs"]
-                if missing:
+                if missing and rule not in SUBSET_RULES:
                     parts.append("  Missing from Reference.md:\n" + format_alternatives(missing))
                 if extra:
                     parts.append("  Not present in Deduce.lark:\n" + format_alternatives(extra))


### PR DESCRIPTION
## Summary

- Inline single-use top-level statement grammar wrappers into `statement` while preserving parse-tree aliases.
- Update strict Reference grammar snippets to document these forms as `statement ::= ...`.
- Allow Reference grammar blocks for `statement` to document checked subsets of the full rule.

## Validation

- `make tests`
- `git diff --check`

## Codex session

codex://threads/019e4559-d554-7ce0-81d5-9019393d9d15

```bash
open 'codex://threads/019e4559-d554-7ce0-81d5-9019393d9d15'
```
