### PR TITLE
Reference.md: migrate Assume, Obtain, Suffices to deduce-grammar blocks (Refs #473)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -383,9 +383,13 @@ assert (if true then 7 else 5+6) = 7
 
 ## Assume
 
-```
-proof_stmt ::= "assume" assumption
-proof_stmt ::= "suppose" assumption
+```deduce-grammar
+proof_stmt ::= "assume" identifier
+proof_stmt ::= "assume" identifier ":" term
+proof_stmt ::= "assume" ":" term
+proof_stmt ::= "suppose" identifier
+proof_stmt ::= "suppose" identifier ":" term
+proof_stmt ::= "suppose" ":" term
 ```
 
 A proof of the form
@@ -1753,8 +1757,9 @@ Deduce treats `x ≠ y` as syntactic sugar for `not (x = y)`.
 
 ## Obtain (Proof)
 
-```
-proof_stmt ::= "obtain" identifier_list "where" assumption "from" proof
+```deduce-grammar
+proof_stmt ::= "obtain" identifier_list "where" identifier "from" proof
+proof_stmt ::= "obtain" identifier_list "where" identifier ":" term "from" proof
 ```
 
 
@@ -2550,8 +2555,8 @@ theorems with `monus` in the name.
 
 ## Suffices (Proof Statement)
 
-```
-proof_stmt ::= "suffices" formula reason
+```deduce-grammar
+proof_stmt ::= "suffices" term reason
 ```
 
 A proof of the form


### PR DESCRIPTION
## Summary

Migrates three unmarked grammar fragments in `gh_pages/doc/Reference.md` to strict ` ```deduce-grammar ` blocks so they participate in the CI check (`gh_pages/scripts/reference_grammar.py`).

The migrated entries are **Assume / Suppose**, **Obtain**, and **Suffices**. Each previously referenced rule names that don't exist in `Deduce.lark` (`assumption`, `formula`), so the rules were silently drifting from the LALR grammar. The new blocks enumerate every alternative defined in `Deduce.lark`:

- **Assume / Suppose**: 6 alternatives (bare label, `label : term`, `: term` for each keyword).
- **Obtain**: 2 alternatives (with and without `: term` annotation on the witness label).
- **Suffices**: just rename `formula` to `term` (the actual lark rule name).

`proof_stmt` is in the checker's `SUBSET_RULES`, so a partial enumeration would be enough — but enumerating all alternatives is more informative and matches the convention already used for other migrated entries.

After the change, `python3 gh_pages/scripts/reference_grammar.py` reports `Checked 77 Reference.md grammar rule(s) against Deduce.lark` (was 74) and `make tests-tokens` passes.

## Scope vs. [#473](https://github.com/jsiek/deduce/issues/473)

This is a single slice of the multi-part issue [#473](https://github.com/jsiek/deduce/issues/473). Using "Refs" rather than "Closes" — the issue stays open.

Completed in this PR:
- Migrated 3 more `Reference.md` grammar fragments (Assume, Obtain, Suffices) to strict `deduce-grammar` blocks.

Still remaining on [#473](https://github.com/jsiek/deduce/issues/473):
- Decide whether and how much of `test/should-error/` should participate in parser equivalence checks.
- Migrate the remaining unmarked grammar fragments in `Reference.md` (the bulk are `term ::=` / `formula ::=` aliases that need an "intentional simplification" marker before they can be checked strictly).
- Expand round-trip coverage after improving the pretty-printer for currently non-parse-preserving proof/declaration forms.

## Test plan

- [x] `python3 gh_pages/scripts/reference_grammar.py` — passes (74 → 77)
- [x] `make static` — passes (ruff + mypy)
- [x] `make tests-tokens` — passes
- [ ] CI on the PR — pending

[Claude session](claude://resume?session=dbfd9e4e-c7b6-4f83-b339-0fd1ce750830) — fallback UUID: `dbfd9e4e-c7b6-4f83-b339-0fd1ce750830`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
