### PR TITLE
docs: use python3 in install/run examples (Closes #775)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Deduce needs Python 3.10+ and the [Lark](https://github.com/lark-parser/lark)
 parsing library. From a fresh clone:
 
 ```sh
-python -m pip install lark
-python deduce.py example.pf
+python3 -m pip install lark
+python3 deduce.py example.pf
 ```
+
+(Use `python` if your system aliases that to Python 3; recent macOS and
+some Linux distros ship only `python3`. On Windows the bundled launcher
+is `py`.)
 
 You should see:
 

--- a/gh_pages/doc/Compiler.md
+++ b/gh_pages/doc/Compiler.md
@@ -3,7 +3,7 @@
 Deduce ships with an experimental compiler that turns the executable
 fragment of a checked `.pf` file into a self-contained C program. Once
 compiled, the binary runs without Python and produces the same output
-as `python deduce.py file.pf` does.
+as `python3 deduce.py file.pf` does.
 
 This page walks through how to use it.
 

--- a/gh_pages/doc/Debugger.md
+++ b/gh_pages/doc/Debugger.md
@@ -14,7 +14,7 @@ derivations, not a stepwise execution).  It steps through *terms*.
 Pass `--debug` to the CLI:
 
 ```sh
-python deduce.py --debug your_file.pf
+python3 deduce.py --debug your_file.pf
 ```
 
 The proof checker runs as usual.  When it reaches the first
@@ -167,7 +167,7 @@ print count_down(suc(suc(zero)))
 Launch the debugger:
 
 ```sh
-python deduce.py --debug count.pf
+python3 deduce.py --debug count.pf
 ```
 
 A typical session:

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -23,19 +23,23 @@ You will need [Python](https://www.python.org/) version 3.10 or later. Here are 
 You will also need the [Lark](https://github.com/lark-parser/lark) parsing library, which you can install by running the following command in the same directory as `deduce.py`
 
 ```
-python -m pip install lark
+python3 -m pip install lark
 ```
+
+On systems whose default Python 3 is just `python`, drop the `3`. Recent
+macOS and several Linux distros ship only `python3` on `PATH`; Windows
+users can also use the bundled `py` launcher.
 
 ### Install Deduce
 
 You can find the stable releases of Deduce on
 [github](https://github.com/jsiek/deduce/releases). Download the zip
 file and unpack it. To check that Deduce is working, go into the top
-`deduce` directory, and run `python` on the `deduce.py` script and the
+`deduce` directory, and run `python3` on the `deduce.py` script and the
 provided example file.  (There is no executable for Deduce.)
 
 ```
-python ./deduce.py ./example.pf
+python3 ./deduce.py ./example.pf
 ```
 
 You should see the following response from Deduce.
@@ -215,7 +219,7 @@ directory, or use the run functionality provided by your deduce
 editor.
 
 ```
-python deduce.py hello.pf
+python3 deduce.py hello.pf
 ```
 
 You should see the output


### PR DESCRIPTION
## Summary

- Replace bare \`python\` with \`python3\` in user-facing install and run examples (README, GettingStarted, Debugger, Compiler).
- Add a one-line note in the README quick start and the GettingStarted prerequisites about systems where \`python\` is the alias for Python 3 and Windows's \`py\` launcher.
- Internal planning docs under \`docs/\` are left alone — those aren't on the new-user path.

Recent macOS and several Linux distros ship only \`python3\` on \`PATH\`. With the old wording, the very first command in the README (\`python -m pip install lark\`) failed with \`command not found\` before a new user ever invoked Deduce.

Closes #775.

## Test plan
- [x] \`grep\` confirms no bare \`python deduce.py\` / \`python ./deduce.py\` / \`python -m pip\` left in user-facing docs (\`README.md\`, \`gh_pages/doc/*.md\`).
- [ ] Reviewer eyeballs the rendered Quick start + GettingStarted Install sections.

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)
\`$CLAUDE_CODE_SESSION_ID\`