### PR TITLE
LSP: add availableLemmasAt + insertLemma wire methods (Part 2 of #690)

### DIFF
--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -153,6 +153,16 @@ ELIMINABLE_VARS_REQUEST = "deduce/eliminableVarsAt"
 FILL_FROM_GIVEN_REQUEST = "deduce/fillFromGivenAt"
 MATCHING_GIVENS_REQUEST = "deduce/matchingGivensAt"
 
+# Custom requests for issue #690 (lemma search at a hole).  Same shape
+# as the eliminate / fill-from-given pair: the editor fetches ranked
+# lemma candidates via ``deduce/availableLemmasAt`` for the picker,
+# then issues ``deduce/insertLemma`` with the user's chosen name.
+# Tier-aware insertion (``conclude ... by``, ``apply ... to``,
+# ``replace``, bare name) is recomputed server-side from the buffer
+# state so the client doesn't have to round-trip the tier.
+AVAILABLE_LEMMAS_REQUEST = "deduce/availableLemmasAt"
+INSERT_LEMMA_REQUEST = "deduce/insertLemma"
+
 # Custom request for the Claude hole-fill sidecar (hole-fill-plan
 # Phase 1 / Step 2). Returns goal + givens + lemmas-in-scope +
 # fingerprint for the ``?`` token at the cursor. Sibling to
@@ -957,6 +967,113 @@ def on_fill_from_given_at(
     path = _path_from_uri(uri)
     edit = _query.fill_from_given_at(
         path, content, pos, str(label), prelude=_prelude_for(path)
+    )
+    if edit is None:
+        return None
+    return _workspace_edit_payload(uri, edit)
+
+
+def _lemma_match_payload(m: _query.LemmaMatch) -> dict[str, object]:
+    """Render a :class:`LemmaMatch` for the LSP wire.
+
+    Mirrors the MCP shape produced by :func:`lsp.mcp_server._to_serializable`
+    so editor clients see the same field names whether they came in
+    via MCP or LSP: ``kind`` and ``unify_tier`` are the enum/string
+    values, ``discharged_premises`` is a list of ``[premise,
+    by_given]`` pairs.
+    """
+    return {
+        "name": m.name,
+        "kind": m.kind.value,
+        "signature": m.signature,
+        "module": m.module,
+        "relevance": m.relevance,
+        "unify_tier": m.unify_tier,
+        "discharged_premises": [
+            [premise, by_given] for premise, by_given in m.discharged_premises
+        ],
+    }
+
+
+@server.feature(AVAILABLE_LEMMAS_REQUEST)
+def on_available_lemmas_at(
+    ls: LanguageServer, params: object
+) -> list[dict[str, object]]:
+    """Custom request: return ranked lemmas relevant at the cursor.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}, "query": str?, "limit": int?}``.  Cursor
+    on a ``?`` drives ranking by goal shape (unify tier first, then
+    head/symbol/module heuristics); ``query`` filters by substring or
+    goal-shape pattern with ``_`` placeholders; off-hole with no
+    query is browse mode -- everything in scope, ranked by module
+    proximity.
+
+    Result: a list of ``{"name", "kind", "signature", "module",
+    "relevance", "unify_tier", "discharged_premises"}`` dicts ordered
+    best-first.  ``unify_tier`` is one of ``"full"``,
+    ``"premises_remain"``, ``"rewrite_subterm"``, or ``null``;
+    ``discharged_premises`` is a list of ``[premise_text, given_label]``
+    pairs (non-empty only for the ``"full"`` tier).  Empty list when
+    nothing is in scope or the ``query`` matches nothing.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _field_as_str(text_doc, "uri")
+    if not uri:
+        return []
+    content = _document_content(ls, uri)
+    if content is None:
+        return []
+    pos = _query_pos_from_lsp(
+        _position_from_param(pos_obj)
+    )
+    path = _path_from_uri(uri)
+    query = _field_as_str(params, "query")
+    limit_obj = _get_field(params, "limit")
+    limit = limit_obj if isinstance(limit_obj, int) else 50
+    matches = _query.available_lemmas_at(
+        path, content, pos,
+        query=query,
+        prelude=_prelude_for(path),
+        limit=limit,
+    )
+    return [_lemma_match_payload(m) for m in matches]
+
+
+@server.feature(INSERT_LEMMA_REQUEST)
+def on_insert_lemma(
+    ls: LanguageServer, params: object
+) -> Optional[dict[str, object]]:
+    """Custom request: return a tier-aware WorkspaceEdit that splices a
+    reference to the named lemma at the cursor.
+
+    Params: ``{"textDocument": {"uri": "..."}, "position": {"line":
+    int, "character": int}, "name": str}``.  ``name`` must be in scope
+    as a theorem, lemma, or postulate at ``position``.
+
+    Result: ``{"changes": {<uri>: [{"range": Range, "newText":
+    str}]}}`` (an LSP-shaped WorkspaceEdit) or ``null`` when ``name``
+    isn't in scope at the cursor.
+
+    Tier is recomputed server-side; see :func:`lsp.query.insert_lemma_at`
+    for the four template shapes.
+    """
+    text_doc = _get_field(params, "textDocument")
+    pos_obj = _get_field(params, "position")
+    uri = _field_as_str(text_doc, "uri")
+    name = _field_as_str(params, "name")
+    if not uri or not name:
+        return None
+    content = _document_content(ls, uri)
+    if content is None:
+        return None
+    pos = _query_pos_from_lsp(
+        _position_from_param(pos_obj)
+    )
+    path = _path_from_uri(uri)
+    edit = _query.insert_lemma_at(
+        path, content, pos, str(name), prelude=_prelude_for(path)
     )
     if edit is None:
         return None

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -87,6 +87,7 @@ __all__ = [
     "apply_at",
     "hole_context_at",
     "available_lemmas_at",
+    "insert_lemma_at",
     "validate_proof_at",
     "preview_replace_at",
     "preview_expand_at",
@@ -3700,6 +3701,124 @@ def available_lemmas_at(
     return tuple(ranked)
 
 
+def insert_lemma_at(
+    path: str,
+    content: str,
+    pos: Position,
+    name: str,
+    prelude: Sequence[str] = (),
+) -> Optional[WorkspaceEdit]:
+    """Return a tier-aware ``WorkspaceEdit`` that references ``name`` at
+    ``pos``.
+
+    Template shape depends on how the lemma's conclusion relates to the
+    current goal at the hole at ``pos`` -- the same tier classifier
+    :func:`available_lemmas_at` uses to rank candidates (see
+    :class:`LemmaMatch`). The four shapes:
+
+    - **full** (conclusion unifies, every premise discharged by a local
+      given): replaces ``?`` with ``conclude <goal> by apply <name> to
+      <p1>, ..., <pN>`` -- or just ``conclude <goal> by <name>`` when
+      the lemma has no premises.
+    - **premises_remain** (conclusion unifies, some premises stay open):
+      replaces ``?`` with ``apply <name> to ?`` -- one fresh ``?`` for
+      the user to fill.
+    - **rewrite_subterm** (equation lemma whose LHS/RHS matches a goal
+      subterm): replaces ``?`` with ``replace <name>``.
+    - **none** (no tier match, or cursor not on a hole, or browse mode):
+      inserts the bare ``<name>`` at ``pos`` (zero-width edit when not
+      on a hole, otherwise replacing the ``?``).
+
+    Tier is recomputed server-side from the current buffer, so callers
+    don't have to round-trip it through the prior
+    :func:`available_lemmas_at` response -- a buffer that changed
+    between picker and insertion still produces a sensible template.
+
+    Returns ``None`` when ``name`` is not in scope as a theorem, lemma,
+    or postulate at ``pos``.
+    """
+    from lsp.library import check_file
+
+    hole_range = _find_hole_at(content, pos)
+    goal_text: Optional[str] = None
+    goal_ast: Any = None
+    env: Any = None
+
+    if hole_range is not None:
+        target = (hole_range.start.line, hole_range.start.column)
+        with _target_hole(target):
+            result = check_file(path, content=content, prelude=prelude)
+        if not result.ok:
+            exc = result.exception
+            goal = _goal_from_exception(exc, hole_range)
+            if goal is not None:
+                goal_text = goal.formula
+            goal_ast = getattr(exc, "formula", None)
+            env = getattr(exc, "env", None)
+        ast_nodes = result.ast
+    else:
+        result = check_file(path, content=content, prelude=prelude)
+        ast_nodes = result.ast
+
+    candidates = _collect_lemma_candidates(path, ast_nodes, prelude)
+    target_formula: Any = None
+    for info, formula, _module in candidates:
+        if info.name == name:
+            target_formula = formula
+            break
+    if target_formula is None:
+        return None
+
+    tier: Optional[str] = None
+    discharged: tuple[tuple[str, str], ...] = ()
+    if goal_ast is not None and env is not None:
+        given_pairs = _collect_local_givens(env)
+        _score, tier, discharged = _unify_score(
+            target_formula, goal_ast, env, given_pairs
+        )
+
+    template = _insert_lemma_template(
+        name, target_formula, tier, discharged, goal_text
+    )
+
+    if hole_range is None:
+        zero_range = Range(start=pos, end=pos)
+        return WorkspaceEdit(path=path, range=zero_range, new_text=template)
+
+    template = _indent_continuation(
+        template, _line_indent_at(content, hole_range.start)
+    )
+    return WorkspaceEdit(path=path, range=hole_range, new_text=template)
+
+
+def _insert_lemma_template(
+    name: str,
+    formula: Any,
+    tier: Optional[str],
+    discharged: tuple[tuple[str, str], ...],
+    goal_text: Optional[str],
+) -> str:
+    """Pick the tactic-shape template for ``insert_lemma_at`` (issue #690).
+
+    The tier picks the surrounding shape; ``discharged`` supplies the
+    given labels for the ``full`` case; ``formula`` is consulted to
+    count premises when there are no labels (e.g. ``premises_remain``
+    where every premise is open, or ``full`` with 0 premises).
+    """
+    if tier == "full":
+        if not discharged and goal_text is not None:
+            return f"conclude {goal_text} by {name}"
+        labels = ", ".join(label for _, label in discharged)
+        if goal_text is not None:
+            return f"conclude {goal_text} by apply {name} to {labels}"
+        return f"apply {name} to {labels}"
+    if tier == "premises_remain":
+        return f"apply {name} to ?"
+    if tier == "rewrite_subterm":
+        return f"replace {name}"
+    return name
+
+
 def _module_for_path(path: str) -> str:
     """Module name for the file at ``path`` -- the path's stem."""
     from pathlib import Path
@@ -4255,8 +4374,8 @@ def _unify_score(
     # Tier 3: equation conclusion -> try LHS/RHS against goal subterms.
     if isinstance(conc, Call) and isinstance(conc.rator, VarRef):
         try:
-            if conc.rator.get_name() == "=" and len(conc.rands) == 2:
-                lhs, rhs = conc.rands
+            if conc.rator.get_name() == "=" and len(conc.args) == 2:
+                lhs, rhs = conc.args
                 subterms = _iter_subterms(goal_ast)
                 for side in (lhs, rhs):
                     for sub in subterms:

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -564,6 +564,38 @@ def test_unify_outranks_head_symbol_only_match() -> None:
     )
 
 
+def test_unify_rewrite_subterm_tier_fires_for_equation_lemma() -> None:
+    """An equation lemma whose LHS unifies with a subterm of the goal
+    -- but whose whole-conclusion shape doesn't unify -- gets the
+    ``rewrite_subterm`` tier.  Regression for the typo in Part 1 of
+    issue #690 where ``conc.rands`` (instead of ``conc.args``) made
+    the tier-3 branch silently dead code."""
+    source = (
+        "theorem not_not: all P:bool. P = not (not P)\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  switch P {\n"
+        "    case true { . }\n"
+        "    case false { . }\n"
+        "  }\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool."
+        " if P and Q then not (not P) and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose h: P and Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "lemmas.pf", source, Position(line=14, column=3)
+    )
+    by_name = {m.name: m for m in matches}
+    assert "not_not" in by_name
+    assert by_name["not_not"].unify_tier == "rewrite_subterm"
+
+
 def test_browse_mode_leaves_unify_tier_unset() -> None:
     """Browse mode (no goal, no query) doesn't run the unifier, so
     ``unify_tier`` stays ``None`` on every result."""

--- a/test/lsp/test_insert_lemma.py
+++ b/test/lsp/test_insert_lemma.py
@@ -1,0 +1,262 @@
+"""Acceptance tests for ``lsp.query.insert_lemma_at`` (issue #690).
+
+Companion to ``test_available_lemmas.py``. ``available_lemmas_at``
+gives the editor a ranked picker of lemma candidates with a unify
+tier on each entry; ``insert_lemma_at`` translates a chosen name
+into a tier-aware ``WorkspaceEdit`` that splices the right Deduce
+tactic shape into the buffer.
+
+Coverage:
+
+(a) ``full`` tier with 0 premises -> ``conclude <goal> by <name>``;
+(b) ``full`` tier with 1 premise discharged by a given ->
+    ``conclude <goal> by apply <name> to <label>``;
+(c) ``full`` tier with N premises discharged ->
+    ``conclude <goal> by apply <name> to <l1>, ..., <lN>``;
+(d) ``premises_remain`` tier -> ``apply <name> to ?``;
+(e) ``rewrite_subterm`` tier -> ``replace <name>``;
+(f) no unify match (off-hole or browse) -> bare ``<name>`` at point;
+(g) name not in scope -> ``None``.
+
+Fixtures stay inside ``bool``-only territory so tests run with no
+prelude.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lsp.query import (  # noqa: E402
+    Position,
+    Range,
+    WorkspaceEdit,
+    insert_lemma_at,
+)
+
+
+# ---------------------------------------------------------------------------
+# `full` tier: conclude ... by ...
+# ---------------------------------------------------------------------------
+
+
+def test_full_tier_no_premises_emits_conclude_by_name() -> None:
+    """Zero-premise theorem unifies the goal directly -> the template
+    is ``conclude <goal> by <name>`` (no ``apply``)."""
+    source = (
+        "theorem helper: true and true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: true and true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=8, column=3), "helper"
+    )
+    assert edit is not None
+    assert isinstance(edit, WorkspaceEdit)
+    # Replaces the `?` 1-char span at line 8, col 3.
+    assert edit.range == Range(
+        start=Position(line=8, column=3),
+        end=Position(line=8, column=4),
+    )
+    # Goal text is rendered with surrounding parens for ``and`` because
+    # that's the canonical ``Goal`` formula spelling the goal-extractor
+    # returns; the template embeds it verbatim.
+    assert edit.new_text == "conclude (true and true) by helper"
+
+
+def test_full_tier_one_premise_discharged_emits_apply_to_label() -> None:
+    """Single-premise theorem whose only premise is discharged by a
+    local given -> ``conclude <goal> by apply <name> to <label>``."""
+    source = (
+        "theorem dup: all P:bool. if P then P and P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume pP: P\n"
+        "  pP, pP\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool. if P then P and P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume h: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=12, column=3), "dup"
+    )
+    assert edit is not None
+    assert edit.new_text == "conclude (P and P) by apply dup to h"
+
+
+def test_full_tier_two_premises_discharged_emits_comma_labels() -> None:
+    """Two-premise theorem whose premises are all discharged -> the
+    label list is comma-separated in the ``apply ... to`` argument."""
+    source = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=14, column=3), "and_intro"
+    )
+    assert edit is not None
+    assert edit.new_text == "conclude (P and Q) by apply and_intro to pP, qQ"
+
+
+# ---------------------------------------------------------------------------
+# `premises_remain` tier: apply ... to ?
+# ---------------------------------------------------------------------------
+
+
+def test_premises_remain_tier_emits_apply_with_hole() -> None:
+    """Conclusion unifies but no local given matches the premise ->
+    template is ``apply <name> to ?``: one fresh hole for the user
+    to fill."""
+    source = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=12, column=3), "and_intro"
+    )
+    assert edit is not None
+    assert edit.new_text == "apply and_intro to ?"
+    # Replaces the `?` 1-char span at line 12, col 3.
+    assert edit.range == Range(
+        start=Position(line=12, column=3),
+        end=Position(line=12, column=4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# `rewrite_subterm` tier: replace ...
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_subterm_tier_emits_replace() -> None:
+    """Equation lemma whose LHS unifies with a goal subterm ->
+    template is ``replace <name>``."""
+    # ``P = not (not P)`` -- the LHS ``P`` matches the subterm ``P``
+    # in the goal ``P and Q``.
+    source = (
+        "theorem not_not: all P:bool. P = not (not P)\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  switch P {\n"
+        "    case true { . }\n"
+        "    case false { . }\n"
+        "  }\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. if P and Q then not (not P) and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose h: P and Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=14, column=3), "not_not"
+    )
+    assert edit is not None
+    # The lemma's conclusion is an equation, and its LHS (``P``) matches
+    # a subterm of the goal -> rewrite_subterm tier -> ``replace`` shape.
+    assert edit.new_text == "replace not_not"
+
+
+# ---------------------------------------------------------------------------
+# No tier match: bare name
+# ---------------------------------------------------------------------------
+
+
+def test_off_hole_emits_bare_name_at_point() -> None:
+    """Cursor off any ``?`` token (e.g. browse mode after picking a
+    lemma to reference): inserts the bare ``<name>`` at the cursor as
+    a zero-width edit."""
+    source = (
+        "theorem alpha: true\nproof\n  .\nend\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=1, column=1), "alpha"
+    )
+    assert edit is not None
+    assert edit.new_text == "alpha"
+    # Zero-width edit at the cursor.
+    assert edit.range == Range(
+        start=Position(line=1, column=1),
+        end=Position(line=1, column=1),
+    )
+
+
+def test_unrelated_lemma_at_hole_emits_bare_name() -> None:
+    """Cursor on ``?`` but the named lemma's conclusion doesn't unify
+    with the goal: tier is ``None`` so we just splice the bare name."""
+    source = (
+        "theorem alpha: true\nproof\n  .\nend\n"
+        "\n"
+        "theorem with_hole: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=8, column=3), "alpha"
+    )
+    assert edit is not None
+    # Replaces the `?` with the bare name; no `conclude` / `apply` /
+    # `replace` wrapping because no tier matched.
+    assert edit.new_text == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# Failure mode: name not in scope
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_name_returns_none() -> None:
+    """Name not in scope as any theorem/lemma/postulate -> ``None``."""
+    source = (
+        "theorem t: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=3, column=3), "no_such_lemma"
+    )
+    assert edit is None

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -128,6 +128,8 @@ def test_all_expected_features_are_registered():
         lsp_server.ELIMINABLE_VARS_REQUEST,
         lsp_server.HOLE_CONTEXT_AT_REQUEST,
         lsp_server.VALIDATE_PROOF_REQUEST,
+        lsp_server.AVAILABLE_LEMMAS_REQUEST,
+        lsp_server.INSERT_LEMMA_REQUEST,
     }
     assert expected.issubset(set(fm.features))
 
@@ -1108,3 +1110,142 @@ def test_eliminate_at_returns_null_when_label_omitted(server, open_doc):
         "position": {"line": 0, "character": 0},
     }
     assert lsp_server.on_eliminate_at(server, params) is None
+
+
+# --------------------------------------------------------------------------
+# Custom requests: deduce/availableLemmasAt and deduce/insertLemma
+# (issue #690 -- Part 2)
+# --------------------------------------------------------------------------
+
+
+def test_available_lemmas_at_returns_ranked_lemmas_with_tier(
+    server, open_doc
+):
+    """Cursor on `?`; the response lists in-scope lemmas, each tagged
+    with a `unify_tier` reflecting how its conclusion relates to the
+    goal."""
+    src = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool."
+        " if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("avail.pf", src)
+    # `?` is at line 14 col 3 (1-indexed) -> LSP line 13, char 2.
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 13, "character": 2},
+    }
+    result = lsp_server.on_available_lemmas_at(server, params)
+    by_name = {m["name"]: m for m in result}
+    assert "and_intro" in by_name
+    assert by_name["and_intro"]["unify_tier"] == "full"
+    assert by_name["and_intro"]["kind"] == "theorem"
+    # discharged_premises is a list of [premise, by_given] pairs on the
+    # wire; check that both local givens contribute.
+    labels = {pair[1] for pair in by_name["and_intro"]["discharged_premises"]}
+    assert labels == {"pP", "qQ"}
+
+
+def test_available_lemmas_at_honours_query_filter(server, open_doc):
+    """A substring `query` narrows the candidate set to matching
+    lemmas, even when the cursor isn't on a hole."""
+    src = (
+        "theorem alpha_keep: true\nproof\n  .\nend\n"
+        "theorem beta_drop: true\nproof\n  .\nend\n"
+    )
+    _, uri = open_doc("query.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 0, "character": 0},
+        "query": "alpha",
+    }
+    result = lsp_server.on_available_lemmas_at(server, params)
+    names = {m["name"] for m in result}
+    assert "alpha_keep" in names
+    assert "beta_drop" not in names
+
+
+def test_available_lemmas_at_returns_empty_when_uri_missing(
+    server, open_doc
+):
+    """Missing `textDocument.uri` -> empty list (defensive)."""
+    result = lsp_server.on_available_lemmas_at(
+        server, {"position": {"line": 0, "character": 0}}
+    )
+    assert result == []
+
+
+def test_insert_lemma_returns_full_tier_workspace_edit(server, open_doc):
+    """Cursor on `?` with a name whose conclusion unifies and whose
+    premises are all discharged -> WorkspaceEdit with `conclude ... by
+    apply <name> to <labels>`."""
+    src = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool."
+        " if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    _, uri = open_doc("insert_full.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 13, "character": 2},
+        "name": "and_intro",
+    }
+    result = lsp_server.on_insert_lemma(server, params)
+    assert result is not None
+    edits = result["changes"][uri]
+    assert len(edits) == 1
+    assert edits[0]["newText"] == (
+        "conclude (P and Q) by apply and_intro to pP, qQ"
+    )
+    assert edits[0]["range"]["start"] == {"line": 13, "character": 2}
+    assert edits[0]["range"]["end"] == {"line": 13, "character": 3}
+
+
+def test_insert_lemma_returns_null_for_unknown_name(server, open_doc):
+    src = (
+        "theorem t: true\nproof\n  ?\nend\n"
+    )
+    _, uri = open_doc("insert_bad.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 2, "character": 2},
+        "name": "no_such_lemma",
+    }
+    assert lsp_server.on_insert_lemma(server, params) is None
+
+
+def test_insert_lemma_returns_null_when_name_omitted(server, open_doc):
+    """Missing `name` field -> null (defensive)."""
+    src = "x"
+    _, uri = open_doc("noop3.pf", src)
+    params = {
+        "textDocument": {"uri": uri},
+        "position": {"line": 0, "character": 0},
+    }
+    assert lsp_server.on_insert_lemma(server, params) is None

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -99,6 +99,7 @@ EXPECTED_PUBLIC = {
     "apply_at",
     "hole_context_at",
     "available_lemmas_at",
+    "insert_lemma_at",
     "validate_proof_at",
     "preview_replace_at",
     "preview_expand_at",


### PR DESCRIPTION
## Summary

- New LSP requests **`deduce/availableLemmasAt`** and **`deduce/insertLemma`**, paired like the existing `matchingGivensAt` / `fillFromGivenAt`. The picker request returns the ranked lemma candidates from #697 with their `unify_tier` and `discharged_premises`; the insertion request takes a chosen name and returns a tier-aware `WorkspaceEdit`.
- Template shapes (recomputed server-side from the current buffer, so a buffer that changed between picker and insertion still produces a sensible result):
  - `full` → `conclude <goal> by apply <name> to <p1>, …, <pN>` (or `conclude <goal> by <name>` when N=0)
  - `premises_remain` → `apply <name> to ?`
  - `rewrite_subterm` → `replace <name>`
  - none (off-hole or no tier match) → bare `<name>`
- Drive-by fix: Part 1's `_unify_score` had `conc.rands` where it meant `conc.args`. The broad `except Exception` made the `rewrite_subterm` tier silently dead code. Test added.

Addresses #690 (Part 2 portion). Parts 3 (Emacs `C-c C-l`) and 4 (VS Code `deduce.searchLemma`) remain.

## Test plan

- [ ] `make static` clean (ruff + mypy; the `--no-site-packages` mypy pass has the same pre-existing untyped-decorator noise as `main`)
- [ ] `pytest test/lsp/test_insert_lemma.py` — 8 cases covering every tier + bare-name fallback + unknown-name None
- [ ] `pytest test/lsp/test_lsp_server.py` — feature registration + 6 new wire-shape cases
- [ ] `pytest test/lsp/test_available_lemmas.py` — adds the `rewrite_subterm`-tier regression for the typo fix
- [ ] CI green

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)