### PR TITLE
Add Int parity successor/predecessor bridges (Refs #660)

### DIFF
--- a/lib/IntEvenOdd.pf
+++ b/lib/IntEvenOdd.pf
@@ -459,6 +459,46 @@ proof
   fwd, bkwd
 end
 
+// Subtracting one from an odd successor leaves an even number.
+theorem int_odd_one_even: all n:Int. if Odd(+1 + n) then Even(n)
+proof
+  arbitrary n:Int
+  assume prem: Odd(+1 + n)
+  cases int_Even_or_Odd[n]
+  case e_n { e_n }
+  case o_n {
+    have odd_one: Odd(+1) by {
+      expand Odd
+      choose +0
+      .
+    }
+    have ev_1n: Even(+1 + n) by apply int_odd_add_odd[+1, n] to odd_one, o_n
+    have not_odd: not Odd(+1 + n)
+      by apply (conjunct 0 of int_Even_not_Odd[+1 + n]) to ev_1n
+    conclude false by apply not_odd to prem
+  }
+end
+
+// Subtracting one from an even successor leaves an odd number.
+theorem int_even_one_odd: all n:Int. if Even(+1 + n) then Odd(n)
+proof
+  arbitrary n:Int
+  assume prem: Even(+1 + n)
+  cases int_Even_or_Odd[n]
+  case e_n {
+    have odd_one: Odd(+1) by {
+      expand Odd
+      choose +0
+      .
+    }
+    have odd_1n: Odd(+1 + n) by apply int_odd_add_even[+1, n] to odd_one, e_n
+    have not_odd: not Odd(+1 + n)
+      by apply (conjunct 0 of int_Even_not_Odd[+1 + n]) to prem
+    conclude false by apply not_odd to odd_1n
+  }
+  case o_n { o_n }
+end
+
 // Odd × Odd is odd.
 theorem int_odd_mult_odd: all x:Int, y:Int.
   if Odd(x) and Odd(y) then Odd(x * y)


### PR DESCRIPTION
## Summary

Adds two small Int parity bridge theorems to `lib/IntEvenOdd.pf`, mirroring the existing `uint_odd_one_even` / `uint_even_one_odd` in `lib/UIntEvenOdd.pf`:

- `int_odd_one_even: all n:Int. if Odd(+1 + n) then Even(n)`
- `int_even_one_odd: all n:Int. if Even(+1 + n) then Odd(n)`

Both proofs route through the Int parity dichotomy (`int_Even_or_Odd`) and the Even/not-Odd equivalence (`int_Even_not_Odd`), reusing the closure theorems `int_odd_add_odd` and `int_odd_add_even`. This sidesteps the subtract-one-from-both-sides algebra that the UInt versions use, because for Int we don't need a positive/successor case-split.

Refs #660 (multi-part tracking issue — does NOT close).

## Issue #660 progress

This PR addresses a continuation of **section 5 (parity)** in #660. After this PR:

- The UInt parity API in `UIntEvenOdd.pf` has analogs in `IntEvenOdd.pf` for: closure under +/× (both polarities), `Even_or_Odd` dichotomy, `Even ⇔ not Odd`, parity via `abs`, distributivity helpers, and now the `Odd(+1 + n) ↔ Even(n)` / `Even(+1 + n) ↔ Odd(n)` successor bridges added here.
- Remaining work on #660: sections 1 (Int conversion/spec theorems beyond what `IntAbs.pf` covers), 2 (strict-order extensions: trichotomy, min/max algebra parity with `UIntLess.pf`, multiplication monotonicity by sign), 3 (`%`/mod, `divides`, `gcd`, `lcm` on Int), 4 (Int power layer), 6 (Int-valued summation lemmas).

## Test plan
- [x] `python deduce.py lib/IntEvenOdd.pf`
- [x] `python deduce.py --lalr lib/IntEvenOdd.pf`
- [ ] CI: full `test-deduce.py` (lib + should-validate + should-error + parser equivalence)

[Claude session](claude://resume?session=60bad654-df9e-4d65-b79d-9d2c717d72ae) (UUID: `60bad654-df9e-4d65-b79d-9d2c717d72ae`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)