### PR TITLE
Add Int multiplication cancellation under ≤ / < by a negative multiplier (Refs #660)

### DIFF
--- a/lib/IntMult.pf
+++ b/lib/IntMult.pf
@@ -861,3 +861,89 @@ proof
        xnyn
   apply int_pos_mult_left_cancel_le[n, x, y] to zn, nxny
 end
+
+// Left cancellation by a negative Int under `<`. Multiplying by a
+// negative number flips the inequality, so `n * y < n * x` cancels to
+// `x < y`.
+theorem int_neg_mult_left_cancel_less: all n:Int, x:Int, y:Int.
+  if n < +0 and n * y < n * x
+  then x < y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nn: n < +0 by conjunct 0 of prem
+  have nynx: n * y < n * x by conjunct 1 of prem
+  have tri: x < y or x = y or y < x by int_trichotomy[x, y]
+  cases tri
+  case x_l_y: x < y { x_l_y }
+  case x_eq_y: x = y {
+    have nx_eq_ny: n * x = n * y by replace x_eq_y.
+    have bad: n * y < n * y by replace nx_eq_ny in nynx
+    conclude false by apply int_less_irreflexive[n * y] to bad
+  }
+  case y_l_x: y < x {
+    have nx_l_ny: n * x < n * y
+      by apply int_neg_mult_mono_less_left[n, y, x] to nn, y_l_x
+    have bad: n * y < n * y
+      by apply int_less_trans[n * y, n * x, n * y] to nynx, nx_l_ny
+    conclude false by apply int_less_irreflexive[n * y] to bad
+  }
+end
+
+// Right cancellation by a negative Int under `<`.
+theorem int_neg_mult_right_cancel_less: all n:Int, x:Int, y:Int.
+  if n < +0 and y * n < x * n
+  then x < y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nn: n < +0 by conjunct 0 of prem
+  have ynxn: y * n < x * n by conjunct 1 of prem
+  have nynx: n * y < n * x
+    by replace int_mult_commute[n, y] | int_mult_commute[n, x]
+       ynxn
+  apply int_neg_mult_left_cancel_less[n, x, y] to nn, nynx
+end
+
+// Left cancellation by a negative Int under `≤`.
+theorem int_neg_mult_left_cancel_le: all n:Int, x:Int, y:Int.
+  if n < +0 and n * y ≤ n * x
+  then x ≤ y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nn: n < +0 by conjunct 0 of prem
+  have nynx: n * y ≤ n * x by conjunct 1 of prem
+  have tri: x < y or x = y or y < x by int_trichotomy[x, y]
+  cases tri
+  case x_l_y: x < y {
+    apply int_less_implies_less_equal[x, y] to x_l_y
+  }
+  case x_eq_y: x = y {
+    replace symmetric x_eq_y
+    int_less_equal_refl[x]
+  }
+  case y_l_x: y < x {
+    have nx_l_ny: n * x < n * y
+      by apply int_neg_mult_mono_less_left[n, y, x] to nn, y_l_x
+    have bad: n * y < n * y
+      by apply int_less_trans_less_equal_left[n * y, n * x, n * y]
+         to nynx, nx_l_ny
+    conclude false by apply int_less_irreflexive[n * y] to bad
+  }
+end
+
+// Right cancellation by a negative Int under `≤`.
+theorem int_neg_mult_right_cancel_le: all n:Int, x:Int, y:Int.
+  if n < +0 and y * n ≤ x * n
+  then x ≤ y
+proof
+  arbitrary n:Int, x:Int, y:Int
+  assume prem
+  have nn: n < +0 by conjunct 0 of prem
+  have ynxn: y * n ≤ x * n by conjunct 1 of prem
+  have nynx: n * y ≤ n * x
+    by replace int_mult_commute[n, y] | int_mult_commute[n, x]
+       ynxn
+  apply int_neg_mult_left_cancel_le[n, x, y] to nn, nynx
+end


### PR DESCRIPTION
## Summary

Sign-flipped counterparts of the positive-multiplier cancellation theorems landed in #705. Multiplying by a negative integer reverses the inequality, so cancelling that factor brings it back.

- `int_neg_mult_left_cancel_less`  — `n < +0 ∧ n*y < n*x → x < y`
- `int_neg_mult_right_cancel_less` — `n < +0 ∧ y*n < x*n → x < y`
- `int_neg_mult_left_cancel_le`    — `n < +0 ∧ n*y ≤ n*x → x ≤ y`
- `int_neg_mult_right_cancel_le`   — `n < +0 ∧ y*n ≤ x*n → x ≤ y`

Each proof mirrors the positive analog: trichotomy on `x`, `y`, and the `y < x` case is dispatched by `int_neg_mult_mono_less_left` (multiplication by a negative reverses `<`) combined with `int_less_trans` / `int_less_trans_less_equal_left` for the contradiction. The right-handed versions commute and delegate to the left.

## Relation to #660

This is one slice of the multi-part tracking issue #660 (Stdlib: fill Int module completeness gaps). Refs #660 — do **not** auto-close.

**Sub-tasks this PR completes:**

- [x] Int multiplication cancellation under `≤` / `<` by a *negative* multiplier — the four `int_neg_mult_*_cancel_*` theorems above. This closes the multiplication monotonicity / cancellation arc for `Int` (positive-multiplier monotonicity in #701, negative-multiplier monotonicity in #703, equality cancellation in #688, positive-multiplier `<` / `≤` cancellation in #705, and now this PR for the negative-multiplier `<` / `≤` cancellation).

**Sub-tasks that remain after this PR:**

- [ ] Slice 2 — Euclidean `div` / `%` plus `div_mod` and basic mod laws
- [ ] Slice 3 — Int `divides` / `gcd` / `lcm`
- [ ] Slice 4 — Int powers
- [ ] Slice 6 — Int-valued summation
- [ ] Conversion / specification cleanup tying literals, `abs`, and `UInt` theorems together (further follow-ups)

[Claude session](claude://resume?session=55d4d8b3-6708-4abd-b07c-796ab486c0e4) — fallback UUID: `55d4d8b3-6708-4abd-b07c-796ab486c0e4`

## Test plan

- [x] `python3.13 deduce.py lib/IntMult.pf` — recursive-descent parser
- [x] `python3.13 deduce.py --lalr lib/IntMult.pf` — LALR parser
- [ ] `make tests` (CI)
- [ ] `make tests-lib` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)