### PR TITLE
Fix examples/maximum.pf: drop replaces handled by new auto rules (Closes #706)

### DIFF
--- a/examples/maximum.pf
+++ b/examples/maximum.pf
@@ -28,8 +28,7 @@ proof
   induction List<UInt>
   case empty {
     arbitrary ys:List<UInt>
-    expand maximum | operator++
-    replace uint_zero_max[maximum(ys)].
+    expand maximum | operator++.
   }
   case node(x, xs') assume IH: (all ys:List<UInt>.
       maximum(xs' ++ ys) = max(maximum(xs'), maximum(ys))) {
@@ -55,8 +54,7 @@ proof
   }
   case node(x, xs') assume IH: maximum(reverse(xs')) = maximum(xs') {
     have singleton_max: maximum([x]) = x
-      by expand 2*maximum
-         replace uint_max_zero[x].
+      by expand 2*maximum.
     equations
       maximum(reverse(node(x, xs')))
           = maximum(reverse(xs') ++ [x])           by expand reverse.


### PR DESCRIPTION
## Summary

- Drop two now-redundant `replace` steps from `examples/maximum.pf` that were left over after #636 promoted `uint_zero_max` and `uint_max_zero` to `auto` rules — these auto rules close the goal before the `replace` fires, tripping Deduce's strict "no redundant replace" check and breaking `make tests-examples` on main.
- Verified with both the recursive-descent and LALR parsers; `make tests-examples` is now green.

Closes #706.

### Diff

```diff
   case empty {
     arbitrary ys:List<UInt>
-    expand maximum | operator++
-    replace uint_zero_max[maximum(ys)].
+    expand maximum | operator++.
   }
…
     have singleton_max: maximum([x]) = x
-      by expand 2*maximum
-         replace uint_max_zero[x].
+      by expand 2*maximum.
```

The second redundancy (`uint_max_zero` in `singleton_max`) was not called out in the issue but tripped the same check once the first was removed — `auto uint_max_zero` was added in the same PR (#636).

## Test plan

- [x] `python3.13 deduce.py --recursive-descent examples/maximum.pf` → `is valid`
- [x] `python3.13 deduce.py --lalr examples/maximum.pf` → `is valid`
- [x] `make tests-examples` → all examples valid under both parsers
- [x] `python3.13 -m ruff check .` + `python3.13 -m mypy .` → clean

[Claude session](claude://resume?session=9226b07f-3391-4f59-b0b4-808f392ee888) (fallback: `9226b07f-3391-4f59-b0b4-808f392ee888`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)