### PR TITLE
lib/BigO: Section B — absorption / dominance lemmas (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -668,16 +668,16 @@ proof
   apply uint_max_less_equal to f_le, g_le
 end
 
-// The pointwise sum is at most twice the pointwise max.
-theorem bigo_add_le_2max: all f:fn UInt->UInt, g:fn UInt->UInt.
-  f + g ≲ 2 * max(f, g)
+// The pointwise sum is bounded by a constant multiple of the pointwise max.
+theorem bigo_add_le_max: all f:fn UInt->UInt, g:fn UInt->UInt.
+  f + g ≲ max(f, g)
 proof
   arbitrary f:fn UInt->UInt, g:fn UInt->UInt
-  expand operator≲ | operator+ | operator* | max
-  choose 0, 1
+  expand operator≲ | operator+ | max
+  choose 0, 2
   arbitrary n:UInt
   assume _
-  show f(n) + g(n) ≤ 1 * (2 * max(f(n), g(n)))
+  show f(n) + g(n) ≤ 2 * max(f(n), g(n))
   have f_le: f(n) ≤ max(f(n), g(n)) by uint_max_greater_left
   have g_le: g(n) ≤ max(f(n), g(n)) by uint_max_greater_right
   have sum_le: f(n) + g(n) ≤ max(f(n), g(n)) + max(f(n), g(n))

--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -622,3 +622,66 @@ proof
   }
   apply bigo_pointwise_eq[f * (g + h), f * g + f * h] to pointwise
 end
+
+// Two-sided sum absorption: a dominated summand can be dropped under ≈.
+theorem bigo_add_dominated_absorb_equiv: all f:fn UInt->UInt, g:fn UInt->UInt.
+  if g ≲ f then f + g ≈ f
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt
+  assume g_f: g ≲ f
+  expand operator≈
+  have A: f + g ≲ f by apply bigo_add_absorb to g_f
+  have B: f ≲ f + g by bigo_self_le_add
+  A, B
+end
+
+// A positive constant factor drops out of ≈.
+theorem bigo_const_mult_equiv: all f:fn UInt->UInt, k:UInt.
+  if 0 < k then k * f ≈ f
+proof
+  arbitrary f:fn UInt->UInt, k:UInt
+  assume k_pos: 0 < k
+  expand operator≈
+  have A: k * f ≲ f by bigo_const_mult
+  have k_ge_1: 1 ≤ k by apply uint_pos_implies_one_le to k_pos
+  have B: f ≲ k * f by apply bigo_le_const_mult[f, k] to k_ge_1
+  A, B
+end
+
+// Pointwise maximum of cost functions.
+fun max (f : fn UInt -> UInt, g : fn UInt -> UInt) {
+  fun n:UInt { max(f(n), g(n)) }
+}
+
+// The pointwise max is bounded above by the pointwise sum.
+theorem bigo_max_le_add: all f:fn UInt->UInt, g:fn UInt->UInt.
+  max(f, g) ≲ f + g
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt
+  expand operator≲ | operator+ | max
+  choose 0, 1
+  arbitrary n:UInt
+  assume _
+  show max(f(n), g(n)) ≤ 1 * (f(n) + g(n))
+  have f_le: f(n) ≤ f(n) + g(n) by uint_less_equal_add
+  have g_le: g(n) ≤ f(n) + g(n) by uint_less_equal_add_left
+  apply uint_max_less_equal to f_le, g_le
+end
+
+// The pointwise sum is at most twice the pointwise max.
+theorem bigo_add_le_2max: all f:fn UInt->UInt, g:fn UInt->UInt.
+  f + g ≲ 2 * max(f, g)
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt
+  expand operator≲ | operator+ | operator* | max
+  choose 0, 1
+  arbitrary n:UInt
+  assume _
+  show f(n) + g(n) ≤ 1 * (2 * max(f(n), g(n)))
+  have f_le: f(n) ≤ max(f(n), g(n)) by uint_max_greater_left
+  have g_le: g(n) ≤ max(f(n), g(n)) by uint_max_greater_right
+  have sum_le: f(n) + g(n) ≤ max(f(n), g(n)) + max(f(n), g(n))
+    by apply uint_add_mono_less_equal to f_le, g_le
+  replace uint_two_mult[max(f(n), g(n))]
+  sum_le
+end


### PR DESCRIPTION
## Summary

Implements Section B of #725 (stronger absorption / two-sided dominance):

- `bigo_add_dominated_absorb_equiv`: if `g ≲ f` then `f + g ≈ f` (strengthens the existing `bigo_add_absorb` to an `≈`).
- `bigo_const_mult_equiv`: if `0 < k` then `k * f ≈ f` (constant factors drop under `≈`).
- Adds a cost-function overload of `max` (`fun max(f, g)` returning the pointwise max), plus the bracketing pair
  - `bigo_max_le_add`: `max(f, g) ≲ f + g`
  - `bigo_add_le_max`: `f + g ≲ max(f, g)` — the `c` in the definition of `≲` already absorbs the factor of 2, so this is the cleaner statement (the proof body picks `c = 2` internally)

The new equivalence theorems are immediate consequences of theorems Section A introduced (`bigo_add_absorb` + `bigo_self_le_add`; `bigo_const_mult` + `bigo_le_const_mult`). The `0 < k` → `1 ≤ k` step uses `uint_pos_implies_one_le` from `lib/UIntAdd.pf`. The two `max`/`+` bounds use the existing `uint_max_*` and `uint_two_mult` lemmas in `lib/UIntLess.pf`.

Sections C–J of #725 (big-Ω/Θ, little-o/ω, polynomial hierarchy, polynomial closure, further log laws, summation, recurrences, docstrings) remain untouched and will need their own slices.

## Test plan
- [x] `python3.13 deduce.py lib/BigO.pf` — file checks
- [x] `python3.13 test-deduce.py --lib` (both parsers) — passes
- [x] `python3.13 test-deduce.py --equiv` — RD/LALR ASTs agree
- [x] `python3.13 test-deduce.py` — full default suite passes

[Claude session](claude://resume?session=378f59b6-b85d-46c5-9f21-01540bc9d934) (fallback UUID: `378f59b6-b85d-46c5-9f21-01540bc9d934`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)