### PR TITLE
Add Int multiplication cancellation theorems (Refs #660)

### DIFF
--- a/lib/IntAbs.pf
+++ b/lib/IntAbs.pf
@@ -12,7 +12,9 @@ import IntMult
   Lifts the structural identities `abs(pos(n)) = n` and
   `abs(negsuc(n)) = 1 + n` to public theorems, gives the
   `abs(x) = 0 ⇔ x = +0` characterization, and shows that absolute value
-  distributes over multiplication.
+  distributes over multiplication. The closing trio (no zero divisors,
+  left/right cancellation by a nonzero factor) lives here because the
+  proofs route through `int_abs_mult` and `int_abs_eq_zero_implies_zero`.
 */
 
 theorem int_abs_pos: all n:UInt. abs(pos(n)) = n
@@ -103,4 +105,83 @@ proof
       }
     }
   }
+end
+
+// Int has no zero divisors: a product is zero only if a factor is.
+theorem int_mult_to_zero: all x:Int, y:Int.
+  if x * y = +0 then x = +0 or y = +0
+proof
+  arbitrary x:Int, y:Int
+  assume prem
+  have abs_prod_zero: abs(x) * abs(y) = 0 by {
+    equations
+          abs(x) * abs(y)
+        = abs(x * y)             by symmetric int_abs_mult[x, y]
+    ... = abs(+0)                by replace prem.
+    ... = 0                      by int_abs_zero
+  }
+  cases apply uint_mult_to_zero[abs(x), abs(y)] to abs_prod_zero
+  case ax_zero {
+    conclude x = +0 or y = +0
+      by apply int_abs_eq_zero_implies_zero[x] to ax_zero
+  }
+  case ay_zero {
+    conclude x = +0 or y = +0
+      by apply int_abs_eq_zero_implies_zero[y] to ay_zero
+  }
+end
+
+// Left cancellation by a nonzero factor in an Int equation.
+theorem int_mult_left_cancel: all n:Int, x:Int, y:Int.
+  if not (n = +0) and n * x = n * y then x = y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nnz: not (n = +0) by conjunct 0 of prem
+  have nxy: n * x = n * y by conjunct 1 of prem
+  // From n * x = n * y, derive n * (y - x) = +0.
+  have prod_zero: n * (y - x) = +0 by {
+    equations
+          n * (y - x)
+        = n * (y + -x)            by expand operator-.
+    ... = n * y + n * (-x)        by int_dist_mult_add[n, y, -x]
+    ... = n * y + -(n * x)        by {
+            have neg_mult: n * (-x) = -(n * x) by {
+              equations
+                    n * (-x)
+                  = (-x) * n          by int_mult_commute[n, -x]
+              ... = -(x * n)          by symmetric dist_neg_mult[x, n]
+              ... = -(n * x)          by replace int_mult_commute[x, n].
+            }
+            replace neg_mult.
+          }
+    ... = n * y + -(n * y)        by replace nxy.
+    ... = +0                      by int_add_inverse[n * y]
+  }
+  cases apply int_mult_to_zero[n, y - x] to prod_zero
+  case n_zero {
+    conclude false by apply nnz to n_zero
+  }
+  case yx_zero {
+    // y - x = +0 implies x = y.
+    have y_neg_x: y + -x = +0 by expand operator- in yx_zero
+    have x_neg_x: x + -x = +0 by int_add_inverse[x]
+    have step: y + -x = x + -x by transitive y_neg_x (symmetric x_neg_x)
+    symmetric apply int_add_both_sides_of_equal_right[-x, y, x] to step
+  }
+end
+
+// Right cancellation by a nonzero factor in an Int equation.
+theorem int_mult_right_cancel: all n:Int, x:Int, y:Int.
+  if not (n = +0) and x * n = y * n then x = y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nnz: not (n = +0) by conjunct 0 of prem
+  have xn_yn: x * n = y * n by conjunct 1 of prem
+  have nxy: n * x = n * y by {
+    replace int_mult_commute[n, x] | int_mult_commute[n, y]
+    xn_yn
+  }
+  apply int_mult_left_cancel[n, x, y] to nnz, nxy
 end


### PR DESCRIPTION
## Summary

Adds three Int multiplication cancellation theorems to `lib/IntAbs.pf` as a small slice of #660:

- `int_mult_to_zero` — Int has no zero divisors: `if x * y = +0 then x = +0 or y = +0`. Proof routes `abs(x * y) = abs(+0)` through `int_abs_mult` and `uint_mult_to_zero`, then peels off `abs(_) = 0` via `int_abs_eq_zero_implies_zero`.
- `int_mult_left_cancel` — `if not (n = +0) and n * x = n * y then x = y`. Reduces to `n * (y - x) = +0` using `int_dist_mult_add` (PR #686) plus the helper `n * (-x) = -(n * x)`, then applies `int_mult_to_zero`.
- `int_mult_right_cancel` — symmetric right form, reduced to the left form by `int_mult_commute`.

These are placed in `IntAbs.pf` rather than `IntMult.pf` so the proofs can use `int_abs_mult` and `int_abs_eq_zero_implies_zero` directly without re-doing the case-on-sign analysis.

Mirrors the UInt analogs `uint_pos_mult_left_cancel` / `uint_pos_mult_right_cancel` in `lib/UIntMult.pf`.

## Sub-task progress for #660

This PR addresses part of the "Int multiplication monotonicity and cancellation" slice (slice 1 follow-up).

Completed by this PR:
- Equality cancellation by a nonzero factor: `int_mult_left_cancel`, `int_mult_right_cancel`
- Supporting no-zero-divisor lemma: `int_mult_to_zero`

Still remaining from #660:
- Strict/non-strict order monotonicity and cancellation by a positive multiplier (and the sign-flipped versions for a negative multiplier).
- Slice 2 — Euclidean div / % plus `div_mod` and basic mod laws
- Slice 3 — Int `divides` / `gcd` / `lcm`
- Slice 4 — Int powers
- Slice 6 — Int-valued summation
- Conversion / specification cleanup tying literals, `abs`, and UInt theorems together

Refs #660

[Claude session](claude://resume?session=56e4039b-50f7-419b-b31d-6c004f22ba1d) (UUID: `56e4039b-50f7-419b-b31d-6c004f22ba1d`)

## Test plan
- [x] `python deduce.py --no-stdlib --dir lib lib/IntAbs.pf` passes under recursive-descent
- [x] `python deduce.py --lalr --no-stdlib --dir lib lib/IntAbs.pf` passes under LALR
- [ ] `make tests` clean locally
- [ ] CI green