### PR TITLE
lib/BigO: polynomial closure at degree 4 (Refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -1532,3 +1532,128 @@ proof
   }
   upper, lower
 end
+
+// Polynomial closure, degree 4: a degree-4 polynomial with positive leading
+// coefficient is asymptotically equivalent to its leading monomial.
+// `a*n*n*n*n + b*n*n*n + c*n*n + d*n + e ≈ n*n*n*n` when `1 ≤ a`. Upper bound
+// at `n0 = 1`, `c0 = a + b + c + d + e`: each lower-order term is dominated by
+// a constant multiple of `n*n*n*n` since `n*n*n ≤ n*n*n*n`, `n*n ≤ n*n*n*n`,
+// `n ≤ n*n*n*n`, and `1 ≤ n*n*n*n` for `n ≥ 1`. Lower bound at `n0 = 0`,
+// `c0 = 1`: `1 ≤ a` gives
+// `n*n*n*n ≤ a*(n*n*n*n) ≤ a*n*n*n*n + b*n*n*n + c*n*n + d*n + e` pointwise.
+theorem bigo_quartic_closure: all a:UInt, b:UInt, c:UInt, d:UInt, e:UInt.
+  if 1 ≤ a then (fun n:UInt { a * n * n * n * n + b * n * n * n + c * n * n + d * n + e })
+              ≈ (fun n:UInt { n * n * n * n })
+proof
+  arbitrary a:UInt, b:UInt, c:UInt, d:UInt, e:UInt
+  assume a_pos: 1 ≤ a
+  expand operator≈
+  have upper: (fun n:UInt { a * n * n * n * n + b * n * n * n + c * n * n + d * n + e })
+            ≲ (fun n:UInt { n * n * n * n }) by {
+    expand operator≲
+    choose 1, a + b + c + d + e
+    arbitrary n:UInt
+    assume n_ge_1: 1 ≤ n
+    show a * n * n * n * n + b * n * n * n + c * n * n + d * n + e
+       ≤ (a + b + c + d + e) * (n * n * n * n)
+    have n_le_n: n ≤ n by .
+    have n_le_nn: n ≤ n * n
+      by apply uint_mult_mono_le2[1, n, n, n] to n_ge_1, n_le_n
+    have one_le_nn: 1 ≤ n * n
+      by apply uint_less_equal_trans to n_ge_1, n_le_nn
+    have nn_le_nn: n * n ≤ n * n by .
+    have nn_le_nnn: n * n ≤ n * n * n
+      by apply uint_mult_mono_le2[1, n*n, n, n*n] to n_ge_1, nn_le_nn
+    have n_le_nnn: n ≤ n * n * n
+      by apply uint_less_equal_trans to n_le_nn, nn_le_nnn
+    have one_le_nnn: 1 ≤ n * n * n
+      by apply uint_less_equal_trans to n_ge_1, n_le_nnn
+    have nnn_le_nnn: n * n * n ≤ n * n * n by .
+    have nnn_le_nnnn: n * n * n ≤ n * n * n * n
+      by apply uint_mult_mono_le2[1, n*n*n, n, n*n*n] to n_ge_1, nnn_le_nnn
+    have nn_le_nnnn: n * n ≤ n * n * n * n
+      by apply uint_less_equal_trans to nn_le_nnn, nnn_le_nnnn
+    have n_le_nnnn: n ≤ n * n * n * n
+      by apply uint_less_equal_trans to n_le_nnn, nnn_le_nnnn
+    have one_le_nnnn: 1 ≤ n * n * n * n
+      by apply uint_less_equal_trans to n_ge_1, n_le_nnnn
+    have annnn_le: a * n * n * n * n ≤ a * (n * n * n * n) by .
+    have bnnn_le_bnnn: b * n * n * n ≤ b * (n * n * n) by .
+    have bnnn_le_bnnnn_lifted: b * (n * n * n) ≤ b * (n * n * n * n)
+      by apply uint_mult_mono_le[b, n*n*n, n*n*n*n] to nnn_le_nnnn
+    have bnnn_le_bnnnn: b * n * n * n ≤ b * (n * n * n * n)
+      by apply uint_less_equal_trans to bnnn_le_bnnn, bnnn_le_bnnnn_lifted
+    have cnn_le_cnn: c * n * n ≤ c * (n * n) by .
+    have cnn_le_cnnnn_lifted: c * (n * n) ≤ c * (n * n * n * n)
+      by apply uint_mult_mono_le[c, n*n, n*n*n*n] to nn_le_nnnn
+    have cnn_le_cnnnn: c * n * n ≤ c * (n * n * n * n)
+      by apply uint_less_equal_trans to cnn_le_cnn, cnn_le_cnnnn_lifted
+    have dn_le_dnnnn: d * n ≤ d * (n * n * n * n)
+      by apply uint_mult_mono_le[d, n, n*n*n*n] to n_le_nnnn
+    have e_le_ennnn: e ≤ e * (n * n * n * n)
+      by apply uint_mult_mono_le[e, 1, n*n*n*n] to one_le_nnnn
+    have sum1: a * n * n * n * n + b * n * n * n
+             ≤ a * (n * n * n * n) + b * (n * n * n * n)
+      by apply uint_add_mono_less_equal to annnn_le, bnnn_le_bnnnn
+    have sum2: a * n * n * n * n + b * n * n * n + c * n * n
+             ≤ a * (n * n * n * n) + b * (n * n * n * n) + c * (n * n * n * n)
+      by apply uint_add_mono_less_equal to sum1, cnn_le_cnnnn
+    have sum3: a * n * n * n * n + b * n * n * n + c * n * n + d * n
+             ≤ a * (n * n * n * n) + b * (n * n * n * n) + c * (n * n * n * n)
+               + d * (n * n * n * n)
+      by apply uint_add_mono_less_equal to sum2, dn_le_dnnnn
+    have sum4: a * n * n * n * n + b * n * n * n + c * n * n + d * n + e
+             ≤ a * (n * n * n * n) + b * (n * n * n * n) + c * (n * n * n * n)
+               + d * (n * n * n * n) + e * (n * n * n * n)
+      by apply uint_add_mono_less_equal to sum3, e_le_ennnn
+    have expand_eq: (a + b + c + d + e) * (n * n * n * n)
+                  = a * (n * n * n * n) + b * (n * n * n * n) + c * (n * n * n * n)
+                    + d * (n * n * n * n) + e * (n * n * n * n) by {
+      have step1: (a + b + c + d + e) * (n * n * n * n)
+                = (a + b + c + d) * (n * n * n * n) + e * (n * n * n * n)
+        by uint_dist_mult_add_right[a + b + c + d, e, n * n * n * n]
+      have step2: (a + b + c + d) * (n * n * n * n)
+                = (a + b + c) * (n * n * n * n) + d * (n * n * n * n)
+        by uint_dist_mult_add_right[a + b + c, d, n * n * n * n]
+      have step3: (a + b + c) * (n * n * n * n)
+                = (a + b) * (n * n * n * n) + c * (n * n * n * n)
+        by uint_dist_mult_add_right[a + b, c, n * n * n * n]
+      have step4: (a + b) * (n * n * n * n)
+                = a * (n * n * n * n) + b * (n * n * n * n)
+        by uint_dist_mult_add_right[a, b, n * n * n * n]
+      replace step1 | step2 | step3 | step4.
+    }
+    replace expand_eq
+    sum4
+  }
+  have lower: (fun n:UInt { n * n * n * n })
+            ≲ (fun n:UInt { a * n * n * n * n + b * n * n * n + c * n * n + d * n + e }) by {
+    expand operator≲
+    choose 0, 1
+    arbitrary n:UInt
+    assume _
+    show n * n * n * n ≤ 1 * (a * n * n * n * n + b * n * n * n + c * n * n + d * n + e)
+    have nnnn_le_nnnn: n * n * n * n ≤ n * n * n * n by .
+    have nnnn_le_annnn: n * n * n * n ≤ a * n * n * n * n
+      by apply uint_mult_mono_le2[1, n*n*n*n, a, n*n*n*n] to a_pos, nnnn_le_nnnn
+    have annnn_le_p1: a * n * n * n * n ≤ a * n * n * n * n + b * n * n * n
+      by uint_less_equal_add
+    have nnnn_le_p1: n * n * n * n ≤ a * n * n * n * n + b * n * n * n
+      by apply uint_less_equal_trans to nnnn_le_annnn, annnn_le_p1
+    have p1_le_p2: a * n * n * n * n + b * n * n * n
+                 ≤ a * n * n * n * n + b * n * n * n + c * n * n
+      by uint_less_equal_add
+    have nnnn_le_p2: n * n * n * n ≤ a * n * n * n * n + b * n * n * n + c * n * n
+      by apply uint_less_equal_trans to nnnn_le_p1, p1_le_p2
+    have p2_le_p3: a * n * n * n * n + b * n * n * n + c * n * n
+                 ≤ a * n * n * n * n + b * n * n * n + c * n * n + d * n
+      by uint_less_equal_add
+    have nnnn_le_p3: n * n * n * n ≤ a * n * n * n * n + b * n * n * n + c * n * n + d * n
+      by apply uint_less_equal_trans to nnnn_le_p2, p2_le_p3
+    have p3_le_p4: a * n * n * n * n + b * n * n * n + c * n * n + d * n
+                 ≤ a * n * n * n * n + b * n * n * n + c * n * n + d * n + e
+      by uint_less_equal_add
+    apply uint_less_equal_trans to nnnn_le_p3, p3_le_p4
+  }
+  upper, lower
+end


