### PR TITLE
CI: add examples matrix entry (RD only) (Closes #782)

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -71,6 +71,9 @@ jobs:
           - name: equiv
             args: --equiv
             requirements: core
+          - name: examples
+            args: --examples
+            requirements: core
 
     steps:
       - name: Checkout repo content

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -31,6 +31,10 @@ Standalone modes (mutually exclusive with the above):
                        These stay RD-only because RD diagnostics are the
                        user-facing diagnostics; LALR is checked for accepted
                        syntax and AST shape by ``--equiv`` instead.
+    --examples         ``examples/`` worked-example proofs (RD only).
+                       LALR/RD parity is already covered by ``--equiv`` for
+                       ``lib/`` + ``should-validate/``; here we just need to
+                       catch regressions in the examples themselves.
     --regenerate-errors      Regenerate every ``test/should-error/*.err``.
     --generate-error <path>  Regenerate one ``.err`` fixture.
     --gen-parse              Regenerate every ``test/parse/*.err``.
@@ -109,6 +113,7 @@ ERROR_DIR = Path("test/should-error")
 PRELUDE_DIR = Path("test/prelude")
 IMPORTS_DIR = Path("test/test-imports")
 PARSE_DIR = Path("test/parse")
+EXAMPLES_DIR = Path("examples")
 EXAMPLE_FILE = Path("example.pf")
 
 
@@ -519,6 +524,23 @@ def run_cli_test() -> list[tuple[str, str, str]]:
     return failures
 
 
+def run_examples_parallel(workers: int) -> list[tuple[str, str, str]]:
+    """``examples/*.pf`` × RD parser only.
+
+    Examples are end-user-facing proofs that rely on the auto-prelude
+    (``import UInt`` etc. is not written out); use the prelude-injection
+    worker so the stdlib is implicitly available, the same way
+    ``deduce.py`` runs them.
+    """
+    files = list_pf(EXAMPLES_DIR)
+    tasks = [(f, True) for f in files]
+    failures: list[tuple[str, str, str]] = []
+    for f, ok, label, msg in _map_or_serial(workers, _worker_prelude, tasks, 4):
+        if not ok:
+            failures.append((f, label, msg))
+    return failures
+
+
 def run_site(workers: int) -> list[tuple[str, str, str]]:
     """Generate ``doc_*.pf`` from ``gh_pages/doc/`` and check them."""
     from gh_pages.scripts.convert import convert_dir
@@ -587,11 +609,12 @@ def parse_args(argv: list[str]) -> dict:
     arguments still in scripts / muscle memory."""
     flags: dict[str, Any] = {
         "cli": False, "lib": False, "passable": False, "errors": False,
-        "equiv": False, "site": False, "parser": False,
+        "equiv": False, "site": False, "parser": False, "examples": False,
         "regen_all": False, "regen_files": [], "gen_parse": False,
         "workers": max(1, (os.cpu_count() or 4)),
     }
-    standalone = {"site", "parser", "regen_all", "regen_files", "gen_parse"}
+    standalone = {"site", "parser", "examples",
+                  "regen_all", "regen_files", "gen_parse"}
     i = 0
     while i < len(argv):
         a = argv[i]
@@ -602,6 +625,7 @@ def parse_args(argv: list[str]) -> dict:
         elif a == "--equiv": flags["equiv"] = True
         elif a == "--site": flags["site"] = True
         elif a == "--parser": flags["parser"] = True
+        elif a == "--examples": flags["examples"] = True
         elif a == "--regenerate-errors": flags["regen_all"] = True
         elif a == "--generate-error":
             flags["regen_files"].append(argv[i + 1])
@@ -619,7 +643,7 @@ def parse_args(argv: list[str]) -> dict:
     # If no flags at all, default to the per-PR regression sweep.
     if not any(flags[k] for k in
                ("cli", "lib", "passable", "errors", "site", "parser",
-                "equiv", "regen_all", "gen_parse")) and not flags["regen_files"]:
+                "examples", "equiv", "regen_all", "gen_parse")) and not flags["regen_files"]:
         flags["cli"] = flags["lib"] = flags["passable"] = True
         flags["errors"] = flags["equiv"] = True
 
@@ -685,6 +709,13 @@ def main(argv: list[str]) -> int:
         _, fails = time_section("test/parse",
                                 lambda: run_err_diff_parallel(
                                     PARSE_DIR, "parser", workers))
+        total_failures.extend(fails)
+        return _report(total_failures, total_t0)
+    if flags["examples"]:
+        print(f"=== --examples: {EXAMPLES_DIR} (RD only, parallel) ===")
+        bootstrap_prelude(lib_modules)
+        _, fails = time_section("examples",
+                                lambda: run_examples_parallel(workers))
         total_failures.extend(fails)
         return _report(total_failures, total_t0)
 


### PR DESCRIPTION
## Summary

- Add a new `--examples` standalone category to `test-deduce.py` that walks every `.pf` under `examples/` with the recursive-descent parser, using the prelude-injection worker (examples rely on the auto-prelude, like `test/prelude` does).
- Add a corresponding `examples` matrix entry to `.github/workflows/test_deduce.yml`'s regression job (`args: --examples`, `requirements: core`) — option 1 from the issue.
- RD only: LALR/RD parity is already covered for `lib/` and `should-validate/` by `--equiv`.

Local sanity:

```
$ python3.13 test-deduce.py --examples
=== --examples: examples (RD only, parallel) ===
  examples                            5.80s
Total wall time: 9.39s
All tests passed.
```

Combining with another category or another standalone errors out as expected (`--examples is standalone; cannot combine with --lib`; `these flags are mutually exclusive: --examples, --site`). Default `python test-deduce.py` sweep is unchanged (still `cli + lib + passable + errors + equiv`).

## Test plan

- [x] `python3.13 test-deduce.py --examples` passes locally (all 10 example files validate under RD).
- [x] `ruff check test-deduce.py` and `mypy test-deduce.py` clean.
- [x] YAML is valid; new matrix entry parses with `yaml.safe_load`.
- [x] Existing standalone-exclusivity messaging still works.
- [ ] CI green on the new `regression (examples)` job.

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)
Fallback (paste into `claude --resume`): \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)