### PR TITLE
Fix no-site-packages mypy noise for LSP/MCP decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,21 +75,21 @@ strict_equality = true
 disallow_subclassing_any = true
 # disallow_untyped_decorators is enabled globally now that the CI
 # workflow installs requirements-lsp.txt (`pygls` and `mcp`). Both
-# ship inline type annotations, so the LSP/MCP decorators no longer
-# resolve to Any in CI. Developers who skip the LSP install will see
-# this flag fire on `lsp/lsp_server.py` / `lsp/mcp_server.py`; install
-# `requirements-lsp.txt` to develop on those modules.
+# ship inline type annotations, so the LSP/MCP decorators resolve to
+# real types in the normal `mypy .` pass. The local `--no-site-packages`
+# pass intentionally hides those packages; the LSP/MCP module override
+# below suppresses only that decorator-boundary noise.
 disallow_untyped_decorators = true
 no_implicit_reexport = true
 exclude = [
     '^test/',
-    '^test-deduce\.py$',
+    '^test-deduce\\.py$',
     '^tmp/',
     '^lark/',
     '^editor/',
     '^live_code_vercel_api/',
     '^autograder_docker/',
-    '^\.claude/',
+    '^\\.claude/',
     '^gh_pages/',
 ]
 
@@ -154,6 +154,14 @@ disallow_untyped_decorators = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 warn_return_any = true
+
+# Keep the no-dependencies mypy pass useful without weakening the rest
+# of strict checking for the LSP/MCP adapters. When `--no-site-packages`
+# hides pygls/mcp, their decorators become Any and otherwise produce a
+# wall of untyped-decorator errors.
+[[tool.mypy.overrides]]
+module = ["lsp.lsp_server", "lsp.mcp_server"]
+disable_error_code = ["untyped-decorator"]
 
 # Submodules of abstract_syntax re-export sibling names through the
 # compatibility facade in abstract_syntax/__init__.py, which conflicts


### PR DESCRIPTION
Closes #764.

## Summary

`make static` runs two mypy passes. The normal `mypy .` pass succeeds because CI and LSP development installs include `pygls` and `mcp`, whose decorators are typed. The second local pass, `mypy . --no-site-packages`, intentionally hides those packages, so `@server.feature(...)` and `@mcp.tool()` resolve to untyped decorators and produce spurious `untyped-decorator` errors.

## Fix

Keep `disallow_untyped_decorators = true` globally and keep the LSP/MCP modules in the strict override list, but add a narrow module override for:

- `lsp.lsp_server`
- `lsp.mcp_server`

The override disables only the `untyped-decorator` error code for those modules. Other strict checks remain active.

## Validation

- Verified the updated `pyproject.toml` parses as valid TOML locally.
- Could not run full `make static` in this workspace because direct GitHub cloning and package installation are blocked by the container network.