### PR TITLE
VS Code: Ctrl+Alt+L lemma search at a hole (Part 4 of #690)

### DIFF
--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -70,9 +70,9 @@ lockstep with it.
   *Deduce: Go to next hole*) moves the cursor to the next
   standalone `?` proof hole, wrapping once at end of file.  Mirror
   of Emacs's `C-c C-n` / `deduce-mode-next-hole`.
-- **Structured-editing commands** — five commands that transform
+- **Structured-editing commands** — seven commands that transform
   a `?` hole into a step closer to a complete proof.  Mirror of
-  Emacs's `C-c C-{r,c,i,e,f}` bindings (`deduce-lsp.el`):
+  Emacs's `C-c C-{r,c,i,e,f,l}` bindings (`deduce-lsp.el`):
 
   | Keybinding   | Command                    | Effect |
   | ------------ | -------------------------- | ------ |
@@ -81,6 +81,8 @@ lockstep with it.
   | `Ctrl+Alt+C` | `deduce.caseSplit`         | Prompt for an in-scope variable (Union-typed term or `or`-shaped proof) via QuickPick, replace the surrounding `?` with the matching `switch` / `cases` skeleton. |
   | `Ctrl+Alt+E` | `deduce.eliminate`         | Prompt for an in-scope hypothesis label via QuickPick, replace the `?` with a tactic that uses that fact based on its formula shape (modus ponens on `if`, destructure on `and`, etc.). |
   | `Ctrl+Alt+F` | `deduce.fillFromGiven`     | Pick the first in-scope given whose formula equals the goal and replace the `?` with `conclude <goal> by <label>`. No prompt. |
+  | `Ctrl+Alt+L` | `deduce.searchLemma`       | Pick an in-scope lemma via QuickPick (server-ranked best-first, with a unify-tier marker and module annotation) and replace the `?` with the right tactic shape — `conclude … by …`, `apply … to ?`, `replace …`, or a bare name — depending on how the lemma matches the goal. |
+  | `Ctrl+Alt+Shift+L` | `deduce.searchLemmaWithQuery` | Same as `deduce.searchLemma`, but first prompts for a substring or `_`-pattern that the server uses to filter the candidate list. |
 
   After every successful edit the cursor jumps to the first new
   `?` inside the inserted text, so the next refine / case-split

--- a/editor/vscode/extension.js
+++ b/editor/vscode/extension.js
@@ -207,6 +207,36 @@ function activate(context) {
             )),
     );
 
+    // --- Lemma search at a hole (issue #690, Part 4) ------------
+    //
+    // Mirror of editor/emacs/deduce-lsp.el's C-c C-l
+    // `deduce-lsp-search-lemma'.  Cursor on a `?': fetch ranked
+    // candidates via `deduce/availableLemmasAt', show them in a
+    // QuickPick with the unify-tier marker and module of origin,
+    // and on selection drive a `deduce/insertLemma' request whose
+    // tier-aware WorkspaceEdit is applied directly.
+    //
+    // Two commands:
+    //
+    //   deduce.searchLemma          no query; lists everything in
+    //                               scope, ranked best-first
+    //   deduce.searchLemmaWithQuery prompts via showInputBox for a
+    //                               substring or `_'-pattern that
+    //                               the server uses to filter --
+    //                               mirror of Emacs's `C-u C-c C-l'
+    context.subscriptions.push(
+        vscode.commands.registerCommand('deduce.searchLemma', () =>
+            searchLemmaCommand(client, null)),
+        vscode.commands.registerCommand('deduce.searchLemmaWithQuery', async () => {
+            const query = await vscode.window.showInputBox({
+                prompt: 'Lemma search (substring or `_`-pattern)',
+                placeHolder: 'e.g. commute, _ + _ = _ + _',
+            });
+            if (query === undefined) return;
+            searchLemmaCommand(client, query);
+        }),
+    );
+
     // --- LLM-driven hole filling --------------------------------
     //
     // Mirror of editor/emacs/deduce-fill-hole.el (C-c C-a).  Flow:
@@ -730,6 +760,107 @@ async function applyFirstCandidateEdit(
         return;
     }
     await applyLspWorkspaceEdit(editor, edit);
