### PR TITLE
docs: use `python3` in install/run commands (Closes #775)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Deduce needs Python 3.10+ and the [Lark](https://github.com/lark-parser/lark)
 parsing library. From a fresh clone:
 
 ```sh
-python -m pip install lark
-python deduce.py example.pf
+python3 -m pip install lark
+python3 deduce.py example.pf
 ```
 
 You should see:

--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -14,7 +14,7 @@ Three layers, each independently usable:
 - **`deduce-fill-hole`** *(optional)* — ask an LLM to fill the hole at
   point. Validated proofs only; the LLM's output is checked before
   it is spliced into your buffer.
-- **`deduce-dap`** *(optional)* — drive the `python deduce.py --debug`
+- **`deduce-dap`** *(optional)* — drive the `python3 deduce.py --debug`
   command-line debugger through `dap-mode`, so gutter breakpoints,
   the call-stack pane, and the locals view all work directly from
   your `.pf` buffer.
@@ -256,7 +256,7 @@ auto-start hook:
   (`*dap-ui-locals*`), program-output pane (`*Deduce :: launch
   current file out*` — `print` results land here), and the
   Debug Console.  The very first pause lands at your file's
-  first user-level statement, mirroring `python deduce.py
+  first user-level statement, mirroring `python3 deduce.py
   --debug`.
 - **Stepping with F-keys.**  `F5` continues, `F10` steps over,
   `F11` steps in, `S-F11` steps out, `S-F5` disconnects.
@@ -747,7 +747,7 @@ also verify the debugger integration:
     expressions) for you automatically (see
     `deduce-dap-auto-ui`).  The source buffer should highlight
     a line at the first user-level statement (matching where
-    `python deduce.py --debug` would initially trap).
+    `python3 deduce.py --debug` would initially trap).
 
 16. The Locals tree starts collapsed — `RET` (or click the
     triangle next to `Locals`) to expand.  Inside a function

--- a/gh_pages/doc/Compiler.md
+++ b/gh_pages/doc/Compiler.md
@@ -3,7 +3,7 @@
 Deduce ships with an experimental compiler that turns the executable
 fragment of a checked `.pf` file into a self-contained C program. Once
 compiled, the binary runs without Python and produces the same output
-as `python deduce.py file.pf` does.
+as `python3 deduce.py file.pf` does.
 
 This page walks through how to use it.
 

--- a/gh_pages/doc/Debugger.md
+++ b/gh_pages/doc/Debugger.md
@@ -14,7 +14,7 @@ derivations, not a stepwise execution).  It steps through *terms*.
 Pass `--debug` to the CLI:
 
 ```sh
-python deduce.py --debug your_file.pf
+python3 deduce.py --debug your_file.pf
 ```
 
 The proof checker runs as usual.  When it reaches the first
@@ -167,7 +167,7 @@ print count_down(suc(suc(zero)))
 Launch the debugger:
 
 ```sh
-python deduce.py --debug count.pf
+python3 deduce.py --debug count.pf
 ```
 
 A typical session:
@@ -238,7 +238,7 @@ repository:
   [`editor/vscode/README.md`](../../editor/vscode/README.md) for the
   full instructions.
 
-Both packages launch `python -m lsp.dap_server` as the adapter and
+Both packages launch `python3 -m lsp.dap_server` as the adapter and
 expose the same UI surface as gdb-style debug clients: gutter
 breakpoints, a call-stack panel, a locals view, an evaluate-in-REPL
 console, and Step Over / Step Into / Step Out / Continue.  The

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -23,19 +23,24 @@ You will need [Python](https://www.python.org/) version 3.10 or later. Here are 
 You will also need the [Lark](https://github.com/lark-parser/lark) parsing library, which you can install by running the following command in the same directory as `deduce.py`
 
 ```
-python -m pip install lark
+python3 -m pip install lark
 ```
+
+> **Note.** Some systems (recent macOS, several Linux distros, the
+> official python.org framework build) ship only `python3` on `PATH`,
+> with no bare `python` command. Use `python3` if `python` is not
+> found.
 
 ### Install Deduce
 
 You can find the stable releases of Deduce on
 [github](https://github.com/jsiek/deduce/releases). Download the zip
 file and unpack it. To check that Deduce is working, go into the top
-`deduce` directory, and run `python` on the `deduce.py` script and the
+`deduce` directory, and run `python3` on the `deduce.py` script and the
 provided example file.  (There is no executable for Deduce.)
 
 ```
-python ./deduce.py ./example.pf
+python3 ./deduce.py ./example.pf
 ```
 
 You should see the following response from Deduce.
@@ -215,7 +220,7 @@ directory, or use the run functionality provided by your deduce
 editor.
 
 ```
-python deduce.py hello.pf
+python3 deduce.py hello.pf
 ```
 
 You should see the output


### PR DESCRIPTION
## Summary

Replaces bare `python` invocations with `python3` in user-facing
install/run docs, so the literal first command a new user copy-pastes
doesn't fail with `command not found` on systems that ship only
`python3` (recent macOS, several Linux distros, the python.org
framework build).

- [README.md](README.md) — Quick start.
- [gh_pages/doc/GettingStarted.md](gh_pages/doc/GettingStarted.md) —
  Install Prerequisites, Install Deduce, Running Deduce Programs.
  Also adds a short note up front explaining the convention.
- [gh_pages/doc/Debugger.md](gh_pages/doc/Debugger.md) — CLI starting
  session, a walkthrough block, and the DAP-adapter command.
- [gh_pages/doc/Compiler.md](gh_pages/doc/Compiler.md) — the
  reference to `python deduce.py` in the intro paragraph.
- [editor/emacs/README.md](editor/emacs/README.md) — references to
  `python deduce.py --debug` in the `deduce-dap` description, the
  initial-pause prose, and the smoke-test walkthrough.

Internal docs (`docs/`, `CLAUDE.md`) and `editor/emacs/README.md`'s
single mention of "the python interpreter" (generic prose, not a
command) are left as-is.

Closes #775.

## Test plan

- [x] Diff is docs-only.
- [x] `gh_pages/scripts/convert.py` only extracts `.deduce` code
  blocks for `--site`, so the touched `sh`/plain-text snippets don't
  flow through the test harness.
- [x] No code paths or tests reference these strings.

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)

\`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)