### PR TITLE
lib/BigO: Section A remainders (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -314,3 +314,93 @@ proof
     by apply log_sum_less_equal_product[f,g] to f_pos, g_pos
   A, B
 end
+
+// Pointwise equality lifts to asymptotic equivalence.
+theorem bigo_pointwise_eq: all f:fn UInt->UInt, g:fn UInt->UInt.
+  if (all n:UInt. f(n) = g(n)) then f ≈ g
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt
+  assume H
+  expand operator≈
+  have fg: f ≲ g by {
+    expand operator≲
+    choose 0, 1
+    arbitrary n:UInt
+    assume _
+    show f(n) ≤ 1 * g(n)
+    have eq: f(n) = g(n) by H
+    replace eq.
+  }
+  have gf: g ≲ f by {
+    expand operator≲
+    choose 0, 1
+    arbitrary n:UInt
+    assume _
+    show g(n) ≤ 1 * f(n)
+    have eq: f(n) = g(n) by H
+    replace symmetric eq.
+  }
+  fg, gf
+end
+
+// Pointwise addition is associative up to ≈.
+theorem bigo_add_assoc: all f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt.
+  (f + g) + h ≈ f + (g + h)
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt
+  have pointwise: all m:UInt. ((f + g) + h)(m) = (f + (g + h))(m) by {
+    arbitrary m:UInt
+    expand operator+.
+  }
+  apply bigo_pointwise_eq[(f + g) + h, f + (g + h)] to pointwise
+end
+
+// Pointwise multiplication is associative up to ≈.
+theorem bigo_mult_assoc: all f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt.
+  (f * g) * h ≈ f * (g * h)
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt
+  have pointwise: all m:UInt. ((f * g) * h)(m) = (f * (g * h))(m) by {
+    arbitrary m:UInt
+    expand operator*.
+  }
+  apply bigo_pointwise_eq[(f * g) * h, f * (g * h)] to pointwise
+end
+
+// The zero cost function is a right identity for + up to ≈.
+theorem bigo_add_zero: all f:fn UInt->UInt.
+  f + (fun n:UInt { 0 }) ≈ f
+proof
+  arbitrary f:fn UInt->UInt
+  have pointwise: all m:UInt. (f + (fun n:UInt { 0 }))(m) = f(m) by {
+    arbitrary m:UInt
+    expand operator+.
+  }
+  apply bigo_pointwise_eq[f + (fun n:UInt { 0 }), f] to pointwise
+end
+
+// The constant-1 function is a right identity for * up to ≈.
+theorem bigo_mult_one_func: all f:fn UInt->UInt.
+  f * (fun n:UInt { 1 }) ≈ f
+proof
+  arbitrary f:fn UInt->UInt
+  have pointwise: all m:UInt. (f * (fun n:UInt { 1 }))(m) = f(m) by {
+    arbitrary m:UInt
+    expand operator*.
+  }
+  apply bigo_pointwise_eq[f * (fun n:UInt { 1 }), f] to pointwise
+end
+
+// Pointwise multiplication distributes over pointwise addition up to ≈.
+theorem bigo_dist: all f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt.
+  f * (g + h) ≈ f * g + f * h
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt
+  have pointwise: all m:UInt. (f * (g + h))(m) = (f * g + f * h)(m) by {
+    arbitrary m:UInt
+    expand operator+ | operator*
+    show f(m) * (g(m) + h(m)) = f(m) * g(m) + f(m) * h(m)
+    uint_dist_mult_add
+  }
+  apply bigo_pointwise_eq[f * (g + h), f * g + f * h] to pointwise
+end


### PR DESCRIPTION
## Summary

Adds the six Section A theorems that PR #726 explicitly left open in its scope. Each is a pointwise identity on cost functions lifted to `≈`:

- `bigo_pointwise_eq` — `(all n. f(n) = g(n))` implies `f ≈ g`.
- `bigo_add_assoc` — `(f + g) + h ≈ f + (g + h)`.
- `bigo_mult_assoc` — `(f * g) * h ≈ f * (g * h)`.
- `bigo_add_zero` — `f + (fun n. 0) ≈ f`.
- `bigo_mult_one_func` — `f * (fun n. 1) ≈ f`.
- `bigo_dist` — `f * (g + h) ≈ f * g + f * h`.

`bigo_pointwise_eq` is proved directly (no dependency on `bigo_pointwise_le` from PR #726), so this PR can land independently of #726. The five algebra theorems then each reduce to a one-line pointwise equality plus a single `apply bigo_pointwise_eq` — the `≈` work is concentrated in one helper.

Pure addition at the end of `lib/BigO.pf`; placed after `log_product_equiv_sum` to minimize textual conflict with #726.

## Sub-task status against #725

#725 is a multi-section catalogue (A–J). This PR finishes Section A, building on PR #726.

### Completed by this PR (Section A remainders)

- [x] `bigo_pointwise_eq`
- [x] `bigo_add_assoc`
- [x] `bigo_mult_assoc`
- [x] `bigo_add_zero`
- [x] `bigo_mult_one_func`
- [x] `bigo_dist`

### Already completed by PR #726 (rest of Section A)

- [x] `bigo_pointwise_le`, `bigo_self_le_add`, `bigo_le_add_self`, `bigo_equiv_refl/sym/trans`, `bigo_add_mono`, `bigo_add_commute`, `bigo_mult_commute`, `bigo_add_absorb`, `bigo_le_const_mult`, `bigo_const_func_le_O_1`.

### Remaining in #725 (NOT touched here — issue stays open after merge)

- [ ] Section B — stronger absorption / two-sided dominance (`bigo_add_dominated_absorb_equiv`, `bigo_const_mult_equiv`, `bigo_max_le_add`, `bigo_add_le_2max`).
- [ ] Section C — big-Omega / big-Theta.
- [ ] Section D — little-o / little-omega.
- [ ] Section E — power / polynomial hierarchy (new named cost functions, `O_n ≲ O_n_log_n ≲ O_n2 ≲ O_n3 ≲ O_2pow_n`).
- [ ] Section F — polynomial closure.
- [ ] Section G — further log laws.
- [ ] Section H — asymptotic summation (blocked on `UIntSum` / #719).
- [ ] Section I — recurrences.
- [ ] Section J — per-theorem docstrings (tracked alongside #99).

After Section A is closed by #726 + this PR, the "in progress" label on #725 still applies for sections B–J.

## Test plan

- [x] `python3.13 deduce.py lib/BigO.pf` — passes with the default (recursive-descent) parser.
- [x] `python3.13 deduce.py --lalr lib/BigO.pf` — passes with the LALR parser.
- [x] `python3.13 test-deduce.py --lib` — full `lib/` corpus, both parsers, 23.61s.
- [x] `python3.13 test-deduce.py --equiv` — RD/LALR AST equivalence + pretty-print round-trip, 58.24s.
- [x] `python3.13 -m mypy .` — clean (50 source files, no issues).
- [ ] CI green on push.

[Claude session](claude://resume?session=d6fa4ef0-9a7c-4a90-9fdb-cc4ce17f7ebf)

Session UUID fallback: `d6fa4ef0-9a7c-4a90-9fdb-cc4ce17f7ebf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)