### PR TITLE
lib/Nat: add per-declaration comments (Refs #99)

### DIFF
--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -25,6 +25,8 @@ public import NatSum
 /*
  Properties of equal
 */
+
+// The boolean-valued `equal` is reflexive.
 theorem equal_refl: all n:Nat. equal(n,n)
 proof
   induction Nat
@@ -37,6 +39,7 @@ proof
   }
 end
 
+// Propositional equality on Nat is equivalent to its boolean `equal`.
 theorem equal_complete_sound : all m:Nat. all n:Nat.
   m = n ⇔ equal(m, n)
 proof
@@ -70,6 +73,7 @@ proof
   }
 end
 
+// Boolean inequality implies propositional inequality.
 theorem not_equal_not_eq: all m:Nat, n:Nat.
   if not equal(m, n) then not (m = n)
 proof
@@ -87,6 +91,8 @@ end
   Greatest Common Divisor
 */
 
+// Euclidean gcd: recurses on `a % b` until the second argument is zero,
+// at which point the first argument is the gcd.
 recfun gcd(a : Nat, b : Nat) -> Nat
   measure b of Nat
 {
@@ -100,6 +106,7 @@ terminates {
   conclude a % b < b by apply mod_less_divisor[a,b] to b_pos
 }
 
+// `gcd(a,b)` is a common divisor of `a` and `b`.
 theorem gcd_divides: all b:Nat, a:Nat. divides(gcd(a,b), a) and divides(gcd(a,b), b)
 proof
   define P = fun b':Nat {all a:Nat. divides(gcd(a,b'), a) and divides(gcd(a,b'), b')}
@@ -154,6 +161,7 @@ end
   Support for automatic arithmetic on literals.
 */
 
+// Truncated subtraction from literal zero is zero.
 theorem nat_zero_monus: all m:Nat.
   lit(zero) ∸ lit(m) = lit(zero)
 proof
@@ -161,6 +169,7 @@ proof
   expand lit | operator∸.
 end
 
+// Subtracting literal zero leaves the operand unchanged.
 theorem nat_monus_zero: all n:Nat.
   n ∸ lit(zero) = n
 proof
@@ -171,6 +180,7 @@ end
 
 auto nat_monus_zero
 
+// Successor cancels on both sides of truncated subtraction.
 theorem lit_suc_monus_suc: all n:Nat, m:Nat.
   lit(suc(n)) ∸ lit(suc(m)) = lit(n) ∸ lit(m)
 proof
@@ -180,6 +190,7 @@ end
 
 auto lit_suc_monus_suc
 
+// Multiplication by a literal distributes over a sum on the right.
 theorem lit_dist_mult_add:
   all a:Nat, x:Nat, y:Nat.
   lit(a) * (x + y) = lit(a) * x + lit(a) * y
@@ -191,6 +202,7 @@ end
 
 auto lit_dist_mult_add
 
+// Multiplication by a literal distributes over a sum on the left.
 theorem lit_dist_mult_add_right:
   all x:Nat, y:Nat, a:Nat.
   (x + y) * lit(a) = x * lit(a) + y * lit(a)
@@ -202,6 +214,7 @@ end
 
 auto lit_dist_mult_add_right
 
+// Doubling expressed as multiplication by literal two.
 theorem mult_two: all n:Nat.
   n + n = lit(suc(suc(zero))) * n
 proof
@@ -210,6 +223,7 @@ proof
   replace two_mult.
 end
 
+// Pull `suc` out of a literal-prefixed sum into the literal.
 theorem lit_suc_add2: all x:Nat, y:Nat.
   suc(lit(x) + y) = lit(suc(x)) + y
 proof
@@ -234,6 +248,7 @@ end
 
 // auto lit_mult_commute
 
+// Shift a `suc` from the right operand into the literal on the left.
 theorem lit_add_suc: all n:Nat, m:Nat.
   lit(n) + suc(m) = lit(suc(n)) + m
 proof
@@ -245,6 +260,7 @@ end
 
 auto lit_add_suc
 
+// Left cancellation of multiplication when the literal factor is positive.
 theorem lit_mult_left_cancel : all m : Nat, a : Nat, b : Nat.
   if lit(suc(m)) * a = lit(suc(m)) * b then a = b
 proof