### PR DESCRIPTION
## Summary

Adds `bigo_quartic_closure` to `lib/BigO.pf`, continuing Section F of [#725](https://github.com/jsiek/deduce/issues/725) (polynomial closure):

```
if 1 ≤ a then (fun n. a*n*n*n*n + b*n*n*n + c*n*n + d*n + e)
            ≈ (fun n. n*n*n*n)
```

Follows the same shape as `bigo_linear_closure` / `bigo_quadratic_closure` (PR #794) and `bigo_cubic_closure` (PR #799):

- **Upper bound** at `n0 = 1`, `c = a + b + c + d + e` — each lower-order term `t * n^k` is dominated by `t * (n*n*n*n)` for `n ≥ 1`, since `n^k ≤ n^4` when `k ≤ 4`; constant `e ≤ e * (n*n*n*n)` by `1 ≤ n^4`; right-distributivity collapses the sum.
- **Lower bound** at `n0 = 0`, `c = 1` — `1 ≤ a` gives `n^4 ≤ a*n^4 ≤ leading + b*n^3 ≤ leading + b*n^3 + c*n^2 ≤ … ≤ a*n^4 + b*n^3 + c*n^2 + d*n + e` pointwise.

Both directions assemble through the existing `uint_mult_mono_le`, `uint_mult_mono_le2`, `uint_add_mono_less_equal`, `uint_less_equal_trans`, `uint_less_equal_add`, and `uint_dist_mult_add_right` lemmas — no new infrastructure needed.

## Status of issue #725 (BigO catalogue)

This PR is one slice of the Section F (polynomial closure) bullet of multi-part issue [#725](https://github.com/jsiek/deduce/issues/725). Not "Closes" — the issue has many remaining slices.

Section F (polynomial closure):

- [x] Degree 1 — `bigo_linear_closure` (PR #794)
- [x] Degree 2 — `bigo_quadratic_closure` (PR #794)
- [x] Degree 3 — `bigo_cubic_closure` (PR #799)
- [x] **Degree 4 — `bigo_quartic_closure` (this PR)**
- [ ] General `k` via coefficient lists
- [ ] Sum of polynomials: `O(p(n)) + O(q(n)) ≈ O(max-degree)`

Other sections of #725 (E rest, G rest, H, I, J rest) are untouched by this PR.

## Test plan

- [x] `python deduce.py --recursive-descent lib/BigO.pf` succeeds.
- [x] `python deduce.py --lalr lib/BigO.pf` succeeds.
- [x] `make tests` — full local suite passes in 118.70s (both parsers; lib + should-validate + should-error + parser equivalence + pretty-print round trip).
- [x] CI — all 8 jobs green (static checks + 7 regression jobs).

[Claude session](claude://resume?session=44ddfbbf-a2e9-4144-a49a-2dce9726e480) — fallback UUID: `44ddfbbf-a2e9-4144-a49a-2dce9726e480`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
