### PR TITLE
Add Int negative-multiplier monotonicity theorems (Refs #660)

### DIFF
--- a/lib/IntMult.pf
+++ b/lib/IntMult.pf
@@ -717,3 +717,63 @@ proof
   have step: n * x < n * y by apply int_pos_mult_mono_less_left[n, x, y] to prem
   replace int_mult_commute[n, x] | int_mult_commute[n, y] in step
 end
+
+// Multiplication on the left by a non-positive Int reverses `≤`.
+theorem int_nonpos_mult_mono_le_left: all n:Int, x:Int, y:Int.
+  if n ≤ +0 and x ≤ y
+  then n * y ≤ n * x
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have npos: n ≤ +0 by conjunct 0 of prem
+  have xy: x ≤ y by conjunct 1 of prem
+  have neg_n_nn0: -+0 ≤ -n by apply int_neg_le_mono[n, +0] to npos
+  have neg_n_nn: +0 ≤ -n by replace neg_zero in neg_n_nn0
+  have neg_n_mult: (-n) * x ≤ (-n) * y
+    by apply int_nonneg_mult_mono_le_left[-n, x, y] to neg_n_nn, xy
+  have eq_x: (-n) * x = -(n * x) by symmetric dist_neg_mult[n, x]
+  have eq_y: (-n) * y = -(n * y) by symmetric dist_neg_mult[n, y]
+  have neg_step: -(n * x) ≤ -(n * y) by replace eq_x | eq_y in neg_n_mult
+  apply (conjunct 1 of int_neg_le_iff[n * y, n * x]) to neg_step
+end
+
+// Multiplication on the right by a non-positive Int reverses `≤`.
+theorem int_nonpos_mult_mono_le_right: all n:Int, x:Int, y:Int.
+  if n ≤ +0 and x ≤ y
+  then y * n ≤ x * n
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have step: n * y ≤ n * x by apply int_nonpos_mult_mono_le_left[n, x, y] to prem
+  replace int_mult_commute[n, x] | int_mult_commute[n, y] in step
+end
+
+// Multiplication on the left by a negative Int reverses `<`.
+theorem int_neg_mult_mono_less_left: all n:Int, x:Int, y:Int.
+  if n < +0 and x < y
+  then n * y < n * x
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nneg: n < +0 by conjunct 0 of prem
+  have xy: x < y by conjunct 1 of prem
+  have neg_n_pos0: -+0 < -n by apply int_neg_less_mono[n, +0] to nneg
+  have neg_n_pos: +0 < -n by replace neg_zero in neg_n_pos0
+  have neg_n_mult: (-n) * x < (-n) * y
+    by apply int_pos_mult_mono_less_left[-n, x, y] to neg_n_pos, xy
+  have eq_x: (-n) * x = -(n * x) by symmetric dist_neg_mult[n, x]
+  have eq_y: (-n) * y = -(n * y) by symmetric dist_neg_mult[n, y]
+  have neg_step: -(n * x) < -(n * y) by replace eq_x | eq_y in neg_n_mult
+  apply (conjunct 1 of int_neg_less_iff[n * y, n * x]) to neg_step
+end
+
+// Multiplication on the right by a negative Int reverses `<`.
+theorem int_neg_mult_mono_less_right: all n:Int, x:Int, y:Int.
+  if n < +0 and x < y
+  then y * n < x * n
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have step: n * y < n * x by apply int_neg_mult_mono_less_left[n, x, y] to prem
+  replace int_mult_commute[n, x] | int_mult_commute[n, y] in step
+end


### PR DESCRIPTION
## Summary

Adds the antitone counterparts of the positive-multiplier monotonicity theorems landed in #701 for the Int stdlib in `lib/IntMult.pf` (Refs #660).

Public theorems added:

- `int_nonpos_mult_mono_le_left`, `int_nonpos_mult_mono_le_right` — multiplication on either side by a non-positive Int reverses `≤`.
- `int_neg_mult_mono_less_left`, `int_neg_mult_mono_less_right` — multiplication on either side by a negative Int reverses `<`.

Each proof:
1. Negates the multiplier (via `int_neg_le_mono` / `int_neg_less_mono`) so the now-nonneg / now-positive value can be fed into `int_nonneg_mult_mono_le_left` / `int_pos_mult_mono_less_left`.
2. Uses `dist_neg_mult` to push the negation outward: `(-n) * x = -(n * x)`.
3. Reverses the inequality back via `int_neg_le_iff` / `int_neg_less_iff`.

## Progress on #660

The "Int multiplication monotonicity by a negative multiplier (sign-flipped versions)" slice listed in the most recent comment on #660 is now complete with this PR.

Remaining slices on #660:
- Int multiplication cancellation under `≤` / `<` (counterparts to the equality cancellation theorems landed in #688).
- Slice 2 — Euclidean `div` / `%` plus `div_mod` and basic mod laws.
- Slice 3 — Int `divides` / `gcd` / `lcm`.
- Slice 4 — Int powers.
- Slice 6 — Int-valued summation.
- Conversion / specification cleanup tying literals, `abs`, and UInt theorems together.

## Test plan

- [x] `python deduce.py --dir lib lib/IntMult.pf` (recursive-descent parser)
- [x] `python deduce.py --lalr --dir lib lib/IntMult.pf` (LALR parser)
- [ ] `make static` (ruff + mypy)
- [ ] `python test-deduce.py` (full lib + should-validate + should-error + prelude + parser equivalence)

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)

Fallback: \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)