### PR TITLE
Add Int constructor + negation injectivity / normalization lemmas (Refs #660)

### DIFF
--- a/lib/IntAbs.pf
+++ b/lib/IntAbs.pf
@@ -80,6 +80,61 @@ proof
   int_abs_eq_zero_implies_zero[x], int_zero_implies_abs_eq_zero[x]
 end
 
+// Two integers share an absolute value exactly when they are equal or
+// negatives of each other. Useful as a normalization step in proofs that
+// would otherwise re-derive this by case-splitting on `pos`/`negsuc`.
+theorem int_abs_eq_iff_eq_or_neg: all x:Int, y:Int.
+  abs(x) = abs(y) ⇔ x = y or x = - y
+proof
+  arbitrary x:Int, y:Int
+  have fwd: if abs(x) = abs(y) then x = y or x = - y by {
+    assume ax_ay: abs(x) = abs(y)
+    switch x {
+      case pos(a) assume xa {
+        switch y {
+          case pos(b) assume yb {
+            have ab: a = b by replace xa | yb in ax_ay
+            conclude pos(a) = pos(b) or pos(a) = - pos(b) by replace ab.
+          }
+          case negsuc(b) assume yb {
+            have ab: a = 1 + b by replace xa | yb in ax_ay
+            have nyb: - negsuc(b) = pos(1 + b) by expand operator-.
+            have eq2: pos(a) = - negsuc(b) by replace ab | nyb.
+            conclude pos(a) = negsuc(b) or pos(a) = - negsuc(b) by eq2
+          }
+        }
+      }
+      case negsuc(a) assume xa {
+        switch y {
+          case pos(b) assume yb {
+            have ab: 1 + a = b by replace xa | yb in ax_ay
+            have nxa: - negsuc(a) = pos(1 + a) by expand operator-.
+            have eq2: - negsuc(a) = pos(b) by replace ab in nxa
+            have eq3: negsuc(a) = - pos(b) by {
+              have h: - - negsuc(a) = - pos(b) by replace eq2.
+              replace neg_involutive[negsuc(a)] in h
+            }
+            conclude negsuc(a) = pos(b) or negsuc(a) = - pos(b) by eq3
+          }
+          case negsuc(b) assume yb {
+            have ab: 1 + a = 1 + b by replace xa | yb in ax_ay
+            have ab2: a = b by apply uint_add_both_sides_of_equal[1, a, b] to ab
+            conclude negsuc(a) = negsuc(b) or negsuc(a) = - negsuc(b)
+              by replace ab2.
+          }
+        }
+      }
+    }
+  }
+  have bwd: if x = y or x = - y then abs(x) = abs(y) by {
+    assume disj
+    cases disj
+    case xy { replace xy. }
+    case xny { replace xny | abs_neg[y]. }
+  }
+  fwd, bwd
+end
+
 // Absolute value distributes over multiplication: |x*y| = |x|*|y|.
 theorem int_abs_mult: all x:Int, y:Int.
   abs(x * y) = abs(x) * abs(y)

--- a/lib/IntAddSub.pf
+++ b/lib/IntAddSub.pf
@@ -188,6 +188,52 @@ proof
   }
 end
 
+// Constructor injectivity and disjointness for `pos` / `negsuc`, plus
+// injectivity of unary negation. These explicitly state the
+// pos/negsuc/`- ·` normalization facts that other Int proofs otherwise
+// derive ad-hoc via `switch`.
+
+theorem int_pos_injective: all x:UInt, y:UInt.
+  if pos(x) = pos(y) then x = y
+proof
+  arbitrary x:UInt, y:UInt
+  assume eq
+  injective pos eq
+end
+
+theorem int_negsuc_injective: all x:UInt, y:UInt.
+  if negsuc(x) = negsuc(y) then x = y
+proof
+  arbitrary x:UInt, y:UInt
+  assume eq
+  injective negsuc eq
+end
+
+theorem int_pos_eq_negsuc_false: all x:UInt, y:UInt.
+  not (pos(x) = negsuc(y))
+proof
+  arbitrary x:UInt, y:UInt
+  assume eq
+  conclude false by eq
+end
+
+theorem int_negsuc_eq_pos_false: all x:UInt, y:UInt.
+  not (negsuc(x) = pos(y))
+proof
+  arbitrary x:UInt, y:UInt
+  assume eq
+  conclude false by eq
+end
+
+theorem int_neg_injective: all x:Int, y:Int.
+  if - x = - y then x = y
+proof
+  arbitrary x:Int, y:Int
+  assume eq
+  have h: - - x = - - y by replace eq.
+  replace neg_involutive[x] | neg_involutive[y] in h
+end
+
 // Properties of addition
 
 theorem int_zero_add: all n:Int.


### PR DESCRIPTION
## Summary

Adds six theorems making the injectivity / disjointness of `pos`, `negsuc`, and unary negation (and the abs-equality characterization) into explicit, named stdlib lemmas, instead of facts that other Int proofs re-derive ad-hoc with `switch` / `injective`:

In [`lib/IntAddSub.pf`](lib/IntAddSub.pf) (placed right after `neg_involutive`):

- `int_pos_injective`: `pos(x) = pos(y) ⇒ x = y`
- `int_negsuc_injective`: `negsuc(x) = negsuc(y) ⇒ x = y`
- `int_pos_eq_negsuc_false`: `not (pos(x) = negsuc(y))`
- `int_negsuc_eq_pos_false`: `not (negsuc(x) = pos(y))`
- `int_neg_injective`: `-x = -y ⇒ x = y`

In [`lib/IntAbs.pf`](lib/IntAbs.pf) (placed after `int_abs_eq_zero_iff_zero`):

- `int_abs_eq_iff_eq_or_neg`: `abs(x) = abs(y) ⇔ x = y or x = -y`

Refs [#660](https://github.com/jsiek/deduce/issues/660) — this is one of the Slice 1 (Conversions and specification theorems) follow-up bullets:

> Injectivity / normalization lemmas explicitly stated for `pos`, `negsuc`, negation, and `abs` (currently obtained ad-hoc via `switch`)

### What this PR completes

- Slice 1, sub-bullet *"Injectivity / normalization lemmas explicitly stated for `pos`, `negsuc`, negation, and `abs`"* — fully covered by the six theorems above.

### What remains open on #660

- Slice 1, sub-bullet *"`fromNat`/literal embedding spec theorems across `+`, `-`, `*`, `÷`, `≤`, `<`"* (division and ordering specification theorems are still missing).
- Slice 3 — Euclidean `div` / `%`, `div_mod`, basic mod laws, `divides` / `gcd` / `lcm` over Int.
- Slice 4 — Int powers.
- Slice 6 — Int-valued summation.
- Further conversion / specification cleanup tying Int literals, `abs`, and UInt theorems together.

The remaining slices are independent of these injectivity / disjointness facts; this PR does **not** close #660.

## Test plan

- [x] `python deduce.py lib/IntAddSub.pf` validates.
- [x] `python deduce.py lib/IntAbs.pf` validates.
- [ ] `make tests-lib` (entire stdlib, both parsers via `test-deduce.py`).
- [ ] CI green (recursive-descent + LALR + parser equivalence + should-validate + should-error).

[Claude session](claude://resume?session=66e8452d-2e8f-42aa-bdfb-0870a7fd35f9)

`66e8452d-2e8f-42aa-bdfb-0870a7fd35f9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)