### PR TITLE
Add Int spec theorems for ÷, ≤, < (Addresses #722)

### DIFF
--- a/lib/Int.pf
+++ b/lib/Int.pf
@@ -15,6 +15,7 @@ import Base
 public import IntDefs
 public import IntAddSub
 public import IntMult
+public import IntDiv
 public import IntLess
 public import IntEvenOdd
 public import IntAbs

--- a/lib/IntAbs.pf
+++ b/lib/IntAbs.pf
@@ -260,9 +260,7 @@ proof
     case pos(n) {
       int_less_equal_refl[pos(n)]
     }
-    case negsuc(n) {
-      expand operator≤.
-    }
+    case negsuc(n) { . }
   }
 end
 
@@ -286,7 +284,7 @@ proof
   arbitrary x:Int, y:UInt
   have fwd: if abs(x) ≤ y then -pos(y) ≤ x and x ≤ pos(y) by {
     assume prem
-    have ax_le_y: pos(abs(x)) ≤ pos(y) by expand operator≤ prem
+    have ax_le_y: pos(abs(x)) ≤ pos(y) by prem
     have x_le_ax: x ≤ pos(abs(x)) by int_le_abs[x]
     have x_le_y: x ≤ pos(y)
       by apply int_less_equal_trans[x, pos(abs(x)), pos(y)] to x_le_ax, ax_le_y
@@ -307,13 +305,11 @@ proof
     }
     switch x {
       case pos(n) assume xp {
-        have ubn: pos(n) ≤ pos(y) by replace xp in ub
-        expand operator≤ in ubn
+        replace xp in ub
       }
       case negsuc(n) assume xn {
         have neg_x_eq: -x = pos(1 + n) by replace xn expand operator-.
-        have h: pos(1 + n) ≤ pos(y) by replace neg_x_eq in neg_x_le
-        expand operator≤ in h
+        replace neg_x_eq in neg_x_le
       }
     }
   }

