### PR TITLE
goal printer: parenthesize `=` inside `and`/`or` (Refs #786)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -952,6 +952,27 @@ def op_arg_str(trm: Term, arg: Term) -> str:
   return str(arg)
 
 
+def _connective_arg_str(connective: str, arg: 'str | Formula') -> str:
+  # `connective` is 'and' or 'or'; `arg` is either a pre-rendered string
+  # (e.g. the synthetic `(P ⇔ Q)` produced by the iff-pair detection
+  # in `And.__str__`) or a Formula.
+  #
+  # An infix-operator Call -- e.g. `Call(=, [a, b])` -- renders as
+  # `a = b` with no outer parens, so embedding it inside an `and`/`or`
+  # would yield `(a = b and c)`, which a reader will misparse as
+  # `a = (b and c)` even though the grammar disambiguated it the other
+  # way. Wrap such a Call when its operator binds looser than the
+  # connective itself, so the goal printer never hides this trap.
+  if isinstance(arg, str):
+    return arg
+  conn_prec = infix_precedence.get(connective)
+  if isinstance(arg, Call) and conn_prec is not None:
+    arg_prec = precedence(arg)
+    if arg_prec is not None and arg_prec < conn_prec:
+      return '(' + str(arg) + ')'
+  return str(arg)
+
+
 
 def do_function_call(loc: Meta, name: str, type_params: list[str],
                      type_args: list[Type], params: list[str],
@@ -1688,7 +1709,8 @@ class And(Formula):
     if len(ret_args) == 1:
       return str(ret_args[0])
 
-    return '(' + ' and '.join([str(arg) for arg in ret_args]) + ')'
+    return '(' + ' and '.join([_connective_arg_str('and', arg)
+                               for arg in ret_args]) + ')'
 
   def __eq__(self, other: object) -> bool:
     if not isinstance(other, And):
@@ -1734,7 +1756,8 @@ class Or(Formula):
   args: list[Formula]
 
   def __str__(self) -> str:
-    return '(' + ' or '.join([str(arg) for arg in self.args]) + ')'
+    return '(' + ' or '.join([_connective_arg_str('or', arg)
+                              for arg in self.args]) + ')'
   
   def __eq__(self, other: object) -> bool:
     if not isinstance(other, Or):

--- a/test/should-error/advice_and_eq_disambig.pf
+++ b/test/should-error/advice_and_eq_disambig.pf
@@ -1,0 +1,9 @@
+// Goal printer must wrap `=` inside `and` in parens so the structure is
+// unambiguous to readers (issue #786). Without the disambiguating parens,
+// the goal renders as `(a = b and c)`, which reads as `a = (b and c)`
+// even though the grammar parses it the other way.
+theorem t: all a:bool, b:bool, c:bool. a = b and c
+proof
+  arbitrary a:bool, b:bool, c:bool
+  ?
+end

--- a/test/should-error/advice_and_eq_disambig.pf.err
+++ b/test/should-error/advice_and_eq_disambig.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/advice_and_eq_disambig.pf:8.3-8.4: incomplete proof
+Goal:
+	((a = b) and c)
+Advice:
+	Prove this logical-and formula by proving each of its parts,
+	shown below, then combine the proofs with commas.
+		a = b
+		c

--- a/test/should-error/advice_or_eq_disambig.pf
+++ b/test/should-error/advice_or_eq_disambig.pf
@@ -1,0 +1,7 @@
+// Goal printer must wrap `=` inside `or` in parens for the same reason
+// as `and` (issue #786).
+theorem t: all a:bool, b:bool, c:bool. a = b or c
+proof
+  arbitrary a:bool, b:bool, c:bool
+  ?
+end

--- a/test/should-error/advice_or_eq_disambig.pf.err
+++ b/test/should-error/advice_or_eq_disambig.pf.err
@@ -1,0 +1,7 @@
+./test/should-error/advice_or_eq_disambig.pf:6.3-6.4: incomplete proof
+Goal:
+	((a = b) or c)
+Advice:
+	Prove this logical-or formula by proving one of its parts:
+		a = b
+		c


### PR DESCRIPTION
## Summary

- When an equality or comparison `Call` appears as a direct operand of an `and`/`or` connective, wrap it in extra parens so the rendered goal is unambiguous.
- Previously `((a = b) and c)` printed as `(a = b and c)`, which a reader naturally misparses as `a = (b and c)`. The grammar already disambiguated it the other way; the goal printer was hiding that.
- Other formulas (`IfThen`, nested `And`/`Or`) already self-wrap with their own parens, so the fix only adds parens around an infix-operator `Call` whose precedence is below the connective's.

Refs #786.

## Test plan

- [x] Added `test/should-error/advice_and_eq_disambig.pf` and `advice_or_eq_disambig.pf` fixtures (with `.err` files) that lock in the new disambiguated output.
- [x] `make static` (the CI-tracked `mypy .` and `ruff` pass).
- [x] `python test-deduce.py --errors` passes.
- [ ] Comprehensive `python test-deduce.py` run on both parsers — running on CI.

[Claude session](claude://resume?session=fbfb80df-d3f4-4e31-82ee-11f28d6bcd7f) — fallback session id: `fbfb80df-d3f4-4e31-82ee-11f28d6bcd7f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)