### PR TITLE
Emacs: C-c C-l lemma search at a hole (Part 3 of #690)

### DIFF
--- a/docs/knowledge-base/emacs-lsp-protocol.md
+++ b/docs/knowledge-base/emacs-lsp-protocol.md
@@ -46,6 +46,7 @@ proper.
 | `C-c C-c` (case split) | `deduce/splittableVarsAt`, `deduce/caseSplitAt` | Two-step: enumerate splittable vars, then split on chosen one |
 | `C-c C-e` (eliminate)  | `deduce/eliminableVarsAt`, `deduce/eliminateAt` | Two-step: enumerate eliminable hypotheses, then apply chosen one |
 | `C-c C-f` (fill-from-given) | `deduce/matchingGivensAt`, `deduce/fillFromGivenAt` | Two-step: enumerate givens whose formula matches the goal, then splice the chosen one |
+| `C-c C-l` (search-lemma) | `deduce/availableLemmasAt`, `deduce/insertLemma` | Two-step: enumerate ranked in-scope lemmas with unify tier + module, then splice the chosen one with a tier-aware template |
 | `C-c C-a` (LLM fill)   | `deduce/holeContextAt`                         | Captures goal, givens, lemmas in scope, and a stable fingerprint for the `tools/claude_fill_hole` sidecar |
 
 The two-step pattern (`*VarsAt` + `*At`) exists so that Emacs can
@@ -58,7 +59,7 @@ which hole the user meant.
 
 The cursor position pinpoints the `?` to be replaced. All hole-filling
 commands (refine, case-split, induction, eliminate, fill-from-given,
-LLM fill) use this convention. Tests that pin the request shape live
+search-lemma, LLM fill) use this convention. Tests that pin the request shape live
 in `editor/emacs/test/deduce-lsp-test.el`.
 
 ## LLM hole-fill sidecar

--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -221,6 +221,23 @@ auto-start hook:
   use. A narrower sibling of `C-c C-e`: eliminate picks by
   hypothesis shape; fill-from-given picks by formula equality with
   the goal.
+- `C-c C-l` — **lemma search at point.** Cursor on a `?`. Emacs
+  fetches the ranked list of in-scope theorems, lemmas, and
+  postulates from the server and prompts (TAB completion) for one
+  via `completing-read`. Each row is annotated with the *unify
+  tier* — `applies (by H, G)` when the lemma's conclusion matches
+  the goal and every premise is discharged by a local given,
+  `premises remain` when the conclusion matches but some premises
+  stay open, `rewrite subterm` for an equation lemma whose LHS
+  matches a goal subterm — plus the module of origin. The top
+  candidate is the default; press RET on an empty filter to pick
+  it. The `?` is then replaced with a tier-aware tactic skeleton:
+  `conclude <goal> by apply <name> to <labels>` for the full tier,
+  `apply <name> to ?` when premises remain, `replace <name>` for a
+  rewrite, or the bare name otherwise. With a prefix arg
+  (`C-u C-c C-l`), Emacs prompts for a query string — substring
+  match against names/signatures or a goal-shape pattern with `_`
+  placeholders — and forwards it to the server.
 - `C-c C-x` — **show the full diagnostic at point** in a `*Deduce
   Diagnostic*` popup buffer. Deduce error messages are multi-line
   (headline + location + grammar / proof context); the echo area
@@ -325,6 +342,7 @@ OpenAI, or IU REALLMs depending on backend choice):
 | `C-c C-i` | Replace `?` with `induction T` skeleton at a forall goal           | `deduce-lsp-induction`           | `deduce-lsp`   |
 | `C-c C-e` | Prompt for hypothesis, replace `?` with use-fact tactic            | `deduce-lsp-eliminate`           | `deduce-lsp`   |
 | `C-c C-f` | Replace `?` with `conclude ... by H` for a given matching the goal | `deduce-lsp-fill-from-given`     | `deduce-lsp`   |
+| `C-c C-l` | Pick an in-scope lemma; splice a tier-aware reference at the hole  | `deduce-lsp-search-lemma`        | `deduce-lsp`   |
 | `C-c C-x` | Show the full diagnostic at point in a popup buffer                | `deduce-show-diagnostic-at-point`| `deduce-lsp`   |
 | `C-c C-a` | Ask an LLM to fill the `?` at point. Async, non-blocking.          | `deduce-fill-hole`               | `deduce-fill-hole` |
 | `C-c C-d` | Launch a debug session on the current `.pf` file                   | `deduce-dap-debug-current-buffer`| `deduce-dap`   |
@@ -681,11 +699,31 @@ Then verify the LSP integration:
     two matching givens in scope (e.g. `assume H1: P` and `assume
     H2: P`), Emacs prompts `Fill from:` with TAB completion against
     the matching labels.
+13. In a scratch `.pf` buffer with a non-trivial arithmetic goal:
+
+    ```
+    import UInt
+
+    theorem t: all a:UInt, b:UInt. a + b = b + a
+    proof
+      arbitrary a:UInt, b:UInt
+      ?
+    end
+    ```
+
+    Place point on the `?` and press `C-c C-l`. Emacs prompts
+    `Lemma:` with TAB completion against the ranked in-scope
+    candidates; each row shows the lemma's signature, the unify
+    tier (e.g. `applies`, `rewrite subterm`), and the module. The
+    top candidate (`uint_add_commute` for this fixture) is the
+    default — press `RET` on the empty filter to pick it. The `?`
+    is replaced with a tier-aware skeleton (here:
+    `conclude a + b = b + a by uint_add_commute`).
 
 If you have `deduce-fill-hole` loaded and an API key exported, also
 verify the LLM path:
 
-13. In a scratch `.pf` buffer with a `theorem t: all P:bool. P = P`
+14. In a scratch `.pf` buffer with a `theorem t: all P:bool. P = P`
     (or similar simple) shape, place point on the `?` and press
     `C-c C-a` ("ask AI"). Emacs reports `deduce-fill-hole: asking
     <model>...` (e.g. `asking claude-opus-4-7...`). Within a few
@@ -699,7 +737,7 @@ If you have `deduce-dap` loaded and `dap-mode` installed
 (`M-x package-install RET dap-mode RET` or via MELPA in your config),
 also verify the debugger integration:
 
-14. Open a `.pf` file that has at least one `print` statement —
+15. Open a `.pf` file that has at least one `print` statement —
     e.g. `tmp/debugger_smoke.pf` if you've worked through the
     Debugger.md walkthrough, or any prelude module like
     `lib/UInt.pf` that contains a top-level `print`. Press
@@ -710,11 +748,11 @@ also verify the debugger integration:
     a line at the first user-level statement (matching where
     `python deduce.py --debug` would initially trap).
 
