### PR TITLE
Fast path for literal-Nat arithmetic (Closes #746)

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -405,33 +405,18 @@ def uintToInt(t: Term) -> int:
 def _extract_lit_nat_names(t: Term) -> tuple[str, str | None, str] | None:
   # If `t` is `lit(suc(suc(...zero)))`, return the uniquified
   # `(lit_name, suc_name_or_None, zero_name)` extracted from its nodes.
-  # `suc_name` is None only when the value is 0 (no `suc` in the AST).
-  if not isinstance(t, Call) or len(t.args) != 1:
+  # `suc_name` is None when the value is 0 (no `suc` in the AST).
+  if not isLitNat(t):
     return None
-  rator = t.rator
-  if isinstance(rator, (Var, OverloadedVar, ResolvedVar)):
-    lit_name = rator.get_name()
-  else:
+  assert isinstance(t, Call) and isinstance(t.rator, VarRef)
+  inner = t.args[0]
+  zname = getZero(inner)
+  if not isinstance(zname, str):
     return None
-  if base_name(lit_name) != 'lit':
-    return None
-  cur: Term = t.args[0]
-  suc_name: str | None = None
-  while isinstance(cur, Call) and len(cur.args) == 1:
-    sub_rator = cur.rator
-    if not isinstance(sub_rator, (Var, OverloadedVar, ResolvedVar)):
-      return None
-    sname = sub_rator.get_name()
-    if base_name(sname) != 'suc':
-      return None
-    suc_name = sname
-    cur = cur.args[0]
-  if not isinstance(cur, (Var, OverloadedVar, ResolvedVar)):
-    return None
-  zero_name = cur.get_name()
-  if base_name(zero_name) != 'zero':
-    return None
-  return (lit_name, suc_name, zero_name)
+  sname = getSuc(inner)
+  return (t.rator.get_name(),
+          sname if isinstance(sname, str) else None,
+          zname)
 
 def try_fast_lit_nat_arith(loc: Meta, rator: Term, args: list[Term],
                            ty: Type | None) -> Term | None:

--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -402,6 +402,107 @@ def uintToInt(t: Term) -> int:
     case _:
       raise InternalError('uintToInt: not a uint ' + str(t))
 
+def _extract_lit_nat_names(t: Term) -> tuple[str, str | None, str] | None:
+  # If `t` is `lit(suc(suc(...zero)))`, return the uniquified
+  # `(lit_name, suc_name_or_None, zero_name)` extracted from its nodes.
+  # `suc_name` is None only when the value is 0 (no `suc` in the AST).
+  if not isinstance(t, Call) or len(t.args) != 1:
+    return None
+  rator = t.rator
+  if isinstance(rator, (Var, OverloadedVar, ResolvedVar)):
+    lit_name = rator.get_name()
+  else:
+    return None
+  if base_name(lit_name) != 'lit':
+    return None
+  cur: Term = t.args[0]
+  suc_name: str | None = None
+  while isinstance(cur, Call) and len(cur.args) == 1:
+    sub_rator = cur.rator
+    if not isinstance(sub_rator, (Var, OverloadedVar, ResolvedVar)):
+      return None
+    sname = sub_rator.get_name()
+    if base_name(sname) != 'suc':
+      return None
+    suc_name = sname
+    cur = cur.args[0]
+  if not isinstance(cur, (Var, OverloadedVar, ResolvedVar)):
+    return None
+  zero_name = cur.get_name()
+  if base_name(zero_name) != 'zero':
+    return None
+  return (lit_name, suc_name, zero_name)
+
+def try_fast_lit_nat_arith(loc: Meta, rator: Term, args: list[Term],
+                           ty: Type | None) -> Term | None:
+  # Compute `op` on `lit`-wrapped Nat literals directly, bypassing the
+  # step-by-step auto-rewrite rules (lit_suc_mult, lit_suc_add, etc.)
+  # whose recursive unfolding is O(N^2) or worse for N-digit operands.
+  # Returns the result as a literal Nat (or Bool for comparisons), or
+  # None if the fast path does not apply.
+  if len(args) < 2:
+    return None
+  if not isinstance(rator, (Var, OverloadedVar, ResolvedVar)):
+    return None
+  op = base_name(rator.get_name())
+  if op not in ('+', '*', '^', '∸', '/', '%', '≤', '<'):
+    return None
+  values: list[int] = []
+  lit_name: str | None = None
+  suc_name: str | None = None
+  zero_name: str | None = None
+  for arg in args:
+    comp = _extract_lit_nat_names(arg)
+    if comp is None:
+      return None
+    ln, sn, zn = comp
+    values.append(natToInt(arg))
+    if lit_name is None:
+      lit_name = ln
+    if suc_name is None:
+      suc_name = sn
+    if zero_name is None:
+      zero_name = zn
+  if lit_name is None or zero_name is None:
+    return None
+  if len(values) > 2 and op not in ('+', '*'):
+    return None
+  if op == '+':
+    result_int = sum(values)
+  elif op == '*':
+    result_int = 1
+    for v in values:
+      result_int *= v
+  elif op == '^':
+    if values[1] > 4096:
+      return None
+    result_int = values[0] ** values[1]
+  elif op == '∸':
+    result_int = max(0, values[0] - values[1])
+  elif op == '/':
+    if values[1] == 0:
+      return None
+    result_int = values[0] // values[1]
+  elif op == '%':
+    if values[1] == 0:
+      return None
+    result_int = values[0] % values[1]
+  elif op == '≤':
+    return Bool(loc, ty, values[0] <= values[1])
+  elif op == '<':
+    return Bool(loc, ty, values[0] < values[1])
+  else:
+    return None
+  if result_int > 0 and suc_name is None:
+    return None
+  inner = intToNat(loc, result_int, zname=zero_name,
+                   sname=suc_name or 'suc')
+  if '.' in lit_name:
+    lit_var: Term = ResolvedVar(loc, None, lit_name)
+  else:
+    lit_var = Var(loc, None, lit_name)
+  return Call(loc, ty, lit_var, [inner])
+
 def _same_numeric_literal(t1: Any, t2: Any) -> bool:
   if isNat(t1) and isNat(t2):
     return natToInt(t1) == natToInt(t2)

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         natToInt,
         nodeListToList,
         nodeListToString,
+        try_fast_lit_nat_arith,
         uintToInt,
     )
     from .ops import (
@@ -1135,6 +1136,16 @@ class Call(Term):
     else:
       flat_args = self.args
     args = [arg.reduce(env) for arg in flat_args]
+    # Fast path: arithmetic/comparison on `lit`-wrapped Nat literals
+    # collapses to a single literal (or Bool) without unfolding the
+    # step-by-step auto-rewrite rules (lit_suc_mult, lit_suc_add,
+    # le_lit_suc, lit_expt_suc, ...).  Those rules are correct but
+    # O(N^2) for N-digit operands, which makes proofs that touch a
+    # concrete `P(10)` instance take minutes (see #746).
+    if not get_eval_all():
+      fast = try_fast_lit_nat_arith(self.location, self.rator, args, self.typeof)
+      if fast is not None:
+        return auto_rewrites(fast, env)
     ret: Term | None = None
     match cast(Any, fun):
       case Var(loc, _, '=') | OverloadedVar(loc, _, ['=']) | ResolvedVar(loc, _, '='):

--- a/test/should-validate/uint_arith.pf
+++ b/test/should-validate/uint_arith.pf
@@ -58,5 +58,24 @@ proof
   .
 end
 
+// Regression for #746: chained multiplications and exponentiation
+// of UInt literals must reduce quickly. Without the literal-arithmetic
+// fast path these took minutes (lit_suc_mult/lit_suc_add unfold one
+// `suc` at a time, which is O(N^2) for N-digit operands).
+theorem cube_le_pow_lit: 10 * 10 * 10 ≤ 2 ^ 10
+proof
+  .
+end
+
+theorem pow_lit: 2 ^ 10 = 1024
+proof
+  .
+end
+
+theorem mul_chain_lit: 10 * 10 * 10 = 1000
+proof
+  .
+end
+
 
 


### PR DESCRIPTION
## Summary

- Chained UInt/Nat literal arithmetic (e.g. `10*10*10 ≤ 2^10`) was reducing via step-by-step `suc`-stripping auto-rewrite rules (`lit_suc_mult`, `lit_suc_add`, `lit_expt_suc`, `le_lit_suc`, ...), giving O(N²) or worse behavior for N-digit operands. The repro from #746 hung for >5 minutes; on the same fixture this PR finishes in ~7s.
- Adds a fast path in `Call.reduce` that, when every argument of a binary/associative arithmetic call is `lit(suc(...zero))`, computes the result directly via `natToInt`/`intToNat` and returns a single literal (or `Bool` for `≤`/`<`). Covers `+`, `*`, `^`, `∸`, `/`, `%`, `≤`, `<` on Nat — UInt operations on literals flow in transparently via the existing `lit_*_fromNat` rules.
- The existing auto-rewrite rules stay in place as the spec / fallback for shapes the fast path doesn't recognize (mixed lit/non-lit operands, etc.).
- Adds three regression theorems to `test/should-validate/uint_arith.pf`.

Closes #746.

## Test plan

- [x] `python test-deduce.py --lib` — green (lib × 2 parsers)
- [x] `python test-deduce.py --passable` — green (should-validate × 2 parsers)
- [x] `python test-deduce.py --errors` — green
- [x] `python test-deduce.py --parser` — green
- [x] `make static` — ruff + mypy clean (the `--no-site-packages` lsp noise is pre-existing and not run by CI)
- [x] Issue #746's exact reproducer (`tmp/cube_repro_h.pf`) — was >5min hang, now ~7s, reports `IncompleteProof` at the `?` hole as expected
- [x] Both parsers (`--recursive-descent`, `--lalr`) on the reproducer

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)