### PR TITLE
Consolidate parser / abstract_syntax into unified strict mypy block (Refs #681)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,29 +100,9 @@ exclude = [
 # regression is caught in CI. Add a module here once `mypy --strict
 # <module> --follow-imports=silent` is clean.
 #
-# The order of expected wins from the remaining error counts (mypy
-# 2.1.0, --python-version 3.12, against this config — measured
-# 2026-05-13):
-#
-#   lsp/benchmark.py                            (4 errors; transitive
-#                                                untyped calls into
-#                                                flags.py / lsp.library
-#                                                — touching those
-#                                                ripples wider)
-#   compiler/lower.py                           (8; missing annotations
-#                                                on helpers and lower_*
-#                                                methods)
-#   tools/claude_fill_hole/__main__.py          (13)
-#   tools/claude_fill_hole/anthropic_backend.py (13)
-#   tools/claude_fill_hole/openai_backend.py    (30)
-#   lsp/mcp_server.py                           (30)
-#   style.py                                    (31)
-#   error.py                                    (65)
-#   lsp/query.py                                (132)
-#   parser.py                                   (310)
-#   abstract_syntax/                            (1192 before package split)
-#   proof_checker.py                            (1337)
-#   rec_desc_parser.py                          (1348)
+# rec_desc_parser.py is the last large module that still fails strict
+# (see #681); once it lands, `strict = true` can move into the global
+# `[tool.mypy]` block and this override list can be deleted.
 #
 # NOTE: mypy does not honor `strict = true` inside per-module overrides
 # (the meta-flag is global-only). The bits it would turn on are set
@@ -132,6 +112,8 @@ exclude = [
 module = [
     "deduce",
     "error",
+    "parser",
+    "abstract_syntax",
     "checker_cache",
     "checker_common",
     "checker_induction",
@@ -173,38 +155,10 @@ disallow_incomplete_defs = true
 check_untyped_defs = true
 warn_return_any = true
 
-# abstract_syntax/ is too big for a one-shot --strict adoption
-# (~1192 errors against full --strict — see #506). Ratchet the
-# heavyweight bits on one flag at a time, cheapest first; once they
-# are all on, move the module into the unified strict block above.
-# Order so far (per the table in #506):
-#   warn_return_any        (4 errors, fixed here)
-#   disallow_any_generics  (6 errors, fixed here)
-#   disallow_untyped_calls (16 errors, fixed here)
-#   disallow_incomplete_defs (18 errors, fixed here)
-#   disallow_untyped_defs  (493 errors, fixed here)
-#   check_untyped_defs     (77 errors, fixed here)
-[[tool.mypy.overrides]]
-module = ["abstract_syntax"]
-disallow_any_generics = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-check_untyped_defs = true
-warn_return_any = true
-
+# Submodules of abstract_syntax re-export sibling names through the
+# compatibility facade in abstract_syntax/__init__.py, which conflicts
+# with the global `no_implicit_reexport = true`. Allow implicit
+# re-export for the submodules only.
 [[tool.mypy.overrides]]
 module = ["abstract_syntax.*"]
 implicit_reexport = true
-
-# parser.py is also being ratcheted in small strictness slices for #506.
-# These flags are clean; the remaining strict bit is check_untyped_defs,
-# which currently reports ~255 errors and needs a wider pass.
-[[tool.mypy.overrides]]
-module = ["parser"]
-disallow_any_generics = true
-disallow_untyped_calls = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-warn_return_any = true


### PR DESCRIPTION
## Summary

Addresses #681 section 2 (pyproject cleanup); does not close the umbrella issue.

Both `parser.py` and `abstract_syntax/` already pass
`mypy --strict <file> --follow-imports=silent` cleanly, so their
dedicated `[[tool.mypy.overrides]]` blocks were just bookkeeping
duplicating the unified strict override.

- Move `parser` and `abstract_syntax` into the unified strict module list.
- Delete the dedicated `parser` strict block (and the stale comment claiming `check_untyped_defs` still reports ~255 errors — called out as stale in the issue).
- Delete the dedicated `abstract_syntax` strict block (and its pre-package-split ratchet history).
- Trim the resolved entries from the "expected wins" table in the header comment; `rec_desc_parser.py` is the only large module that still fails strict.
- Keep the `abstract_syntax.*` override solely for `implicit_reexport = true`, with a refreshed comment explaining why it survives.

No source-code changes are needed; this is purely bookkeeping.

## What this completes / what remains in #681

Completed by this PR:

- Section 2 (pyproject cleanup): `parser.py` and `abstract_syntax` dedicated strict blocks consolidated.

Still open in #681:

- Section 1: `rec_desc_parser.py` strict adoption (~1224 strict errors).
- Section 3: `Any` narrowing across `checker_*`, `abstract_syntax`, `parser`, `lsp/*`, `tools/claude_fill_hole/*`, and small modules.
- Section 4: global `strict = true` (blocked on section 1).

Section 4's optional-decorator carve-out is being handled in #682.

## Test plan

- [x] `python3.13 -m mypy .` clean (50 source files, no issues).
- [x] `python3.13 -m mypy --strict parser.py --follow-imports=silent` clean.
- [x] `python3.13 -m mypy --strict abstract_syntax --follow-imports=silent` clean.
- [x] `python3.13 -m ruff check .` clean.
- [x] `python test-deduce.py` full suite (129.63s, "All tests passed").
- [x] CI green: `static checks` (21s) + all 6 `regression` matrix jobs (`equiv` 2m6s, `errors` 1m25s, `lib` 2m21s, `parser` 1m11s, `passable` 3m13s, `site` 1m26s).

[Claude session](claude://resume?session=3c17e7c1-f741-4c34-9a4d-136721cc86a3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)