--- a/lib/IntDiv.pf
+++ b/lib/IntDiv.pf
@@ -1,0 +1,91 @@
+module Int
+
+import UInt
+import Base
+import IntDefs
+import IntAddSub
+import IntMult
+
+/*
+  Structural spec theorems for Int division.
+
+  Int division is defined in `IntDefs.pf` by combining the sign of the
+  dividend/divisor with the unsigned quotient `abs(n) / abs(m)`. These
+  theorems peel off the four `pos`/`negsuc` cases of `Int / Int` and the
+  two cases of `Int / UInt`, reducing each to the corresponding UInt
+  quotient. They mirror `mult_pos_pos` / `mult_pos_negsuc` in
+  `IntMult.pf` and the `Nat`/`UInt` division spec lemmas in
+  `lib/UIntDiv.pf`.
+*/
+
+// Both operands nonnegative: divide as UInts.
+theorem div_pos_pos: all au:UInt, bu:UInt.
+  pos(au) / pos(bu) = pos(au / bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  show #pos(au) / pos(bu)# = pos(au / bu)
+  expand operator/
+  replace sign_pos | abs_pos | mult_pos_any | mult_pos_uint.
+end
+
+auto div_pos_pos
+
+// Nonnegative dividend, negative divisor: negate the unsigned quotient.
+theorem div_pos_negsuc: all au:UInt, bu:UInt.
+  pos(au) / negsuc(bu) = - pos(au / (1 + bu))
+proof
+  arbitrary au:UInt, bu:UInt
+  show #pos(au) / negsuc(bu)# = - pos(au / (1 + bu))
+  expand operator/
+  replace sign_pos | sign_negsuc | abs_pos | abs_negsuc | mult_pos_neg | mult_neg_uint.
+end
+
+auto div_pos_negsuc
+
+// Negative dividend, nonnegative divisor: negate the unsigned quotient.
+theorem div_negsuc_pos: all au:UInt, bu:UInt.
+  negsuc(au) / pos(bu) = - pos((1 + au) / bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  show #negsuc(au) / pos(bu)# = - pos((1 + au) / bu)
+  expand operator/
+  replace sign_negsuc | sign_pos | abs_negsuc | abs_pos | mult_neg_pos | mult_neg_uint.
+end
+
+auto div_negsuc_pos
+
+// Both operands negative: signs cancel, quotient is nonnegative.
+theorem div_negsuc_negsuc: all au:UInt, bu:UInt.
+  negsuc(au) / negsuc(bu) = pos((1 + au) / (1 + bu))
+proof
+  arbitrary au:UInt, bu:UInt
+  show #negsuc(au) / negsuc(bu)# = pos((1 + au) / (1 + bu))
+  expand operator/
+  replace sign_negsuc | abs_negsuc | mult_neg_neg | mult_pos_uint.
+end
+
+auto div_negsuc_negsuc
+
+// `Int / UInt`: nonnegative dividend.
+theorem div_pos_uint: all au:UInt, bu:UInt.
+  pos(au) / bu = pos(au / bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  show #pos(au) / bu# = pos(au / bu)
+  expand operator/
+  replace sign_pos | abs_pos | mult_pos_uint.
+end
+
+auto div_pos_uint
+
+// `Int / UInt`: negative dividend.
+theorem div_negsuc_uint: all au:UInt, bu:UInt.
+  negsuc(au) / bu = - pos((1 + au) / bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  show #negsuc(au) / bu# = - pos((1 + au) / bu)
+  expand operator/
+  replace sign_negsuc | abs_negsuc | mult_neg_uint.
+end
+
+auto div_negsuc_uint

--- a/lib/IntLess.pf
+++ b/lib/IntLess.pf
@@ -963,44 +963,92 @@ proof
   int_max_min_absorb_left[x, y]
 end
 
+// Structural spec theorems for `≤` and `<` on Int.
+//
+// Each constructor-pair case reduces to the corresponding UInt comparison
+// (or to a constant `true`/`false` for the cross-sign cases). These are
+// the Int-side analogue of `uint_lit_less_equal` / `uint_lit_less` and
+// the `≤`/`<` part of the conversion-and-specification story described
+// in the `lib/UIntToFrom.pf` source comment.
+
+theorem int_pos_le_pos: all au:UInt, bu:UInt.
+  (pos(au) ≤ pos(bu)) = (au ≤ bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator≤ | operator≤.
+end
+
+auto int_pos_le_pos
+
+theorem int_pos_le_negsuc: all au:UInt, bu:UInt.
+  (pos(au) ≤ negsuc(bu)) = false
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator≤.
+end
+
+auto int_pos_le_negsuc
+
+theorem int_negsuc_le_pos: all au:UInt, bu:UInt.
+  (negsuc(au) ≤ pos(bu)) = true
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator≤.
+end
+
+auto int_negsuc_le_pos
+
+theorem int_negsuc_le_negsuc: all au:UInt, bu:UInt.
+  (negsuc(au) ≤ negsuc(bu)) = (bu ≤ au)
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator≤ | operator≤.
+end
+
+auto int_negsuc_le_negsuc
+
+theorem int_pos_less_pos: all au:UInt, bu:UInt.
+  (pos(au) < pos(bu)) = (au < bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator<.
+end
+
+auto int_pos_less_pos
+
+theorem int_pos_less_negsuc: all au:UInt, bu:UInt.
+  (pos(au) < negsuc(bu)) = false
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator<.
+end
+
+auto int_pos_less_negsuc
+
+theorem int_negsuc_less_pos: all au:UInt, bu:UInt.
+  (negsuc(au) < pos(bu)) = true
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator<.
+end
+
+auto int_negsuc_less_pos
+
+theorem int_negsuc_less_negsuc: all au:UInt, bu:UInt.
+  (negsuc(au) < negsuc(bu)) = (bu < au)
+proof
+  arbitrary au:UInt, bu:UInt
+  expand operator<.
+end
+
+auto int_negsuc_less_negsuc
+
 // Addition monotonicity and cancellation for ≤ and <.
 //
 // The strategy is to characterize `a ≤ b` as `+0 ≤ b - a` (via `a ⊝ b`
 // being non-negative iff `b ≤ a`), prove the algebraic identity
 // `(x + z) - (x + y) = z - y`, and then read off both directions of
 // `x + y ≤ x + z ⇔ y ≤ z`.
-
-lemma int_le_pos_pos: all au:UInt, bu:UInt.
-  pos(au) ≤ pos(bu) ⇔ au ≤ bu
-proof
-  arbitrary au:UInt, bu:UInt
-  have f: if pos(au) ≤ pos(bu) then au ≤ bu by {
-    assume h
-    expand operator≤ in h
-  }
-  have b: if au ≤ bu then pos(au) ≤ pos(bu) by {
-    assume h
-    expand operator≤
-    h
-  }
-  f, b
-end
-
-lemma int_le_negsuc_negsuc: all au:UInt, bu:UInt.
-  negsuc(au) ≤ negsuc(bu) ⇔ bu ≤ au
-proof
-  arbitrary au:UInt, bu:UInt
-  have f: if negsuc(au) ≤ negsuc(bu) then bu ≤ au by {
-    assume h
-    expand operator≤ in h
-  }
-  have b: if bu ≤ au then negsuc(au) ≤ negsuc(bu) by {
-    assume h
-    expand operator≤
-    h
-  }
-  f, b
-end
 
 lemma pos_zero_le_monuso: all a:UInt, b:UInt.
   +0 ≤ (a ⊝ b) ⇔ b ≤ a
@@ -1031,7 +1079,7 @@ proof
         neg_suc[w]
       }
       have absurd: +0 ≤ negsuc(w) by replace lhs_neg in prem
-      conclude false by expand operator≤ in absurd
+      absurd
     }
   }
   have bkwd: if b ≤ a then +0 ≤ (a ⊝ b) by {
@@ -1047,7 +1095,7 @@ proof
       simplify with not_alb.
     }
     replace form
-    suffices 0 ≤ a ∸ b by expand operator≤.
+    suffices 0 ≤ a ∸ b by .
     uint_zero_le[a ∸ b]
   }
   fwd, bkwd
@@ -1085,12 +1133,9 @@ proof
         case pos(bu) {
           have diff: pos(bu) - pos(au) = (bu ⊝ au) by symmetric subo_monus[bu, au]
           replace diff
-          apply iff_trans[pos(au) ≤ pos(bu), au ≤ bu, +0 ≤ (bu ⊝ au)]
-            to int_le_pos_pos[au, bu],
-               apply iff_symm to pos_zero_le_monuso[bu, au]
+          apply iff_symm to pos_zero_le_monuso[bu, au]
         }
         case negsuc(bu) {
-          have a_le_b_false: (pos(au) ≤ negsuc(bu)) = false by expand operator≤.
           have diff_form: (negsuc(bu) - pos(au)) = (0 ⊝ (1 + bu + au)) by {
             equations
                   negsuc(bu) - pos(au)
@@ -1107,7 +1152,6 @@ proof
               apply uint_less_equal_zero to bad
             }
           }
-          replace a_le_b_false
           replace apply iff_equal to rhs_iff
           replace rhs_false.
         }
@@ -1116,7 +1160,6 @@ proof
     case negsuc(au) {
       switch b {
         case pos(bu) {
-          have a_le_b_true: (negsuc(au) ≤ pos(bu)) = true by expand operator≤.
           have diff_form: (pos(bu) - negsuc(au)) = pos(bu + 1 + au) by {
             equations
                   pos(bu) - negsuc(au)
@@ -1124,13 +1167,7 @@ proof
             ... = pos(bu) + pos(1 + au)       by expand operator-.
             ... = pos(bu + 1 + au)            by add_pos_pos
           }
-          replace diff_form
-          have rhs_pos: +0 ≤ pos(bu + 1 + au) by {
-            expand operator≤
-            uint_zero_le[bu + 1 + au]
-          }
-          have rhs_true: (+0 ≤ pos(bu + 1 + au)) = true by apply eq_true to rhs_pos
-          replace a_le_b_true | rhs_true.
+          replace diff_form.
         }
         case negsuc(bu) {
           have diff_form: (negsuc(bu) - negsuc(au)) = (au ⊝ bu) by {
@@ -1142,9 +1179,7 @@ proof
             ... = au ⊝ bu                       by suc_uint_monuso[au, bu]
           }
           replace diff_form
-          apply iff_trans[negsuc(au) ≤ negsuc(bu), bu ≤ au, +0 ≤ (au ⊝ bu)]
-            to int_le_negsuc_negsuc[au, bu],
-               apply iff_symm to pos_zero_le_monuso[au, bu]
+          apply iff_symm to pos_zero_le_monuso[au, bu]
         }
       }
     }

--- a/lib/IntMult.pf
+++ b/lib/IntMult.pf
@@ -533,24 +533,14 @@ proof
     case pos(au) {
       switch b {
         case pos(bu) {
-          assume _prem
           replace mult_pos_pos
           show +0 ≤ pos(au * bu)
-          expand operator≤
           uint_zero_le[au * bu]
         }
-        case negsuc(bu) {
-          assume prem
-          have bad: +0 ≤ negsuc(bu) by conjunct 1 of prem
-          conclude false by expand operator≤ in bad
-        }
+        case negsuc(bu) { . }
       }
     }
-    case negsuc(au) {
-      assume prem
-      have bad: +0 ≤ negsuc(au) by conjunct 0 of prem
-      conclude false by expand operator≤ in bad
-    }
+    case negsuc(au) { . }
   }
 end
 
