### PR TITLE
test/lsp: parameterise tuple return annotation in signature checks

### DIFF
--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -240,7 +240,7 @@ def test_splittable_vars_at_signature():
     _check_sig(
         splittable_vars_at,
         ["path", "content", "pos", "prelude"],
-        tuple,
+        tuple[str, ...],
     )
 
 
@@ -264,7 +264,7 @@ def test_eliminable_vars_at_signature():
     _check_sig(
         eliminable_vars_at,
         ["path", "content", "pos", "prelude"],
-        tuple,
+        tuple[str, ...],
     )
 
 


### PR DESCRIPTION
## Summary
- Fixes #737: `test_splittable_vars_at_signature` and `test_eliminable_vars_at_signature` were comparing the parameterised `tuple[str, ...]` annotation returned by `inspect.signature` (under Python 3.13) against the bare `tuple` class, which compares unequal.
- Change both `expected_return` arguments from `tuple` to `tuple[str, ...]`, matching the actual annotation on `splittable_vars_at` / `eliminable_vars_at` in `lsp/query.py` and following the convention every other `test_*_signature` in the file already uses.

## Why
Local-only papercut — CI doesn't run `pytest test/lsp/`, so these failures don't gate any PR, but they muddy the "did my change break something?" signal for anyone running the lsp suite locally.

## Test plan
- [x] `python3.13 -m pytest test/lsp/test_query.py` — all 32 tests pass (previously 2 failures on the two signature tests).
- [x] `make static` — ruff + mypy (the CI pass) clean. The Makefile's extra `--no-site-packages` pass surfaces pre-existing untyped-decorator noise unrelated to this change and is not run by CI.

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)
Fallback UUID: \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)