### PR TITLE
parser: point users at fun/recursive when define gets type params (Closes #743)

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -939,8 +939,11 @@ def parse(program_text: str,
               if m:
                   name = m.group(1)
                   hint = ('\n`define` does not take type parameters.'
-                          ' For a generic value, use:\n'
-                          '\tfun ' + name + '<T>(...) { ... }\nor\n'
+                          ' For a generic value, put the type parameters'
+                          ' on the right:\n'
+                          '\tdefine ' + name + ' : fn <T> ... -> ... = generic T { ... }\n'
+                          'or use `fun`/`recursive`:\n'
+                          '\tfun ' + name + '<T>(...) { ... }\n'
                           '\trecursive ' + name + '<T>(...) -> ... { ... }')
           msg = (get_filename() + ":" + str(t.token.line) + "." + str(t.token.column)
                  + "-" + str(t.token.end_line) + "." + str(t.token.end_column) + ": "

--- a/parser.py
+++ b/parser.py
@@ -18,6 +18,7 @@ from abstract_syntax import (
     get_default_mark_LHS, intToNat, listToNodeList, mkEqual, mkIntLit,
     mkUIntLit, remove_mark,
 )
+import re
 from lark import Lark, Token, exceptions
 from lark.tree import Meta
 from typing import Any, cast
@@ -931,9 +932,19 @@ def parse(program_text: str,
           # surface the message without their process being killed.
           # The CLI in deduce.py catches this and prints str(e), which
           # produces the same stdout the print() did before.
+          hint = ''
+          if t.token.type == 'LESSTHAN':
+              preceding = program_text[:t.token.start_pos]
+              m = re.search(r'\bdefine\s+([A-Za-z_]\w*)\s*\Z', preceding)
+              if m:
+                  name = m.group(1)
+                  hint = ('\n`define` does not take type parameters.'
+                          ' For a generic value, use:\n'
+                          '\tfun ' + name + '<T>(...) { ... }\nor\n'
+                          '\trecursive ' + name + '<T>(...) -> ... { ... }')
           msg = (get_filename() + ":" + str(t.token.line) + "." + str(t.token.column)
                  + "-" + str(t.token.end_line) + "." + str(t.token.end_column) + ": "
                  + "error in parsing, unexpected token: " + token_str(t.token, program_text) + '\n'
-                 + "(The error may be immediately before this token.)")
+                 + "(The error may be immediately before this token.)" + hint)
           raise Exception(msg)
         

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1605,6 +1605,13 @@ def parse_define(visibility):
     start_token = current_token()
     advance()
     name = parse_identifier()
+    if current_token().type == 'LESSTHAN':
+      raise ParseError(meta_from_tokens(current_token(), current_token()),
+            '`define` does not take type parameters.\n'
+            'For a generic value, use:\n'
+            '\tfun ' + name + '<T>(...) { ... }\n'
+            'or\n'
+            '\trecursive ' + name + '<T>(...) -> ... { ... }')
     if current_token().type == 'COLON':
       advance()
       while_parsing = 'while parsing\n' \

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1608,9 +1608,10 @@ def parse_define(visibility):
     if current_token().type == 'LESSTHAN':
       raise ParseError(meta_from_tokens(current_token(), current_token()),
             '`define` does not take type parameters.\n'
-            'For a generic value, use:\n'
+            'For a generic value, put the type parameters on the right:\n'
+            '\tdefine ' + name + ' : fn <T> ... -> ... = generic T { ... }\n'
+            'or use `fun`/`recursive`:\n'
             '\tfun ' + name + '<T>(...) { ... }\n'
-            'or\n'
             '\trecursive ' + name + '<T>(...) -> ... { ... }')
     if current_token().type == 'COLON':
       advance()

--- a/test/should-error/define_with_type_params.pf
+++ b/test/should-error/define_with_type_params.pf
@@ -1,0 +1,4 @@
+// Issue #743: `define name<T> : ...` should point users at `fun`/`recursive`
+// rather than just complaining about the `<` token.
+import List
+define id_list<T> : fn List<T> -> List<T> = λxs { xs }

--- a/test/should-error/define_with_type_params.pf.err
+++ b/test/should-error/define_with_type_params.pf.err
@@ -6,7 +6,8 @@ define id_list<T> : fn List<T> -> List<T> = λxs { xs }
               ^
 
 ./test/should-error/define_with_type_params.pf:4.15-4.16: `define` does not take type parameters.
-For a generic value, use:
+For a generic value, put the type parameters on the right:
+	define id_list : fn <T> ... -> ... = generic T { ... }
+or use `fun`/`recursive`:
 	fun id_list<T>(...) { ... }
-or
 	recursive id_list<T>(...) -> ... { ... }

--- a/test/should-error/define_with_type_params.pf.err
+++ b/test/should-error/define_with_type_params.pf.err
@@ -1,0 +1,12 @@
+./test/should-error/define_with_type_params.pf:4.1-4.15: while parsing
+	proof_stmt ::= "define" identifier "=" term
+
+
+define id_list<T> : fn List<T> -> List<T> = λxs { xs }
+              ^
+
+./test/should-error/define_with_type_params.pf:4.15-4.16: `define` does not take type parameters.
+For a generic value, use:
+	fun id_list<T>(...) { ... }
+or
+	recursive id_list<T>(...) -> ... { ... }


### PR DESCRIPTION
## Summary
- When a user writes `define name<T> : ... = ...`, both the RD and LALR parsers now emit a hint that leads with the direct fix — keep `define`, put the type parameters on the type and wrap the body in `generic` — and lists `fun`/`recursive` as alternatives.
- Previously the error blamed the `<` and asked for `=`, which gives a beginner nothing to act on.
- New `test/should-error/define_with_type_params.pf` fixture pins the diagnostic.

Closes #743.

### Before
```
tmp/example.pf:2.15-2.16: expected "=" after name in "define", not
	<
```

### After (recursive descent)
```
tmp/example.pf:2.15-2.16: `define` does not take type parameters.
For a generic value, put the type parameters on the right:
	define id_list : fn <T> ... -> ... = generic T { ... }
or use `fun`/`recursive`:
	fun id_list<T>(...) { ... }
	recursive id_list<T>(...) -> ... { ... }
```

### After (LALR)
```
tmp/example.pf:2.15-2.16: error in parsing, unexpected token: <
(The error may be immediately before this token.)
`define` does not take type parameters. For a generic value, put the type parameters on the right:
	define id_list : fn <T> ... -> ... = generic T { ... }
or use `fun`/`recursive`:
	fun id_list<T>(...) { ... }
	recursive id_list<T>(...) -> ... { ... }
```

## Test plan
- [x] `make static` (ruff + CI's mypy) passes
- [x] `python test-deduce.py` passes (lib + should-validate + should-error + parser equivalence)
- [x] New `should-error` fixture diff-matches the helpful hint

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)
fallback session id: \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)