### PR TITLE
lib/BigO: Section G (partial) — log of a function is bounded by the function (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -906,3 +906,32 @@ proof
   show n^a ≤ 1 * n^b
   apply (apply uint_pow_le_mono_r[b, n, a] to one_n) to a_le_b
 end
+
+// Pointwise: `log(f)(n) = log(f(n)) ≤ f(n)` by `uint_logn_le_n`.
+// Hence `log(f) ≲ f` for any cost function `f`.
+theorem bigo_log_le_self: all f:fn UInt->UInt. log(f) ≲ f
+proof
+  arbitrary f:fn UInt->UInt
+  expand operator≲ | log
+  choose 0, 1
+  arbitrary n:UInt
+  assume _
+  show log(f(n)) ≤ 1 * f(n)
+  uint_logn_le_n
+end
+
+// Log of a constant function is bounded: `log(O_1) ≲ O_1`.
+// Instance of `bigo_log_le_self` at `f = O_1`.
+theorem bigo_log_const: log(O_1) ≲ O_1
+proof
+  bigo_log_le_self[O_1]
+end
+
+// Iterated log is bounded by log: `log(O_log) ≲ O_log`.
+// Instance of `bigo_log_le_self` at `f = O_log`; concretely
+// `log(log(n)) ≤ log(n)` for every `n`, which is the
+// `n_log_log(n) ≤ log(n)` step in the `O(n log log n)` discussion.
+theorem bigo_log_log: log(O_log) ≲ O_log
+proof
+  bigo_log_le_self[O_log]
+end


### PR DESCRIPTION
## Summary

Extends `lib/BigO.pf` with the first three theorems from Section G
(logarithm laws) of the catalogue in #725: the general bound
`log(f) ≲ f` plus its two named corollaries at `O_1` and `O_log`.

## Section G bullet status (per #725)

Issue #725 Section G lists four bullets. This PR covers bullets 1 and 3
and defers bullets 2 and 4.

- [x] **Bullet 1** — `bigo_log_const`: `log(O_1) ≲ O_1`.
- [ ] **Bullet 2** — `bigo_log_pow`: `log((fun n. n^k)) ≈ log(O_n)` for `k ≥ 1`. Deferred — the equivalence direction needs care for the `UInt` floor `log` (where `log(n^k) ≠ k · log(n)` in general).
- [x] **Bullet 3** — `bigo_log_log`: `log(O_log) ≲ O_log`.
- [ ] **Bullet 4** — Change of base. Deferred — Deduce currently exposes only `log = log_2`; this bullet either needs a `log_b` operator or a documented convention.

## New theorems

- `bigo_log_le_self : log(f) ≲ f` — pointwise consequence of [`uint_logn_le_n`](lib/UIntPowLog.pf): `log(f(n)) ≤ f(n)` for every `n`. Holds for any cost function `f`, with no positivity assumption.
- `bigo_log_const : log(O_1) ≲ O_1` — instance at `f = O_1`. Concretely `log(1) = 0 ≤ 1`.
- `bigo_log_log : log(O_log) ≲ O_log` — instance at `f = O_log`. Concretely `log(log(n)) ≤ log(n)` for every `n`, the iterated-log bound that sits beneath linear-log in the `O(n log log n)` discussion.

## Why these three

`bigo_log_le_self` is the natural "hero" theorem for the layer: every other "log of … is bounded by …" fact in the basic story is an instance of it. The two named corollaries pin down the levels (`O_1`, `O_log`) where it shows up in the standard hierarchy, mirroring how `constant_le_log`, `log_le_linear`, `linear_le_quadratic` pin down the linear chain.

## Out of scope (follow-ups)

- `bigo_log_pow` (Section G bullet 2): the `≈` direction is non-trivial under the `UInt` floor log because `log(n^k)` and `k · log(n)` differ by up to `k − 1`. The argument needs the `n ≥ 2 ⇒ log(n) ≥ 1` slack from `uint_log_greater_one` and a polynomial induction. Own slice.
- Change of base (Section G bullet 4): orthogonal — needs a `log_b` operator or a documented convention before the comparison can even be stated.
- Section F (polynomial closure) and Section H (asymptotic summation) remain blocked on the same prereqs called out in #733: a `polynomial-absorbed-by-exponential` story for the closure bullets, and #719 for summation.

## Test plan

- [x] `python deduce.py lib/BigO.pf` (recursive-descent)
- [x] `python deduce.py --lalr lib/BigO.pf`
- [x] `python -m ruff check .` + `python -m mypy .`
- [x] `python test-deduce.py` (full default: lib + should-validate + should-error + parser equivalence) — all passed in ~113s.

## Provenance

[Claude session](claude://resume?session=67c5ce25-e894-4856-a886-d5fa7b6ba246)

```
67c5ce25-e894-4856-a886-d5fa7b6ba246
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)