### PR TITLE
Add tails example to examples/: definition + 3 correctness theorems

### DIFF
--- a/examples/tails.pf
+++ b/examples/tails.pf
@@ -1,0 +1,81 @@
+// tails.pf
+//
+// The classic Haskell intro-FP function:
+//
+//     tails :: [a] -> [[a]]
+//     tails []     = [[]]
+//     tails (x:xs) = (x:xs) : tails xs
+//
+// `tails(xs)` is the list of all suffixes of `xs`, starting with `xs`
+// itself and ending with the empty list. For example,
+//   tails([1,2,3]) = [[1,2,3], [2,3], [3], []]
+//
+// We define `tails` and prove three correctness theorems:
+//
+//   1. length_tails:          length(tails(xs)) = 1 + length(xs)
+//   2. head_tails:            head(tails(xs)) = just(xs)
+//   3. tails_contains_empty:  contains(tails(xs), empty) = true
+
+import List
+
+recursive tails<T>(List<T>) -> List< List<T> > {
+  tails(empty) = node(empty, empty)
+  tails(node(x, xs)) = node(node(x, xs), tails(xs))
+}
+
+assert tails([1, 2, 3]) = [[1,2,3], [2,3], [3], []]
+assert tails(@[]<UInt>) = [@[]<UInt>]
+
+// The length of tails(xs) is one more than length(xs),
+// since tails always ends with the empty suffix.
+theorem length_tails: all T:type. all xs:List<T>.
+  length(tails(xs)) = 1 + length(xs)
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    expand tails | 2*length.
+  }
+  case node(x, xs') assume IH: length(tails(xs')) = 1 + length(xs') {
+    equations
+      length(tails(node(x, xs')))
+          = length(node(node(x, xs'), tails(xs')))   by expand tails.
+      ... = 1 + length(tails(xs'))                   by expand length.
+      ... = 1 + (1 + length(xs'))                    by replace IH.
+      ... = # 1 + length(node(x, xs')) #             by expand length.
+  }
+end
+
+// The head of tails(xs) is xs itself: the first suffix is the
+// whole list. No induction is needed --- the result is immediate
+// once we have unfolded `tails` once.
+theorem head_tails: all T:type. all xs:List<T>.
+  head(tails(xs)) = just(xs)
+proof
+  arbitrary T:type
+  arbitrary xs:List<T>
+  switch xs {
+    case empty {
+      expand tails | head.
+    }
+    case node(x, xs') {
+      expand tails | head.
+    }
+  }
+end
+
+// Every tails(xs) contains the empty list as a suffix --- it is
+// always the last element produced.
+theorem tails_contains_empty: all T:type. all xs:List<T>.
+  contains(tails(xs), @empty<T>) = true
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    expand tails | contains.
+  }
+  case node(x, xs') assume IH: contains(tails(xs'), @empty<T>) = true {
+    expand tails | contains
+    replace IH.
+  }
+end


### PR DESCRIPTION
## Summary

Adds [examples/tails.pf](examples/tails.pf) — the classic Haskell-Prelude `tails` (list of all suffixes), with three correctness theorems matching the style of the existing `examples/*.pf` files (count, partition, take_while, replicate, …).

```deduce
recursive tails<T>(List<T>) -> List< List<T> > {
  tails(empty) = node(empty, empty)
  tails(node(x, xs)) = node(node(x, xs), tails(xs))
}
```

Theorems proved:

1. `length_tails`:          `length(tails(xs)) = 1 + length(xs)`
2. `head_tails`:            `head(tails(xs)) = just(xs)`
3. `tails_contains_empty`:  `contains(tails(xs), empty) = true`

## Friction surfaced while writing this

Three issues filed against `main` (none are blockers for this PR):

- [#706](https://github.com/jsiek/deduce/issues/706) — pre-existing regression: `examples/maximum.pf` is broken on `main` after #636 marked `uint_zero_max` as an auto rule. Surfaces via `make tests-examples`.
- [#707](https://github.com/jsiek/deduce/issues/707) — `TacticsCheatSheet`'s `evaluate` row reads like a transformer; it's actually a closing tactic.
- [#708](https://github.com/jsiek/deduce/issues/708) — `lib/List.pf` is missing classic Haskell-Prelude functions: `last`, `init`, `tails`, `inits`, `intersperse`. (This PR's `tails` is a candidate for promotion to `lib/` if there is interest — see issue.)

Refs #708.

## Test plan

- [x] `python deduce.py examples/tails.pf` → valid (default recursive-descent parser)
- [x] `python deduce.py --lalr examples/tails.pf` → valid (LALR parser)
- [ ] `make tests-examples` — currently blocked on the pre-existing maximum.pf failure (#706); the `tails.pf` lines pass individually with both parsers above.

[Claude session](claude://resume?session=613819af-e1dd-4256-b2a1-6be6405f6c60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)