### PR TITLE
Migrate proof_stmt and conclusion grammar to checked blocks

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -514,11 +514,8 @@ assert length(list_example) = 3
 
 ## Cases (Disjunction Elimination)
 
-```
-conclusion ::= "cases" proof case_list
-```
-
 ```deduce-grammar
+conclusion ::= "cases" proof case_list
 case_list ::= case
 case_list ::= case case_list
 case ::= "case" identifier "{" proof "}"
@@ -555,7 +552,7 @@ case y_l_x: y < x {
 
 ## Choose (Proof)
 
-```
+```deduce-grammar
 proof_stmt ::= "choose" term_list
 ```
 
@@ -663,8 +660,8 @@ must be one of the following:
 
 ## Conjunct
 
-```
-conclusion ::= "conjunct" number "of" proof 
+```deduce-grammar
+conclusion ::= "conjunct" number "of" proof
 ```
 
 A proof of the form
@@ -853,7 +850,7 @@ assert gcd(17, 13) = 1
 
 ## Expand (Proof)
 
-```
+```deduce-grammar
 proof_stmt ::= "expand" identifier_list_bar
 ```
 
@@ -876,7 +873,7 @@ end
 
 ## Expand-In (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "expand" identifier_list_bar "in" proof
 ```
 
@@ -1229,9 +1226,9 @@ assert not (0 ≥ 1)
 
 ## Have (Proof Statement)
 
-```
-proof_stmt ::= "have" identifier ":" term reason 
-proof_stmt ::= "have" ":" term reason 
+```deduce-grammar
+proof_stmt ::= "have" identifier ":" term reason
+proof_stmt ::= "have" ":" term reason
 ```
 
 Use `have` to prove a formula that may help you later to prove the
@@ -1253,7 +1250,7 @@ used inside the proof `Y`.
 
 ## Help (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "help" proof
 ```
 
@@ -2062,7 +2059,7 @@ reason ::= "proof" proof "end"
 
 ## Recall (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "recall" term_list
 ```
 
@@ -2159,7 +2156,7 @@ The proof `reflexive` proves that `a = a` for any term `a`.
 
 ## Replace (Proof)
 
-```
+```deduce-grammar
 proof_stmt ::= "replace" proof_list
 ```
 
@@ -2188,7 +2185,7 @@ end
 
 ## Replace-In (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "replace" proof_list "in" proof
 ```
 
@@ -2655,7 +2652,7 @@ For case analysis on a member of an inductively-defined predicate
 
 ## Symmetric (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "symmetric" proof
 ```
 
@@ -2734,7 +2731,7 @@ Where `bzero`, `3`, `5`, and `6` are the return values of `sum`.
 
 ## Transitive (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "transitive" proof proof
 ```
 

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -32,7 +32,7 @@ TOKEN_ALIASES = {
     "unsigned_integer": "INT",
 }
 PASSTHROUGH_RULES = {"type_hi"}
-SUBSET_RULES = {"statement"}
+SUBSET_RULES = {"statement", "proof_stmt", "conclusion"}
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Continues the `Reference.md` <-> `Deduce.lark` sync slice for #473.

- `gh_pages/scripts/reference_grammar.py`: add `proof_stmt` and `conclusion` to `SUBSET_RULES` so the user-facing entries can document one alternative at a time, mirroring how `statement` already works.
- `gh_pages/doc/Reference.md`: convert the plain code-fence grammar snippets in 12 proof-related sections into strict `deduce-grammar` blocks:
  - Cases (Disjunction Elimination) — merges its `conclusion` line into the existing `case_list`/`case` block.
  - Choose, Conjunct, Expand, Expand-In, Have, Help, Recall, Replace, Replace-In, Symmetric, Transitive.

Each migrated production is verified to match the corresponding alternative in `Deduce.lark` exactly (after the script's existing token-alias normalization).

The Reference grammar checker now covers 62 rules against `Deduce.lark` (up from 50).

Refs #473.

## Sub-task progress for #473

This PR addresses part of the second remaining sub-task from the issue. The latest checklist from the issue:

- Decide whether and how much of `test/should-error/` should participate in parser equivalence checks. — **remains**
- Migrate more `Reference.md` grammar fragments to strict `deduce-grammar` blocks, marking intentional simplifications before strict comparison. — **incrementally addressed here** (12 more proof-related sections); more Reference.md sections still need migration (most term-level operator sections, plus buggy snippets in Conclude, Contradict, Show, Arbitrary, Injective, Reflexive that need their grammar fixed before migration).
- Expand round-trip coverage after improving the pretty-printer for currently non-parse-preserving proof/declaration forms. — **remains**

## Test plan

- [x] `make tests-tokens` — `Checked 62 Reference.md grammar rule(s) against Deduce.lark.`
- [x] `make static` — ruff + mypy pass
- [ ] CI green

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)