-15. The Locals tree starts collapsed — `RET` (or click the
+16. The Locals tree starts collapsed — `RET` (or click the
     triangle next to `Locals`) to expand.  Inside a function
     call, the pattern-bound names appear there.
 
-16. Set a breakpoint at a line of interest: `C-c d b` with
+17. Set a breakpoint at a line of interest: `C-c d b` with
     cursor on the target line (or `M-x dap-breakpoint-toggle`).
     Resume with `F5` / `C-c d c`; step over with `F10` /
     `C-c d n`; step into with `F11` / `C-c d s`.  Or open
@@ -722,16 +760,16 @@ also verify the debugger integration:
     (See the keybinding caveats above if F-keys don't work on
     your OS.)
 
-17. While paused inside a function, the locals panel should show
+18. While paused inside a function, the locals panel should show
     the pattern-bound names (e.g. `n' = suc(zero)` inside
     `count_down`'s `suc` case). The call-stack panel shows one
     entry per frame, gdb-style with the innermost at the top.
 
-18. In the `*dap-ui-repl*` window (or via `dap-eval-region`), type
+19. In the `*dap-ui-repl*` window (or via `dap-eval-region`), type
     an expression like `suc(zero)` to invoke the DAP `evaluate`
     request — the same reducer the CLI's `print` command uses.
 
-19. Press `C-c d q` (or `M-x dap-disconnect`) to end the run.
+20. Press `C-c d q` (or `M-x dap-disconnect`) to end the run.
     The DAP adapter exits cleanly when stdin is closed.
 
 If `dap-mode` isn't installed, `C-c C-d` reports an error pointing

--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -388,6 +388,7 @@ RET deduce RET` (root group), or any of the per-layer groups:
 | `deduce-lsp-python-program`    | `"python3"` | Python interpreter used to launch the language server                  |
 | `deduce-lsp-deduce-root`       | `nil`       | Path to a Deduce checkout; sets `PYTHONPATH` for the spawned server    |
 | `deduce-lsp-prelude-disabled`  | `nil`       | If non-nil, sets `DEDUCE_NO_STDLIB=1` so the server skips the prelude  |
+| `deduce-lsp-search-lemma-timeout` | `60`     | Per-request timeout (seconds) for the `C-c C-l` round trip. Bumps past the 10s jsonrpc default because ranking the stdlib's ~200 lemmas exceeds it on a cold-prelude first call. Set to nil to fall back to the default. |
 
 For full control over the launch command, `defun deduce-lsp-server-command`
 in your `init.el` returning whatever list eglot should spawn.

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -757,6 +757,28 @@ identity."
     (nreverse result)))
 
 
+(defun deduce-lsp--ranked-completion-table (candidates)
+  "Build a completion table over CANDIDATES that preserves order.
+
+`completing-read' sorts candidates alphabetically by default,
+which throws away the server's best-first relevance ranking --
+the whole point of the unify-tier ranker is to surface the right
+match first.  Setting `display-sort-function' and
+`cycle-sort-function' to `identity' via the table's `metadata'
+tells the completion machinery (including `vertico', `ivy', the
+standard `*Completions*' buffer, and `M-n'/`M-p' cycling) to leave
+the order alone."
+  (lambda (string pred action)
+    (cond
+     ((eq action 'metadata)
+      '(metadata
+        (category . deduce-lemma)
+        (display-sort-function . identity)
+        (cycle-sort-function . identity)))
+     (t
+      (complete-with-action action candidates string pred)))))
+
+
 (defun deduce-lsp--read-lemma (lemmas)
   "Prompt the user to pick one of LEMMAS via `completing-read'.
 Returns the chosen lemma plist.  Preserves the server's ordering
@@ -771,7 +793,7 @@ RET-on-empty-input.  Errors out when LEMMAS is empty."
                 (deduce-lsp--lemma-annotation-fn alist)))
          (chosen (completing-read
                   "Lemma: "
-                  candidates
+                  (deduce-lsp--ranked-completion-table candidates)
                   nil t nil nil
                   (car candidates))))
     (cdr (assoc chosen alist))))

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -729,13 +729,21 @@ and returns the tier + module annotation."
 
 (defun deduce-lsp--lemma-display-string (lemma)
   "Return the picker-row display string for LEMMA.
-The signature is included so a student who has not memorized
-every theorem in the prelude can pick by formula shape, not just
-by name."
+
+The server's `:signature' field is the `.thm'-style rendering of
+the declaration -- already prefixed with `NAME: ' for theorems
+and postulates, or starting with the keyword (`recursive', `auto',
+etc.) for other declaration kinds.  Showing it verbatim keeps a
+student's eyes on formula shape, not just on the bare name, and
+avoids the `t : t: (...)' duplication that prefixing a redundant
+NAME would produce.
+
+Falls back to just the name when the signature is missing or
+empty (defensive -- the server always sets one in practice)."
   (let ((name (plist-get lemma :name))
         (signature (plist-get lemma :signature)))
     (if (and signature (not (equal signature "")))
-        (format "%s : %s" name signature)
+        signature
       name)))
 
 

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -224,7 +224,7 @@ LSP positions are 0-indexed (line and character)."
         :character (current-column)))
 
 
-(defun deduce-lsp--request (server method params)
+(defun deduce-lsp--request (server method params &optional timeout)
   "Issue an LSP request to SERVER, flushing pending buffer changes first.
 
 `jsonrpc-request' on its own races with eglot's didChange
@@ -241,6 +241,14 @@ This helper sends pending changes synchronously, then issues
 the JSON-RPC request.  Mirrors the pattern eglot's internal
 `eglot--request' uses by default.
 
+When TIMEOUT (seconds) is non-nil, it overrides
+`jsonrpc-default-request-timeout' (10s) for this single call.
+Use this for requests that are structurally more expensive than
+goal-shape lookups: e.g. `deduce/availableLemmasAt' has to unify
+every in-scope lemma's conclusion against the goal AST, which
+on first call (cold prelude) exceeds the default budget on the
+stdlib's ~200 candidates.
+
 Note on private API: `eglot--signal-textDocument/didChange' has
 the `--' private-symbol convention, but the function name and
 behaviour have been stable across recent eglot releases and it's
@@ -248,7 +256,9 @@ the explicit primitive eglot itself uses for this purpose.  If a
 future eglot release renames it, this function is the single
 point of update."
   (eglot--signal-textDocument/didChange)
-  (jsonrpc-request server method params))
+  (if timeout
+      (jsonrpc-request server method params :timeout timeout)
+    (jsonrpc-request server method params)))
 
 
 (defun deduce-lsp--render-goal (response)
@@ -767,6 +777,21 @@ RET-on-empty-input.  Errors out when LEMMAS is empty."
     (cdr (assoc chosen alist))))
 
 
+(defcustom deduce-lsp-search-lemma-timeout 60
+  "Per-request timeout (seconds) for the lemma-search round trip.
+
+The `deduce/availableLemmasAt' request unifies every in-scope
+lemma's conclusion against the goal AST -- on a cold-prelude
+first call against the stdlib's ~200 lemmas this can exceed the
+10s default `jsonrpc-default-request-timeout' on slower machines.
+60s is a generous budget that still surfaces a genuine hang.
+
+Set to nil to fall back to the jsonrpc default (10s)."
+  :type '(choice (const :tag "jsonrpc default (10s)" nil)
+                 (number :tag "seconds"))
+  :group 'deduce-lsp)
+
+
 (defun deduce-lsp-search-lemma (&optional query)
   "Pick an in-scope lemma and splice a reference to it at point.
 
@@ -788,7 +813,12 @@ depends on the server-computed tier at the time of insertion (see
 `lsp/query.py:insert_lemma_at'): `conclude ... by apply <name> to
 ...' for a full match with discharged premises, `apply <name> to
 ?' when premises remain, `replace <name>' for an equation match
-against a goal subterm, or just the bare `<name>' otherwise."
+against a goal subterm, or just the bare `<name>' otherwise.
+
+Both round trips use `deduce-lsp-search-lemma-timeout' instead of
+the 10s jsonrpc default -- the ranking pass is structurally more
+expensive than goal-shape lookups, and the first call after
+server start additionally pays the prelude-bootstrap cost."
   (interactive
    (list (when current-prefix-arg
            (read-string "Lemma search (substring or `_'-pattern): "))))
@@ -802,7 +832,8 @@ against a goal subterm, or just the bare `<name>' otherwise."
                      base-params))
            (response (deduce-lsp--request server
                                           :deduce/availableLemmasAt
-                                          params))
+                                          params
+                                          deduce-lsp-search-lemma-timeout))
            (lemmas (if (vectorp response) response (or response []))))
       (when (or (null lemmas) (zerop (length lemmas)))
         (user-error "No lemma candidates at point"))
@@ -811,7 +842,8 @@ against a goal subterm, or just the bare `<name>' otherwise."
              (insert-params (append base-params (list :name name)))
              (edit (deduce-lsp--request server
                                         :deduce/insertLemma
-                                        insert-params)))
+                                        insert-params
+                                        deduce-lsp-search-lemma-timeout)))
         (unless edit
           (user-error
            "Server returned no edit for lemma `%s'" name))

--- a/editor/emacs/deduce-lsp.el
+++ b/editor/emacs/deduce-lsp.el
@@ -654,15 +654,180 @@ out without applying when the server returns null."
       (deduce-lsp--apply-workspace-edit edit))))
 
 
