### PR TITLE
Add Int negation monotonicity theorems (Refs #660)

### DIFF
--- a/lib/IntLess.pf
+++ b/lib/IntLess.pf
@@ -1289,3 +1289,79 @@ proof
   have step2: a + d < c + d by apply int_add_less_mono_right[d, a, c] to ac
   apply int_less_trans[a + b, a + d, c + d] to step1, step2
 end
+
+theorem int_neg_le_mono: all x:Int, y:Int.
+  if x ≤ y then -y ≤ -x
+proof
+  arbitrary x:Int, y:Int
+  assume xy
+  have step: x + ((-x) + (-y)) ≤ y + ((-x) + (-y))
+    by apply int_add_le_right_mono[(-x) + (-y), x, y] to xy
+  have lhs_eq: x + ((-x) + (-y)) = -y by {
+    equations
+          x + ((-x) + (-y))
+        = (x + (-x)) + (-y)   by symmetric int_add_assoc[x, -x, -y]
+    ... = +0 + (-y)           by replace int_add_inverse[x].
+    ... = -y                  by int_zero_add[-y]
+  }
+  have rhs_eq: y + ((-x) + (-y)) = -x by {
+    equations
+          y + ((-x) + (-y))
+        = y + ((-y) + (-x))   by replace int_add_commute[-x, -y].
+    ... = (y + (-y)) + (-x)   by symmetric int_add_assoc[y, -y, -x]
+    ... = +0 + (-x)           by replace int_add_inverse[y].
+    ... = -x                  by int_zero_add[-x]
+  }
+  replace lhs_eq | rhs_eq in step
+end
+
+theorem int_neg_le_iff: all x:Int, y:Int.
+  x ≤ y ⇔ -y ≤ -x
+proof
+  arbitrary x:Int, y:Int
+  have fwd: if x ≤ y then -y ≤ -x by int_neg_le_mono[x, y]
+  have bkwd: if -y ≤ -x then x ≤ y by {
+    assume neg_le
+    have step: -(-x) ≤ -(-y) by apply int_neg_le_mono[-y, -x] to neg_le
+    replace neg_involutive[x] | neg_involutive[y] in step
+  }
+  fwd, bkwd
+end
+
+theorem int_neg_less_mono: all x:Int, y:Int.
+  if x < y then -y < -x
+proof
+  arbitrary x:Int, y:Int
+  assume xy
+  have step: x + ((-x) + (-y)) < y + ((-x) + (-y))
+    by apply int_add_less_mono_right[(-x) + (-y), x, y] to xy
+  have lhs_eq: x + ((-x) + (-y)) = -y by {
+    equations
+          x + ((-x) + (-y))
+        = (x + (-x)) + (-y)   by symmetric int_add_assoc[x, -x, -y]
+    ... = +0 + (-y)           by replace int_add_inverse[x].
+    ... = -y                  by int_zero_add[-y]
+  }
+  have rhs_eq: y + ((-x) + (-y)) = -x by {
+    equations
+          y + ((-x) + (-y))
+        = y + ((-y) + (-x))   by replace int_add_commute[-x, -y].
+    ... = (y + (-y)) + (-x)   by symmetric int_add_assoc[y, -y, -x]
+    ... = +0 + (-x)           by replace int_add_inverse[y].
+    ... = -x                  by int_zero_add[-x]
+  }
+  replace lhs_eq | rhs_eq in step
+end
+
+theorem int_neg_less_iff: all x:Int, y:Int.
+  x < y ⇔ -y < -x
+proof
+  arbitrary x:Int, y:Int
+  have fwd: if x < y then -y < -x by int_neg_less_mono[x, y]
+  have bkwd: if -y < -x then x < y by {
+    assume neg_less
+    have step: -(-x) < -(-y) by apply int_neg_less_mono[-y, -x] to neg_less
+    replace neg_involutive[x] | neg_involutive[y] in step
+  }
+  fwd, bkwd
+end


### PR DESCRIPTION
## Summary

Negation-flips-order slice for the Int stdlib. Adds to `lib/IntLess.pf`:

- `int_neg_le_mono`: if `x ≤ y` then `-y ≤ -x`
- `int_neg_le_iff`: `x ≤ y ⇔ -y ≤ -x`
- `int_neg_less_mono`: if `x < y` then `-y < -x`
- `int_neg_less_iff`: `x < y ⇔ -y < -x`

Builds on the addition monotonicity theorems landed earlier in the #660 series (`int_add_le_right_mono`, `int_add_less_mono_right`) together with `int_add_inverse` and `neg_involutive`. No new auto/recfun rules.

Refs #660 (strict-order / monotonicity slice follow-up). Leaving the issue open for the remaining slices: Int multiplication monotonicity by sign, Euclidean div/`%` with `div_mod`, divisibility/gcd/lcm, powers, summation, conversion/spec cleanup.

## Test plan

- [x] `python deduce.py lib/IntLess.pf` validates (recursive-descent parser)
- [x] `python deduce.py --lalr lib/IntLess.pf` validates
- [ ] `python test-deduce.py` (running locally in parallel with CI)

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID) — fallback UUID in backticks: \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)