@@ -257,7 +273,8 @@ end
   More Properties of Summation
   */
 
-theorem sum_n : all n : Nat. 
+// Closed form: twice the sum 0+1+...+(n-1) equals n*(n-1).
+theorem sum_n : all n : Nat.
     ℕ2 * summation(n, ℕ0, λ x {x}) = n * (n ∸ ℕ1)
 proof
     induction Nat
@@ -294,7 +311,8 @@ proof
     }
 end
 
-theorem sum_n' : all n : Nat. 
+// Closed form: twice the sum 0+1+...+n equals n*(n+1).
+theorem sum_n' : all n : Nat.
     ℕ2 * summation(suc(n), ℕ0, λ x {x}) = n * (n + ℕ1)
 proof
     induction Nat
@@ -323,6 +341,7 @@ end
   Public versions of theorems involving literals
 */
 
+// Left cancellation of multiplication when the left factor is positive.
 theorem pos_mult_left_cancel : all m : Nat, a : Nat, b : Nat.
   if ℕ0 < m and m * a = m * b then a = b
 proof
@@ -338,6 +357,7 @@ proof
   }
 end
 
+// Right cancellation of strict inequality when the right factor is positive.
 theorem pos_mult_right_cancel_less : all c : Nat, a : Nat, b : Nat.
   if ℕ0 < c and a * c < b * c then a < b
 proof
@@ -347,6 +367,7 @@ proof
   apply (apply mult_lt_mono_r[c,a,b] to prem) to prem
 end
 
+// Left cancellation of `≤` when the left factor is positive.
 theorem pos_mult_left_cancel_less_equal : all n : Nat, x : Nat, y : Nat.
   if ℕ0 < n and n * x ≤ n * y then x ≤ y
 proof