+}
+
+// Lemma search shape: query the ranked candidate list via
+// `deduce/availableLemmasAt', show them in a QuickPick with the
+// unify-tier marker + module annotation, and on selection drive a
+// `deduce/insertLemma' request whose tier-aware WorkspaceEdit is
+// applied directly.  Mirror of editor/emacs/deduce-lsp.el's
+// `deduce-lsp-search-lemma'.  ``query'' is null for browse mode (no
+// server-side filter), or a substring / `_'-pattern string that the
+// server uses to filter candidates.
+async function searchLemmaCommand(client, query) {
+    const editor = ensureDeduceEditor();
+    if (!editor || !client) return;
+    const params = textDocumentPosition(editor);
+    if (query !== null && query !== '') {
+        params.query = query;
+    }
+    let lemmas;
+    try {
+        lemmas = await client.sendRequest('deduce/availableLemmasAt', params);
+    } catch (err) {
+        vscode.window.showErrorMessage(
+            `Deduce: availableLemmasAt failed: ${err.message || err}`);
+        return;
+    }
+    const list = Array.isArray(lemmas) ? lemmas : [];
+    if (list.length === 0) {
+        vscode.window.showInformationMessage(
+            'Deduce: no lemma candidates at point.');
+        return;
+    }
+    const items = list.map((lemma) => lemmaQuickPickItem(lemma));
+    const pick = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Lemma:',
+        matchOnDescription: true,
+        matchOnDetail: true,
+    });
+    if (!pick) return;
+    let edit;
+    try {
+        edit = await client.sendRequest('deduce/insertLemma', {
+            ...textDocumentPosition(editor),
+            name: pick.lemma.name,
+        });
+    } catch (err) {
+        vscode.window.showErrorMessage(
+            `Deduce: insertLemma failed: ${err.message || err}`);
+        return;
+    }
+    if (!edit) {
+        vscode.window.showErrorMessage(
+            `Deduce: server returned no edit for lemma '${pick.lemma.name}'.`);
+        return;
+    }
+    await applyLspWorkspaceEdit(editor, edit);
+}
+
+// Build the QuickPickItem shape for one lemma row.  Matches the
+// mockup in issue #690 Part 4:
+//
+//   label        signature (the .thm-style declaration line; the
+//                server already prefixes `NAME: ' for theorems and
+//                postulates, so showing it verbatim avoids the
+//                `t : t: (...)' duplication noted in Bug 6 of #690)
+//   description  tier marker (e.g. "applies (by h, g)")
+//   detail       "[ModuleName]"
+//
+// VS Code's QuickPick filter looks at all three fields when
+// `matchOnDescription' / `matchOnDetail' are on, so type-to-filter
+// hits the formula text as well as the name.
+function lemmaQuickPickItem(lemma) {
+    const item = {
+        label: lemma.signature || lemma.name,
+        lemma,
+    };
+    const tier = lemmaTierTag(lemma);
+    if (tier) item.description = tier;
+    const module = lemma.module;
+    if (module && module !== '') {
+        item.detail = `[${module}]`;
+    }
+    return item;
+}
+
+// Convert a lemma's unify_tier + discharged_premises into the short
+// annotation string shown to the right of the QuickPick label.
+// Returns the empty string when the tier didn't match (browse mode,
+// or no goal AST available at this cursor).
+function lemmaTierTag(lemma) {
+    const tier = lemma.unify_tier;
+    const discharged = lemma.discharged_premises || [];
+    if (tier === 'full') {
+        if (discharged.length > 0) {
+            const labels = discharged.map((pair) => pair[1]).join(', ');
+            return `applies (by ${labels})`;
+        }
+        return 'applies';
+    }
+    if (tier === 'premises_remain') return 'premises remain';
+    if (tier === 'rewrite_subterm') return 'rewrite subterm';
+    return '';
 }
 
 // Pretty-print a deduce/goalAt response into the goal Output channel.

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -94,6 +94,16 @@
         "command": "deduce.fillHole",
         "title": "Deduce: Fill hole with LLM",
         "category": "Deduce"
