### PR TITLE
docs(GettingStarted): explain prelude "> checking" output on first run

### DIFF
--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -44,6 +44,12 @@ You should see the following response from Deduce.
 example.pf is valid
 ```
 
+On the very first run Deduce also prints one `> checking <module>` line for
+each module in the standard-library prelude (around three dozen) while it
+builds the per-module `.thm` cache under `lib/`; subsequent runs reuse that
+cache and print just the `example.pf is valid` line above. This is normal
+output, not an error — pass `--quiet` to suppress it.
+
 This response means that all the proofs in `example.pf` are complete and flawless!
 Most of the time you will be working on incomplete or flawed proofs and
 Deduce will try to give you helpful feedback. For example, if you replace


### PR DESCRIPTION
## Summary

Fixes #694. The install walkthrough in [`GettingStarted.md`](gh_pages/doc/GettingStarted.md) tells a new user the expected response is:

```
example.pf is valid
```

But on a fresh checkout (no `lib/*.thm` cache yet) the actual output is 37 lines — 36 prelude-checking lines followed by the validity line — which is easy for a nervous beginner to misread as an error. Going with option 1 from the issue (the cheapest of the three): document the prelude noise inline rather than changing the runtime behavior.

The added paragraph:

> On the very first run Deduce also prints one `> checking <module>` line for each module in the standard-library prelude (around three dozen) while it builds the per-module `.thm` cache under `lib/`; subsequent runs reuse that cache and print just the `example.pf is valid` line above. This is normal output, not an error — pass `--quiet` to suppress it.

## Test plan

- [x] Reproduced cold-start behavior: `rm -f lib/*.thm && python3.13 deduce.py example.pf | wc -l` → `37`; second run → `1`.
- [x] Sanity-checked that `--quiet` does suppress the prelude lines ([`checker_pipeline.py:316`](checker_pipeline.py:316) gates the print on `get_quiet_mode()`).
- [x] Markdown renders correctly in the surrounding section.

Pure documentation change to a single `.md` file; no code or tests touched.

[Claude session](claude://resume?session=75868e95-d5d2-48a6-8932-8eeb1660a6ba)
`75868e95-d5d2-48a6-8932-8eeb1660a6ba`

🤖 Generated with [Claude Code](https://claude.com/claude-code)