@@ -357,6 +378,7 @@ proof
   apply mult_nonzero_mono_le[n', x, y] to (replace ns in prem)
 end
   
+// Multiplying both sides of a strict inequality by a positive factor preserves it.
 theorem pos_mult_both_sides_of_less : all n : Nat, x : Nat, y : Nat.
   if ℕ0 < n and x < y then n * x < n * y
 proof
@@ -368,6 +390,7 @@ proof
   apply mono_nonzero_mult_le[n', x, y] to (replace ns in prem)
 end
   
+// `1 + n` is positive for every `n`.
 theorem nat_zero_less_one_add: all n:Nat.
   ℕ0 < ℕ1 + n
 proof
@@ -376,6 +399,7 @@ proof
   zero_less_one_add
 end
 
+// If two naturals sum to zero then both are zero.
 theorem nat_add_to_zero: all n:Nat, m:Nat.
   if n + m = ℕ0
   then n = ℕ0 and m = ℕ0
@@ -385,6 +409,7 @@ proof
   add_to_zero
 end
 
+// Adding a positive amount strictly increases the value.
 theorem nat_less_add_pos: all x:Nat, y:Nat.
   if ℕ0 < y
   then x < x + y
@@ -394,6 +419,7 @@ proof
   less_add_pos
 end
 
+// `x ≤ y` is equivalent to truncated subtraction `x ∸ y` being zero.
 theorem nat_monus_zero_iff_less_eq : all x : Nat, y : Nat.
   x ≤ y  ⇔  x ∸ y = ℕ0
 proof
@@ -402,6 +428,7 @@ proof
   monus_zero_iff_less_eq[x, y]
 end
 
+// Subtracting one is the predecessor function.
 theorem nat_monus_one_pred : all x : Nat. x ∸ ℕ1 = pred(x)
 proof
   arbitrary x:Nat
@@ -409,6 +436,7 @@ proof
   monus_one_pred
 end
 
+// Any value minus itself (truncated) is zero.
 theorem nat_monus_cancel: all n:Nat. n ∸ n = ℕ0
 proof
   arbitrary n:Nat
@@ -416,6 +444,7 @@ proof
   monus_cancel
 end
 
+// Every natural is either zero or strictly positive.
 theorem nat_zero_or_positive: all x:Nat. x = ℕ0 or ℕ0 < x
 proof
   arbitrary x:Nat
@@ -423,6 +452,7 @@ proof
   zero_or_positive[x]
 end
 
+// `1 + n` is never zero.
 theorem nat_not_one_add_zero: all n:Nat.
   not (ℕ1 + n = ℕ0)
 proof
@@ -431,6 +461,7 @@ proof
   not_one_add_zero[n]
 end
 
+// Every positive natural is `1 + n'` for some `n'`.
 theorem nat_positive_suc: all n:Nat.
   if ℕ0 < n
   then some n':Nat. n = ℕ1 + n'
@@ -442,6 +473,7 @@ proof
   apply positive_suc[n] to prem
 end
 
+// The only natural `≤ 0` is zero itself.
 theorem nat_zero_le_zero: all x:Nat. if x ≤ ℕ0 then x = ℕ0
 proof
   arbitrary x:Nat
@@ -449,6 +481,7 @@ proof
   zero_le_zero
 end
   
+// Extending the summation range by one appends `f(s + n)`.
 theorem summation_next: all n:Nat, s:Nat, f:fn Nat->Nat.
   summation(ℕ1 + n, s, f) = summation(n, s, f) + f(s + n)
 proof
@@ -457,6 +490,7 @@ proof
   summation_suc_add
 end
 
+// Nothing is strictly less than zero (boolean form).
 theorem less_zero_false: all x:Nat. (x < zero) = false
 proof
   arbitrary x:Nat
@@ -465,6 +499,7 @@ end
 
 auto less_zero_false
   
+// Zero is `≤` everything (boolean form).
 theorem zero_less_equal_true: all x:Nat. (zero ≤ x) = true
 proof
   arbitrary x:Nat
@@ -473,12 +508,14 @@ end
 
 auto zero_less_equal_true
 
+// A successor cannot be `≤ 0`.
 theorem not_suc_less_equal_zero: all x:Nat. not (suc(x) ≤ zero)
 proof
   arbitrary x:Nat
   expand operator≤.
 end
 
+// Literal form: `suc(x) ≤ 0` is false.
 theorem lit_suc_less_equal_zero_false: all x:Nat. (lit(suc(x)) ≤ lit(zero)) = false
 proof
   arbitrary x:Nat
@@ -489,6 +526,7 @@ end
 auto lit_suc_less_equal_zero_false
   
 
+// Successor cancels on both sides of `≤` (literal form).
 theorem le_lit_suc: all x:Nat, y:Nat. (lit(suc(x)) ≤ lit(suc(y))) = (lit(x) ≤ lit(y))
 proof
   arbitrary x:Nat, y:Nat
@@ -497,6 +535,7 @@ proof
 end
 auto le_lit_suc  
 
+// Successor cancels on both sides of `<` (literal form).
 theorem less_lit_suc: all x:Nat, y:Nat. (lit(suc(x)) < lit(suc(y))) = (lit(x) < lit(y))
 proof
   arbitrary x:Nat, y:Nat
@@ -505,6 +544,7 @@ proof
 end
 auto less_lit_suc  
 
+// Literal zero is strictly less than every successor.
 theorem less_lit_zero_suc: all y:Nat. (lit(zero) < lit(suc(y))) = true
 proof
   arbitrary y:Nat
@@ -512,6 +552,7 @@ proof
 end
 auto less_lit_zero_suc
 
+// Literal zero divided by any positive literal is zero.
 theorem lit_zero_div: all x:Nat. lit(zero) / lit(suc(x)) = lit(zero)
 proof
   arbitrary x:Nat
@@ -524,6 +565,7 @@ proof
 end
 auto lit_zero_div
 
+// A positive literal divided by itself is one.
 theorem lit_div_cancel: all y:Nat. lit(suc(y)) / lit(suc(y)) = lit(suc(zero))
 proof
   arbitrary y:Nat
@@ -536,8 +578,12 @@ proof
 end
 auto lit_div_cancel
 
+// Helper used by the literal-division `auto` rewrites below: shifts the
+// quotient computation into a tail-recursive form `add_div(a,b,y) = (a+b)/y`,
+// maintaining the invariant `a ≤ y`.
 fun add_div(a : Nat, b : Nat, y : Nat) { (a + b) / y } // invariant: a ≤ y
 
+// Entry rewrite: route literal division through `add_div` with accumulator zero.
 theorem lit_div: all x:Nat, y:Nat. lit(x) / lit(y) = add_div(zero, x, y)
 proof
   arbitrary x:Nat, y:Nat
@@ -545,6 +591,7 @@ proof
 end
 auto lit_div
 
+// When the accumulator equals the divisor, emit a `1` and reset the accumulator.
 theorem lit_add_div: all b:Nat, y:Nat. add_div(suc(y), b, suc(y)) = lit(suc(zero)) + add_div(zero, b, suc(y))
 proof
   arbitrary b:Nat, y:Nat
@@ -556,6 +603,7 @@ proof
 end
 auto lit_add_div
 
+// Step rewrite: move a `suc` from the dividend remainder into the accumulator.
 theorem lit_add_div_suc: all a:Nat, b:Nat, y:Nat. add_div(a, suc(b), y) = add_div(suc(a), b, y)
 proof
   arbitrary a:Nat, b:Nat, y:Nat
@@ -565,6 +613,7 @@ proof
 end
 auto lit_add_div_suc
 
+// Terminating case: with no remaining dividend and accumulator below the divisor, the quotient is zero.
 theorem lit_add_div_zero: all a:Nat, y:Nat. if a < y then add_div(a, zero, y) = lit(zero)
 proof
   arbitrary a:Nat, y:Nat
@@ -574,6 +623,7 @@ proof
 end
 auto lit_add_div_zero
 
+// Nothing is strictly less than literal zero (boolean form).
 theorem lit_less_zero_false: all x:Nat. (x < lit(zero)) = false
 proof
   arbitrary x:Nat
@@ -582,6 +632,7 @@ end
 
 auto lit_less_zero_false
 
+// Literal zero is `≤` everything (boolean form).
 theorem lit_zero_less_equal_true: all x:Nat. (lit(zero) ≤ x) = true
 proof
   arbitrary x:Nat
@@ -590,6 +641,7 @@ end
 
 auto lit_zero_less_equal_true
 
+// Squaring expressed as the literal exponent two.
 theorem lit_expt_two : all n : Nat.
   n ^ ℕ2 = n * n
 proof
@@ -598,6 +650,7 @@ proof
   expt_two
 end
 
+// One raised to any power is one (literal form).
 theorem lit_one_expt : all n :Nat.
   ℕ1 ^ n = ℕ1
 proof


### PR DESCRIPTION
## Summary

Add a one-line WHAT comment before each declaration in `lib/Nat.pf` (~30 new comments). Continues the per-declaration commenting pattern from PRs #747 (NatPowLog), #756 (UIntPowLog), #757 (UIntAdd), #770 (NatDiv), #783 (UIntLess), and #791 (NatAdd).

Sections covered:
- Properties of `equal` (reflexivity, completeness/soundness vs. propositional `=`, contrapositive).
- Greatest common divisor (definition and `gcd_divides`).
- Literal arithmetic rewrites (monus, distributivity, `lit_suc_add*`, `lit_mult_left_cancel`).
- Summation closed forms `sum_n` and `sum_n'`.
- Public literal-versions block (`pos_mult_*`, `nat_zero_less_one_add`, `nat_add_to_zero`, `nat_monus_*`, `nat_positive_suc`, `nat_zero_le_zero`, `summation_next`, literal `<`/`≤` rewrites, the `add_div` helper and its `auto` rewrite chain, `lit_expt_two` / `lit_one_expt`).

No proofs or signatures change.

Refs #99.

## Test plan

- [x] `python3.13 deduce.py lib/Nat.pf` (recursive descent)
- [x] `python3.13 deduce.py --lalr lib/Nat.pf`
- [x] `python3.13 test-deduce.py --lib` (both parsers, 47s)
- [x] `make static` — ruff + mypy clean (the `--no-site-packages` block surfaces pre-existing untyped-decorator noise unrelated to this change; CI does not run that pass).

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)

Fallback: \`$CLAUDE_CODE_SESSION_ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)