### PR TITLE
examples: add take_drop_correct.pf (take(xs,n) ++ drop(xs,n) = xs)

### DIFF
--- a/examples/take_drop_correct.pf
+++ b/examples/take_drop_correct.pf
@@ -1,0 +1,47 @@
+// take_drop_correct.pf
+//
+// An introductory-functional-programming example. The list functions
+// `take(xs, n)` and `drop(xs, n)` from the standard library split a
+// list into its first `n` elements and everything after them:
+//
+//   take([10,20,30,40], 2) = [10,20]
+//   drop([10,20,30,40], 2) = [30,40]
+//
+// A natural correctness property is that the two pieces really do
+// partition the list: appending `drop` onto the end of `take`
+// reconstructs the original list, no matter how many elements we asked
+// to take.
+//
+//   take_drop_append:  take(xs, n) ++ drop(xs, n) = xs
+//
+// The proof is by induction on the list, with a case split on whether
+// `n` is zero (using `uint_zero_or_add_one`).
+
+// A couple of quick tests of the definitions.
+assert take([10,20,30,40], 2) = [10,20]
+assert drop([10,20,30,40], 2) = [30,40]
+
+theorem take_drop_append: all T:type, xs:List<T>, n:UInt.
+  take(xs, n) ++ drop(xs, n) = xs
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary n:UInt
+    expand take | drop | operator++.
+  }
+  case node(x, xs') assume IH: all n:UInt. take(xs', n) ++ drop(xs', n) = xs' {
+    arbitrary n:UInt
+    cases uint_zero_or_add_one[n]
+    case nz {
+      replace nz
+      expand take | drop | operator++.
+    }
+    case n1 {
+      obtain n' where n_sn from n1
+      replace n_sn
+      expand take | drop | operator++
+      replace IH[n'].
+    }
+  }
+end


### PR DESCRIPTION
## What

Adds `examples/take_drop_correct.pf`, a new worked example proving a classic
introductory-functional-programming correctness property:

```
take_drop_append:  take(xs, n) ++ drop(xs, n) = xs
```

The stdlib `take`/`drop` functions split a list into its first `n` elements and
the rest; this theorem shows the two pieces really do partition the list —
appending `drop` onto `take` reconstructs the original, for any count `n`.

The proof goes by induction on the list, with a zero/successor case split on
the count using `uint_zero_or_add_one`. It mirrors the style of the existing
`examples/sum_correct.pf` (header comment, `assert` sanity checks, `induction`
+ `expand`/`replace`).

## Testing

- `python3 deduce.py examples/take_drop_correct.pf` → valid
- Both parsers pass: `--recursive-descent` and `--lalr` over `examples/`.

## Notes — friction found while writing this (filed separately)

Writing this proof as a "new user" surfaced three issues, filed independently
(this PR does not fix them):

- #774 — `switch` on a `UInt` rejects the public zero/successor view and forces
  the private binary constructors; the smooth path (`uint_zero_or_add_one`) is
  undocumented.
- #775 — install docs use `python`, but many systems only ship `python3`.
- #776 — the `switch` arity error doesn't name the expected constructors.

[Claude session](claude://resume?session=609928a2-5aed-45a0-ab4d-716a51f52a45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