@@ -565,27 +555,16 @@ proof
       switch b {
         case pos(bu) {
           assume prem
-          have zlt_au: 0 < au by expand operator< in (conjunct 0 of prem)
-          have zlt_bu: 0 < bu by expand operator< in (conjunct 1 of prem)
+          have zlt_au: 0 < au by conjunct 0 of prem
+          have zlt_bu: 0 < bu by conjunct 1 of prem
           replace mult_pos_pos
           show +0 < pos(au * bu)
-          expand operator<
-          have step: 0 < au * bu
-            by apply uint_pos_mult_both_sides_of_less[au, 0, bu] to zlt_au, zlt_bu
-          step
+          apply uint_pos_mult_both_sides_of_less[au, 0, bu] to zlt_au, zlt_bu
         }
-        case negsuc(bu) {
-          assume prem
-          have bad: +0 < negsuc(bu) by conjunct 1 of prem
-          conclude false by expand operator< in bad
-        }
+        case negsuc(bu) { . }
       }
     }
-    case negsuc(au) {
-      assume prem
-      have bad: +0 < negsuc(au) by conjunct 0 of prem
-      conclude false by expand operator< in bad
-    }
+    case negsuc(au) { . }
   }
 end
 

--- a/test/should-validate/IntTests.pf
+++ b/test/should-validate/IntTests.pf
@@ -1,4 +1,5 @@
 import Int
