### PR TITLE
lib/MultiSet: add per-declaration comments (Refs #99)

### DIFF
--- a/lib/MultiSet.pf
+++ b/lib/MultiSet.pf
@@ -45,6 +45,7 @@ proof
   expand cnt.
 end
          
+// Every element has count zero in the empty multiset.
 theorem cnt_empty: all T:type. all x:T. cnt(@m_empty<T>())(x) = 0
 proof
   arbitrary T:type
@@ -54,6 +55,7 @@ end
 
 auto cnt_empty
 
+// The singleton multiset `m_one(x)` has count one at `x` itself.
 theorem cnt_one: all T:type. all x:T. cnt(m_one(x))(x) = 1
 proof
   arbitrary T:type
@@ -63,6 +65,7 @@ end
 
 auto cnt_one
 
+// Counts add pointwise across `⨄`.
 theorem cnt_sum: all T:type. all A:MultiSet<T>, B:MultiSet<T>, x:T.
   cnt(A ⨄ B)(x) = cnt(A)(x) + cnt(B)(x)
 proof
@@ -73,6 +76,7 @@ end
 
 //auto cnt_sum  This is problematic. -Jeremy
 
+// Multisets with identical count functions are equal: `cnt` is injective.
 theorem cnt_equal: all T:type, A:MultiSet<T>, B:MultiSet<T>.
   if cnt(A) = cnt(B) then A = B
 proof
@@ -89,6 +93,8 @@ proof
   }
 end
 
+// Equational form of `cnt_equal`, registered as an auto rewrite so that
+// equality of multisets reduces to equality of their count functions.
 theorem cnt_equal_equal: all T:type, A:MultiSet<T>, B:MultiSet<T>.
   (cnt(A) = cnt(B)) = (A = B)
 proof
@@ -103,7 +109,8 @@ end
 
 auto cnt_equal_equal
   
-// Testing alternate asci notation 
+// The empty multiset is a right identity for `⨄` (here written with the
+// ASCII alias `.+.` to exercise the alternate notation).
 theorem m_sum_empty: all T:type. all A:MultiSet<T>.
   A .+. @m_empty<T>() = A
 proof
@@ -121,6 +128,7 @@ end
 
 auto m_sum_empty
 
+// The empty multiset is a left identity for `⨄`.
 theorem empty_m_sum: all T:type. all A:MultiSet<T>.
   @m_empty<T>() ⨄ A = A
 proof
@@ -140,6 +148,7 @@ end
 
 auto empty_m_sum
 
+// Multiset sum is commutative.
 theorem m_sum_commutes: all T:type. all A:MultiSet<T>, B:MultiSet<T>.
   A ⨄ B = B ⨄ A
 proof
@@ -162,6 +171,8 @@ proof
   }
 end
 
+// Multiset sum is associative; the trailing `associative` directive
+// registers this for the auto-associativity machinery.
 theorem m_sum_assoc:
   all T:type. all A:MultiSet<T>, B:MultiSet<T>, C:MultiSet<T>.
   (A ⨄ B) ⨄ C = A ⨄ (B ⨄ C)
@@ -188,9 +199,13 @@ end
 
 associative operator⨄ <T> in MultiSet<T>
 
+/* Underlying set */
+
+// The underlying set of a multiset: those elements with positive count.
 define set_of_mset : fn<T> MultiSet<T> -> Set<T>
   = generic T {λM{set_of_pred(λx{ if cnt(M)(x) = 0 then false else true })}}
 
+// The underlying set of the empty multiset is the empty set.
 theorem som_empty: all T:type.
   set_of_mset( @m_empty<T>() ) = @empty_set<T>()
 proof
@@ -211,6 +226,7 @@ proof
   fwd, bkwd
 end
 
+// The underlying set of a singleton multiset is the corresponding singleton set.
 theorem som_one_single: all T:type. all x:T.
   set_of_mset(m_one(x)) = single(x)
 proof
@@ -240,6 +256,7 @@ proof
   replace eq | single_pred<T>[z].
 end
 
+// `set_of_mset` is a homomorphism: it sends `⨄` to set union.
 theorem som_union: all T:type. all A:MultiSet<T>, B:MultiSet<T>.
   set_of_mset(A ⨄ B) = set_of_mset(A) ∪ set_of_mset(B)
 proof


### PR DESCRIPTION
## Summary

Adds a one-line WHAT comment above each previously uncommented declaration in [lib/MultiSet.pf](lib/MultiSet.pf), continuing the per-file commenting passes from #793 (Set), #791 (NatAdd), #796 (Nat), #797 (Maps), ….

Specifically:

- New comments on `cnt_empty`, `cnt_one`, `cnt_sum`, `cnt_equal`, `cnt_equal_equal`, `empty_m_sum`, `m_sum_commutes`, `m_sum_assoc`, the `set_of_mset` define, `som_empty`, `som_one_single`, `som_union`.
- The prior `// Testing alternate asci notation` comment on `m_sum_empty` is replaced with a real description that names the `.+.` ASCII alias.
- Small `Underlying set` section header above `set_of_mset`.

Pre-existing comments on `cnt`, `m_empty`, `m_one`, `operator ⨄`, and `cnt_m_fun` are left untouched.

No proofs or signatures change.

## Sub-task status (issue #99)

Completes: per-declaration comments for `lib/MultiSet.pf`.

Stdlib files still sparse after this PR (from the rough scan in #796/#797 comments):

- `lib/NatLess.pf` — 3 / 76
- `lib/IntLess.pf` — 17 / 67
- `lib/IntMult.pf` — 26 / 35
- `lib/UIntDiv.pf` — 18 / 48

Plus the open meta-questions in #99 (Javadoc-style extraction; surfacing comments in generated theorem/reference files).

Using "Refs #99" rather than "Closes #99" because the parent issue tracks multiple files.

## Test plan

- [x] `python3.13 deduce.py lib/MultiSet.pf` — valid
- [x] `python3.13 deduce.py --lalr lib/MultiSet.pf` — valid
- [x] `python3.13 test-deduce.py --lib` — all tests passed under both parsers

[Claude session](claude://resume?session=3494a35d-a5a2-4385-8f63-54996e624f8d) — fallback UUID: `3494a35d-a5a2-4385-8f63-54996e624f8d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)