### PR TITLE
docs(TacticsCheatSheet): clarify evaluate is a closing tactic (#707)

### DIFF
--- a/gh_pages/doc/TacticsCheatSheet.md
+++ b/gh_pages/doc/TacticsCheatSheet.md
@@ -36,11 +36,12 @@ If a name on this page is unfamiliar, follow the link in the Reference column fo
 
 | Form | Effect |
 | --- | --- |
-| `.` (period) | Close the goal trivially: definitional equality, reflexivity, or `true`. |
-| `evaluate` | Reduce both sides of the goal to normal form. |
+| `.` (period) | **Closes the goal** trivially: definitional equality, reflexivity, or `true`. |
+| `evaluate` | **Closes the goal** by expanding every (non-opaque) definition on both sides; fails if the result is not `true`. It is a terminal tactic — cannot be followed by `replace`/`expand`/etc. For the transforming variant, see `evaluate in p` below. |
 | `expand f \| g` | Unfold the definitions of `f` and `g` in the goal. |
 | `replace eq` | Rewrite the **goal** left-to-right using `eq : LHS = RHS`. |
 | `replace eq in p` | Rewrite within proof `p`'s formula and return a new proof of the rewritten formula. |
+| `evaluate in p` | Given a proof `p : P`, return a proof of `P` with every (non-opaque) definition expanded. The transforming counterpart of `evaluate`. |
 | `replace eq1 \| eq2 \| ...` | Apply rewrites in sequence. |
 | `simplify with h` | Like `replace`, but accepts non-equation hypotheses: `h : not P` substitutes `P` with `false` in the goal; `h : P` (bare boolean) substitutes `P` with `true`. Use in the `case false` arm of a boolean `switch`, where `replace` rejects the `not P` hypothesis. |
 | `symmetric p` | If `p : a = b`, returns a proof of `b = a`. |


### PR DESCRIPTION
## Summary

Closes #707.

The Equality-tactics row for `evaluate` in [gh_pages/doc/TacticsCheatSheet.md](gh_pages/doc/TacticsCheatSheet.md) previously described it as *"Reduce both sides of the goal to normal form"* — wording that reads like a goal-transforming tactic in the same family as `expand`. In reality `evaluate` is a **closing tactic**: it succeeds only if the simplified formula is `true`, and the parser does not allow it to be followed by another tactic. A beginner who reaches for `evaluate` mid-proof and then writes `replace IH.` (the situation described in the issue) hits a confusing parse error.

## What changed

In the Equality-tactics table:

- Reword the `evaluate` row to lead with **"Closes the goal"**, mirror the bolding of the `.` row, and explicitly call out that it is a terminal tactic (cannot be followed by `replace` / `expand` / etc.).
- Add a sibling row for `evaluate in p` — the transforming counterpart — so the closing/transforming contrast is visible inline rather than buried in the Reference manual.
- Lightly reword the `.` row from "Close" to "**Closes**" for parallelism.

No code or fenced-deduce-block changes — pure prose. `python test-deduce.py --site` does not touch this content; the change is markdown-only.

## Test plan

- [x] Render the modified table mentally / visually for correctness
- [ ] CI passes (markdown-only change, no `.pf` code blocks affected)

[Claude session](claude://resume?session=43026871-0713-476f-8236-38156f70e3a3) (UUID: \`43026871-0713-476f-8236-38156f70e3a3\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)