### PR TITLE
lib/BigO: Section E follow-up — quadratic-to-exponential (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -935,3 +935,98 @@ theorem bigo_log_log: log(O_log) ≲ O_log
 proof
   bigo_log_le_self[O_log]
 end
+
+// Polynomial-vs-exponential domination, base case k = 2: n*n ≤ 2^n for n ≥ 4.
+// Proven by k-induction starting at 4. The inductive step uses the polynomial
+// slack 1 + 2m ≤ m*m (via 1 + 2m ≤ 4m ≤ m*m, both valid for m ≥ 4) to bound
+// (1+m)*(1+m) = 1 + 2m + m*m ≤ 2 * m*m, then folds the IH m*m ≤ 2^m through a
+// factor of 2 to land on 2^(1+m).
+lemma uint_quad_le_2pow: all n:UInt. if 4 ≤ n then n * n ≤ 2 ^ n
+proof
+  define P = fun n:UInt { n * n ≤ 2 ^ n }
+  have base: P(4) by {
+    expand P
+    show 4 * 4 ≤ 2 ^ 4
+    .
+  }
+  have ind: all m:UInt. if 4 ≤ m and P(m) then P(1 + m) by {
+    arbitrary m:UInt
+    assume prem
+    have m_ge_4: 4 ≤ m by prem
+    have IH: m * m ≤ 2 ^ m by expand P in prem
+    expand P
+    show (1 + m) * (1 + m) ≤ 2 ^ (1 + m)
+
+    have expand_sq: (1 + m) * (1 + m) = 1 + 2 * m + m * m by {
+      replace uint_dist_mult_add_right[1, m, 1+m]
+           | uint_dist_mult_add[m, 1, m]
+           | uint_two_mult[m].
+    }
+
+    have m_ge_1: 1 ≤ m by {
+      have one_le_four: (1:UInt) ≤ 4 by .
+      apply uint_less_equal_trans to one_le_four, m_ge_4
+    }
+
+    have m_le_m: m ≤ m by .
+    have four_m_le_m_m: 4 * m ≤ m * m
+      by apply uint_mult_mono_le2 to m_ge_4, m_le_m
+
+    have one_le_2m: (1:UInt) ≤ 2 * m by {
+      have one_le_two: (1:UInt) ≤ 2 by .
+      have two_le_2m: (2:UInt) ≤ 2 * m by apply uint_mult_mono_le[2] to m_ge_1
+      apply uint_less_equal_trans to one_le_two, two_le_2m
+    }
+
+    have four_m_eq: (4:UInt) * m = 2 * m + 2 * m
+      by uint_dist_mult_add_right[2, 2, m]
+
+    have step_2m_le_4m: 1 + 2 * m ≤ 4 * m by {
+      replace four_m_eq
+      have two_m_le: 2 * m ≤ 2 * m by .
+      apply uint_add_mono_less_equal to one_le_2m, two_m_le
+    }
+
+    have slack: 1 + 2 * m ≤ m * m
+      by apply uint_less_equal_trans to step_2m_le_4m, four_m_le_m_m
+
+    have step_sum: (1 + 2 * m) + m * m ≤ m * m + m * m by {
+      have mm_le_mm: m * m ≤ m * m by .
+      apply uint_add_mono_less_equal to slack, mm_le_mm
+    }
+
+    have two_mm_eq: m * m + m * m = 2 * (m * m)
+      by symmetric uint_two_mult[m * m]
+    have step_2mm: (1 + 2 * m) + m * m ≤ 2 * (m * m)
+      by replace two_mm_eq in step_sum
+
+    have step_lhs_2mm: (1 + m) * (1 + m) ≤ 2 * (m * m) by {
+      replace expand_sq
+      step_2mm
+    }
+
+    have step_two_pow_m: 2 * (m * m) ≤ 2 * 2 ^ m
+      by apply uint_mult_mono_le[2] to IH
+
+    have step_chain: (1 + m) * (1 + m) ≤ 2 * 2 ^ m
+      by apply uint_less_equal_trans to step_lhs_2mm, step_two_pow_m
+
+    have pow_step: 2 ^ (1 + m) = 2 * 2 ^ m by uint_pow_add_r[2, 1, m]
+
+    replace pow_step
+    step_chain
+  }
+  expand P in apply uint_k_induction[P, 4] to base, ind
+end
+
+// Quadratic is bounded by exponential: O(n^2) ≲ O(2^n). Threshold n0 = 4,
+// constant c = 1 (uint_quad_le_2pow gives the pointwise inequality directly).
+theorem bigo_quadratic_le_2pow_n: O_n2 ≲ O_2pow_n
+proof
+  expand operator≲ | O_n2 | O_2pow_n
+  choose 4, 1
+  arbitrary n:UInt
+  assume four_n: 4 ≤ n
+  show n * n ≤ 1 * 2 ^ n
+  apply uint_quad_le_2pow to four_n
+end


### PR DESCRIPTION
## Summary

Extends `lib/BigO.pf` with `bigo_quadratic_le_2pow_n: O_n2 ≲ O_2pow_n`, closing the gap PR #733 explicitly deferred ("the broader `n^k ≲ 2^n` family ... non-trivial enough to be its own slice"). The chain `O_1 ≲ O_log ≲ O_n ≲ O_n_log_n ≲ O_n2 ≲ O_2pow_n` is now complete; only the cubic-to-exponential link `O_n3 ≲ O_2pow_n` remains in the Section E follow-up backlog.

## New theorems

- `uint_quad_le_2pow : all n. if 4 ≤ n then n * n ≤ 2 ^ n` — local helper. The standard polynomial-absorbed-by-exponential argument, with threshold `n0 = 4` so that the polynomial slack `1 + 2m ≤ m*m` holds in the inductive step.
- `bigo_quadratic_le_2pow_n : O_n2 ≲ O_2pow_n` — the BigO-level consequence. Threshold `n0 = 4`, constant `c = 1`.

## Proof technique

`uint_quad_le_2pow` uses `uint_k_induction[P, 4]` with `P(n) = n*n ≤ 2^n`. The inductive step assumes `m ≥ 4` and `m*m ≤ 2^m`:

1. Expand `(1+m)*(1+m) = 1 + 2*m + m*m` (distributivity + `uint_two_mult`).
2. Polynomial slack `1 + 2*m ≤ m*m` for `m ≥ 4`, via `1 + 2*m ≤ 4*m ≤ m*m`. The first inequality uses `1 ≤ 2*m` (from `m ≥ 1 ⊆ m ≥ 4`); the second uses `4 ≤ m` and `uint_mult_mono_le2`.
3. Add `m*m` to both sides of the slack: `(1 + 2*m) + m*m ≤ m*m + m*m = 2*(m*m)`.
4. Apply the IH through the factor of 2: `2*(m*m) ≤ 2 * 2^m`.
5. `2 * 2^m = 2^(1 + m)` via `uint_pow_add_r[2, 1, m]`.

## Section E bullet status (per #725)

This PR addresses the cubic-to-exponential gap *partially* — covering the quadratic case. The cubic case `O_n3 ≲ O_2pow_n` needs a parallel argument with the larger threshold `n0 = 10` (since `9^3 > 2^9` but `10^3 < 2^10`) and a more elaborate `3m^2 + 3m + 1 ≤ m^3` polynomial-slack lemma; left for a follow-up to keep this slice focused.

- [x] **Bullet 1** — Named functions `O_n_log_n`, `O_n3`, `O_2pow_n` (from #733).
- [x] **Bullet 2 (partial → mostly done)** — Chain extended: `O_n2 ≲ O_2pow_n` added here. Still missing: `O_n3 ≲ O_2pow_n` and the general `n^k ≲ 2^n` family.
- [x] **Bullet 3** — Polynomial-exponent monotonicity (from #733).
- [ ] **Bullet 4** — Strict little-o form of polynomial-exponent comparison. Still deferred.

## Out of scope (follow-ups)

- `O_n3 ≲ O_2pow_n` and the general `(fun n. n^k) ≲ O_2pow_n` family. Each higher polynomial needs its own threshold + slack lemma; doable as a follow-up using the same `uint_k_induction` pattern, with the cubic case proving `3*m*m + 3*m + 1 ≤ m*m*m` for `m ≥ 4`.
- Section E bullet 4 (strict little-o form) — depends on the same infrastructure.

## Test plan

- [x] `python deduce.py lib/BigO.pf` (recursive-descent)
- [x] `python deduce.py --lalr lib/BigO.pf`
- [x] `python -m ruff check . && python -m mypy .` — clean
- [x] `python test-deduce.py` (full default: lib + should-validate + should-error + parser equivalence) — all passed in ~132s.

## Provenance

[Claude session](claude://resume?session=4d8210c8-de03-4cea-be7c-daba0649ee78)

\`4d8210c8-de03-4cea-be7c-daba0649ee78\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)