### PR TITLE
Install pygls+mcp in CI, drop LSP decorator carve-out (Refs #681)

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -22,6 +22,7 @@ jobs:
           cache: pip
           cache-dependency-path: |
             requirements.txt
+            requirements-lsp.txt
             gh_pages/requirements.txt
 
       - name: Install dependencies
@@ -29,6 +30,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f ./gh_pages/requirements.txt ]; then pip install -r ./gh_pages/requirements.txt; fi
+          if [ -f requirements-lsp.txt ]; then pip install -r requirements-lsp.txt; fi
           pip install ruff mypy
 
       - name: Lint with ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,15 +73,13 @@ warn_unreachable = true
 no_implicit_optional = true
 strict_equality = true
 disallow_subclassing_any = true
-# disallow_untyped_decorators is intentionally NOT enabled globally:
-# lsp/lsp_server.py and lsp/mcp_server.py use `@server.feature(...)`
-# / `@mcp.tool(...)` from `pygls` and `mcp`, neither of which is
-# installed in CI (they're optional and only needed when running the
-# LSP/MCP servers). Under `ignore_missing_imports = true` those
-# packages resolve to Any, which makes every decorator from them
-# "untyped" and trips the flag. The flag is set per-module in the
-# strict overrides below so the protection still applies to modules
-# whose decorators are real.
+# disallow_untyped_decorators is enabled globally now that the CI
+# workflow installs requirements-lsp.txt (`pygls` and `mcp`). Both
+# ship inline type annotations, so the LSP/MCP decorators no longer
+# resolve to Any in CI. Developers who skip the LSP install will see
+# this flag fire on `lsp/lsp_server.py` / `lsp/mcp_server.py`; install
+# `requirements-lsp.txt` to develop on those modules.
+disallow_untyped_decorators = true
 no_implicit_reexport = true
 exclude = [
     '^test/',
@@ -155,6 +153,8 @@ module = [
     "lsp.debugger",
     "lsp.dap_server",
     "lsp.library",
+    "lsp.lsp_server",
+    "lsp.mcp_server",
     "lsp.query",
     "claude_fill_hole.__main__",
     "claude_fill_hole.agent",
@@ -169,22 +169,6 @@ disallow_any_generics = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_untyped_decorators = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-warn_return_any = true
-
-# lsp/mcp_server.py and lsp/lsp_server.py use decorators from optional
-# dev-only deps (`mcp` and `pygls`) that the CI workflow does not
-# install. Under `ignore_missing_imports = true`, those decorators
-# resolve to `Any` on CI and trip disallow_untyped_decorators. They
-# live in this strict override without the decorator check, since mypy
-# refuses to merge two overrides setting conflicting values for the
-# same key.
-[[tool.mypy.overrides]]
-module = ["lsp.mcp_server", "lsp.lsp_server"]
-disallow_any_generics = true
-disallow_untyped_calls = true
-disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 warn_return_any = true


### PR DESCRIPTION
## Summary

Addresses #681 (the optional-decorator carve-out called out in section 4); does not close the umbrella issue.

- Install `requirements-lsp.txt` (`pygls>=2.1.0`, `mcp>=1.27.0`) in the `static` CI job. Both ship inline type annotations, so their decorators no longer resolve to `Any` under `ignore_missing_imports = true`.
- Enable `disallow_untyped_decorators` globally in `[tool.mypy]` and delete the dedicated override block that existed solely to enforce strict on `lsp.lsp_server` / `lsp.mcp_server` without that flag.
- Add `lsp.lsp_server` and `lsp.mcp_server` to the unified strict override list — they already pass `mypy --strict <file> --follow-imports=silent` once the real types resolve.

No source-code changes were needed; both modules were already strict-clean once their decorators had real types.

## What this completes / what remains in #681

Completed by this PR:

- The optional-decorator carve-out for `lsp.lsp_server` / `lsp.mcp_server`, mentioned as the only deliberate exception in section 4 of #681.

Still open in #681:

- `rec_desc_parser.py` strict adoption (~1224 strict errors).
- Pyproject cleanup: fold `parser.py` and `abstract_syntax` / `abstract_syntax.*` dedicated blocks into the unified strict block now that those modules pass full strict.
- Reduce `Any` usage everywhere (~521 mentions across the source tree, table in #681).
- Global `strict = true` once the above land.

## Test plan

- [x] `mypy .` clean locally (50 source files, no issues).
- [x] `ruff check .` clean.
- [x] Local `test-deduce.py` full suite passed (129.75s wall, "All tests passed").
- [x] CI green: `static` (29s) + all 6 `regression` matrix jobs (`equiv`, `errors`, `lib`, `parser`, `passable`, `site`).

[Claude session](claude://resume?session=5ed280e4-bf72-4470-b3ef-3ca81020a38b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

