### PR TITLE
lib/BigO: polynomial closure at degree 3 (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -1439,3 +1439,96 @@ proof
   }
   upper, lower
 end
+
+// Polynomial closure, degree 3: a degree-3 polynomial with positive leading
+// coefficient is asymptotically equivalent to its leading monomial.
+// `a*n*n*n + b*n*n + c*n + d ≈ n*n*n` when `1 ≤ a`. Upper bound at `n0 = 1`,
+// `c0 = a + b + c + d`: each lower-order term is dominated by a constant
+// multiple of `n*n*n` since `n*n ≤ n*n*n`, `n ≤ n*n*n`, and `1 ≤ n*n*n` for
+// `n ≥ 1`. Lower bound at `n0 = 0`, `c0 = 1`: `1 ≤ a` gives
+// `n*n*n ≤ a*(n*n*n) ≤ a*n*n*n + b*n*n + c*n + d` pointwise.
+theorem bigo_cubic_closure: all a:UInt, b:UInt, c:UInt, d:UInt.
+  if 1 ≤ a then (fun n:UInt { a * n * n * n + b * n * n + c * n + d })
+              ≈ (fun n:UInt { n * n * n })
+proof
+  arbitrary a:UInt, b:UInt, c:UInt, d:UInt
+  assume a_pos: 1 ≤ a
+  expand operator≈
+  have upper: (fun n:UInt { a * n * n * n + b * n * n + c * n + d })
+            ≲ (fun n:UInt { n * n * n }) by {
+    expand operator≲
+    choose 1, a + b + c + d
+    arbitrary n:UInt
+    assume n_ge_1: 1 ≤ n
+    show a * n * n * n + b * n * n + c * n + d ≤ (a + b + c + d) * (n * n * n)
+    have n_le_n: n ≤ n by .
+    have n_le_nn: n ≤ n * n
+      by apply uint_mult_mono_le2[1, n, n, n] to n_ge_1, n_le_n
+    have one_le_nn: 1 ≤ n * n
+      by apply uint_less_equal_trans to n_ge_1, n_le_nn
+    have nn_le_nn: n * n ≤ n * n by .
+    have nn_le_nnn: n * n ≤ n * n * n
+      by apply uint_mult_mono_le2[1, n*n, n, n*n] to n_ge_1, nn_le_nn
+    have n_le_nnn: n ≤ n * n * n
+      by apply uint_less_equal_trans to n_le_nn, nn_le_nnn
+    have one_le_nnn: 1 ≤ n * n * n
+      by apply uint_less_equal_trans to n_ge_1, n_le_nnn
+    have annn_le: a * n * n * n ≤ a * (n * n * n) by .
+    have bnn_le_bnn: b * n * n ≤ b * (n * n) by .
+    have bnn_le_bnnn_lifted: b * (n * n) ≤ b * (n * n * n)
+      by apply uint_mult_mono_le[b, n*n, n*n*n] to nn_le_nnn
+    have bnn_le_bnnn: b * n * n ≤ b * (n * n * n)
+      by apply uint_less_equal_trans to bnn_le_bnn, bnn_le_bnnn_lifted
+    have cn_le_cnnn: c * n ≤ c * (n * n * n)
+      by apply uint_mult_mono_le[c, n, n*n*n] to n_le_nnn
+    have d_le_dnnn: d ≤ d * (n * n * n)
+      by apply uint_mult_mono_le[d, 1, n*n*n] to one_le_nnn
+    have sum1: a * n * n * n + b * n * n ≤ a * (n * n * n) + b * (n * n * n)
+      by apply uint_add_mono_less_equal to annn_le, bnn_le_bnnn
+    have sum2: a * n * n * n + b * n * n + c * n
+             ≤ a * (n * n * n) + b * (n * n * n) + c * (n * n * n)
+      by apply uint_add_mono_less_equal to sum1, cn_le_cnnn
+    have sum3: a * n * n * n + b * n * n + c * n + d
+             ≤ a * (n * n * n) + b * (n * n * n) + c * (n * n * n) + d * (n * n * n)
+      by apply uint_add_mono_less_equal to sum2, d_le_dnnn
+    have expand_eq: (a + b + c + d) * (n * n * n)
+                  = a * (n * n * n) + b * (n * n * n) + c * (n * n * n) + d * (n * n * n) by {
+      have step1: (a + b + c + d) * (n * n * n)
+                = (a + b + c) * (n * n * n) + d * (n * n * n)
+        by uint_dist_mult_add_right[a + b + c, d, n * n * n]
+      have step2: (a + b + c) * (n * n * n)
+                = (a + b) * (n * n * n) + c * (n * n * n)
+        by uint_dist_mult_add_right[a + b, c, n * n * n]
+      have step3: (a + b) * (n * n * n)
+                = a * (n * n * n) + b * (n * n * n)
+        by uint_dist_mult_add_right[a, b, n * n * n]
+      replace step1 | step2 | step3.
+    }
+    replace expand_eq
+    sum3
+  }
+  have lower: (fun n:UInt { n * n * n })
+            ≲ (fun n:UInt { a * n * n * n + b * n * n + c * n + d }) by {
+    expand operator≲
+    choose 0, 1
+    arbitrary n:UInt
+    assume _
+    show n * n * n ≤ 1 * (a * n * n * n + b * n * n + c * n + d)
+    have nnn_le_nnn: n * n * n ≤ n * n * n by .
+    have nnn_le_annn: n * n * n ≤ a * n * n * n
+      by apply uint_mult_mono_le2[1, n*n*n, a, n*n*n] to a_pos, nnn_le_nnn
+    have annn_le_p1: a * n * n * n ≤ a * n * n * n + b * n * n
+      by uint_less_equal_add
+    have nnn_le_p1: n * n * n ≤ a * n * n * n + b * n * n
+      by apply uint_less_equal_trans to nnn_le_annn, annn_le_p1
+    have p1_le_p2: a * n * n * n + b * n * n ≤ a * n * n * n + b * n * n + c * n
+      by uint_less_equal_add
+    have nnn_le_p2: n * n * n ≤ a * n * n * n + b * n * n + c * n
+      by apply uint_less_equal_trans to nnn_le_p1, p1_le_p2
+    have p2_le_p3: a * n * n * n + b * n * n + c * n
+                 ≤ a * n * n * n + b * n * n + c * n + d
+      by uint_less_equal_add
+    apply uint_less_equal_trans to nnn_le_p2, p2_le_p3
+  }
+  upper, lower
+end


