### PR TITLE
Migrate more Reference.md grammar fragments to checked blocks (Refs #473)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -305,7 +305,7 @@ assert [1,2] ++ [3,4] = [1,2,3,4]
 
 ## Apply-To Proof (Modus Ponens)
 
-```
+```deduce-grammar
 conclusion ::= "apply" proof "to" proof
 ```
 
@@ -578,7 +578,7 @@ end
 
 ## Comma (Logical And Introduction)
 
-```
+```deduce-grammar
 conclusion ::= proof "," proof
 ```
 
@@ -935,7 +935,7 @@ Deduce.)
 
 ## Equations
 
-```
+```deduce-grammar
 conclusion ::= "equations" equation equation_list
 ```
 
@@ -991,7 +991,7 @@ end
 
 ## Evaluate (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "evaluate"
 ```
 
@@ -1001,7 +1001,7 @@ simplified to `true`.
 
 ## Evaluate-In (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "evaluate" "in" proof
 ```
 
@@ -1011,7 +1011,7 @@ a proof of the simplified formula.
 
 ## Extensionality
 
-```
+```deduce-grammar
 proof_stmt ::= "extensionality"
 ```
 
@@ -1388,11 +1388,8 @@ assert 1 ∈ S and 2 ∈ S and 3 ∈ S and not (4 ∈ S)
 
 ## Induction
 
-```
-conclusion ::= "induction" type induction_case_list
-```
-
 ```deduce-grammar
+conclusion ::= "induction" type induction_case_list
 induction_case_list ::= induction_case
 induction_case_list ::= induction_case induction_case_list
 induction_case ::= "case" pattern "{" proof "}"
@@ -1790,7 +1787,7 @@ end
 
 ## Opaque (Visibility)
 
-```
+```deduce-grammar
 visibility ::= "opaque"
 ```
 
@@ -1887,7 +1884,7 @@ A period is a proof of the formula `true` in Deduce.
 
 ## Private (Visibility)
 
-```
+```deduce-grammar
 visibility ::= "private"
 ```
 
@@ -1896,7 +1893,7 @@ See [Visibility](#visibility).
 
 ## Public (Visibility)
 
-```
+```deduce-grammar
 visibility ::= "public"
 ```
 
@@ -2209,11 +2206,8 @@ end
 
 ## Rule Induction (Proof)
 
-```
-conclusion ::= "rule" "induction" identifier rule_induction_case_list
-```
-
 ```deduce-grammar
+conclusion ::= "rule" "induction" identifier rule_induction_case_list
 rule_induction_case ::= "case" identifier "{" proof "}"
 rule_induction_case_list ::= rule_induction_case
 rule_induction_case_list ::= rule_induction_case rule_induction_case_list
@@ -2288,7 +2282,7 @@ induction hypothesis.
 
 ## Rule Inversion (Proof)
 
-```
+```deduce-grammar
 conclusion ::= "rule" "inversion" identifier rule_induction_case_list
 ```
 

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -32,7 +32,7 @@ TOKEN_ALIASES = {
     "unsigned_integer": "INT",
 }
 PASSTHROUGH_RULES = {"type_hi"}
-SUBSET_RULES = {"statement", "proof_stmt", "conclusion"}
+SUBSET_RULES = {"statement", "proof_stmt", "conclusion", "visibility"}
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Continues the Reference.md ↔ Deduce.lark sync slice for #473, following the same pattern as #674, #677, #679, and #685.

- `reference_grammar.py`: add `visibility` to `SUBSET_RULES` so user-facing entries can document one alternative at a time (the same pattern already used for `statement`, `proof_stmt`, and `conclusion`).
- `Reference.md`: convert the plain code-fence grammar snippets in Apply-To Proof, Comma, Equations, Evaluate, Evaluate-In, Extensionality, Rule Inversion, Opaque, Private, and Public into strict `deduce-grammar` blocks. Induction and Rule Induction merge their conclusion line into the existing case_list/case block (same trick used by Cases in #685).

The Reference grammar checker now covers **74 rules** against `Deduce.lark` (up from 62).

## Issue progress

This PR addresses #473's "Migrate more `Reference.md` grammar fragments to strict `deduce-grammar` blocks" sub-task incrementally — it does not finish that sub-task or the parent issue.

**Sub-tasks of #473 completed by this PR:**
- Migrated 12 more plain-fenced grammar snippets in `Reference.md` to strict `deduce-grammar` blocks (Apply-To Proof, Comma, Equations, Evaluate, Evaluate-In, Extensionality, Induction, Rule Induction, Rule Inversion, Opaque, Private, Public).

**Sub-tasks of #473 that remain:**
- Decide whether and how much of `test/should-error/` should participate in parser equivalence checks.
- Migrate the remaining plain-fenced grammar fragments (most of the operator/precedence blocks like Add, Append, All, And, Less, etc., plus a few proof entries with `formula`/`variable_list` simplifications such as Arbitrary, Conclude, Contradict, Define-Proof, Injective, Obtain, Show, Suffices) — these need either a TOKEN_ALIASES extension (e.g. `formula` → `term`), a tweak to the doc to use the actual rule name, or new SUBSET-style allowances for `term_*` rules.
- Expand parser round-trip coverage after improving the pretty-printer for currently non-parse-preserving proof/declaration forms.

## Test plan

- [x] `make tests-tokens` passes: `Checked 74 Reference.md grammar rule(s) against Deduce.lark.`
- [x] No `.pf` files touched; no parser or runtime code touched
- [x] Pre-existing `make static` failures (35 unrelated `pygls` decorator errors in `lsp/lsp_server.py` and `lsp/mcp_server.py`) verified identical on `main`

[Claude session](claude://resume?session=0004c415-52f1-46b6-9846-a41afde95be6) (UUID: \`0004c415-52f1-46b6-9846-a41afde95be6\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)