+import Nat
 
 assert +1 ≤ +1
 assert +1 ≤ +2
@@ -24,4 +25,69 @@ theorem abs_zero_iff_int_zero_sample: all x:Int.
   abs(x) = 0 ⇔ x = +0
 proof
   int_abs_eq_zero_iff_zero
+end
+
+// === Spec theorems for ÷, ≤, < (Issue #722) ===
+
+// Order: literal cross-sign assertions
+assert (+1 ≤ -1) = false
+assert (-1 ≤ +1) = true
+assert (-3 ≤ -2) = true
+assert (+1 < +2) = true
+assert (-2 < -1) = true
+assert (+5 < -1) = false
+assert (-5 < +0) = true
+
+// Division: each constructor pair reduces to UInt division.
+assert +6 / +2 = +3
+assert +6 / -2 = -3
+assert -7 / +2 = -3       // negsuc(6) / pos(2) = -((1+6)/2) = -3
+assert -6 / -2 = +3       // negsuc(5) / negsuc(1) = (1+5)/(1+1) = 3
+assert +6 / 2 = +3        // Int / UInt
+assert -6 / 2 = -3        // Int / UInt with negative dividend
+
+theorem int_pos_le_pos_sample: all au:UInt, bu:UInt.
+  (pos(au) ≤ pos(bu)) = (au ≤ bu)
+proof
+  int_pos_le_pos
+end
+
+theorem int_negsuc_le_negsuc_sample: all au:UInt, bu:UInt.
+  (negsuc(au) ≤ negsuc(bu)) = (bu ≤ au)
+proof
+  int_negsuc_le_negsuc
+end
+
+theorem int_pos_less_pos_sample: all au:UInt, bu:UInt.
+  (pos(au) < pos(bu)) = (au < bu)
+proof
+  int_pos_less_pos
+end
+
+theorem div_pos_pos_sample: all au:UInt, bu:UInt.
+  pos(au) / pos(bu) = pos(au / bu)
+proof
+  div_pos_pos
+end
+
+theorem div_negsuc_negsuc_sample: all au:UInt, bu:UInt.
+  negsuc(au) / negsuc(bu) = pos((1 + au) / (1 + bu))
+proof
+  div_negsuc_negsuc
+end
+
+// Literal-level: the structural auto rules chain with `uint_lit_div`
+// to evaluate divisions on integer literals.
+theorem div_pos_lit_pos_lit: all x:Nat, y:Nat.
+  pos(fromNat(lit(x))) / pos(fromNat(lit(y))) = pos(fromNat(lit(x) / lit(y)))
+proof
+  arbitrary x:Nat, y:Nat
+  .
+end
+
+theorem pos_lit_le_pos_lit: all x:Nat, y:Nat.
+  (pos(fromNat(lit(x))) ≤ pos(fromNat(lit(y)))) = (lit(x) ≤ lit(y))
+proof
+  arbitrary x:Nat, y:Nat
+  .
 end


