### PR TITLE
Hint `evaluate`/`expand` when `.` closes a closed ground goal (Closes #772)

### DIFF
--- a/checker_logic.py
+++ b/checker_logic.py
@@ -22,6 +22,7 @@ from abstract_syntax import (
     Call,
     Env,
     Formula,
+    GenRecFun,
     IfThen,
     Lambda,
     MarkException,
@@ -29,18 +30,23 @@ from abstract_syntax import (
     OverloadedVar,
     Pattern,
     PatternCons,
+    RecFun,
     ResolvedVar,
     Switch,
     SwitchCase,
+    TermBinding,
     TLet,
     Term,
     VarRef,
+    ViewRecFun,
     base_name,
     count_marks,
     find_mark,
     formula_match,
     formulas_equal_modulo_numeric_literals,
+    get_dont_reduce_opaque,
     get_num_rewrites,
+    get_reduce_all,
     get_reduced_defs,
     is_equation,
     is_true,
@@ -49,6 +55,8 @@ from abstract_syntax import (
     reset_num_rewrites,
     reset_reduced_defs,
     rewrite_aux,
+    set_dont_reduce_opaque,
+    set_reduce_all,
     split_equation,
 )
 from checker_common import *
@@ -482,6 +490,89 @@ def expand_residual_hint(residual: Any, defs: Any, env: Env) -> str:
   listed = ', '.join('`' + n + '`' for n in still_present)
   return ('\nThe goal still contains ' + listed + '. ' \
           'Chain another expand with `|` (e.g. `expand f | f.`) or use `N*f` to unfold further.')
+
+
+def _collect_unfoldable_recfun_names(formula: Any, env: Any) -> list[str]:
+  # Walk `formula`; return display names of any `VarRef` whose binding is
+  # a non-opaque recursive function (`recursive`, `generic recursive`,
+  # `view recursive`). Used to name concrete `expand` targets in the
+  # closed-goal hint below; we deliberately skip `define`/operator
+  # bindings here -- `expand` accepts them, but the dominant beginner
+  # trip-up is forgetting to unfold a `recursive` definition, and naming
+  # only those keeps the hint focused.
+  names: list[str] = []
+  seen_ids: set[int] = set()
+  seen_names: set[str] = set()
+  stack: list[Any] = [formula]
+  while stack:
+    n = stack.pop()
+    nid = id(n)
+    if nid in seen_ids:
+      continue
+    seen_ids.add(nid)
+    if isinstance(n, VarRef):
+      if isinstance(n, OverloadedVar):
+        candidates = list(n.resolved_names)
+      else:
+        candidates = [n.get_name()]
+      for nm in candidates:
+        if nm not in env.dict:
+          continue
+        binding = env.dict[nm]
+        if not isinstance(binding, TermBinding):
+          continue
+        if not isinstance(binding.defn, (RecFun, GenRecFun, ViewRecFun)):
+          continue
+        if binding.visibility == 'opaque' \
+           and binding.module != env.get_current_module():
+          continue
+        display = base_name(nm)
+        if display in seen_names:
+          continue
+        seen_names.add(display)
+        names.append(display)
+    if hasattr(n, '__dict__'):
+      for v in vars(n).values():
+        if isinstance(v, (list, tuple)):
+          stack.extend(v)
+        elif isinstance(v, dict):
+          stack.extend(v.values())
+        elif v is not None and not isinstance(v, (str, int, float, bool)):
+          stack.append(v)
+  return names
+
+
+def ground_goal_evaluate_hint(form_red: Any, formula_red: Any, env: Any) -> str:
+  # Fires when the user supplies `.` (proof of `true`) for a non-`true`
+  # goal and that goal would actually evaluate to `true` once recursive
+  # definitions are unfolded. Points the beginner at `evaluate` (and
+  # names the unfoldable recursive functions, if any, for `expand`) so
+  # the bare "proof of true vs. <complex goal>" error isn't a dead end.
+  if not is_true(form_red):
+    return ''
+  if is_true(formula_red):
+    return ''
+  prev_reduce_all = get_reduce_all()
+  prev_dont_reduce_opaque = get_dont_reduce_opaque()
+  set_reduce_all(True)
+  set_dont_reduce_opaque(True)
+  try:
+    fully_reduced = formula_red.reduce(env)
+  except Exception:
+    return ''
+  finally:
+    set_reduce_all(prev_reduce_all)
+    set_dont_reduce_opaque(prev_dont_reduce_opaque)
+  if not is_true(fully_reduced):
+    return ''
+  fns = _collect_unfoldable_recfun_names(formula_red, env)
+  base = '\nThe goal is a closed term but is not yet reduced. Try `evaluate`'
+  if not fns:
+    return base + '.'
+  if len(fns) == 1:
+    return base + ', or `expand ' + fns[0] + '` to unfold the definition.'
+  return base + ', or `expand ' + ' | '.join(fns) \
+              + '` to unfold the definitions.'
 
 
 def expand_backward_mark_hint(formula: Any, var: Any, env: Any) -> str:

--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -36,8 +36,8 @@ from abstract_syntax import (
 from checker_common import *
 from checker_logic import (
     apply_rewrites, check_implies, collect_all_if_then,
-    expand_definitions, expand_residual_hint, instantiate,
-    isolate_difference, pattern_to_term, rewrite,
+    expand_definitions, expand_residual_hint, ground_goal_evaluate_hint,
+    instantiate, isolate_difference, pattern_to_term, rewrite,
 )
 from checker_types import (
     check_formula, check_pattern, check_type, type_check_term,
@@ -1646,12 +1646,14 @@ def _check_synthesized_proof_against_goal(proof: Any, formula: Any, env: Env) ->
   except UserError as e:
     # It could be that form is never reduced, such as in a PHelpUse.
     # In that case, we don't give 'replace' advice.
-    replace_advice = ''
+    extra_advice = ''
     try:
       if is_equation(form_red):
-        replace_advice = '\nDid you mean `replace ' + str(proof) + '`?'
+        extra_advice = '\nDid you mean `replace ' + str(proof) + '`?'
+      else:
+        extra_advice = ground_goal_evaluate_hint(form_red, formula_red, env)
     finally:
-      raise wrap_user_error(e, replace_advice) from e
+      raise wrap_user_error(e, extra_advice) from e
 
 def _check_proof_of_goal_agnostic(proof: Any, formula: Any, env: Env) -> None:
   return _check_synthesized_proof_against_goal(proof, formula, env)

--- a/test/should-error/advice_evaluate_ground.pf
+++ b/test/should-error/advice_evaluate_ground.pf
@@ -1,0 +1,26 @@
+// Issue #772: when the user closes a goal with `.` but the goal is a
+// closed ground term that needs to be reduced (e.g. an induction base
+// case before `evaluate`/`expand`), suggest `evaluate` instead of
+// failing with no advice.
+
+union Tree<T> {
+  empty_tree
+  tree_node(Tree<T>, T, Tree<T>)
+}
+
+recursive mirror<T>(Tree<T>) -> Tree<T> {
+  mirror(empty_tree) = empty_tree
+  mirror(tree_node(l, x, r)) = tree_node(mirror(r), x, mirror(l))
+}
+
+theorem tree_mirror_involutive: all T:type. all t:Tree<T>. mirror(mirror(t)) = t
+proof
+  arbitrary T:type
+  induction Tree<T>
+  case empty_tree {
+    .
+  }
+  case tree_node(l, x, r) assume IH_l: mirror(mirror(l)) = l, IH_r: mirror(mirror(r)) = r {
+    expand mirror replace IH_l | IH_r.
+  }
+end

--- a/test/should-error/advice_evaluate_ground.pf.err
+++ b/test/should-error/advice_evaluate_ground.pf.err
@@ -1,0 +1,6 @@
+test/should-error/advice_evaluate_ground.pf:21.5-21.6: 
+You provided a proof of:
+	true
+but that is different from what you need to prove:
+	mirror(mirror(@empty_tree<T>)) = @empty_tree<T>
+The goal is a closed term but is not yet reduced. Try `evaluate`, or `expand mirror` to unfold the definition.

--- a/test/should-error/advice_evaluate_ground.pf.err
+++ b/test/should-error/advice_evaluate_ground.pf.err
@@ -1,4 +1,4 @@
-test/should-error/advice_evaluate_ground.pf:21.5-21.6: 
+./test/should-error/advice_evaluate_ground.pf:21.5-21.6: 
 You provided a proof of:
 	true
 but that is different from what you need to prove:


### PR DESCRIPTION
## Summary

Closes #772.

When the user supplies `.` (proof of `true`) for a non-`true` goal that
would actually reduce to `true` under `evaluate`, append a hint pointing
at `evaluate` (and name the recursive functions in the goal as concrete
`expand` targets). The bare "proof of true vs. <complex goal>" message
previously left newcomers with no breadcrumb in a very common base-case
trap.

The detection mimics the `evaluate` tactic itself: temporarily set
`reduce_all=True` and `dont_reduce_opaque=True`, run `formula.reduce(env)`,
and check whether the result is `true`. This is a strict guarantee — if
the hint fires, `evaluate` is guaranteed to discharge the goal.

### Before
```
You provided a proof of:
        true
but that is different from what you need to prove:
        mirror(mirror(@empty_tree<T>)) = @empty_tree<T>
```

### After
```
You provided a proof of:
        true
but that is different from what you need to prove:
        mirror(mirror(@empty_tree<T>)) = @empty_tree<T>
The goal is a closed term but is not yet reduced. Try `evaluate`, or `expand mirror` to unfold the definition.
```

### Implementation
- `ground_goal_evaluate_hint(form_red, formula_red, env)` in
  [checker_logic.py](checker_logic.py) — returns `''` unless `form_red`
  is `true`, `formula_red` is not `true`, and a full `reduce_all` pass
  on `formula_red` produces `true`.
- Wired into `_check_synthesized_proof_against_goal` in
  [checker_proofs.py](checker_proofs.py) alongside the existing
  `replace` advice path (mutually exclusive with that one).
- `_collect_unfoldable_recfun_names` walks the goal AST and collects the
  display names of `RecFun`/`GenRecFun`/`ViewRecFun` bindings to name in
  the suggested `expand` form. Only recursive functions are listed (not
  every `define`) — beginners hit this trap on `recursive`, and the
  short list keeps the hint focused.

## Test plan

- [x] Reproduce the original error from #772 → new hint appears.
- [x] Hint does NOT fire when `evaluate` wouldn't help (e.g. inductive
      step `myapp(xs, mynil) = xs` where `xs` is a free variable).
- [x] `python3.13 -m ruff check .` clean
- [x] `python3.13 -m mypy .` clean
- [x] New `test/should-error/advice_evaluate_ground.pf` fixture +
      `.pf.err` checked in.
- [ ] `make tests` (running)
- [ ] CI green (pushed)

[Claude session](claude://resume?session=5089fe61-6871-4c81-a94f-319bac39bba9) — fallback UUID: `5089fe61-6871-4c81-a94f-319bac39bba9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)