### PR TITLE
Add quick-start section to top-level README (Closes #744)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,39 @@
 
 ![Blue Hippo next to the word Deduce.](/logos/Main-Logo.svg)
 
-The web page for Deduce is at the following link:
+A proof checker and small functional language for teaching logic.
 
-**[https://jsiek.github.io/deduce/](https://jsiek.github.io/deduce/)**
+## Quick start
 
-The directory structure:
+Deduce needs Python 3.10+ and the [Lark](https://github.com/lark-parser/lark)
+parsing library. From a fresh clone:
+
+```sh
+python -m pip install lark
+python deduce.py example.pf
+```
+
+You should see:
+
+```
+example.pf is valid
+```
+
+For installation details, editor integrations, AI-assisted proof
+completion, and the language introduction, see
+[Getting Started](gh_pages/doc/GettingStarted.md) or the
+[Deduce website](https://jsiek.github.io/deduce/).
+
+More worked examples live in [`examples/`](examples).
+
+## Repo layout
+
 * `/compiler` Deduce-to-C compiler ([user guide](https://jsiek.github.io/deduce/pages/compiler.html))
 * `/docs` Documentation for contributing to Deduce
+* `/editor` Editor integrations (Emacs, VS Code)
+* `/examples` Worked example proofs
 * `/gh_pages` Source code for the [Deduce website](https://jsiek.github.io/deduce/)
 * `/lib` Deduce library files. This includes Nat, List, etc.
 * `/live_code_vercel_api` Source code for [Deduce live code](https://jsiek.github.io/deduce/sandbox.html)
 * `/logos` The Hippopotamus logo and other images.
 * `/test` Deduce files used for testing Deduce.
-


### PR DESCRIPTION
## Summary

- Replace the directory-listing-only README with a minimal quick-start: `pip install lark` → `python deduce.py example.pf` → `example.pf is valid`.
- Link to [`gh_pages/doc/GettingStarted.md`](gh_pages/doc/GettingStarted.md) and the website for the deeper install / editor / MCP / intro material rather than duplicating it (per the author's follow-up comment on #744).
- Add `/editor` and `/examples` to the directory layout — both are user-facing and existed already (the latter is where #742's `fast_reverse.pf` lives).

## Why

A new user landing on the repo currently sees only the logo, a link to the website, and a list of seven directories. There's no actionable `install` / `first run` command, and no link from the README to the in-tree `example.pf` or to GettingStarted.md. This was flagged in #744 (priority:high, documentation) during a user-acceptance run.

## Test plan

- [x] `python deduce.py example.pf` prints `example.pf is valid` (matches the new README's expected output).
- [x] Rendered README on GitHub shows the new structure; links to GettingStarted.md, the website, and `examples/` all resolve.

[Claude session](claude://resume?session=802bf724-9199-4efa-b718-4647f4dd8806)

Fallback (if the link above doesn't render): `802bf724-9199-4efa-b718-4647f4dd8806`

🤖 Generated with [Claude Code](https://claude.com/claude-code)