### PR TITLE
checker_logic: reword auto_simplified_hint (Closes #761)

### DIFF
--- a/checker_logic.py
+++ b/checker_logic.py
@@ -368,8 +368,9 @@ def collect_all(frm: Formula) -> tuple[list[Term], Formula]:
 
 def auto_simplified_hint(new_formula: Formula) -> str:
   if is_true(new_formula):
-    return '\nThe goal has been simplified to `true`, possibly by an `auto` rewrite rule.\n' \
-           'Finish the proof with `.` (which closes any goal of the form `true`).'
+    return '\nThe goal has been simplified to `true`, possibly by an earlier transformation\n' \
+           'in this chain or an `auto` rewrite rule. Drop the remaining transformation(s)\n' \
+           'and end the step with `.`, or replace the whole step with `evaluate`.'
   return ''
 
 

--- a/test/should-error/expand_after_auto_simplify.pf.err
+++ b/test/should-error/expand_after_auto_simplify.pf.err
@@ -1,4 +1,5 @@
 ./test/should-error/expand_after_auto_simplify.pf:8.3-8.13: could not find a place to expand definition of foo in:
 	true
-The goal has been simplified to `true`, possibly by an `auto` rewrite rule.
-Finish the proof with `.` (which closes any goal of the form `true`).
+The goal has been simplified to `true`, possibly by an earlier transformation
+in this chain or an `auto` rewrite rule. Drop the remaining transformation(s)
+and end the step with `.`, or replace the whole step with `evaluate`.

--- a/test/should-error/replace_after_auto_simplify.pf.err
+++ b/test/should-error/replace_after_auto_simplify.pf.err
@@ -5,5 +5,6 @@ in
 	true
 while trying to replace using the below equation, left to right
 	(all x:UInt, y:UInt. toNat(x * y) = toNat(x) * toNat(y))
-The goal has been simplified to `true`, possibly by an `auto` rewrite rule.
-Finish the proof with `.` (which closes any goal of the form `true`).
+The goal has been simplified to `true`, possibly by an earlier transformation
+in this chain or an `auto` rewrite rule. Drop the remaining transformation(s)
+and end the step with `.`, or replace the whole step with `evaluate`.


### PR DESCRIPTION
## Summary

- Reword the hint emitted by [`auto_simplified_hint`](checker_logic.py#L369-L373) so it advises *dropping* the failing transformation instead of *replacing the whole step* with `.`.
- Update the two `.err` fixtures (`expand_after_auto_simplify.pf.err`, `replace_after_auto_simplify.pf.err`) that capture this message.

The old wording, "Finish the proof with `.` (which closes any goal of the form `true`)", reads as "replace the whole step with `.`" — which fails, because at the outer level the goal is still the unsimplified original. The user's report on #761 documents exactly that confusion. The new wording (from the issue):

> The goal has been simplified to `true`, possibly by an earlier transformation
> in this chain or an `auto` rewrite rule. Drop the remaining transformation(s)
> and end the step with `.`, or replace the whole step with `evaluate`.

## Test plan

- [x] `python3.13 -m ruff check .` clean
- [x] `python3.13 -m mypy .` clean (50 source files)
- [x] `python3.13 test-deduce.py --errors` passes (RD parser; both `.err` fixtures match)
- [ ] Full `python3.13 test-deduce.py` run (in flight)
- [ ] CI passes

Closes #761.

---

[Claude session](claude://resume?session=) — bare UUID fallback: ``

🤖 Generated with [Claude Code](https://claude.com/claude-code)