+;; ---------------------------------------------------------------------
+;; Lemma search at a hole (issue #690, Part 3)
+;; ---------------------------------------------------------------------
+;;
+;; Cursor on a `?', the interactive form fetches ranked lemma candidates
+;; via `deduce/availableLemmasAt' and presents them through
+;; `completing-read', with an annotation column showing the unify tier
+;; (e.g. "applies (by H, G)", "premises remain", "rewrite subterm") and
+;; the module of origin.  The selected name drives a
+;; `deduce/insertLemma' request whose tier-aware WorkspaceEdit is
+;; applied directly (see `lsp/query.py:insert_lemma_at' for the four
+;; template shapes).
+;;
+;; With a prefix arg (or off-hole), the user is prompted for a query
+;; string -- substring or goal-shape pattern with `_' placeholders --
+;; which the server uses to filter candidates.
+;;
+;; This is the human-facing surface of the lemma-search work: agents
+;; can already reach `available_lemmas_at' via MCP, but a student
+;; stuck on a `?' had no path to it before this binding (see issue
+;; #690 for the full rationale).
+
+(defun deduce-lsp--lemma-tier-tag (lemma)
+  "Return a short annotation string describing LEMMA's unify tier.
+LEMMA is a plist with `:unify_tier' and `:discharged_premises'
+fields, as returned by `deduce/availableLemmasAt'.  Returns nil
+when no tier matched (browse mode or no goal AST available)."
+  (let ((tier (plist-get lemma :unify_tier))
+        (discharged (plist-get lemma :discharged_premises)))
+    (cond
+     ((equal tier "full")
+      (if (and discharged (> (length discharged) 0))
+          (format "applies (by %s)"
+                  (mapconcat
+                   (lambda (pair)
+                     ;; `pair' is `[premise label]' (a JSON array
+                     ;; decodes to a vector by default).
+                     (format "%s" (elt pair 1)))
+                   discharged
+                   ", "))
+        "applies"))
+     ((equal tier "premises_remain") "premises remain")
+     ((equal tier "rewrite_subterm") "rewrite subterm"))))
+
+
+(defun deduce-lsp--lemma-annotation-fn (lemma-by-name)
+  "Build an `:annotation-function' for the lemma-search picker.
+LEMMA-BY-NAME is an alist mapping a unique display string to the
+lemma plist; the returned function looks the display string up
+and returns the tier + module annotation."
+  (lambda (display)
+    (let* ((lemma (cdr (assoc display lemma-by-name)))
+           (tier-tag (and lemma (deduce-lsp--lemma-tier-tag lemma)))
+           (module (and lemma (plist-get lemma :module)))
+           (parts nil))
+      (when tier-tag (push (concat "  -- " tier-tag) parts))
+      (when (and module (not (equal module ""))
+                 (not (eq module :null))
+                 (not (eq module :json-null)))
+        (push (format "  [%s]" module) parts))
+      (apply #'concat (nreverse parts)))))
+
+
+(defun deduce-lsp--lemma-display-string (lemma)
+  "Return the picker-row display string for LEMMA.
+The signature is included so a student who has not memorized
+every theorem in the prelude can pick by formula shape, not just
+by name."
+  (let ((name (plist-get lemma :name))
+        (signature (plist-get lemma :signature)))
+    (if (and signature (not (equal signature "")))
+        (format "%s : %s" name signature)
+      name)))
+
+
+(defun deduce-lsp--build-lemma-alist (lemmas)
+  "Build an alist of (display . lemma) entries from LEMMAS.
+LEMMAS is the vector or list returned by
+`deduce/availableLemmasAt'.  Duplicate display strings are
+disambiguated by appending ` (2)', ` (3)', ... -- this keeps each
+key unique so `completing-read' can look the candidate up by
+identity."
+  (let ((counts (make-hash-table :test 'equal))
+        (result nil))
+    (seq-doseq (lemma lemmas)
+      (let* ((display (deduce-lsp--lemma-display-string lemma))
+             (n (gethash display counts 0))
+             (key (if (zerop n) display (format "%s (%d)" display (1+ n)))))
+        (puthash display (1+ n) counts)
+        (push (cons key lemma) result)))
+    (nreverse result)))
+
+
+(defun deduce-lsp--read-lemma (lemmas)
+  "Prompt the user to pick one of LEMMAS via `completing-read'.
+Returns the chosen lemma plist.  Preserves the server's ordering
+(best-first) so the top candidate is the natural default for
+RET-on-empty-input.  Errors out when LEMMAS is empty."
+  (when (or (null lemmas) (zerop (length lemmas)))
+    (user-error "No lemma candidates at point"))
+  (let* ((alist (deduce-lsp--build-lemma-alist lemmas))
+         (candidates (mapcar #'car alist))
+         (completion-extra-properties
+          (list :annotation-function
+                (deduce-lsp--lemma-annotation-fn alist)))
+         (chosen (completing-read
+                  "Lemma: "
+                  candidates
+                  nil t nil nil
+                  (car candidates))))
+    (cdr (assoc chosen alist))))
+
+
+(defun deduce-lsp-search-lemma (&optional query)
+  "Pick an in-scope lemma and splice a reference to it at point.
+
+Cursor on a `?': issues `deduce/availableLemmasAt' with no query,
+presents the ranked candidates via `completing-read' with
+annotations showing the unify tier (e.g. \"applies (by H, G)\",
+\"premises remain\", \"rewrite subterm\") and the module of
+origin.  The top entry is the natural default -- RET on an empty
+filter picks it.
+
+With a prefix arg (`C-u'), or when called non-interactively with
+a non-nil QUERY argument, prompts for a query string -- substring
+match against names + signatures, or a goal-shape pattern with
+`_' placeholders.  The query is forwarded to the server.
+
+The selected name then drives a `deduce/insertLemma' request; the
+returned WorkspaceEdit is applied directly.  Template shape
+depends on the server-computed tier at the time of insertion (see
+`lsp/query.py:insert_lemma_at'): `conclude ... by apply <name> to
+...' for a full match with discharged premises, `apply <name> to
+?' when premises remain, `replace <name>' for an equation match
+against a goal subterm, or just the bare `<name>' otherwise."
+  (interactive
+   (list (when current-prefix-arg
+           (read-string "Lemma search (substring or `_'-pattern): "))))
+  (let ((server (eglot-current-server)))
+    (unless server
+      (user-error
+       "No eglot server active in this buffer; M-x eglot first"))
+    (let* ((base-params (deduce-lsp--text-document-position))
+           (params (if (and query (not (equal query "")))
+                       (append base-params (list :query query))
+                     base-params))
+           (response (deduce-lsp--request server
+                                          :deduce/availableLemmasAt
+                                          params))
+           (lemmas (if (vectorp response) response (or response []))))
+      (when (or (null lemmas) (zerop (length lemmas)))
+        (user-error "No lemma candidates at point"))
+      (let* ((chosen (deduce-lsp--read-lemma lemmas))
+             (name (plist-get chosen :name))
+             (insert-params (append base-params (list :name name)))
+             (edit (deduce-lsp--request server
+                                        :deduce/insertLemma
+                                        insert-params)))
+        (unless edit
+          (user-error
+           "Server returned no edit for lemma `%s'" name))
+        (deduce-lsp--apply-workspace-edit edit)))))
+
+
 ;; Bind `C-c C-r' (refine), `C-c C-c' (case split), `C-c C-i'
-;; (induction), `C-c C-e' (eliminate), and `C-c C-f' (fill from
-;; given) in `deduce-mode-map'.  Same rationale as `C-c C-g': only
-;; meaningful when LSP is loaded.
+;; (induction), `C-c C-e' (eliminate), `C-c C-f' (fill from
+;; given), and `C-c C-l' (lemma search) in `deduce-mode-map'.
+;; Same rationale as `C-c C-g': only meaningful when LSP is loaded.
 (define-key deduce-mode-map (kbd "C-c C-r") #'deduce-lsp-refine-hole)
 (define-key deduce-mode-map (kbd "C-c C-c") #'deduce-lsp-case-split)
 (define-key deduce-mode-map (kbd "C-c C-i") #'deduce-lsp-induction)
 (define-key deduce-mode-map (kbd "C-c C-e") #'deduce-lsp-eliminate)
 (define-key deduce-mode-map (kbd "C-c C-f") #'deduce-lsp-fill-from-given)
+(define-key deduce-mode-map (kbd "C-c C-l") #'deduce-lsp-search-lemma)
 
 
 ;; ---------------------------------------------------------------------

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -1267,6 +1267,297 @@ own [severity] header so the user can tell them apart."
       (delete-file tmp))))
 
 
+;; ---------------------------------------------------------------------
+;; deduce-lsp-search-lemma (issue #690, Part 3, fronted by `C-c C-l')
+;; ---------------------------------------------------------------------
+;;
+;; Cursor on `?', the interactive form fetches ranked lemmas via
+;; `deduce/availableLemmasAt' and presents them through
+;; `completing-read'.  The chosen lemma drives a `deduce/insertLemma'
+;; request whose WorkspaceEdit is applied directly.  The picker
+;; annotates each candidate with the unify tier and module.
+
+(ert-deftest deduce-lsp/search-lemma-bound-to-c-c-c-l ()
+  "`C-c C-l' in deduce-mode-map runs `deduce-lsp-search-lemma'."
+  (should (eq (lookup-key deduce-mode-map (kbd "C-c C-l"))
+              #'deduce-lsp-search-lemma)))
+
+
+(ert-deftest deduce-lsp/search-lemma-tier-tag-full-no-discharged ()
+  "Tier `full' with no discharged premises renders as `applies'."
+  (let ((lemma '(:unify_tier "full" :discharged_premises [])))
+    (should (equal (deduce-lsp--lemma-tier-tag lemma) "applies"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-tier-tag-full-with-discharged ()
+  "Tier `full' with discharged premises lists the given labels."
+  (let ((lemma '(:unify_tier "full"
+                 :discharged_premises [["a <= b" "h"]
+                                       ["b <= c" "g"]])))
+    (should (equal (deduce-lsp--lemma-tier-tag lemma)
+                   "applies (by h, g)"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-tier-tag-premises-remain ()
+  "Tier `premises_remain' renders as `premises remain'."
+  (let ((lemma '(:unify_tier "premises_remain"
+                 :discharged_premises [])))
+    (should (equal (deduce-lsp--lemma-tier-tag lemma)
+                   "premises remain"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-tier-tag-rewrite-subterm ()
+  "Tier `rewrite_subterm' renders as `rewrite subterm'."
+  (let ((lemma '(:unify_tier "rewrite_subterm"
+                 :discharged_premises [])))
+    (should (equal (deduce-lsp--lemma-tier-tag lemma)
+                   "rewrite subterm"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-tier-tag-no-tier ()
+  "Nil `unify_tier' returns nil -- the annotation column collapses."
+  (let ((lemma '(:unify_tier nil :discharged_premises [])))
+    (should (null (deduce-lsp--lemma-tier-tag lemma)))))
+
+
+(ert-deftest deduce-lsp/search-lemma-display-string-includes-signature ()
+  "Picker rows show `name : signature' so users can pick by formula
+shape, not just by memorized name."
+  (let ((lemma '(:name "uint_add_commute"
+                 :signature "all a:UInt, b:UInt. a + b = b + a")))
+    (should (equal (deduce-lsp--lemma-display-string lemma)
+                   "uint_add_commute : all a:UInt, b:UInt. a + b = b + a"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-display-string-no-signature ()
+  "When the signature is missing or empty, fall back to just the name."
+  (let ((lemma '(:name "lemma_x" :signature "")))
+    (should (equal (deduce-lsp--lemma-display-string lemma)
+                   "lemma_x"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-build-alist-disambiguates-duplicates ()
+  "Two lemmas with the same display string get unique alist keys --
+otherwise `completing-read' can't tell them apart."
+  (let* ((lemmas (list '(:name "foo" :signature "Sig" :module "A")
+                       '(:name "foo" :signature "Sig" :module "B")))
+         (alist (deduce-lsp--build-lemma-alist lemmas))
+         (keys (mapcar #'car alist)))
+    (should (= (length keys) 2))
+    (should (equal (length (delete-dups (copy-sequence keys))) 2))
+    ;; The second occurrence is suffixed; the first keeps the plain
+    ;; form so the common case has no visual noise.
+    (should (equal (car keys) "foo : Sig"))
+    (should (equal (cadr keys) "foo : Sig (2)"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-annotation-fn-renders-tier-and-module ()
+  "The annotation function appends `-- <tier-tag> [<module>]' to each
+picker row so the user sees how each candidate applies."
+  (let* ((lemma '(:name "uint_add_commute"
+                  :signature "all a,b:UInt. a + b = b + a"
+                  :module "UInt"
+                  :unify_tier "rewrite_subterm"
+                  :discharged_premises []))
+         (alist `(("uint_add_commute : sig" . ,lemma)))
+         (anno (deduce-lsp--lemma-annotation-fn alist))
+         (result (funcall anno "uint_add_commute : sig")))
+    (should (string-match-p "rewrite subterm" result))
+    (should (string-match-p "\\[UInt\\]" result))))
+
+
+(ert-deftest deduce-lsp/search-lemma-annotation-fn-handles-null-module ()
+  "JSON `null' for module (`:null' or `:json-null') is treated as no
+module -- the bracket is omitted rather than printed as `[:null]'."
+  (let* ((lemma '(:name "x" :signature "" :module :null
+                  :unify_tier nil :discharged_premises []))
+         (alist `(("x" . ,lemma)))
+         (anno (deduce-lsp--lemma-annotation-fn alist)))
+    (should (equal (funcall anno "x") ""))))
+
+
+(ert-deftest deduce-lsp/search-lemma-issues-availableLemmasAt-and-insertLemma ()
+  "Calling `deduce-lsp-search-lemma' issues the picker request first,
+then the insertion request with the picked lemma name."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf"))
+        calls)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool. P = P\nproof\n  arbitrary P:bool\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          ;; `?` at line 4 col 3 -> LSP line 3, char 2.
+          (goto-char (point-min))
+          (forward-line 3)
+          (forward-char 2)
+          (let ((lemma `(:name "eq_refl"
+                         :kind "theorem"
+                         :signature "all x:bool. x = x"
+                         :module "Base"
+                         :relevance 1.0
+                         :unify_tier "full"
+                         :discharged_premises [])))
+            (cl-letf (((symbol-function 'eglot-current-server)
+                       (lambda () 'mock-server))
+                      ((symbol-function 'eglot--signal-textDocument/didChange)
+                       (lambda () nil))
+                      ((symbol-function 'jsonrpc-request)
+                       (lambda (_server method params)
+                         (push (cons method params) calls)
+                         (cond
+                          ((eq method :deduce/availableLemmasAt)
+                           (vector lemma))
+                          ((eq method :deduce/insertLemma) nil))))
+                      ((symbol-function 'completing-read)
+                       (lambda (&rest _args)
+                         "eq_refl : all x:bool. x = x")))
+              (ignore-errors (deduce-lsp-search-lemma))))
+          (let* ((calls (reverse calls))
+                 (call1 (assq :deduce/availableLemmasAt calls))
+                 (call2 (assq :deduce/insertLemma calls))
+                 (p1 (cdr call1))
+                 (p2 (cdr call2)))
+            (should call1)
+            (should call2)
+            (should (string-prefix-p "file://"
+                                      (plist-get
+                                       (plist-get p1 :textDocument) :uri)))
+            (should (= (plist-get (plist-get p1 :position) :line) 3))
+            (should (= (plist-get (plist-get p1 :position) :character) 2))
+            (should (equal (plist-get p2 :name) "eq_refl"))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/search-lemma-passes-query-with-prefix-arg ()
+  "With a non-nil QUERY argument, `deduce/availableLemmasAt' carries a
+`:query' field so the server can filter the candidate list."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf"))
+        captured-params)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method params)
+                       (when (eq method :deduce/availableLemmasAt)
+                         (setq captured-params params))
+                       nil)))
+            (ignore-errors (deduce-lsp-search-lemma "commute"))))
+      (delete-file tmp))
+    (should (equal (plist-get captured-params :query) "commute"))))
+
+
+(ert-deftest deduce-lsp/search-lemma-empty-candidates-errors ()
+  "When the server returns an empty candidate list, the command
+user-errors rather than calling `completing-read' with an empty
+candidate set."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server _method _params) [])))
+            (should-error (deduce-lsp-search-lemma) :type 'user-error)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/search-lemma-null-insert-response-errors ()
+  "If the server returns null for `insertLemma' (lemma not in scope),
+the command user-errors rather than silently doing nothing."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () 'mock-server))
+                    ((symbol-function 'eglot--signal-textDocument/didChange)
+                     (lambda () nil))
+                    ((symbol-function 'jsonrpc-request)
+                     (lambda (_server method _params)
+                       (cond
+                        ((eq method :deduce/availableLemmasAt)
+                         (vector '(:name "eq_refl" :kind "theorem"
+                                   :signature "" :module "Base"
+                                   :relevance 1.0
+                                   :unify_tier nil
+                                   :discharged_premises [])))
+                        ((eq method :deduce/insertLemma) nil))))
+                    ((symbol-function 'completing-read)
+                     (lambda (&rest _args) "eq_refl")))
+            (should-error (deduce-lsp-search-lemma) :type 'user-error)))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/search-lemma-applies-workspace-edit ()
+  "A successful `insertLemma' response splices its newText into the
+buffer at the picker's chosen lemma."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "theorem t: all P:bool. P = P\nproof\n  arbitrary P:bool\n  ?\nend\n")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (goto-char (point-min))
+          (forward-line 3)
+          (forward-char 2)
+          (let* ((uri (deduce-lsp--current-uri))
+                 (skeleton "conclude P = P by eq_refl")
+                 (edit `(:changes
+                         (,(intern (concat ":" uri))
+                          [(:range (:start (:line 3 :character 2)
+                                    :end (:line 3 :character 3))
+                                   :newText ,skeleton)]))))
+            (cl-letf (((symbol-function 'eglot-current-server)
+                       (lambda () 'mock-server))
+                      ((symbol-function 'eglot--signal-textDocument/didChange)
+                       (lambda () nil))
+                      ((symbol-function 'jsonrpc-request)
+                       (lambda (_server method _params)
+                         (cond
+                          ((eq method :deduce/availableLemmasAt)
+                           (vector '(:name "eq_refl" :kind "theorem"
+                                     :signature "all x:bool. x = x"
+                                     :module "Base"
+                                     :relevance 1.0
+                                     :unify_tier "full"
+                                     :discharged_premises [])))
+                          ((eq method :deduce/insertLemma) edit))))
+                      ((symbol-function 'completing-read)
+                       (lambda (&rest _args)
+                         "eq_refl : all x:bool. x = x")))
+              (deduce-lsp-search-lemma)))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "conclude P = P by eq_refl" text))))
+      (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/search-lemma-without-server-errors ()
+  "Without an active eglot server, the command signals a user error."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf")))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (cl-letf (((symbol-function 'eglot-current-server)
+                     (lambda () nil)))
+            (should-error (deduce-lsp-search-lemma) :type 'user-error)))
+      (delete-file tmp))))
+
+
 (provide 'deduce-lsp-test)
 
 ;;; deduce-lsp-test.el ends here

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -1320,13 +1320,17 @@ own [severity] header so the user can tell them apart."
     (should (null (deduce-lsp--lemma-tier-tag lemma)))))
 
 
-(ert-deftest deduce-lsp/search-lemma-display-string-includes-signature ()
-  "Picker rows show `name : signature' so users can pick by formula
-shape, not just by memorized name."
+(ert-deftest deduce-lsp/search-lemma-display-string-uses-signature-verbatim ()
+  "Picker rows show the server's `:signature' verbatim.
+
+The server already renders the declaration in `.thm' style --
+`NAME: formula' for theorems/postulates -- so prepending the
+name again would produce the `t : t: (...)' duplication the
+user reported."
   (let ((lemma '(:name "uint_add_commute"
-                 :signature "all a:UInt, b:UInt. a + b = b + a")))
+                 :signature "uint_add_commute: all x:UInt, y:UInt. x + y = y + x")))
     (should (equal (deduce-lsp--lemma-display-string lemma)
-                   "uint_add_commute : all a:UInt, b:UInt. a + b = b + a"))))
+                   "uint_add_commute: all x:UInt, y:UInt. x + y = y + x"))))
 
 
 (ert-deftest deduce-lsp/search-lemma-display-string-no-signature ()
@@ -1339,16 +1343,16 @@ shape, not just by memorized name."
 (ert-deftest deduce-lsp/search-lemma-build-alist-disambiguates-duplicates ()
   "Two lemmas with the same display string get unique alist keys --
 otherwise `completing-read' can't tell them apart."
-  (let* ((lemmas (list '(:name "foo" :signature "Sig" :module "A")
-                       '(:name "foo" :signature "Sig" :module "B")))
+  (let* ((lemmas (list '(:name "foo" :signature "foo: Sig" :module "A")
+                       '(:name "foo" :signature "foo: Sig" :module "B")))
          (alist (deduce-lsp--build-lemma-alist lemmas))
          (keys (mapcar #'car alist)))
     (should (= (length keys) 2))
     (should (equal (length (delete-dups (copy-sequence keys))) 2))
     ;; The second occurrence is suffixed; the first keeps the plain
     ;; form so the common case has no visual noise.
-    (should (equal (car keys) "foo : Sig"))
-    (should (equal (cadr keys) "foo : Sig (2)"))))
+    (should (equal (car keys) "foo: Sig"))
+    (should (equal (cadr keys) "foo: Sig (2)"))))
 
 
 (ert-deftest deduce-lsp/search-lemma-annotation-fn-renders-tier-and-module ()
@@ -1392,7 +1396,7 @@ then the insertion request with the picked lemma name."
           (forward-char 2)
           (let ((lemma `(:name "eq_refl"
                          :kind "theorem"
-                         :signature "all x:bool. x = x"
+                         :signature "eq_refl: all x:bool. x = x"
                          :module "Base"
                          :relevance 1.0
                          :unify_tier "full"
@@ -1410,7 +1414,7 @@ then the insertion request with the picked lemma name."
                           ((eq method :deduce/insertLemma) nil))))
                       ((symbol-function 'completing-read)
                        (lambda (&rest _args)
-                         "eq_refl : all x:bool. x = x")))
+                         "eq_refl: all x:bool. x = x")))
               (ignore-errors (deduce-lsp-search-lemma))))
           (let* ((calls (reverse calls))
                  (call1 (assq :deduce/availableLemmasAt calls))

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -472,7 +472,7 @@ doesn't try to flush against a non-existent server."
               ((symbol-function 'eglot--signal-textDocument/didChange)
                (lambda () nil))
               ((symbol-function 'jsonrpc-request)
-               (lambda (_server method params)
+               (lambda (_server method params &rest _kwargs)
                  (push (cons method params) calls)
                  (cdr (assq method responses-by-method)))))
       (funcall thunk))
@@ -1402,7 +1402,7 @@ then the insertion request with the picked lemma name."
                       ((symbol-function 'eglot--signal-textDocument/didChange)
                        (lambda () nil))
                       ((symbol-function 'jsonrpc-request)
-                       (lambda (_server method params)
+                       (lambda (_server method params &rest _kwargs)
                          (push (cons method params) calls)
                          (cond
                           ((eq method :deduce/availableLemmasAt)
@@ -1443,7 +1443,7 @@ then the insertion request with the picked lemma name."
                     ((symbol-function 'eglot--signal-textDocument/didChange)
                      (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
-                     (lambda (_server method params)
+                     (lambda (_server method params &rest _kwargs)
                        (when (eq method :deduce/availableLemmasAt)
                          (setq captured-params params))
                        nil)))
@@ -1467,7 +1467,7 @@ candidate set."
                     ((symbol-function 'eglot--signal-textDocument/didChange)
                      (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
-                     (lambda (_server _method _params) [])))
+                     (lambda (_server _method _params &rest _kwargs) [])))
             (should-error (deduce-lsp-search-lemma) :type 'user-error)))
       (delete-file tmp))))
 
@@ -1486,7 +1486,7 @@ the command user-errors rather than silently doing nothing."
                     ((symbol-function 'eglot--signal-textDocument/didChange)
                      (lambda () nil))
                     ((symbol-function 'jsonrpc-request)
-                     (lambda (_server method _params)
+                     (lambda (_server method _params &rest _kwargs)
                        (cond
                         ((eq method :deduce/availableLemmasAt)
                          (vector '(:name "eq_refl" :kind "theorem"
@@ -1525,7 +1525,7 @@ buffer at the picker's chosen lemma."
                       ((symbol-function 'eglot--signal-textDocument/didChange)
                        (lambda () nil))
                       ((symbol-function 'jsonrpc-request)
-                       (lambda (_server method _params)
+                       (lambda (_server method _params &rest _kwargs)
                          (cond
                           ((eq method :deduce/availableLemmasAt)
                            (vector '(:name "eq_refl" :kind "theorem"
@@ -1542,6 +1542,51 @@ buffer at the picker's chosen lemma."
           (let ((text (buffer-substring-no-properties (point-min) (point-max))))
             (should (string-match-p "conclude P = P by eq_refl" text))))
       (delete-file tmp))))
+
+
+(ert-deftest deduce-lsp/search-lemma-passes-custom-timeout-to-jsonrpc ()
+  "Both `availableLemmasAt' and `insertLemma' round trips use
+`deduce-lsp-search-lemma-timeout' instead of the 10s default --
+ranking the stdlib's ~200 lemmas exceeds it on a cold prelude."
+  (let ((tmp (make-temp-file "deduce-lsp-lemma" nil ".pf"))
+        timeouts)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "x")
+          (setq buffer-file-name tmp)
+          (deduce-mode)
+          (let ((deduce-lsp-search-lemma-timeout 60))
+            (cl-letf (((symbol-function 'eglot-current-server)
+                       (lambda () 'mock-server))
+                      ((symbol-function 'eglot--signal-textDocument/didChange)
+                       (lambda () nil))
+                      ;; Intercept `jsonrpc-request' directly so we
+                      ;; can read the `:timeout' keyword arg.
+                      ((symbol-function 'jsonrpc-request)
+                       (lambda (_server method _params &rest kwargs)
+                         (push (cons method (plist-get kwargs :timeout))
+                               timeouts)
+                         (cond
+                          ((eq method :deduce/availableLemmasAt)
+                           (vector '(:name "eq_refl" :kind "theorem"
+                                     :signature "" :module "Base"
+                                     :relevance 1.0
+                                     :unify_tier nil
+                                     :discharged_premises [])))
+                          ((eq method :deduce/insertLemma)
+                           '(:changes nil)))))
+                      ((symbol-function 'completing-read)
+                       (lambda (&rest _args) "eq_refl"))
+                      ;; The mock insertLemma response above has no
+                      ;; edits; ignore the resulting user-error so we
+                      ;; can still inspect captured timeouts.
+                      )
+              (ignore-errors (deduce-lsp-search-lemma)))))
+      (delete-file tmp))
+    (let ((avail (cdr (assq :deduce/availableLemmasAt timeouts)))
+          (insert (cdr (assq :deduce/insertLemma timeouts))))
+      (should (equal avail 60))
+      (should (equal insert 60)))))
 
 
 (ert-deftest deduce-lsp/search-lemma-without-server-errors ()

--- a/editor/emacs/test/deduce-lsp-test.el
+++ b/editor/emacs/test/deduce-lsp-test.el
@@ -1544,6 +1544,33 @@ buffer at the picker's chosen lemma."
       (delete-file tmp))))
 
 
+(ert-deftest deduce-lsp/search-lemma-completion-table-disables-sort ()
+  "The completion table the picker hands to `completing-read' must
+declare `display-sort-function' and `cycle-sort-function' as
+`identity', so vertico / ivy / the standard `*Completions*'
+buffer all leave the server's best-first ranking alone instead
+of re-sorting alphabetically (which would bury the right match
+under unrelated lemmas whose names happen to come first in the
+alphabet)."
+  (let* ((table (deduce-lsp--ranked-completion-table
+                 '("c_first" "a_second" "b_third")))
+         (meta (funcall table "" nil 'metadata))
+         (cat (alist-get 'category (cdr meta)))
+         (display-sort (alist-get 'display-sort-function (cdr meta)))
+         (cycle-sort (alist-get 'cycle-sort-function (cdr meta))))
+    (should (eq (car meta) 'metadata))
+    (should (eq cat 'deduce-lemma))
+    (should (eq display-sort 'identity))
+    (should (eq cycle-sort 'identity))
+    ;; The table still answers completion queries against the
+    ;; underlying candidate list -- metadata isn't a replacement,
+    ;; it's an annotation on top of `complete-with-action'.
+    (should (member "c_first"
+                    (all-completions "" table)))
+    (should (member "a_second"
+                    (all-completions "" table)))))
+
+
 (ert-deftest deduce-lsp/search-lemma-passes-custom-timeout-to-jsonrpc ()
   "Both `availableLemmasAt' and `insertLemma' round trips use
 `deduce-lsp-search-lemma-timeout' instead of the 10s default --

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -3696,6 +3696,7 @@ def available_lemmas_at(
         return ()
 
     given_pairs = _collect_local_givens(env)
+    typed_by_name = _typed_formula_index(env)
     ranked = _rank_lemmas(
         candidates,
         goal_text,
@@ -3704,6 +3705,7 @@ def available_lemmas_at(
         goal_ast=goal_ast,
         env=env,
         given_pairs=given_pairs,
+        typed_formula_by_name=typed_by_name,
     )
     if not ranked:
         return ()
@@ -4341,10 +4343,9 @@ def _iter_subterms(node: Any) -> Any:
     return out
 
 
-def _resolve_typed_formula(name: str, env: Any) -> Any:
-    """Return the post-typecheck formula for the named lemma from
-    ``env``, or ``None`` when ``env`` doesn't surface a
-    :class:`ProofBinding` under any key whose base name is ``name``.
+def _typed_formula_index(env: Any) -> dict[str, Any]:
+    """Build a one-shot ``base_name -> typed_formula`` index over the
+    proof bindings in ``env``.
 
     The formula stored on :class:`abstract_syntax.declarations.Theorem`
     and :class:`Postulate` is the parsed, pre-typecheck AST -- bound
@@ -4368,18 +4369,25 @@ def _resolve_typed_formula(name: str, env: Any) -> Any:
     Theorem names are forbidden from being overloaded (see
     :meth:`Postulate.uniquify`), so a base-name lookup uniquely
     identifies the binding.
+
+    Building this index once per request -- instead of scanning
+    ``env.dict`` per lemma in the ranker -- saves a quadratic walk
+    over an env that holds ~2000 entries when the full stdlib is in
+    scope.
     """
     if env is None or not hasattr(env, "dict"):
-        return None
+        return {}
     from abstract_syntax import ProofBinding, base_name
 
-    for key in env.dict:
-        if base_name(key) != name:
+    out: dict[str, Any] = {}
+    for key, binding in env.dict.items():
+        if not isinstance(binding, ProofBinding):
             continue
-        binding = env.dict[key]
-        if isinstance(binding, ProofBinding):
-            return binding.formula
-    return None
+        # First entry wins -- the env may have shadowed re-bindings,
+        # but theorem names can't be overloaded so this is at most
+        # one real entry per base name anyway.
+        out.setdefault(base_name(key), binding.formula)
+    return out
 
 
 def _unify_score(
@@ -4509,6 +4517,7 @@ def _rank_lemmas(
     goal_ast: Any = None,
     env: Any = None,
     given_pairs: tuple[tuple[str, Any], ...] = (),
+    typed_formula_by_name: Optional[dict[str, Any]] = None,
 ) -> list[LemmaMatch]:
     """Score and sort candidate lemmas.
 
@@ -4553,6 +4562,20 @@ def _rank_lemmas(
     raw_scores: list[
         tuple[float, LemmaInfo, str, Optional[str], tuple[tuple[str, str], ...]]
     ] = []
+
+    # First pass: compute every cheap signal (proximity, head, overlap,
+    # substring, pattern) for each candidate.  ``_unify_score`` is the
+    # only expensive scorer -- it walks the lemma's conclusion against
+    # the goal AST, applying ``auto_rewrites`` at every subterm, and
+    # costs ~10ms per lemma on the typical stdlib (Bug 1 of #690: with
+    # ~600 lemmas in scope this added up to ~6s before the picker
+    # appeared).  Deferring the unifier to a top-K subset of cheap-
+    # ranked candidates trims that to ~1s while keeping the lemmas
+    # that actually unify (which always share head/operator tokens
+    # with the goal) in the considered set.
+    prelim: list[
+        tuple[float, LemmaInfo, Any, str, float]
+    ] = []  # (cheap_raw, info, formula, module, proximity-marker)
     for info, formula, module in candidates:
         proximity = 1.0 if module == user_module else 0.0
 
@@ -4586,21 +4609,6 @@ def _rank_lemmas(
             raw_scores.append((1.0 + proximity, info, module, None, ()))
             continue
 
-        if has_unify_signal:
-            # Prefer the env-resolved typed formula over the parsed
-            # one when available: the latter still has OverloadedVar
-            # candidate lists for both operators and variable types,
-            # and the matcher's first-candidate-only comparison
-            # produces both false-positive and false-negative full
-            # tiers depending on lexical order (issue #690 Bug 2/3).
-            typed_formula = _resolve_typed_formula(info.name, env)
-            unify_input = typed_formula if typed_formula is not None else formula
-            unify_score, unify_tier, discharged = _unify_score(
-                unify_input, goal_ast, env, given_pairs
-            )
-        else:
-            unify_score, unify_tier, discharged = 0.0, None, ()
-
         if goal_head is not None:
             head = _formula_head_symbol(formula)
             head_score = 1.0 if head == goal_head else 0.0
@@ -4609,24 +4617,73 @@ def _rank_lemmas(
 
         if goal_syms:
             symbols = _formula_symbols(formula)
-            overlap = len(goal_syms & symbols) / len(goal_syms)
+            shared = goal_syms & symbols
+            overlap = len(shared) / len(goal_syms)
+            # Jaccard breaks ties between lemmas with the same overlap
+            # by preferring those whose formula has no symbols outside
+            # the goal -- ``uint_add_commute`` ({+, =}) outranks
+            # ``uint_minus_add`` ({+, -, =}) on a ``+ = +`` goal because
+            # the latter is "noisier". Important once UNIFY_TOP_K cuts
+            # off the tail: without this, dozens of equation lemmas
+            # tied at overlap=1.0 elbowed the real match out of the
+            # window (issue #690 Bug 1).
+            denom = len(goal_syms | symbols)
+            specificity = len(shared) / denom if denom else 0.0
         else:
             overlap = 0.0
+            specificity = 0.0
 
-        raw = (
-            8.0 * unify_score
-            + 4.0 * head_score
+        cheap_raw = (
+            4.0 * head_score
             + 2.0 * overlap
+            + 1.5 * specificity
             + 1.0 * proximity
             + 2.0 * substring_score
             + 3.0 * pattern_score
         )
 
-        # No goal AND no query that this lemma matched -> nothing to
-        # score on.  Skip.
-        if raw <= 0.0:
+        # Skip candidates with no positive cheap signal: a lemma whose
+        # conclusion head differs from the goal, shares no operator
+        # tokens with it, lives in another module, and matches no
+        # query has zero chance of being relevant.  Running the
+        # unifier on it would be pure waste.
+        if cheap_raw <= 0.0:
             continue
 
+        prelim.append((cheap_raw, info, formula, module, proximity))
+
+    # Second pass: run the unifier only on the K cheapest-ranked
+    # survivors.  K is intentionally a few multiples of the LSP
+    # default ``limit`` (50) -- a lemma that would unify but ranks
+    # outside the top 150 by textual signals is exotic, and the
+    # latency win (≈6s -> ≈1s on stdlib-sized preludes) outweighs
+    # the rare miss.  When a future request needs a bigger window,
+    # widen this constant rather than the per-candidate cost.
+    prelim.sort(key=lambda t: (-t[0], t[1].name))
+    UNIFY_TOP_K = 50
+    for idx, (cheap_raw, info, formula, module, _proximity) in enumerate(
+        prelim
+    ):
+        if has_unify_signal and idx < UNIFY_TOP_K:
+            # Prefer the env-resolved typed formula over the parsed
+            # one when available: the latter still has OverloadedVar
+            # candidate lists for both operators and variable types,
+            # and the matcher's first-candidate-only comparison
+            # produces both false-positive and false-negative full
+            # tiers depending on lexical order (issue #690 Bug 2/3).
+            typed_formula = (
+                typed_formula_by_name.get(info.name)
+                if typed_formula_by_name is not None
+                else None
+            )
+            unify_input = typed_formula if typed_formula is not None else formula
+            unify_score, unify_tier, discharged = _unify_score(
+                unify_input, goal_ast, env, given_pairs
+            )
+        else:
+            unify_score, unify_tier, discharged = 0.0, None, ()
+
+        raw = 8.0 * unify_score + cheap_raw
         raw_scores.append((raw, info, module, unify_tier, discharged))
 
     if not raw_scores:

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -3679,7 +3679,19 @@ def available_lemmas_at(
         result = check_file(path, content=content, prelude=prelude)
         ast_nodes = result.ast
 
-    candidates = _collect_lemma_candidates(path, ast_nodes, prelude)
+    # A proof can't cite the theorem it's proving -- circularity --
+    # so drop the enclosing theorem from candidates before ranking.
+    # Only applies when the cursor is at a hole inside a proof body;
+    # browse mode (cursor anywhere else) keeps every declaration
+    # visible, including the theorem that happens to start at pos.
+    exclude = (
+        _enclosing_theorem_name(ast_nodes, pos)
+        if hole_range is not None
+        else None
+    )
+    candidates = _collect_lemma_candidates(
+        path, ast_nodes, prelude, exclude_name=exclude
+    )
     if not candidates:
         return ()
 
@@ -3826,8 +3838,45 @@ def _module_for_path(path: str) -> str:
     return Path(path).stem
 
 
+def _enclosing_theorem_name(ast_nodes: Any, pos: Position) -> Optional[str]:
+    """Return the base name of the user-file ``Theorem`` whose body
+    encloses ``pos``, or ``None`` when ``pos`` isn't inside one.
+
+    Theorems don't nest at the top level, so the enclosing one is the
+    last ``Theorem`` whose start ``location`` is at or before ``pos``
+    and which has no later top-level statement starting at or before
+    ``pos``. The intent is to skip the theorem currently being proved
+    when surfacing lemmas at one of its holes -- the proof can't
+    refer to itself.
+    """
+    if ast_nodes is None:
+        return None
+    from abstract_syntax import Theorem, base_name
+
+    enclosing: Optional[str] = None
+    for stmt in ast_nodes:
+        loc = getattr(stmt, "location", None)
+        if loc is None or getattr(loc, "empty", True):
+            continue
+        if not _meta_at_or_before(loc, pos):
+            # ``ast_nodes`` is in source order; no later sibling can be
+            # at-or-before ``pos`` either.
+            break
+        if isinstance(stmt, Theorem):
+            enclosing = base_name(stmt.name)
+        else:
+            # A non-Theorem starts at-or-before pos, which means any
+            # earlier Theorem ended before this stmt -- pos is outside
+            # it. Reset.
+            enclosing = None
+    return enclosing
+
+
 def _collect_lemma_candidates(
-    path: str, ast_nodes: Any, prelude: Sequence[str]
+    path: str,
+    ast_nodes: Any,
+    prelude: Sequence[str],
+    exclude_name: Optional[str] = None,
 ) -> tuple[tuple[LemmaInfo, Any, str], ...]:
     """Build the ranking input: theorems/lemmas/postulates with their
     formula AST and module of origin.
@@ -3845,6 +3894,11 @@ def _collect_lemma_candidates(
       ``using``/``hiding`` clause.
     - Each module named in ``prelude`` (public theorems/postulates
       only, matching ``print_theorems``' visibility filter).
+
+    When ``exclude_name`` is set, any theorem/postulate with that
+    base name is dropped from the user-file slice -- used to keep
+    the theorem currently being proved out of the picker at one of
+    its own holes.
     """
     from abstract_syntax import (
         Import as _ImportNode,
@@ -3897,6 +3951,8 @@ def _collect_lemma_candidates(
             if info is None:
                 continue
             if info.name in seen_names:
+                continue
+            if exclude_name is not None and info.name == exclude_name:
                 continue
             seen_names.add(info.name)
             out.append((info, stmt.what, user_module))

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -4285,6 +4285,47 @@ def _iter_subterms(node: Any) -> Any:
     return out
 
 
+def _resolve_typed_formula(name: str, env: Any) -> Any:
+    """Return the post-typecheck formula for the named lemma from
+    ``env``, or ``None`` when ``env`` doesn't surface a
+    :class:`ProofBinding` under any key whose base name is ``name``.
+
+    The formula stored on :class:`abstract_syntax.declarations.Theorem`
+    and :class:`Postulate` is the parsed, pre-typecheck AST -- bound
+    variables and operators are still :class:`OverloadedVar` carrying
+    a list of candidate resolved names. The matcher's
+    ``get_name()`` returns only the first candidate, which produces
+    both false positives (an unrelated lemma whose first overload
+    happens to alias the goal's resolved operator -- e.g.
+    ``add_commute_uint_int : all x:UInt, y:Int. x + y = y + x``
+    against a ``UInt + UInt`` goal) and false negatives (a
+    right-type lemma whose first overload doesn't alias the goal --
+    e.g. ``uint_add_commute`` when its first candidate is the
+    inherited Nat ``+``).
+
+    The proof environment, by contrast, stores the post-typecheck
+    formula -- overloads have been resolved to single names and
+    variable types pinned to a single overload candidate during the
+    prelude's check pass. Using that formula for unification (issue
+    #690) fixes both classes of bug at once.
+
+    Theorem names are forbidden from being overloaded (see
+    :meth:`Postulate.uniquify`), so a base-name lookup uniquely
+    identifies the binding.
+    """
+    if env is None or not hasattr(env, "dict"):
+        return None
+    from abstract_syntax import ProofBinding, base_name
+
+    for key in env.dict:
+        if base_name(key) != name:
+            continue
+        binding = env.dict[key]
+        if isinstance(binding, ProofBinding):
+            return binding.formula
+    return None
+
+
 def _unify_score(
     formula: Any,
     goal_ast: Any,
@@ -4490,8 +4531,16 @@ def _rank_lemmas(
             continue
 
         if has_unify_signal:
+            # Prefer the env-resolved typed formula over the parsed
+            # one when available: the latter still has OverloadedVar
+            # candidate lists for both operators and variable types,
+            # and the matcher's first-candidate-only comparison
+            # produces both false-positive and false-negative full
+            # tiers depending on lexical order (issue #690 Bug 2/3).
+            typed_formula = _resolve_typed_formula(info.name, env)
+            unify_input = typed_formula if typed_formula is not None else formula
             unify_score, unify_tier, discharged = _unify_score(
-                formula, goal_ast, env, given_pairs
+                unify_input, goal_ast, env, given_pairs
             )
         else:
             unify_score, unify_tier, discharged = 0.0, None, ()

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -677,6 +677,68 @@ def test_unify_rejects_wrong_type_overload_as_full_tier() -> None:
         )
 
 
+def test_specificity_pushes_clean_match_above_noisy_ties() -> None:
+    """When many lemmas tie on head match + overlap, the Jaccard-like
+    specificity signal must keep the lemma whose formula contains no
+    extra operators above the noisy ones.
+
+    Issue #690 Bug 1 (latency): ``_rank_lemmas`` only runs the
+    expensive unifier on the top ``UNIFY_TOP_K`` cheap-ranked
+    candidates.  Without specificity as a secondary signal, dozens of
+    equation lemmas would tie on a ``a + b = b + a`` goal and the
+    real ``uint_add_commute`` could be elbowed past the cutoff -- the
+    user would never see the unify signal that earns it the top
+    slot.
+
+    Drives the ranker directly with synthetic ``LemmaInfo`` rows so
+    the assertion lands on the cheap-signal path without needing a
+    real stdlib import.
+    """
+    from lsp.query import _rank_lemmas
+
+    # Two synthetic lemmas tying on head=``=`` and 100% overlap with
+    # the goal tokens; ``noisy`` adds an unrelated ``-``.  Distinct
+    # sentinel strings stand in for the formula AST so the patched
+    # ``_formula_symbols`` can tell them apart.
+    candidates = (
+        (
+            LemmaInfo(name="add_pure", kind=SymbolKind.THEOREM,
+                      signature="add_pure: all a, b. a + b = b + a"),
+            "FORMULA_PURE",
+            "user",
+        ),
+        (
+            LemmaInfo(name="add_noisy", kind=SymbolKind.THEOREM,
+                      signature="add_noisy: all a, b, c. (a + b) - c = (b + a) - c"),
+            "FORMULA_NOISY",
+            "user",
+        ),
+    )
+    # Patch ``_formula_symbols`` for this call -- the real one walks
+    # an AST; we want to control symbol sets directly.
+    import lsp.query as Q
+    real = Q._formula_symbols
+    Q._formula_symbols = lambda f: (
+        frozenset({"+", "="}) if f == "FORMULA_PURE" else frozenset({"+", "-", "="})
+    )
+    try:
+        ranked = _rank_lemmas(
+            candidates,
+            goal_text="all x, y. x + y = y + x",
+            query=None,
+            user_module="user",
+        )
+    finally:
+        Q._formula_symbols = real
+
+    by_name = {m.name: m for m in ranked}
+    assert "add_pure" in by_name and "add_noisy" in by_name
+    assert by_name["add_pure"].relevance > by_name["add_noisy"].relevance, (
+        "Lemma with no extra operators must outrank one carrying "
+        "irrelevant `-` on a `+=+` goal"
+    )
+
+
 def test_current_theorem_excluded_from_lemma_list() -> None:
     """The theorem currently being proved must not appear in the
     candidate list -- a proof can't cite itself (issue #690 Bug 5).

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -677,6 +677,35 @@ def test_unify_rejects_wrong_type_overload_as_full_tier() -> None:
         )
 
 
+def test_current_theorem_excluded_from_lemma_list() -> None:
+    """The theorem currently being proved must not appear in the
+    candidate list -- a proof can't cite itself (issue #690 Bug 5).
+
+    User report: with cursor on the ``?`` inside ``theorem t``,
+    `C-c C-l` listed ``t`` as one of the applicable lemmas.
+    """
+    source = (
+        "theorem helper: true\nproof\n  .\nend\n"
+        "\n"
+        "theorem t: all a:UInt, b:UInt. a + b = b + a\n"
+        "proof\n"
+        "  arbitrary a:UInt, b:UInt\n"
+        "  ?\n"
+        "end\n"
+    )
+    # Hole sits on line 9 inside ``theorem t``.
+    matches = available_lemmas_at(
+        "user.pf", source, Position(line=9, column=3),
+    )
+    names = {m.name for m in matches}
+    assert "t" not in names, (
+        "The current theorem must not be offered as a lemma -- "
+        "citing it from its own proof is circular"
+    )
+    # Sibling theorems remain visible.
+    assert "helper" in names
+
+
 def test_browse_mode_leaves_unify_tier_unset() -> None:
     """Browse mode (no goal, no query) doesn't run the unifier, so
     ``unify_tier`` stays ``None`` on every result."""

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -596,6 +596,87 @@ def test_unify_rewrite_subterm_tier_fires_for_equation_lemma() -> None:
     assert by_name["not_not"].unify_tier == "rewrite_subterm"
 
 
+def test_unify_uses_typed_lemma_overload_for_right_type_match() -> None:
+    """A right-type lemma whose first lexically-resolved overload
+    candidate does NOT alias the goal's resolved operator must still
+    match as ``full``.
+
+    Reproduces Bug 3 from issue #690: ``stmt.what`` (the parsed,
+    pre-typecheck lemma AST) keeps :class:`OverloadedVar` with a
+    candidate list whose first entry is just whatever uniquify saw
+    first.  The matcher's name-equality check compares only that
+    first candidate, so a lemma about ``A * A`` whose first ``*``
+    overload happens to be the ``B * B`` one gets rejected even
+    though it's the right answer.
+
+    The fix is to look the lemma up in the proof environment (where
+    overloads have been resolved during the prelude's type check)
+    before unifying."""
+    source = (
+        "import OverloadShared\n"
+        "\n"
+        "theorem t: all a:A, c:A. a * c = c * a\n"
+        "proof\n"
+        "  arbitrary a:A, c:A\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf", source, Position(line=6, column=3),
+        prelude=("OverloadShared",),
+    )
+    by_name = {m.name: m for m in matches}
+    assert "aa_star_commute" in by_name, (
+        "the right-type lemma should appear in the candidate list"
+    )
+    assert by_name["aa_star_commute"].unify_tier == "full", (
+        "aa_star_commute applies to an A * A goal -- it should be "
+        "the full-tier top match, not buried at None"
+    )
+
+
+def test_unify_rejects_wrong_type_overload_as_full_tier() -> None:
+    """A wrong-type lemma whose first lexically-resolved overload
+    candidate ALIASES the goal's resolved operator must not match as
+    ``full``.
+
+    Reproduces Bug 2 from issue #690: ``bb_star_commute`` and
+    ``ab_star_refl`` both reference ``*`` with an :class:`OverloadedVar`
+    candidate list that includes the A*A overload (because all three
+    overloads are in scope where they were declared).  The matcher's
+    first-candidate-only name-equality test mis-accepts the wrong-type
+    lemma whenever that lexical first candidate happens to be the A*A
+    one.
+
+    The fix (looking up the typed formula in the proof environment)
+    sees the resolved single overload and rejects the mismatch."""
+    source = (
+        "import OverloadShared\n"
+        "\n"
+        "theorem t: all a:A, c:A. a * c = c * a\n"
+        "proof\n"
+        "  arbitrary a:A, c:A\n"
+        "  ?\n"
+        "end\n"
+    )
+    matches = available_lemmas_at(
+        "user.pf", source, Position(line=6, column=3),
+        prelude=("OverloadShared",),
+    )
+    by_name = {m.name: m for m in matches}
+    if "bb_star_commute" in by_name:
+        assert by_name["bb_star_commute"].unify_tier != "full", (
+            "bb_star_commute is about B * B; an A * A goal must not "
+            "full-match it just because the first overload of `*` in "
+            "the lemma's candidate list happens to be the A*A one"
+        )
+    if "ab_star_refl" in by_name:
+        assert by_name["ab_star_refl"].unify_tier != "full", (
+            "ab_star_refl is about A * B; an A * A goal must not "
+            "full-match it"
+        )
+
+
 def test_browse_mode_leaves_unify_tier_unset() -> None:
     """Browse mode (no goal, no query) doesn't run the unifier, so
     ``unify_tier`` stays ``None`` on every result."""

--- a/test/test-imports/OverloadShared.pf
+++ b/test/test-imports/OverloadShared.pf
@@ -1,0 +1,45 @@
+/*
+  Test fixture for issue #690 (Bug 2 + Bug 3 in `_unify_score`):
+  two distinct types `A` and `B` that share an overloaded operator
+  `*`, plus three theorems that exercise the matcher's overload
+  handling.
+
+  In a `?` over an `A*A` goal, the typed-formula resolver must:
+    - accept `aa_star_commute` (the right-type lemma) as `full`
+    - reject `ab_star_swap` (mixed-overload lemma) as not `full`
+    - reject `bb_star_commute` (wrong-type lemma) as not `full`
+
+  Without the fix, the matcher's first-candidate-only comparison of
+  `OverloadedVar.resolved_names` produces both false positives and
+  false negatives depending on the lexical order of the overload
+  candidates.
+*/
+
+union A {
+  ma
+}
+
+union B {
+  mb
+}
+
+fun operator *(x:A, y:A) {
+  ma
+}
+
+fun operator *(x:B, y:B) {
+  mb
+}
+
+fun operator *(x:A, y:B) {
+  mb
+}
+
+postulate aa_star_commute: all x:A, y:A. x * y = y * x
+postulate bb_star_commute: all x:B, y:B. x * y = y * x
+// A mixed-overload `*` reference, but trivially refl on the RHS so
+// the type checker can resolve the lemma itself. Plays the role of
+// `add_commute_uint_int` in the stdlib reproducer for issue #690:
+// a real lemma about an A×B `*` whose first-resolved-name aliases
+// the A×A overload, fooling the matcher's first-candidate check.
+postulate ab_star_refl:    all x:A, y:B. x * y = x * y


### PR DESCRIPTION
## Summary

- New **`deduce-lsp-search-lemma`** Emacs command bound to **`C-c C-l`**.  Cursor on a `?`, fetches ranked in-scope lemmas via the `deduce/availableLemmasAt` LSP method (added in #702) and presents them through `completing-read` with annotations showing the unify tier and module of origin.
- The picker rows look like:
  ```
  uint_add_commute: (all x:UInt, y:UInt. x + y = y + x)   -- applies          [UIntAdd]
  uint_less_equal_trans: ... if a <= b and b <= c...      -- applies (by h, g)  [UIntLess]
  ```
- The top candidate is the natural default; `RET` on an empty filter picks it. Selecting drives a `deduce/insertLemma` request whose tier-aware WorkspaceEdit (see `lsp/query.py:insert_lemma_at`) is applied directly -- `conclude ... by ...` / `apply ... to ?` / `replace ...` / bare name, picked server-side.
- `C-u C-c C-l` prompts for a query string (substring or goal-shape pattern with `_` placeholders) forwarded to the server.
- Also extends `editor/emacs/README.md` (feature blurb + keybinding table + smoke test step 13) and `docs/knowledge-base/emacs-lsp-protocol.md` (custom-request table + hole-replacement enumeration).

## Follow-up ranker fixes (smoke-tested live, layered on this branch)

Per user request, five bugs surfaced by manual smoke testing were fixed in the same branch rather than spun off to a separate PR:

- **Bug 2/3 — wrong/missing type-overload matches** (`e145c14`): the matcher was comparing pre-typecheck `OverloadedVar` candidate lists, so e.g. `add_commute_uint_int` mis-matched a `UInt + UInt` goal and `uint_add_commute` was missing entirely. Now uses the env's post-typecheck typed formula.
- **Bug 5 — current theorem suggested itself** (`b91da80`): `_collect_lemma_candidates` always included every user-file theorem; the proof at `?` inside `theorem t` listed `t` as a candidate. `_enclosing_theorem_name(ast_nodes, pos)` filters it out when at a hole; browse mode is untouched.
- **Bug 6 — name duplicated in picker label** (`b91da80`): server's `:signature` already starts with `NAME: ` for theorems/postulates, and the Emacs picker prepended `NAME : ` again. `deduce-lsp--lemma-display-string` now uses `:signature` verbatim.
- **Bug 1 — picker latency 6s → 1.3s warm** (`f9f25fc`): two-pass ranker that runs the expensive `_unify_score` only on the top K=50 cheap-ranked candidates, plus a Jaccard specificity signal that keeps the right match in that window, plus a one-shot typed-formula index built once per request.

## Test plan

- [x] `python -m pytest test/lsp/test_available_lemmas.py` — 25/25 (4 new tests pin the bug-2/3 typed-formula path, bug-5 self-filter, and bug-1 specificity tie-breaker)
- [x] `python -m pytest test/lsp/ --ignore=test/lsp/test_query.py` — 423/423 (`test_query.py` has 2 pre-existing failures on `main`, unrelated)
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-lsp-test -f ert-run-tests-batch-and-exit` — 76/76 (3 existing ert tests updated to match the real server signature format with `NAME: ` prefix)
- [x] `emacs --batch -L editor/emacs -L editor/emacs/test -l deduce-mode-test -f ert-run-tests-batch-and-exit` — 31/31 still green
- [x] `emacs --batch -L editor/emacs -f batch-byte-compile editor/emacs/deduce-lsp.el` — no warnings
- [x] `make static` — `ruff` + `mypy .` clean
- [x] Manual smoke test (5 iterations): `C-c C-l` at a `?` inside `theorem t: all a:UInt, b:UInt. a + b = b + a` now returns `uint_add_commute` top-1 at "applies" tier with no `t` self-suggestion and no `t : t: (...)` doubling, in ~1.3s warm.
- [ ] CI green

Addresses #690 (Part 3 portion; Parts 1 ranker fixes layered in). Part 4 (VS Code `deduce.searchLemma`) remains.

[Claude session](claude://resume?session=86c6c5a7-d4c7-4e01-b246-10c12f98b51d)

`86c6c5a7-d4c7-4e01-b246-10c12f98b51d`