### PR TITLE
checker_proofs: forward expand-residual hint to collect_errors sink (Closes #745)

### DIFF
--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -1073,6 +1073,8 @@ def _check_proof_of_apply_defs_goal(proof: Any, formula: Any, env: Env) -> None:
   loc = proof.location
   new_formula = expand_definitions(loc, formula, proof.definitions, env)
   red_formula = new_formula.reduce(env)
+  sink = get_active_sink()
+  before_len = len(sink.errors) if sink is not None else 0
   try:
     _try_check_proof_of(proof.body, red_formula, env)
   except UserError as e:
@@ -1080,6 +1082,17 @@ def _check_proof_of_apply_defs_goal(proof: Any, formula: Any, env: Env) -> None:
     if hint:
       raise wrap_user_error(e, hint) from e
     raise
+  # Sink path: _try_check_proof_of swallows the exception into the sink
+  # and returns normally, so the except clause above never fires. Walk
+  # any entries it added during this call and attach the same hint so
+  # collect_errors mode (MCP / LSP) sees the helpful tail the CLI gets.
+  if sink is not None and len(sink.errors) > before_len:
+    hint = expand_residual_hint(red_formula, proof.definitions, env)
+    if hint:
+      for i in range(before_len, len(sink.errors)):
+        entry = sink.errors[i]
+        if isinstance(entry, UserError):
+          sink.errors[i] = wrap_user_error(entry, hint)
 
 def _check_proof_of_all_intro(proof: Any, formula: Any, env: Env) -> None:
   loc = proof.location

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -129,3 +129,23 @@ def test_unsaved_content_bypasses_module_cache(tmp_path: Path) -> None:
 
     assert result.ok
     assert path.stem not in get_uniquified_modules()
+
+
+def test_collect_errors_includes_expand_residual_hint() -> None:
+    """Regression test for issue #745: the ``expand_residual_hint``
+    appended by ``_check_proof_of_apply_defs_goal`` must reach the
+    diagnostic surfaced through ``collect_errors=True`` (MCP / LSP),
+    not just the CLI. The fixture file at
+    ``test/should-error/advice_expand_more.pf`` is the same one the
+    CLI ``test/should-error`` sweep uses; here we additionally verify
+    the hint round-trips through the sink path."""
+    path = ERROR_DIR / "advice_expand_more.pf"
+    result = check_file(str(path), collect_errors=True)
+    assert result.errors is not None
+    assert not result.ok
+    assert len(result.errors) >= 1
+    body = getattr(result.errors[0], "message_body", str(result.errors[0]))
+    assert "goal still contains" in body and "sum_test" in body, (
+        "expand-residual hint missing from collect_errors diagnostic:\n"
+        + body
+    )


### PR DESCRIPTION
## Summary

- `_check_proof_of_apply_defs_goal` only attached the `expand_residual_hint` inside an `except UserError` branch. Under `collect_errors=True` (MCP / LSP), `_try_check_proof_of` catches the exception into the active sink and returns normally — so the wrapper never fired and the hint was dropped from MCP / LSP diagnostics.
- After the inner call, this PR walks any entries the sink picked up during this call and rewraps each `UserError` with the same hint via `wrap_user_error`, so both `str(exc)` and `exc.message_body` carry the trailing advice the CLI path already produced.
- Adds a regression test (`test_collect_errors_includes_expand_residual_hint`) that runs the existing CLI fixture `test/should-error/advice_expand_more.pf` through `check_file(..., collect_errors=True)` and asserts the hint survives in the sink-shaped diagnostic.

## Test plan

- [x] `python deduce.py test/should-error/advice_expand_more.pf` still produces the original CLI hint
- [x] `python -m pytest test/lsp/test_library.py` (17 tests, including the new one)
- [x] `python -m pytest test/lsp/` (459 tests)
- [x] `python test-deduce.py --errors` (full should-error sweep)
- [x] `python test-deduce.py --passable` (should-validate, both parsers)
- [x] `python test-deduce.py --lib` (stdlib, both parsers)
- [x] `python -m mypy .` clean (the `--no-site-packages` second pass is pre-existing noise — see CLAUDE.md memory)
- [x] `python -m ruff check .` clean

Closes #745.

[Claude session](claude://resume?session=a42d3304-5c0e-48ec-b9af-9571cf137f99) (fallback id: \`a42d3304-5c0e-48ec-b9af-9571cf137f99\`)

```
open "claude://resume?session=a42d3304-5c0e-48ec-b9af-9571cf137f99"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)