### PR TITLE
Narrow Any in error.py: typed formula/env, Iterator speculative_probe (Refs #681)

### DIFF
--- a/error.py
+++ b/error.py
@@ -1,9 +1,17 @@
 import contextlib
-from typing import Any, List, NoReturn, Optional
+from typing import Iterator, List, NoReturn, Optional, TYPE_CHECKING
 
 from lark.tree import Meta
 
 import style
+
+# Type-only imports to avoid an import cycle: abstract_syntax.core
+# imports `internal_error` from this module, so error.py sits below
+# abstract_syntax in the import stack. The IncompleteProof refine
+# pipeline still wants the structured `formula` / `env` payloads
+# typed precisely, so we forward-reference them under TYPE_CHECKING.
+if TYPE_CHECKING:
+  from abstract_syntax import Env, Term
 
 class Diagnostic(Exception):
   """Base class for exceptions that represent user-facing diagnostics.
@@ -41,8 +49,8 @@ class IncompleteProof(Diagnostic):
   # structured fields for the LSP/MCP refine pipeline (the goal AST
   # and the type-checking env at the hole). ``None`` outside of
   # opted-in flows.
-  formula: Optional[Any]
-  env: Optional[Any]
+  formula: Optional['Term']
+  env: Optional['Env']
 
 def get_location_text_lines(location: Meta) -> List[str]:
   if not location.empty:
@@ -141,8 +149,8 @@ def internal_error(location: Meta, msg: str) -> NoReturn:
   raise InternalError(error_header(location) + msg)
 
 def incomplete_error(location: Meta, msg: str, *,
-                     formula: Optional[Any] = None,
-                     env: Optional[Any] = None) -> NoReturn:
+                     formula: Optional['Term'] = None,
+                     env: Optional['Env'] = None) -> NoReturn:
   exc = IncompleteProof(error_header(location) + msg)
   exc.depth = 0
   exc.location = location
@@ -219,7 +227,7 @@ _speculative_depth = 0
 
 
 @contextlib.contextmanager
-def speculative_probe() -> Any:
+def speculative_probe() -> Iterator[None]:
   """Make a speculative proof-checker probe well-behaved when an
   error sink is active.
 
@@ -281,8 +289,8 @@ def add_diagnostic(location: Meta, msg: str) -> None:
   _active_sink.add(exc)
 
 def add_incomplete(location: Meta, msg: str,
-                   formula: Optional[Any] = None,
-                   env: Optional[Any] = None) -> None:
+                   formula: Optional['Term'] = None,
+                   env: Optional['Env'] = None) -> None:
   """Record a user-visible diagnostic in the active sink and *return
   normally*, unlike :func:`user_error` which raises. Use at sites whose
   enclosing function can tolerate falling through.


### PR DESCRIPTION
## Summary

Small slice of the "Reduce `Any` usage everywhere" follow-up (Section 3 of #681).

`error.py` had 8 word-boundary `Any` mentions — all of them removable without touching the import-cycle constraint:

- `IncompleteProof.formula` / `IncompleteProof.env` (and the matching keyword params on `incomplete_error` and `add_incomplete`) were typed `Optional[Any]`. They actually hold the goal AST (a `Term`, returned by `check_formula` and threaded through to `add_incomplete(..., formula=new_formula, env=env)` in `checker_proofs.py`) and the type-checking `Env`. Narrowed via a `TYPE_CHECKING` block so the existing import cycle stays unbroken (`abstract_syntax.core` imports `internal_error` from this module, so `error.py` sits below `abstract_syntax` in the import stack).
- `speculative_probe() -> Any` is a `@contextmanager` that yields no value; the proper return type is `Iterator[None]`.

`Any` count in `error.py` drops from 8 → 0. Same shape as the merged narrowing PRs (#630 / #631 / #639).

## Issue #681 status after this PR

Section 3 — "Reduce `Any` usage everywhere":

- [x] `error.py` (this PR, 8 → 0)
- [x] `checker_cache.py` (#630, prior)
- [x] `checker_logic.py` (#631, prior)
- [x] `checker_induction.py` (#639, prior)
- [ ] All other modules still listed in the #681 table (`lsp/query.py`, `checker_proofs.py`, `checker_pipeline.py`, `abstract_syntax/*`, etc.) — untouched by this PR
- [ ] `flags.py`'s `Any | None` carve-out for `debugger` — also intentionally untouched here (could be a separate small slice)

Sections 1 (`rec_desc_parser.py`), 2 (pyproject cleanup), and 4 (global strict mode) of #681 also remain.

Refs #681.

## Test plan

- [x] `python3 -m mypy --strict error.py --follow-imports=silent` clean
- [x] `python3 -m mypy .` (project mypy under the per-module strict overrides) clean — no regressions
- [x] `python3 test-deduce.py` (lib + should-validate + should-error + prelude + parser equivalence) — 159s, all green

[Claude session](claude://resume?session=bcb246fd-a442-4754-8e58-daece1536eba) — fallback UUID: `bcb246fd-a442-4754-8e58-daece1536eba`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
