### PR TITLE
Add Int multiplication cancellation under ≤ / < (Refs #660)

### DIFF
--- a/lib/IntMult.pf
+++ b/lib/IntMult.pf
@@ -777,3 +777,87 @@ proof
   have step: n * y < n * x by apply int_neg_mult_mono_less_left[n, x, y] to prem
   replace int_mult_commute[n, x] | int_mult_commute[n, y] in step
 end
+
+// Left cancellation by a positive Int under `<`.
+theorem int_pos_mult_left_cancel_less: all n:Int, x:Int, y:Int.
+  if +0 < n and n * x < n * y
+  then x < y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have zn: +0 < n by conjunct 0 of prem
+  have nxny: n * x < n * y by conjunct 1 of prem
+  have tri: x < y or x = y or y < x by int_trichotomy[x, y]
+  cases tri
+  case x_l_y: x < y { x_l_y }
+  case x_eq_y: x = y {
+    have nx_eq_ny: n * x = n * y by replace x_eq_y.
+    have bad: n * y < n * y by replace nx_eq_ny in nxny
+    conclude false by apply int_less_irreflexive[n * y] to bad
+  }
+  case y_l_x: y < x {
+    have ny_l_nx: n * y < n * x
+      by apply int_pos_mult_mono_less_left[n, y, x] to zn, y_l_x
+    have bad: n * y < n * y
+      by apply int_less_trans[n * y, n * x, n * y] to ny_l_nx, nxny
+    conclude false by apply int_less_irreflexive[n * y] to bad
+  }
+end
+
+// Right cancellation by a positive Int under `<`.
+theorem int_pos_mult_right_cancel_less: all n:Int, x:Int, y:Int.
+  if +0 < n and x * n < y * n
+  then x < y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have zn: +0 < n by conjunct 0 of prem
+  have xnyn: x * n < y * n by conjunct 1 of prem
+  have nxny: n * x < n * y
+    by replace int_mult_commute[n, x] | int_mult_commute[n, y]
+       xnyn
+  apply int_pos_mult_left_cancel_less[n, x, y] to zn, nxny
+end
+
+// Left cancellation by a positive Int under `≤`.
+theorem int_pos_mult_left_cancel_le: all n:Int, x:Int, y:Int.
+  if +0 < n and n * x ≤ n * y
+  then x ≤ y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have zn: +0 < n by conjunct 0 of prem
+  have nxny: n * x ≤ n * y by conjunct 1 of prem
+  have tri: x < y or x = y or y < x by int_trichotomy[x, y]
+  cases tri
+  case x_l_y: x < y {
+    apply int_less_implies_less_equal[x, y] to x_l_y
+  }
+  case x_eq_y: x = y {
+    replace symmetric x_eq_y
+    int_less_equal_refl[x]
+  }
+  case y_l_x: y < x {
+    have ny_l_nx: n * y < n * x
+      by apply int_pos_mult_mono_less_left[n, y, x] to zn, y_l_x
+    have bad: n * y < n * y
+      by apply int_less_trans_less_equal_right[n * y, n * x, n * y]
+         to ny_l_nx, nxny
+    conclude false by apply int_less_irreflexive[n * y] to bad
+  }
+end
+
+// Right cancellation by a positive Int under `≤`.
+theorem int_pos_mult_right_cancel_le: all n:Int, x:Int, y:Int.
+  if +0 < n and x * n ≤ y * n
+  then x ≤ y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have zn: +0 < n by conjunct 0 of prem
+  have xnyn: x * n ≤ y * n by conjunct 1 of prem
+  have nxny: n * x ≤ n * y
+    by replace int_mult_commute[n, x] | int_mult_commute[n, y]
+       xnyn
+  apply int_pos_mult_left_cancel_le[n, x, y] to zn, nxny
+end


### PR DESCRIPTION
## Summary

Add four Int multiplication cancellation theorems to `lib/IntMult.pf` that complement the equality cancellation theorems landed in #688 and the positive-multiplier monotonicity theorems from #701:

- `int_pos_mult_left_cancel_less`: `if +0 < n and n*x < n*y then x < y`
- `int_pos_mult_right_cancel_less`: `if +0 < n and x*n < y*n then x < y`
- `int_pos_mult_left_cancel_le`: `if +0 < n and n*x ≤ n*y then x ≤ y`
- `int_pos_mult_right_cancel_le`: `if +0 < n and x*n ≤ y*n then x ≤ y`

These mirror `uint_pos_mult_left_cancel_less` / `_right_cancel_less` / `_left_cancel_less_equal` / `_right_cancel_less_equal` in `lib/UIntMult.pf`.

The strict-inequality proofs go through `int_trichotomy` plus `int_pos_mult_mono_less_left`; the `≤` proofs additionally use `int_less_trans_less_equal_right` to combine `n*y < n*x` with `n*x ≤ n*y` into a contradiction.

## #660 sub-task status

Completed by this PR (slice from the issue's open list):

- [x] **Int multiplication cancellation under `≤` / `<` by a positive multiplier** — the counterparts to the equality cancellation theorems landed in #688.

Still remaining for #660:

- Int multiplication cancellation under `≤` / `<` by a *negative* multiplier (sign-flipped versions of these four).
- Slice 2 — Euclidean `div` / `%` plus `div_mod` and basic mod laws.
- Slice 3 — Int `divides` / `gcd` / `lcm`.
- Slice 4 — Int powers.
- Slice 6 — Int-valued summation.
- Conversion / specification cleanup tying literals, `abs`, and UInt theorems together.

Refs #660.

## Test plan

- [x] \`python deduce.py lib/IntMult.pf\` (default recursive-descent)
- [x] \`python deduce.py --lalr lib/IntMult.pf\`
- [x] \`python -m mypy .\` and \`python -m ruff check .\` clean
- [x] \`python test-deduce.py --lib\` passes locally (21.91s)
- [x] \`python test-deduce.py\` full suite passes locally (114.61s)

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID) (UUID fallback: \`1a2d51dc-a913-4418-8b92-59d29f9f5668\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)