### PR DESCRIPTION
## Summary

Mirror lib/UIntToFrom.pf's literal/embedding spec story on the Int side. Implements the **division** and **ordering** portions of #722's scope as a single coherent slice (per the issue's "do not further subdivide" instruction).

- **Order spec theorems (`lib/IntLess.pf`):** eight new `auto` theorems — `int_pos_le_pos`, `int_pos_le_negsuc`, `int_negsuc_le_pos`, `int_negsuc_le_negsuc` and their `<` analogs — so `pos(_) ≤ pos(_)` reduces to the UInt comparison and cross-sign cases reduce to the constant `true`/`false`.
- **Division spec theorems (new `lib/IntDiv.pf`):** six `auto` theorems for the four `Int / Int` sign combinations and the two `Int / UInt` cases (`div_pos_pos`, `div_pos_negsuc`, `div_negsuc_pos`, `div_negsuc_negsuc`, `div_pos_uint`, `div_negsuc_uint`). Wired into `lib/Int.pf` as a `public import`.
- **Cleanup naturally pulled in:** removes the older private `int_le_pos_pos` / `int_le_negsuc_negsuc` lemmas now subsumed by the public spec theorems; trims now-redundant `expand operator≤` / `expand operator<` lines from `int_le_iff_diff_nonneg`, `int_nonneg_mult_nonneg`, and `int_pos_mult_pos`.
- **No separate literal lemmas needed:** the structural `auto` rules chain with the existing `uint_lit_less_equal` / `uint_lit_less` / `uint_lit_div` (also `auto`) so `pos(fromNat(lit(x))) ≤ pos(fromNat(lit(y)))` and `pos(fromNat(lit(x))) / pos(fromNat(lit(y)))` reduce automatically. Smoke checks in `test/should-validate/IntTests.pf` exercise both the literal-assertion form and the structural theorems.

## Issue #722 scope

Done in this PR:
- [x] Division (`÷`) embedding spec theorems
- [x] Order (`≤`, `<`) embedding spec theorems
- [x] Residual cleanup naturally pulled in by the new `auto` rules

Not in this PR (the optional `toNat`-style candidate from the issue body):
- [ ] `toNat`-like absolute/spec theorem families for Int routed through `abs : Int -> UInt` (the issue lists this as an exploratory "Candidate"; the abs core / bounds / triangle inequality / injectivity / normalization pieces have already landed via #675, #687, #715, #718). Leaving the residual `abs`-routed spec family for a follow-up if any specific gap is identified.

## Test plan

- [x] `python deduce.py lib/IntLess.pf`
- [x] `python deduce.py lib/IntDiv.pf`
- [x] `python deduce.py lib/IntMult.pf`
- [x] `python deduce.py lib/Int.pf`
- [x] `python deduce.py test/should-validate/IntTests.pf`
- [x] `python test-deduce.py --lib`
- [x] `make static` (mypy clean; the trailing `--no-site-packages` pass is the non-CI noise variant)
- [ ] `python test-deduce.py` (full RD/LALR/should-error/parser-equiv) — running in CI

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)

Fallback session UUID (if the link doesn't open Claude.app): \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)