+      },
+      {
+        "command": "deduce.searchLemma",
+        "title": "Deduce: Search for a lemma at cursor",
+        "category": "Deduce"
+      },
+      {
+        "command": "deduce.searchLemmaWithQuery",
+        "title": "Deduce: Search for a lemma at cursor (with query)",
+        "category": "Deduce"
       }
     ],
     "keybindings": [
@@ -135,6 +145,16 @@
       {
         "command": "deduce.fillHole",
         "key": "ctrl+alt+a",
+        "when": "editorTextFocus && editorLangId == deduce"
+      },
+      {
+        "command": "deduce.searchLemma",
+        "key": "ctrl+alt+l",
+        "when": "editorTextFocus && editorLangId == deduce"
+      },
+      {
+        "command": "deduce.searchLemmaWithQuery",
+        "key": "ctrl+alt+shift+l",
         "when": "editorTextFocus && editorLangId == deduce"
       }
     ],


### PR DESCRIPTION
## Summary

- New **`deduce.searchLemma`** VS Code command bound to **`Ctrl+Alt+L`** — the VS Code analogue of Emacs's `C-c C-l` from #704.
- Cursor on a `?`: fetches ranked in-scope lemmas via the `deduce/availableLemmasAt` LSP method (added in #702) and shows them in a `vscode.window.showQuickPick`. Each row uses:
  - `label`: the lemma's `.thm`-style signature (verbatim, prefixed with `NAME: ` for theorems / postulates, matching the Emacs picker)
  - `description`: the unify-tier marker — `applies (by h, g)` / `premises remain` / `rewrite subterm`
  - `detail`: `[ModuleName]`
- Picking a row drives a `deduce/insertLemma` request whose tier-aware `WorkspaceEdit` (see `lsp/query.py:insert_lemma_at`) is applied directly — `conclude … by …`, `apply … to ?`, `replace …`, or the bare name, picked server-side.
- The server preserves best-first ranking; QuickPick's `matchOnDescription` / `matchOnDetail` are enabled so type-to-filter hits the formula text and the module too.
- Companion **`deduce.searchLemmaWithQuery`** command bound to **`Ctrl+Alt+Shift+L`** mirrors Emacs's `C-u C-c C-l` — first prompts via `showInputBox` for a substring or `_`-pattern that the server uses to filter, since the goal-shape `_`-pattern is server-side and unreachable from QuickPick's client-side fuzzy filter alone.
- After the splice, the cursor jumps to the first `?` inside the inserted text via the existing `jumpToFirstHole` helper, so chaining (refine → search-lemma → case-split) feels snappy.

## #690 sub-task status

- [x] **Part 1** — `_unify_score` in the ranker (landed in #697)
- [x] **Part 2** — LSP wire methods `deduce/availableLemmasAt` and `deduce/insertLemma` (landed in #702)
- [x] **Part 3** — Emacs `C-c C-l` `deduce-lsp-search-lemma` (landed in #704)
- [x] **Part 4** — VS Code `deduce.searchLemma` command **(this PR)**

Addresses #690 (Part 4 — the last remaining sub-task). Once this merges, the issue can be closed manually.

## Test plan

- [x] `node --check editor/vscode/extension.js` — no syntax errors
- [x] `python3.13 -c "import json; json.load(open('editor/vscode/package.json'))"` — manifest parses
- [x] `make static` — ruff + mypy clean (the `--no-site-packages` pass is not run by CI, per CLAUDE.md)
- [ ] Manual smoke test in a VS Code dev host: scratch buffer with `theorem t: all a:UInt, b:UInt. a + b = b + a`, place cursor on the `?`, press `Ctrl+Alt+L`, confirm `uint_add_commute` is the top entry at the "applies" tier and that selecting it splices `conclude a + b = b + a by uint_add_commute` into the buffer
- [ ] Manual smoke test of the with-query variant: press `Ctrl+Alt+Shift+L`, enter `commute`, confirm the picker is filtered server-side
- [ ] CI green

[Claude session](claude://resume?session=2d1c2139-3ffa-4d2b-a01f-458a7f99e819)

`2d1c2139-3ffa-4d2b-a01f-458a7f99e819`