### PR TITLE
[codex] Narrow debugger plumbing types

### DIFF
--- a/deduce.py
+++ b/deduce.py
@@ -15,8 +15,11 @@ import sys
 import os
 from pathlib import Path
 from types import FrameType
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 import style
+
+if TYPE_CHECKING:
+    from lsp.debugger import Debugger
 
 traceback_flag = False
 suppress_theorems = False
@@ -28,7 +31,7 @@ def handle_sigint(signal: int, stack_frame: Optional[FrameType]) -> None:
 def deduce_file(filename: str, error_expected: bool,
                 tracing_functions: Sequence[str],
                 prelude: list[str] = [],
-                debugger: Optional[Any] = None) -> None:
+                debugger: Optional["Debugger"] = None) -> None:
     """CLI wrapper around lsp.library.check_file.
 
     Translates CheckResult into the historical print/exit behavior so
@@ -121,7 +124,7 @@ def compile_file(filename: str, output: str, prelude: list[str],
 def deduce_directory(directory: str, recursive_directories: bool,
                      tracing_functions: Sequence[str],
                      prelude: list[str] = [],
-                     debugger: Optional[Any] = None) -> None:
+                     debugger: Optional["Debugger"] = None) -> None:
     for file in sorted(os.listdir(directory)):
         fpath = os.path.join(directory, file)
         if os.path.isfile(fpath):
@@ -265,7 +268,7 @@ if __name__ == "__main__":
     # all deducables in this CLI invocation.  Detached during prelude
     # bootstrap (lsp.library handles that) so the user lands in their
     # own file rather than stepping through lib/.
-    debugger = None
+    debugger: Optional["Debugger"] = None
     if debug_enabled:
         from lsp.debugger import Debugger
         debugger = Debugger()

--- a/flags.py
+++ b/flags.py
@@ -1,7 +1,10 @@
 from enum import Enum
 import os
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:
+  from lsp.debugger import Debugger
 
 class VerboseLevel(Enum):
   NONE = 0
@@ -151,17 +154,16 @@ def set_target_hole_location(loc: Optional[tuple[int, int]]) -> None:
 # of one call (paired ``set_debugger(d)`` / ``set_debugger(None)`` in
 # a try/finally).
 #
-# Typed as `Any | None` to avoid an import cycle: flags.py sits at the
-# bottom of the import stack and lsp.debugger imports from it. The
-# stored object is an `lsp.debugger.Debugger` instance.
+# The Debugger import is type-only to avoid an import cycle: flags.py
+# sits at the bottom of the import stack and lsp.debugger imports from it.
 
-debugger: Optional[Any] = None
+debugger: Optional["Debugger"] = None
 
-def get_debugger() -> Optional[Any]:
+def get_debugger() -> Optional["Debugger"]:
   global debugger
   return debugger
 
-def set_debugger(d: Optional[Any]) -> None:
+def set_debugger(d: Optional["Debugger"]) -> None:
   global debugger
   debugger = d
 

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -46,7 +46,10 @@ import threading
 import traceback as _traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Optional, Sequence, cast
+
+if TYPE_CHECKING:
+    from lsp.debugger import Debugger
 
 
 # Process-wide lock around ``check_file``.  The Deduce pipeline
@@ -143,7 +146,7 @@ def check_file(
     prelude: Sequence[str] = (),
     content: Optional[str] = None,
     collect_errors: bool = False,
-    debugger: Optional[Any] = None,
+    debugger: Optional["Debugger"] = None,
     prewarm_modules: Sequence[str] = (),
 ) -> CheckResult:
     """Run the Deduce pipeline on ``filename`` and return a CheckResult.
@@ -221,7 +224,7 @@ def _check_file_locked(
     prelude: Sequence[str],
     content: Optional[str],
     collect_errors: bool,
-    debugger: Optional[Any],
+    debugger: Optional["Debugger"],
     prewarm_modules: Sequence[str] = (),
 ) -> CheckResult:
     """Body of ``check_file``, run under the global pipeline lock."""


### PR DESCRIPTION
## Summary

- Narrow debugger plumbing annotations from `Optional[Any]` to `Optional[Debugger]`.
- Use type-only `Debugger` imports to avoid introducing runtime import cycles.
- Carry the concrete debugger type through CLI and `lsp.library.check_file` entry points.

## Tests

- `make tests`

## Codex session

codex://threads/019e8a5b-2bcf-70c2-a9f4-06feb0182f70

```bash
open 'codex://threads/019e8a5b-2bcf-70c2-a9f4-06feb0182f70'
```