### PR DESCRIPTION
## Summary

Adds `bigo_cubic_closure` to `lib/BigO.pf`, continuing Section F (polynomial closure) of the `lib/BigO` catalogue from #725. PR #794 covered degrees 1 and 2; this slice extends the family to degree 3.

`a*n*n*n + b*n*n + c*n + d ≈ n*n*n` when `1 ≤ a`. Upper bound at `n0 = 1`, `c0 = a + b + c + d`: each lower-order term is dominated by a constant multiple of `n*n*n` since `n*n ≤ n*n*n`, `n ≤ n*n*n`, and `1 ≤ n*n*n` for `n ≥ 1`. Lower bound at `n0 = 0`, `c0 = 1`: `1 ≤ a` gives `n*n*n ≤ a*(n*n*n) ≤ a*n*n*n + b*n*n + c*n + d` pointwise.

The proof structure mirrors `bigo_linear_closure` and `bigo_quadratic_closure` exactly — same `expand operator≈ / choose / arbitrary / show / monotonicity-chain / distributive expand / sum` shape — so it remains easy to read alongside its siblings.

Refs #725 (Section F slice).

### Section F status

Completed by this PR:
- `bigo_cubic_closure` — degree 3 fixed-`k` instance.

Already completed (prior PRs):
- `bigo_linear_closure`, `bigo_quadratic_closure` — degree 1 and 2 fixed-`k` instances (#794).

Still open in Section F:
- Higher fixed-degree instances (degree 4 and up) as further slices, if desired.
- General-`k` polynomial closure via a list-of-coefficients formulation.
- `Sum of polynomials: O(p(n)) + O(q(n)) ≈ O(max-degree)`.

#725 has many other sections (A–J) outside Section F that are unaffected by this PR.

## Test plan

- [x] `python3.13 deduce.py --recursive-descent lib/BigO.pf` — valid
- [x] `python3.13 deduce.py --lalr lib/BigO.pf` — valid
- [x] `python3.13 test-deduce.py --lib` — all tests passed (26.7s)
- [x] `python3.13 test-deduce.py --equiv` — RD/LALR ASTs agree across lib + should-validate (53.8s)
- [x] `make static` — ruff + mypy clean

[Claude session](claude://resume?session=86b752cf-e914-4c37-99ac-837121465052) — fallback UUID: `86b752cf-e914-4c37-99ac-837121465052`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
