### PR TITLE
Add Int div/order literal embedding spec theorems (Closes #722)

### DIFF
--- a/lib/Int.pf
+++ b/lib/Int.pf
@@ -220,3 +220,201 @@ proof
 end
 
 auto mult_neg_lit_lit
+
+// Foundational division lemmas: pushing `pos` / `negsuc` through Int division.
+
+lemma div_pos_pos: all x:UInt, y:UInt. pos(x) / pos(y) = pos(x / y)
+proof
+  arbitrary x:UInt, y:UInt
+  suffices # pos(x) / pos(y) # = pos(x / y) by .
+  expand operator/
+  replace sign_pos | mult_pos_any | mult_pos_uint.
+end
+
+lemma div_pos_negsuc: all x:UInt, y:UInt.
+  pos(x) / negsuc(y) = - pos(x / (1 + y))
+proof
+  arbitrary x:UInt, y:UInt
+  suffices # pos(x) / negsuc(y) # = - pos(x / (1 + y)) by .
+  expand operator/
+  replace sign_pos | sign_negsuc | mult_pos_neg | mult_neg_uint.
+end
+
+lemma div_negsuc_pos: all x:UInt, y:UInt.
+  negsuc(x) / pos(y) = - pos((1 + x) / y)
+proof
+  arbitrary x:UInt, y:UInt
+  suffices # negsuc(x) / pos(y) # = - pos((1 + x) / y) by .
+  expand operator/
+  replace sign_pos | sign_negsuc | mult_neg_pos | mult_neg_uint.
+end
+
+lemma div_negsuc_negsuc: all x:UInt, y:UInt.
+  negsuc(x) / negsuc(y) = pos((1 + x) / (1 + y))
+proof
+  arbitrary x:UInt, y:UInt
+  suffices # negsuc(x) / negsuc(y) # = pos((1 + x) / (1 + y)) by .
+  expand operator/
+  replace sign_negsuc | mult_neg_neg | mult_pos_uint.
+end
+
+lemma div_pos_uint: all x:UInt, y:UInt. pos(x) / y = pos(x / y)
+proof
+  arbitrary x:UInt, y:UInt
+  suffices # pos(x) / y # = pos(x / y) by .
+  expand operator/
+  replace sign_pos | mult_pos_uint.
+end
+
+lemma div_negsuc_uint: all x:UInt, y:UInt.
+  negsuc(x) / y = - pos((1 + x) / y)
+proof
+  arbitrary x:UInt, y:UInt
+  suffices # negsuc(x) / y # = - pos((1 + x) / y) by .
+  expand operator/
+  replace sign_negsuc | mult_neg_uint.
+end
+
+// Division literal embedding theorems.
+
+theorem div_pos_lit_pos_lit: all x:Nat, y:Nat.
+  pos(fromNat(lit(x))) / pos(fromNat(lit(y))) = pos(fromNat(lit(x) / lit(y)))
+proof
+  arbitrary x:Nat, y:Nat
+  replace div_pos_pos.
+end
+
+auto div_pos_lit_pos_lit
+
+theorem div_pos_lit_lit: all x:Nat, y:Nat.
+  pos(fromNat(lit(x))) / fromNat(lit(y)) = pos(fromNat(lit(x) / lit(y)))
+proof
+  arbitrary x:Nat, y:Nat
+  replace div_pos_uint.
+end
+
+auto div_pos_lit_lit
+
+theorem div_pos_lit_neg_lit: all x:Nat, y:Nat.
+  pos(fromNat(lit(x))) / negsuc(fromNat(lit(y)))
+  = - pos(fromNat(lit(x)) / (1 + fromNat(lit(y))))
+proof
+  arbitrary x:Nat, y:Nat
+  replace div_pos_negsuc.
+end
+
+auto div_pos_lit_neg_lit
+
+theorem div_neg_lit_pos_lit: all x:Nat, y:Nat.
+  negsuc(fromNat(lit(x))) / pos(fromNat(lit(y)))
+  = - pos((1 + fromNat(lit(x))) / fromNat(lit(y)))
+proof
+  arbitrary x:Nat, y:Nat
+  replace div_negsuc_pos.
+end
+
+auto div_neg_lit_pos_lit
+
+theorem div_neg_lit_lit: all x:Nat, y:Nat.
+  negsuc(fromNat(lit(x))) / fromNat(lit(y))
+  = - pos((1 + fromNat(lit(x))) / fromNat(lit(y)))
+proof
+  arbitrary x:Nat, y:Nat
+  replace div_negsuc_uint.
+end
+
+auto div_neg_lit_lit
+
+theorem div_neg_lit_neg_lit: all x:Nat, y:Nat.
+  negsuc(fromNat(lit(x))) / negsuc(fromNat(lit(y)))
+  = pos((1 + fromNat(lit(x))) / (1 + fromNat(lit(y))))
+proof
+  arbitrary x:Nat, y:Nat
+  replace div_negsuc_negsuc.
+end
+
+auto div_neg_lit_neg_lit
+
+// Order ≤ literal embedding theorems.
+
+theorem int_lit_less_equal_pos_pos: all x:Nat, y:Nat.
+  (pos(fromNat(lit(x))) ≤ pos(fromNat(lit(y)))) = (lit(x) ≤ lit(y))
+proof
+  arbitrary x:Nat, y:Nat
+  suffices # pos(fromNat(lit(x))) ≤ pos(fromNat(lit(y))) # = (lit(x) ≤ lit(y))
+    by .
+  expand operator≤.
+end
+
+auto int_lit_less_equal_pos_pos
+
+theorem int_lit_less_equal_pos_negsuc: all x:Nat, y:Nat.
+  (pos(fromNat(lit(x))) ≤ negsuc(fromNat(lit(y)))) = false
+proof
+  arbitrary x:Nat, y:Nat
+  expand operator≤.
+end
+
+auto int_lit_less_equal_pos_negsuc
+
+theorem int_lit_less_equal_negsuc_pos: all x:Nat, y:Nat.
+  (negsuc(fromNat(lit(x))) ≤ pos(fromNat(lit(y)))) = true
+proof
+  arbitrary x:Nat, y:Nat
+  expand operator≤.
+end
+
+auto int_lit_less_equal_negsuc_pos
+
+theorem int_lit_less_equal_negsuc_negsuc: all x:Nat, y:Nat.
+  (negsuc(fromNat(lit(x))) ≤ negsuc(fromNat(lit(y)))) = (lit(y) ≤ lit(x))
+proof
+  arbitrary x:Nat, y:Nat
+  suffices # negsuc(fromNat(lit(x))) ≤ negsuc(fromNat(lit(y))) # = (lit(y) ≤ lit(x))
+    by .
+  expand operator≤.
+end
+
+auto int_lit_less_equal_negsuc_negsuc
+
+// Order < literal embedding theorems.
+
+theorem int_lit_less_pos_pos: all x:Nat, y:Nat.
+  (pos(fromNat(lit(x))) < pos(fromNat(lit(y)))) = (lit(x) < lit(y))
+proof
+  arbitrary x:Nat, y:Nat
+  suffices # pos(fromNat(lit(x))) < pos(fromNat(lit(y))) # = (lit(x) < lit(y))
+    by .
+  expand operator<.
+end
+
+auto int_lit_less_pos_pos
+
+theorem int_lit_less_pos_negsuc: all x:Nat, y:Nat.
+  (pos(fromNat(lit(x))) < negsuc(fromNat(lit(y)))) = false
+proof
+  arbitrary x:Nat, y:Nat
+  expand operator<.
+end
+
+auto int_lit_less_pos_negsuc
+
+theorem int_lit_less_negsuc_pos: all x:Nat, y:Nat.
+  (negsuc(fromNat(lit(x))) < pos(fromNat(lit(y)))) = true
+proof
+  arbitrary x:Nat, y:Nat
+  expand operator<.
+end
+
+auto int_lit_less_negsuc_pos
+
+theorem int_lit_less_negsuc_negsuc: all x:Nat, y:Nat.
+  (negsuc(fromNat(lit(x))) < negsuc(fromNat(lit(y)))) = (lit(y) < lit(x))
+proof
+  arbitrary x:Nat, y:Nat
+  suffices # negsuc(fromNat(lit(x))) < negsuc(fromNat(lit(y))) # = (lit(y) < lit(x))
+    by .
+  expand operator<.
+end
+
+auto int_lit_less_negsuc_negsuc

--- a/test/should-validate/int_arith.pf
+++ b/test/should-validate/int_arith.pf
@@ -127,3 +127,97 @@ theorem negM23: -(2 * 3) = -6
 proof
   .
 end
+
+// Division literal embeddings.
+
+theorem Dpp: +6 / +2 = +3
+proof
+  .
+end
+
+theorem Dpu: +6 / 2 = +3
+proof
+  .
+end
+
+theorem Dpn: +6 / -2 = -3
+proof
+  .
+end
+
+theorem Dnp: -6 / +2 = -3
+proof
+  .
+end
+
+theorem Dnu: -6 / 2 = -3
+proof
+  .
+end
+
+theorem Dnn: -6 / -2 = +3
+proof
+  .
+end
+
+// Order literal embeddings (≤ and <).
+
+theorem Lpp_t: (+2 ≤ +3) = true
+proof
+  .
+end
+
+theorem Lpp_f: (+3 ≤ +2) = false
+proof
+  .
+end
+
+theorem Lpn: (+1 ≤ -1) = false
+proof
+  .
+end
+
+theorem Lnp: (-1 ≤ +1) = true
+proof
+  .
+end
+
+theorem Lnn_t: (-3 ≤ -2) = true
+proof
+  .
+end
+
+theorem Lnn_f: (-2 ≤ -3) = false
+proof
+  .
+end
+
+theorem LTpp_t: (+2 < +3) = true
+proof
+  .
+end
+
+theorem LTpp_f: (+2 < +2) = false
+proof
+  .
+end
+
+theorem LTpn: (+1 < -1) = false
+proof
+  .
+end
+
+theorem LTnp: (-1 < +1) = true
+proof
+  .
+end
+
+theorem LTnn_t: (-3 < -2) = true
+proof
+  .
+end
+
+theorem LTnn_f: (-2 < -3) = false
+proof
+  .
+end


### PR DESCRIPTION
## Summary

Closes #722. Mirrors the existing `lit_add_pos_pos` / `mult_pos_lit_pos_lit` style in `lib/Int.pf` to give Int's `÷`, `≤`, and `<` a per-operation specification story comparable to `UIntToFrom.pf`.

### What was added

**Foundational division lemmas (push `pos`/`negsuc` through Int division):**
- `div_pos_pos`, `div_pos_negsuc`, `div_negsuc_pos`, `div_negsuc_negsuc`
- `div_pos_uint`, `div_negsuc_uint` (for the `Int / UInt` overload)

**`auto` literal-embedding theorems for `÷`** covering the literal cases for both Int/Int and Int/UInt overloads:
- `div_pos_lit_pos_lit`, `div_pos_lit_lit`
- `div_pos_lit_neg_lit`, `div_neg_lit_pos_lit`
- `div_neg_lit_lit`, `div_neg_lit_neg_lit`

(There is no `UInt / Int` overload in `IntDefs.pf`, so the corresponding `div_lit_pos_lit` / `div_lit_neg_lit` cases are intentionally not included.)

**`auto` literal-embedding theorems for `≤` and `<`** characterizing the four sign combinations:
- `int_lit_less_equal_pos_pos`, `int_lit_less_equal_pos_negsuc`, `int_lit_less_equal_negsuc_pos`, `int_lit_less_equal_negsuc_negsuc`
- `int_lit_less_pos_pos`, `int_lit_less_pos_negsuc`, `int_lit_less_negsuc_pos`, `int_lit_less_negsuc_negsuc`

The pos/pos and negsuc/negsuc cases produce a Nat literal comparison on the right-hand side; the mixed pos/negsuc cases reduce to `true` / `false`.

### Smoke tests

[test/should-validate/int_arith.pf](test/should-validate/int_arith.pf) gets 18 new one-line `proof . end` theorems exercising the new auto rules:

- Division: `+6 / +2 = +3`, `+6 / -2 = -3`, `-6 / -2 = +3`, plus `Int / UInt` variants
- Order: `(+2 ≤ +3) = true`, `(-1 ≤ +1) = true`, `(-3 < -2) = true`, etc.

These all close by `.` because the new auto rules fire end-to-end.

## Test plan

- [x] `python deduce.py lib/Int.pf` — valid (both `--lalr` and `--recursive-descent`)
- [x] `python test-deduce.py --lib` — all lib modules pass under both parsers
- [x] `python test-deduce.py --equiv` — RD/LALR ASTs match for all accepted files
- [x] `python test-deduce.py` — full suite (lib + should-validate + should-error + parser equivalence) passes
- [x] `make static` — ruff + mypy clean (the `--no-site-packages` mypy run that prints decorator noise is not run by CI)

## Notes on the proofs

A small subtlety: for the foundational division lemmas, both sides of the equation contain a `/` (Int / on the left, UInt / on the right). A bare `expand operator/` expands both, which destroys the goal because UInt division is a `recfun` that unfolds into a conditional. The proofs use the `# ... #` mark syntax with `suffices` to restrict expansion to the Int-division subterm. Similarly for the order theorems where Nat `<` would otherwise unfold via the `<` overload as well.

[Claude session](claude://resume?session=11a28e93-d965-4fcf-b070-4598b367bd2e)

\`\`\`
open "claude://resume?session=11a28e93-d965-4fcf-b070-4598b367bd2e"
\`\`\`

\`11a28e93-d965-4fcf-b070-4598b367bd2e\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)