### PR TITLE
lib/BigO: Section C — Big-Omega and Big-Theta (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -685,3 +685,53 @@ proof
   replace uint_two_mult[max(f(n), g(n))]
   sum_le
 end
+
+// Big-Omega: `bigo_omega(f, g)` means `f` asymptotically dominates `g`
+// — equivalently, `g ≲ f`. Big-Omega is the dual of the `≲` (Big-O) preorder.
+fun bigo_omega(f : fn UInt -> UInt, g : fn UInt -> UInt) {
+  g ≲ f
+}
+
+// Big-Omega is reflexive.
+theorem bigo_omega_refl: all f:fn UInt->UInt. bigo_omega(f, f)
+proof
+  arbitrary f:fn UInt->UInt
+  expand bigo_omega
+  bigo_refl
+end
+
+// Big-Omega is transitive.
+theorem bigo_omega_trans:
+  all f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt.
+  if bigo_omega(f, g) and bigo_omega(g, h) then bigo_omega(f, h)
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt, h:fn UInt->UInt
+  assume prem
+  have gf: g ≲ f by expand bigo_omega in prem
+  have hg: h ≲ g by expand bigo_omega in prem
+  expand bigo_omega
+  apply bigo_trans to hg, gf
+end
+
+// Asymptotic equivalence is exactly Big-Theta: `f ≈ g` iff `f` is both
+// Big-O and Big-Omega of `g`.
+theorem bigo_equiv_iff_theta: all f:fn UInt->UInt, g:fn UInt->UInt.
+  f ≈ g ⇔ (f ≲ g and bigo_omega(f, g))
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt
+  have fwd: if f ≈ g then (f ≲ g and bigo_omega(f, g)) by {
+    assume H
+    have fg: f ≲ g by expand operator≈ in H
+    have gf: g ≲ f by expand operator≈ in H
+    have go: bigo_omega(f, g) by { expand bigo_omega gf }
+    fg, go
+  }
+  have bkwd: if (f ≲ g and bigo_omega(f, g)) then f ≈ g by {
+    assume H
+    have fg: f ≲ g by H
+    have gf: g ≲ f by expand bigo_omega in H
+    expand operator≈
+    fg, gf
+  }
+  fwd, bkwd
+end


### PR DESCRIPTION
## Summary

Implements Section C of #725 (big-Omega and big-Theta) in `lib/BigO.pf`:

- `bigo_omega(f, g)` — big-Omega: `f` asymptotically dominates `g` (i.e. `g ≲ f`).
- `bigo_omega_refl` — big-Omega is reflexive.
- `bigo_omega_trans` — big-Omega is transitive.
- `bigo_equiv_iff_theta` — `f ≈ g ⇔ (f ≲ g and bigo_omega(f, g))`, documenting that asymptotic equivalence is exactly big-Theta.

## Design notes

Big-Omega is defined as a regular `fun` rather than a new infix operator. Adding `≳` to the lexer would have to touch `Deduce.lark`, both parsers, and the `gh_pages` key/operator tables — that's outside the scope of the missing-theorems catalogue this slice belongs to. The "convenience aliases / notation if desired" bullet in #725 Section C explicitly leaves notation open, so this PR ships the theorems and defers the symbol choice.

Pure addition at the end of `lib/BigO.pf` (after `bigo_add_le_max` from PR #728); no other files touched.

## Sub-task status against #725

#725 is a multi-section catalogue (A–J). This PR finishes Section C, building on PRs #726, #727, #728.

### Completed by this PR (Section C)

- [x] `bigo_omega` definition
- [x] `bigo_omega_refl`
- [x] `bigo_omega_trans`
- [x] `bigo_equiv_iff_theta` (≈ is big-Theta)

### Already completed by earlier PRs

- [x] Section A (algebra of `≲`/`≈`) — PRs #726, #727
- [x] Section B (absorption / dominance) — PR #728

### Remaining in #725 (NOT touched here — issue stays open after merge)

- [ ] Section D — little-o, little-omega.
- [ ] Section E — power / polynomial hierarchy (new named cost functions).
- [ ] Section F — polynomial closure.
- [ ] Section G — further log laws.
- [ ] Section H — asymptotic summation (blocked on `UIntSum`/#719).
- [ ] Section I — recurrences.
- [ ] Section J — per-theorem docstrings (tracked alongside #99).

The "in progress" label on #725 still applies for sections D–J after this merges.

## Test plan

- [x] `python3.13 deduce.py lib/BigO.pf` — passes (RD parser).
- [x] `python3.13 deduce.py --lalr lib/BigO.pf` — passes (LALR parser).
- [x] `python3.13 test-deduce.py --lib` — full `lib/` corpus, both parsers, 23.73s.
- [x] `python3.13 test-deduce.py --equiv` — RD/LALR AST equivalence + pretty-print round trip, 54.11s.
- [x] `python3.13 test-deduce.py` — full default suite, 111.25s.
- [x] `python3.13 -m mypy .` — clean (50 source files).
- [ ] CI green on push.

[Claude session](claude://resume?session=8eb7c489-fbf1-493e-8cc0-65178297604b)

Session UUID fallback: `8eb7c489-fbf1-493e-8cc0-65178297604b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)