### PR TITLE
Document inline lambda syntax in FunctionalProgramming.md (#693)

### DIFF
--- a/gh_pages/doc/FunctionalProgramming.md
+++ b/gh_pages/doc/FunctionalProgramming.md
@@ -13,6 +13,7 @@ Deduce supports the following language features:
 * [Recursive Functions](#recursive-functions)
 * [Views](#views)
 * [Generic Functions](#generic-functions)
+* [Inline Functions (Lambdas)](#inline-functions-lambdas)
 * [Higher-order Functions](#higher-order-functions)
 * [Pairs](#pairs)
 
@@ -407,6 +408,42 @@ assert length(@[]<UInt>) = 0
 ```
 
 
+## Inline Functions (Lambdas)
+
+The `fun` keyword you saw in [Function (Statement)](#function-statement)
+also has an *inline* form that is just an expression, useful wherever a
+function value is needed (e.g. on the right-hand side of a `define` or
+as an argument to a higher-order function). The inline form starts with
+`fun`, followed by the parameter list, then the body in braces.
+
+```{.deduce^#double_lambda}
+define double = fun n:UInt { 2 * n }
+assert double(3) = 6
+```
+
+The inline form differs from the `fun` statement form in a few ways:
+
+* There is **no function name**, and the parameter list is **not enclosed
+  in parentheses**. Multiple parameters are separated by commas:
+  `fun h:UInt, w:UInt { h * w }`.
+* A type annotation on each parameter is required when Deduce cannot
+  otherwise infer the parameter types. So the standalone form
+  `define is_even = fun n { n % 2 = 0 }` is rejected, while either of the
+  following works because the function's type is already known from context:
+
+```{.deduce^#is_even_lambda}
+define is_even : fn UInt -> bool = fun n { n % 2 = 0 }
+assert is_even(4)
+assert not is_even(5)
+```
+
+* The Greek letter `λ` may be used in place of `fun`.
+
+Inline functions are most often used as arguments to
+[higher-order functions](#higher-order-functions); the
+[`remove_if` exercise](#remove-elements-from-a-list) below is an example.
+
+
 ## Higher-order Functions
 
 Functions may be passed as parameters to a function and they may be
@@ -507,6 +544,8 @@ The division operator `/`  is defined in `UInt.pf`.
 <<apply_length>>
 <<apply_length_empty>>
 <<head>>
+<<double_lambda>>
+<<is_even_lambda>>
 <<all_elements>>
 <<Pair>>
 ```


### PR DESCRIPTION
## Summary

Addresses #693. Adds an **Inline Functions (Lambdas)** subsection to `gh_pages/doc/FunctionalProgramming.md`, placed between *Generic Functions* and *Higher-order Functions*.

The new section:

- Shows the inline form (`fun n:UInt { 2 * n }`) and explains it is just an expression.
- Calls out the two differences from the `fun` *statement* form — no function name, and **no parentheses** around the parameter list — to head off the exact trap the issue describes (`fun (n:UInt) { ... }` parses as a statement form and is rejected).
- Notes that the parameter type annotation is required only when the function's type isn't otherwise known from context; with `define is_even : fn UInt -> bool = fun n { ... }` the annotation can be dropped.
- Mentions that `λ` is an alias for `fun`.
- Cross-links to the existing `remove_if` exercise, which is the only prior example in this file that uses the inline form (`fun x {x ≤ 1}`).

The TOC at the top is updated and the two new fenced code blocks are added to the literate-doc inclusion list at the bottom of the file so they get extracted into `test/should-validate/doc_programming.pf` and validated by `test-deduce.py --site` with both parsers.

## Test plan

- [x] `python3.13 test-deduce.py --site` — passes (12 doc files × 2 parsers).
- [x] Hand-checked that the two new examples (`#double_lambda`, `#is_even_lambda`) appear in the generated `test/should-validate/doc_programming.pf` and check successfully.

[Claude session](claude://resume?session=b77aa68f-c4d8-4cbb-99f8-f3d1467e5c09) (fallback: `b77aa68f-c4d8-4cbb-99f8-f3d1467e5c09`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)