### PR TITLE
lsp: emit explicit forall instantiations in lemma-search splices (#734)

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -3785,14 +3785,15 @@ def insert_lemma_at(
 
     tier: Optional[str] = None
     discharged: tuple[tuple[str, str], ...] = ()
+    instantiations: tuple[str, ...] = ()
     if goal_ast is not None and env is not None:
         given_pairs = _collect_local_givens(env)
-        _score, tier, discharged = _unify_score(
+        _score, tier, discharged, instantiations = _unify_score(
             target_formula, goal_ast, env, given_pairs
         )
 
     template = _insert_lemma_template(
-        name, target_formula, tier, discharged, goal_text
+        name, target_formula, tier, discharged, goal_text, instantiations
     )
 
     if hole_range is None:
@@ -3811,6 +3812,7 @@ def _insert_lemma_template(
     tier: Optional[str],
     discharged: tuple[tuple[str, str], ...],
     goal_text: Optional[str],
+    instantiations: tuple[str, ...] = (),
 ) -> str:
     """Pick the tactic-shape template for ``insert_lemma_at`` (issue #690).
 
@@ -3818,18 +3820,27 @@ def _insert_lemma_template(
     given labels for the ``full`` case; ``formula`` is consulted to
     count premises when there are no labels (e.g. ``premises_remain``
     where every premise is open, or ``full`` with 0 premises).
+
+    ``instantiations`` (issue #734) supplies the explicit ``[t1, ..., tN]``
+    forall-instantiation suffix: when the unifier resolved every
+    all-bound variable of the lemma, the splice writes
+    ``name[t1, ..., tN]`` instead of bare ``name`` so the resulting
+    ``apply ... to ?`` (or ``conclude``/``replace``) elaborates with
+    the right inner subgoal. Empty tuple ``()`` means either no
+    forall to instantiate, or the unifier didn't resolve all vars.
     """
+    name_inst = f"{name}[{', '.join(instantiations)}]" if instantiations else name
     if tier == "full":
         if not discharged and goal_text is not None:
-            return f"conclude {goal_text} by {name}"
+            return f"conclude {goal_text} by {name_inst}"
         labels = ", ".join(label for _, label in discharged)
         if goal_text is not None:
-            return f"conclude {goal_text} by apply {name} to {labels}"
-        return f"apply {name} to {labels}"
+            return f"conclude {goal_text} by apply {name_inst} to {labels}"
+        return f"apply {name_inst} to {labels}"
     if tier == "premises_remain":
-        return f"apply {name} to ?"
+        return f"apply {name_inst} to ?"
     if tier == "rewrite_subterm":
-        return f"replace {name}"
+        return f"replace {name_inst}"
     return name
 
 
@@ -4390,12 +4401,38 @@ def _typed_formula_index(env: Any) -> dict[str, Any]:
     return out
 
 
+def _render_instantiations(
+    vars: Sequence[Any], matching: dict[str, Any]
+) -> tuple[str, ...]:
+    """Render ``matching[v.name]`` for each ``v`` in ``vars``.
+
+    Returns the rendered terms in declaration order so the caller can
+    emit ``name[t1, ..., tN]``. Returns ``()`` if any var is missing
+    from ``matching`` or any rendering raises -- a partial
+    instantiation suffix would be ill-formed.
+    """
+    out: list[str] = []
+    for v in vars:
+        if v.name not in matching:
+            return ()
+        try:
+            out.append(str(matching[v.name]))
+        except Exception:
+            return ()
+    return tuple(out)
+
+
 def _unify_score(
     formula: Any,
     goal_ast: Any,
     env: Any,
     given_pairs: tuple[tuple[str, Any], ...],
-) -> tuple[float, Optional[str], tuple[tuple[str, str], ...]]:
+) -> tuple[
+    float,
+    Optional[str],
+    tuple[tuple[str, str], ...],
+    tuple[str, ...],
+]:
     """Score how well ``formula``'s conclusion unifies with ``goal_ast``.
 
     Three-tier classifier (see :class:`LemmaMatch` for the meaning of
@@ -4407,12 +4444,16 @@ def _unify_score(
       open. Score ``0.7``.
     - ``"rewrite_subterm"`` -- conclusion is an equation whose LHS
       (or RHS) unifies with a subterm of the goal. Score ``0.4``.
-    - falls back to ``(0.0, None, ())`` on no match, missing AST/env,
-      or any internal exception in the unifier.
+    - falls back to ``(0.0, None, (), ())`` on no match, missing AST/
+      env, or any internal exception in the unifier.
 
-    Returns ``(score, tier, discharged_premises)`` where
+    Returns ``(score, tier, discharged_premises, instantiations)``.
     ``discharged_premises`` is a tuple of ``(premise_text, given_label)``
     pairs filled in for the ``"full"`` tier (empty otherwise).
+    ``instantiations`` is the rendered substitution for the lemma's
+    outermost ``all``-bound variables, in declaration order, so
+    callers can emit ``name[t1, ..., tN]`` splices (issue #734).
+    Empty when no tier matched or the lemma had no forall to peel.
 
     The implementation reuses :func:`formula_match` from
     ``abstract_syntax.rewrite`` -- the same first-order matcher
@@ -4421,14 +4462,14 @@ def _unify_score(
     heuristic: a failed unification must never crash the caller.
     """
     if goal_ast is None or env is None or formula is None:
-        return (0.0, None, ())
+        return (0.0, None, (), ())
 
     from abstract_syntax import Call, VarRef, formula_match
     from error import MatchFailed
 
     peeled = _peel_quantified_implication(formula)
     if peeled is None:
-        return (0.0, None, ())
+        return (0.0, None, (), ())
     vars, premises, conc = peeled
 
     location = getattr(formula, "location", None)
@@ -4447,8 +4488,9 @@ def _unify_score(
         pass
 
     if conc_matched:
+        instantiations = _render_instantiations(vars, matching)
         if not premises:
-            return (_UNIFY_TIER_SCORE["full"], "full", ())
+            return (_UNIFY_TIER_SCORE["full"], "full", (), instantiations)
 
         discharged: list[tuple[str, str]] = []
         all_discharged = True
@@ -4473,8 +4515,14 @@ def _unify_score(
                 _UNIFY_TIER_SCORE["full"],
                 "full",
                 tuple(discharged),
+                instantiations,
             )
-        return (_UNIFY_TIER_SCORE["premises_remain"], "premises_remain", ())
+        return (
+            _UNIFY_TIER_SCORE["premises_remain"],
+            "premises_remain",
+            (),
+            instantiations,
+        )
 
     # Tier 3: equation conclusion -> try LHS/RHS against goal subterms.
     if isinstance(conc, Call) and isinstance(conc.rator, VarRef):
@@ -4483,6 +4531,14 @@ def _unify_score(
                 lhs, rhs = conc.args
                 subterms = _iter_subterms(goal_ast)
                 for side in (lhs, rhs):
+                    # When the side is a bare forall-var, ``formula_match``
+                    # binds it to the first subterm visited -- typically
+                    # the whole goal -- which is a meaningless
+                    # "instantiation" for the splice. Skip emitting
+                    # instantiations in that case: a bare ``replace name``
+                    # lets the rewrite engine pattern-match across the
+                    # goal as before.
+                    side_is_bare_var = isinstance(side, VarRef) and side in vars
                     for sub in subterms:
                         sub_matching: dict[str, Any] = {}
                         try:
@@ -4498,15 +4554,21 @@ def _unify_score(
                         ]
                         if unmatched:
                             continue
+                        insts: tuple[str, ...] = (
+                            ()
+                            if side_is_bare_var
+                            else _render_instantiations(vars, sub_matching)
+                        )
                         return (
                             _UNIFY_TIER_SCORE["rewrite_subterm"],
                             "rewrite_subterm",
                             (),
+                            insts,
                         )
         except Exception:
             pass
 
-    return (0.0, None, ())
+    return (0.0, None, (), ())
 
 
 def _rank_lemmas(
@@ -4677,7 +4739,7 @@ def _rank_lemmas(
                 else None
             )
             unify_input = typed_formula if typed_formula is not None else formula
-            unify_score, unify_tier, discharged = _unify_score(
+            unify_score, unify_tier, discharged, _insts = _unify_score(
                 unify_input, goal_ast, env, given_pairs
             )
         else:

--- a/test/lsp/test_insert_lemma.py
+++ b/test/lsp/test_insert_lemma.py
@@ -10,13 +10,18 @@ Coverage:
 
 (a) ``full`` tier with 0 premises -> ``conclude <goal> by <name>``;
 (b) ``full`` tier with 1 premise discharged by a given ->
-    ``conclude <goal> by apply <name> to <label>``;
+    ``conclude <goal> by apply <name>[t1,...] to <label>``;
 (c) ``full`` tier with N premises discharged ->
-    ``conclude <goal> by apply <name> to <l1>, ..., <lN>``;
-(d) ``premises_remain`` tier -> ``apply <name> to ?``;
-(e) ``rewrite_subterm`` tier -> ``replace <name>``;
+    ``conclude <goal> by apply <name>[t1,...] to <l1>, ..., <lN>``;
+(d) ``premises_remain`` tier -> ``apply <name>[t1,...] to ?``;
+(e) ``rewrite_subterm`` tier -> ``replace <name>`` (bare-var-pattern
+    skips instantiation; structured patterns include it);
 (f) no unify match (off-hole or browse) -> bare ``<name>`` at point;
-(g) name not in scope -> ``None``.
+(g) name not in scope -> ``None``;
+(h) explicit forall-instantiation suffix when the unifier resolves
+    every all-bound variable (issue #734) -- the splice writes
+    ``name[t1, ..., tN]`` so ``apply ... to ?`` elaborates with a
+    usable inner subgoal.
 
 Fixtures stay inside ``bool``-only territory so tests run with no
 prelude.
@@ -76,7 +81,10 @@ def test_full_tier_no_premises_emits_conclude_by_name() -> None:
 
 def test_full_tier_one_premise_discharged_emits_apply_to_label() -> None:
     """Single-premise theorem whose only premise is discharged by a
-    local given -> ``conclude <goal> by apply <name> to <label>``."""
+    local given -> ``conclude <goal> by apply <name>[t] to <label>``.
+
+    The unifier resolved ``P := P`` from the conclusion match, so the
+    splice carries the explicit instantiation (issue #734)."""
     source = (
         "theorem dup: all P:bool. if P then P and P\n"
         "proof\n"
@@ -96,7 +104,7 @@ def test_full_tier_one_premise_discharged_emits_apply_to_label() -> None:
         "lemmas.pf", source, Position(line=12, column=3), "dup"
     )
     assert edit is not None
-    assert edit.new_text == "conclude (P and P) by apply dup to h"
+    assert edit.new_text == "conclude (P and P) by apply dup[P] to h"
 
 
 def test_full_tier_two_premises_discharged_emits_comma_labels() -> None:
@@ -123,7 +131,9 @@ def test_full_tier_two_premises_discharged_emits_comma_labels() -> None:
         "lemmas.pf", source, Position(line=14, column=3), "and_intro"
     )
     assert edit is not None
-    assert edit.new_text == "conclude (P and Q) by apply and_intro to pP, qQ"
+    assert edit.new_text == (
+        "conclude (P and Q) by apply and_intro[P, Q] to pP, qQ"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -133,8 +143,10 @@ def test_full_tier_two_premises_discharged_emits_comma_labels() -> None:
 
 def test_premises_remain_tier_emits_apply_with_hole() -> None:
     """Conclusion unifies but no local given matches the premise ->
-    template is ``apply <name> to ?``: one fresh hole for the user
-    to fill."""
+    template is ``apply <name>[t1, ..., tN] to ?``: explicit
+    instantiations (issue #734) so the inner ``?`` displays the
+    instantiated premise as its subgoal; one fresh hole for the
+    user to fill."""
     source = (
         "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
         "proof\n"
@@ -154,7 +166,7 @@ def test_premises_remain_tier_emits_apply_with_hole() -> None:
         "lemmas.pf", source, Position(line=12, column=3), "and_intro"
     )
     assert edit is not None
-    assert edit.new_text == "apply and_intro to ?"
+    assert edit.new_text == "apply and_intro[P, Q] to ?"
     # Replaces the `?` 1-char span at line 12, col 3.
     assert edit.range == Range(
         start=Position(line=12, column=3),
@@ -169,7 +181,13 @@ def test_premises_remain_tier_emits_apply_with_hole() -> None:
 
 def test_rewrite_subterm_tier_emits_replace() -> None:
     """Equation lemma whose LHS unifies with a goal subterm ->
-    template is ``replace <name>``."""
+    template is ``replace <name>``.
+
+    The lemma's LHS is a bare forall-var, so the auto-inferred
+    "match" binds it to the whole goal -- a meaningless splice
+    instantiation. The rewrite_subterm branch skips the
+    ``[t1, ..., tN]`` suffix in that case so the rewrite engine
+    can pattern-match across the goal as before (issue #734)."""
     # ``P = not (not P)`` -- the LHS ``P`` matches the subterm ``P``
     # in the goal ``P and Q``.
     source = (
@@ -260,3 +278,101 @@ def test_unknown_name_returns_none() -> None:
         "lemmas.pf", source, Position(line=3, column=3), "no_such_lemma"
     )
     assert edit is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #734: forall instantiations on splice
+# ---------------------------------------------------------------------------
+#
+# The unifier may resolve substitutions for the lemma's outer
+# all-bound variables when matching its conclusion against the goal.
+# Before the fix, those substitutions were dropped on the floor and
+# the splice emitted bare ``apply name to ?`` -- the inner ``?``
+# could not elaborate because deduce had nothing to instantiate the
+# implication's premise with, so editor "goal at point" lookups
+# returned empty. The fix threads the substitution through into a
+# ``name[t1, ..., tN]`` suffix on every shape (full / premises_remain
+# / rewrite_subterm-with-structured-LHS) so the inner subgoal
+# displays.
+
+
+def test_premises_remain_emits_explicit_instantiation_when_resolved() -> None:
+    """Issue #734 reproducer: every all-bound variable resolved by
+    the conclusion match ends up in the ``[t1, ..., tN]`` splice
+    suffix so the inner ``?`` elaborates with a usable subgoal.
+
+    Postulate ``flip: all P:bool, Q:bool. if P and Q then Q and P``:
+    matching the conclusion ``Q and P`` against the goal ``Q and P``
+    binds ``P := P, Q := Q``. With both forall-vars resolved, the
+    splice must read ``apply flip[P, Q] to ?`` -- without the
+    instantiation, the bare ``apply flip to ?`` form leaves
+    deduce unable to display a subgoal for the inner hole."""
+    source = (
+        "postulate flip: all P:bool, Q:bool. if P and Q then Q and P\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. Q and P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=6, column=3), "flip"
+    )
+    assert edit is not None
+    assert edit.new_text == "apply flip[P, Q] to ?"
+
+
+def test_full_tier_emits_explicit_instantiation_when_resolved() -> None:
+    """``full`` tier with one premise discharged: the apply splice
+    carries the explicit instantiation alongside the given label.
+
+    The fix applies uniformly across template shapes -- ``full``
+    (this case), ``full`` with no premises, ``premises_remain``,
+    and ``rewrite_subterm`` with a structured LHS -- so the
+    instantiation suffix never gets dropped when the unifier knew
+    it (issue #734).
+
+    Postulate ``id_imp: all P:bool. if P then P``: matching the
+    conclusion ``P`` against the goal ``P`` binds ``P := P``; the
+    single premise ``P`` is discharged by the local given ``h: P``,
+    so the tier is ``full``. Splice: ``conclude P by apply
+    id_imp[P] to h``."""
+    source = (
+        "postulate id_imp: all P:bool. if P then P\n"
+        "\n"
+        "theorem with_hole: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume h: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=7, column=3), "id_imp"
+    )
+    assert edit is not None
+    assert edit.new_text == "conclude P by apply id_imp[P] to h"
+
+
+def test_no_instantiation_suffix_when_lemma_has_no_forall() -> None:
+    """A theorem without an outer ``all`` quantifier has no vars to
+    instantiate -- ``instantiations`` is empty, so the splice omits
+    the ``[]`` suffix entirely. Guards against an off-by-one that
+    would emit ``apply name[] to ?`` (empty brackets, parse error
+    in some grammars) when there are no forall-bound variables."""
+    source = (
+        "postulate refl_t: true = true\n"
+        "\n"
+        "theorem with_hole: true = true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    edit = insert_lemma_at(
+        "lemmas.pf", source, Position(line=5, column=3), "refl_t"
+    )
+    assert edit is not None
+    # No forall to peel -> instantiations are empty -> bare name
+    # in the ``conclude ... by name`` template.
+    assert edit.new_text == "conclude true = true by refl_t"

--- a/test/lsp/test_lsp_server.py
+++ b/test/lsp/test_lsp_server.py
@@ -1220,8 +1220,11 @@ def test_insert_lemma_returns_full_tier_workspace_edit(server, open_doc):
     assert result is not None
     edits = result["changes"][uri]
     assert len(edits) == 1
+    # The unifier resolves ``P := P, Q := Q`` from the conclusion
+    # match, so the splice carries explicit instantiations (issue
+    # #734) ahead of the discharged-given labels.
     assert edits[0]["newText"] == (
-        "conclude (P and Q) by apply and_intro to pP, qQ"
+        "conclude (P and Q) by apply and_intro[P, Q] to pP, qQ"
     )
     assert edits[0]["range"]["start"] == {"line": 13, "character": 2}
     assert edits[0]["range"]["end"] == {"line": 13, "character": 3}


### PR DESCRIPTION
## Summary

Fixes #734. ``deduce/insertLemma`` (VS Code Ctrl+Alt+L / Emacs C-c C-l)
was dropping the unifier's substitution before rendering the splice,
producing bare ``apply name to ?`` even when the unifier already knew
how to instantiate the lemma's outer ``all``-bound variables. The
inner ``?`` then had no usable subgoal -- ``Ctrl+Alt+G`` / ``C-c C-g``
showed nothing and the LSP diagnostic just read "incomplete proof."

- Thread the substitution through ``_unify_score``'s return tuple so
  ``insert_lemma_at`` knows the resolved instantiations alongside the
  tier / discharged-premises bookkeeping.
- ``_insert_lemma_template`` renders the suffix as ``name[t1, ..., tN]``
  across every template shape (``conclude``, ``conclude ... by apply``,
  bare ``apply ... to ?``, ``replace``).
- ``rewrite_subterm`` deliberately skips the suffix when the equation's
  matched side is itself a forall-var -- the resulting "match-anything"
  instantiation would over-constrain the rewrite.

The fix lights up the inner subgoal display for any lemma where the
unifier resolves the forall: e.g. for the issue's ``fromNat_injective``
reproducer the splice now reads ``apply fromNat_injective[0, 1] to ?``
and deduce surfaces ``expected Nat but the call returns UInt`` as a
concrete instantiation-type mismatch instead of silently dropping the
inner goal; for Nat-typed goals the splice reads
``apply fromNat_injective[zero, suc(zero)] to ?`` as the issue
described and elaborates cleanly.

## Test plan

- [x] ``pytest test/lsp/test_insert_lemma.py`` (11 passing, including
      three new cases for the instantiation suffix)
- [x] ``pytest test/lsp/test_available_lemmas.py test/lsp/test_insert_lemma.py test/lsp/test_lsp_server.py test/lsp/test_mcp_server.py``
      (147 passing; 2 pre-existing failures in ``test_query.py`` on
      ``test_*_at_signature`` are unrelated tuple-annotation drift)
- [x] Manual smoke against the issue's reproducer: bug-reproducer's
      Nat-typed variant now elaborates the inner ``?`` to the
      substituted premise rather than swallowing the subgoal silently.

[Claude session](claude://resume?session=625acb1a-0f42-4e1c-9dd5-385a6ad108ac)

\`625acb1a-0f42-4e1c-9dd5-385a6ad108ac\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)