### PR TITLE
[codex] Use public grammar rule names in reference docs

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -11,60 +11,60 @@ LINECOMMENT: "//" /[^\n]*/
 COMMENT: /\/\*(\*(?!\/)|[^*])*\*\//
 ARROW: "->"
 
-?term:  term_iff
+?term:  iff_term
 
-?term_iff: term_iff "iff" term_log                     -> iff_formula
-    | term_iff "<=>" term_log                          -> iff_formula
-    | term_iff "⇔" term_log                            -> iff_formula
-    | term_log
+?iff_term: iff_term "iff" logical_term                     -> iff_formula
+    | iff_term "<=>" logical_term                          -> iff_formula
+    | iff_term "⇔" logical_term                            -> iff_formula
+    | logical_term
 
-?term_log: term_log "and" term_equal                    -> and_formula
-    | term_log "or" term_equal                      -> or_formula
-    | term_log ":" type                           -> annote_type
-    | term_equal
+?logical_term: logical_term "and" equality_term                    -> and_formula
+    | logical_term "or" equality_term                      -> or_formula
+    | logical_term ":" type                           -> annote_type
+    | equality_term
 
-?term_equal: term_equal "=" term_compare  -> equal
-    | term_equal "≠" term_compare                       -> not_equal
-    | term_equal "/=" term_compare                       -> not_equal
-    | term_compare
+?equality_term: equality_term "=" comparison_term  -> equal
+    | equality_term "≠" comparison_term                       -> not_equal
+    | equality_term "/=" comparison_term                       -> not_equal
+    | comparison_term
 
-?term_compare: term_compare "<" term_add                        -> less
-    | term_compare ">" term_add                        -> greater
-    | term_compare "≤" term_add                       -> less_equal
-    | term_compare "<=" term_add                       -> less_equal
-    | term_compare "≥" term_add                       -> greater_equal
-    | term_compare ">=" term_add                       -> greater_equal
-    | term_compare "⊆" term_add                       -> subset_equal
-    | term_compare "(=" term_add                       -> subset_equal
-    | term_compare "∈" term_add                       -> membership
-    | term_compare "≲" term_add                       -> approx_less_equal
-    | term_compare "≈" term_add                       -> approx_equal
-    | term_compare "in" term_add                       -> membership
-    | term_add
+?comparison_term: comparison_term "<" additive_term                        -> less
+    | comparison_term ">" additive_term                        -> greater
+    | comparison_term "≤" additive_term                       -> less_equal
+    | comparison_term "<=" additive_term                       -> less_equal
+    | comparison_term "≥" additive_term                       -> greater_equal
+    | comparison_term ">=" additive_term                       -> greater_equal
+    | comparison_term "⊆" additive_term                       -> subset_equal
+    | comparison_term "(=" additive_term                       -> subset_equal
+    | comparison_term "∈" additive_term                       -> membership
+    | comparison_term "≲" additive_term                       -> approx_less_equal
+    | comparison_term "≈" additive_term                       -> approx_equal
+    | comparison_term "in" additive_term                       -> membership
+    | additive_term
 
-?term_add: term_add "+" term_med                   -> add
-    | term_add "∪" term_med                        -> union_op
-    | term_add "|" term_med                        -> union_op
-    | term_add "∩" term_med                        -> intersect
-    | term_add "&" term_med                        -> intersect
-    | term_add "⨄" term_med                        -> multiset_sum
-    | term_add ".+." term_med                      -> multiset_sum
-    | term_add "++" term_med                       -> append
-    | term_add "-" term_med                        -> sub
-    | term_add "∸" term_med                        -> nat_sub
-    | term_add ".-." term_med                      -> nat_sub
-    | term_add "⊝" term_med                        -> o_sub
-    | term_med
+?additive_term: additive_term "+" multiplicative_term                   -> add
+    | additive_term "∪" multiplicative_term                        -> union_op
+    | additive_term "|" multiplicative_term                        -> union_op
+    | additive_term "∩" multiplicative_term                        -> intersect
+    | additive_term "&" multiplicative_term                        -> intersect
+    | additive_term "⨄" multiplicative_term                        -> multiset_sum
+    | additive_term ".+." multiplicative_term                      -> multiset_sum
+    | additive_term "++" multiplicative_term                       -> append
+    | additive_term "-" multiplicative_term                        -> sub
+    | additive_term "∸" multiplicative_term                        -> nat_sub
+    | additive_term ".-." multiplicative_term                      -> nat_sub
+    | additive_term "⊝" multiplicative_term                        -> o_sub
+    | multiplicative_term
 
-?term_med: term_med "/" term_exp                    -> div
-    | term_med "%" term_exp                         -> mod
-    | term_med "*" term_exp                         -> mul
-    | term_med "∘" term_exp                         -> circ
-    | term_med ".o." term_exp                       -> circ
-    | term_exp
+?multiplicative_term: multiplicative_term "/" exponent_term                    -> div
+    | multiplicative_term "%" exponent_term                         -> mod
+    | multiplicative_term "*" exponent_term                         -> mul
+    | multiplicative_term "∘" exponent_term                         -> circ
+    | multiplicative_term ".o." exponent_term                       -> circ
+    | exponent_term
 
-?term_exp : term_exp "^" term_hi                    -> pow
-    | term_hi
+?exponent_term : exponent_term "^" atomic_term                    -> pow
+    | atomic_term
 
 ?switch_case: "case" pattern "{" term "}"           -> switch_case
 
@@ -86,20 +86,20 @@ identifier: IDENT              -> identifier
     | "operator" ">="      -> identifier_greater_equal
     | "operator" "/="      -> identifier_not_equal
 
-?term_hi: INT                                      -> int
+?atomic_term: INT                                      -> int
     | NAT                                          -> nat
     | "+" INT                                      -> pos_int
-    | "-" term_hi                                  -> neg_int
+    | "-" atomic_term                                  -> neg_int
     | "true"                                       -> true_literal
     | "false"                                      -> false_literal
     | "∅"                                         -> emptyset_literal
     | ".0."                                        -> emptyset_literal
-    | "not" term_hi                                -> logical_not
+    | "not" atomic_term                                -> logical_not
     | IDENT                                        -> term_var
-    | "@" term_hi "<" type_list ">"                -> term_inst
+    | "@" atomic_term "<" type_list ">"                -> term_inst
     | "array" "(" term ")"                         -> make_array
-    | term_hi "(" term_list ")"                    -> call
-    | term_hi "[" term "]"                         -> array_get
+    | atomic_term "(" term_list ")"                    -> call
+    | atomic_term "[" term "]"                         -> array_get
     | "λ" type_params_opt variable_list "{" term "}"    -> lambda
     | "fun" type_params_opt variable_list "{" term "}"  -> lambda
     | "generic" identifier_list "{" term "}"            -> generic
@@ -168,9 +168,9 @@ identifier: IDENT              -> identifier
 ?switch_proof_case_list: switch_proof_case               -> single
     | switch_proof_case switch_proof_case_list           -> push
 
-?equation: term_compare "=" term_add reason    -> equation
+?equation: comparison_term "=" additive_term reason    -> equation
 
-?half_equation:  "..." "=" term_add reason     -> half_equation
+?half_equation:  "..." "=" additive_term reason     -> half_equation
 
 ?equation_list: half_equation                      -> single
     | half_equation equation_list                  -> push
@@ -208,14 +208,14 @@ identifier: IDENT              -> identifier
     | "symmetric" proof                                  -> sym_proof
     | "transitive" proof proof                           -> trans_proof
     | "help" proof                                       -> help_use_proof
-    | proof_hi
+    | atomic_proof
 
-?proof_hi: IDENT                                              -> proof_var
+?atomic_proof: IDENT                                              -> proof_var
     | "."                                                -> true_proof
     | "?"                                                -> hole_proof
     | "(" proof ")"                                      -> paren
-    | proof_hi "[" term_list "]"                         -> all_elim
-    | proof_hi "<" type_list ">"                         -> all_elim_types
+    | atomic_proof "[" term_list "]"                         -> all_elim
+    | atomic_proof "<" type_list ">"                         -> all_elim_types
     | "sorry"                                            -> sorry_proof
     | "{" proof "}"
 
@@ -257,9 +257,9 @@ identifier: IDENT              -> identifier
 
 ?type: "fn" type_params_opt type_list "->" type        -> function_type
  | IDENT "<" type_list ">"                             -> type_inst
- | type_hi
+ | atomic_type
 
-?type_hi: IDENT   -> type_name
+?atomic_type: IDENT   -> type_name
  | "bool"         -> bool_type
  | "type"         -> type_type
  | "(" type ")"   -> paren
@@ -323,7 +323,7 @@ identifier: IDENT              -> identifier
  | visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}" -> view_declaration
  | definition
  | "associative" identifier type_params_opt "in" type -> associative_declaration
- | "auto" proof_hi -> auto_declaration
+ | "auto" atomic_proof -> auto_declaration
  | import
  | "export" IDENT -> export
  | "assert" term -> assert
@@ -331,7 +331,7 @@ identifier: IDENT              -> identifier
  | theorem
  | "module" identifier -> module_declaration
  | "trace" identifier -> trace
- | "inductive" type "by" proof_hi -> inductive_decl
+ | "inductive" type "by" atomic_proof -> inductive_decl
 
 ?statement_list: statement                               -> single
     | statement statement_list                           -> push

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -192,7 +192,7 @@ assert cnt(X)(7) = 0
 ## All (Universal Quantifier)
 
 ```deduce-grammar
-term_hi ::= "all" type_annotation_list "." term
+atomic_term ::= "all" type_annotation_list "." term
 ```
 
 A formula of the form `all x1:T1,...,xn:Tn. P` is true
@@ -435,7 +435,7 @@ See the entry for [Instantiation](#instantiation-term).
 ## Auto `auto` (Automatic Reduction)
 
 ```deduce-grammar
-statement ::= "auto" proof_hi
+statement ::= "auto" atomic_proof
 ```
 
 To tell Deduce to automatically apply an equation, left to right, use
@@ -507,7 +507,7 @@ A proof may be surrounded in curly braces.
 ## Call (Term)
 
 ```deduce-grammar
-term_hi ::= term_hi "(" term_list ")"
+atomic_term ::= atomic_term "(" term_list ")"
 ```
 
 A term of the form `t0(t1, ..., tn)` calls the function indicated by
@@ -779,7 +779,7 @@ colon.  In the above, `six` holds an unsigned integer, so its type is `UInt`.
 ## Define (Term)
 
 ```deduce-grammar
-term_hi ::= "define" identifier "=" term ";" term
+atomic_term ::= "define" identifier "=" term ";" term
 ```
 
 This associates a name with a term for use in the term after the semicolon.
@@ -945,8 +945,8 @@ conclusion ::= "equations" equation equation_list
 ```
 
 ```deduce-grammar
-equation ::= term_compare "=" term_add reason
-half_equation ::= "..." "=" term_add reason
+equation ::= comparison_term "=" additive_term reason
+half_equation ::= "..." "=" additive_term reason
 equation_list ::= half_equation
 equation_list ::= half_equation equation_list
 equation_list ::= "$" equation equation_list
@@ -1038,7 +1038,7 @@ end
 ## False
 
 ```deduce-grammar
-term_hi ::= "false"
+atomic_term ::= "false"
 ```
 
 One can prove `false` when there are assumptions that contradict
@@ -1062,8 +1062,8 @@ formula ::= term
 ## Function (Term)
 
 ```deduce-grammar
-term_hi ::= "fun" type_params_opt variable_list "{" term "}"
-term_hi ::= "λ" type_params_opt variable_list "{" term "}"
+atomic_term ::= "fun" type_params_opt variable_list "{" term "}"
+atomic_term ::= "λ" type_params_opt variable_list "{" term "}"
 ```
 
 Functions are created with a `fun` expression.  Their syntax starts with
@@ -1122,7 +1122,7 @@ enclosed in `<` and `>`.
 ## Generic (Formula)
 
 ```deduce-grammar
-term_hi ::= "<" identifier_list ">" term
+atomic_term ::= "<" identifier_list ">" term
 ```
 
 This parametrizes a formula by a list of type parameters.  For
@@ -1138,7 +1138,7 @@ this formula applies to lists with any element type.
 ## Generic (Term)
 
 ```deduce-grammar
-term_hi ::= "generic" identifier_list "{" term "}"
+atomic_term ::= "generic" identifier_list "{" term "}"
 ```
 
 A term of the form
@@ -1165,8 +1165,8 @@ statement (see [Recursive Function](#recursive-function-statement)).
 ## Generic Function (Term)
 
 ```deduce-grammar
-term_hi ::= "fun" type_params_opt variable_list "{" term "}"
-term_hi ::= "λ" type_params_opt variable_list "{" term "}"
+atomic_term ::= "fun" type_params_opt variable_list "{" term "}"
+atomic_term ::= "λ" type_params_opt variable_list "{" term "}"
 ```
 
 To make a [Function](#function-term) generic, add type parameters surrounded
@@ -1442,7 +1442,7 @@ union type), see [`rule induction`](#rule-induction-proof).
 
 ## Inductive (Statement)
 ```deduce-grammar
-statement ::= "inductive" type "by" proof_hi
+statement ::= "inductive" type "by" atomic_proof
 ```
 
 The `inductive` statement allows you to declare custom inductive structure
@@ -1518,8 +1518,8 @@ end
 ## Instantiation (Proof)
 
 ```deduce-grammar
-proof_hi ::= proof_hi "<" type_list ">"
-proof_hi ::= proof_hi "[" term_list "]"
+atomic_proof ::= atomic_proof "<" type_list ">"
+atomic_proof ::= atomic_proof "[" term_list "]"
 ```
 
 Use square brackets `[` and `]` to instantiate an `all` formula with 
@@ -1546,7 +1546,7 @@ end
 ## Instantiation (Term)
 
 ```deduce-grammar
-term_hi ::= "@" term_hi "<" type_list ">"
+atomic_term ::= "@" atomic_term "<" type_list ">"
 ```
 
 Instantiates a generic function or constructor, replaces its type
@@ -1617,7 +1617,7 @@ assert not (2 ≤ 1)
 ## List (Term)
 
 ```deduce-grammar
-term_hi ::= "[" term_list "]"
+atomic_term ::= "[" term_list "]"
 ```
 
 Deduce treats `[t1,t2,...,tn]` as syntactic sugar for
@@ -1646,7 +1646,7 @@ define list_example = node(3, node(8, node(4, empty)))
 ## Mark 
 
 ```deduce-grammar
-term_hi ::= "#" term "#"
+atomic_term ::= "#" term "#"
 ```
 
 Marking a subterm with hash symbols restricts a `replace` or `expand`
@@ -1739,7 +1739,7 @@ The operations on natural numbers and theorems about them are in `Nat.thm`.
 ## Not
 
 ```deduce-grammar
-term_hi ::= "not" term_hi
+atomic_term ::= "not" atomic_term
 ```
 
 The formula `not P` is true when `P` is false.
@@ -1802,24 +1802,29 @@ See [Visibility](#visibility).
 
 ## Operator Precedence
 
-When parentheses are omitted, Deduce's binary operators group according
-to the precedence levels below, listed from **tightest** (binds first)
-to **loosest** (binds last). Function application `f(x, ...)` and array
-indexing `a[i]` bind tighter than every binary operator in the table.
+When parentheses are omitted, Deduce's terms group according to the
+precedence levels below, listed from **tightest** (binds first) to
+**loosest** (binds last). The `Deduce.lark` rule column names the
+grammar rule that implements each level. The parser starts at the
+loosest rule, `iff_term`, and each rule falls through toward the
+tighter rule listed above it.
+
+| Level | `Deduce.lark` rule     | Operators or forms                                                                 | Meaning                                                            |
+|------:|------------------------|------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+|     0 | `atomic_term`          | literals, identifiers, parentheses, `f(...)`, `a[i]`, `@f<T>`, `not P`, `-n`       | primary and prefix forms                                           |
+|     1 | `exponent_term`        | `^`                                                                                | exponent                                                           |
+|     2 | `multiplicative_term`  | `*`  `/`  `%`  `∘` (also `.o.`)                                                    | multiply, divide, modulo, function composition                     |
+|     3 | `additive_term`        | `+`  `-`  `∸` (also `.-.`)  `⊝`  `++`  `∪`  `∩`  `⨄` (also `.+.`)                  | add, subtract, monus, list append, set/multiset union/intersection |
+|     4 | `comparison_term`      | `<`  `>`  `≤` (also `<=`)  `≥` (also `>=`)  `⊆` (also `(=`)  `∈` (also `in`)  `≲`  `≈` | comparisons, subset, membership                                |
+|     5 | `equality_term`        | `=`  `≠` (also `/=`)                                                               | equality, inequality                                               |
+|     6 | `logical_term`         | `and`  `or`  `:`                                                                   | logical conjunction, disjunction, type annotation                  |
+|     7 | `iff_term`             | `iff` (also `<=>`, `⇔`)                                                            | biconditional                                                      |
+
 The unary prefix forms `not P` and `-n` apply only to the immediately
 following atom — for example, `not P and Q` means `(not P) and Q`, and
-`-x * y` means `(-x) * y`.
-
-| Level | Operators                                                                          | Meaning                                                            |
-|------:|------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-|     1 | `^`                                                                                | exponent                                                           |
-|     2 | `*`  `/`  `%`  `∘` (also `.o.`)                                                    | multiply, divide, modulo, function composition                     |
-|     3 | `+`  `-`  `∸` (also `.-.`)  `⊝`  `++`  `∪`  `∩`  `⨄` (also `.+.`)                  | add, subtract, monus, list append, set/multiset union/intersection |
-|     4 | `<`  `>`  `≤` (also `<=`)  `≥` (also `>=`)  `⊆` (also `(=`)  `∈` (also `in`)  `≲`  `≈` | comparisons, subset, membership                                |
-|     5 | `=`  `≠` (also `/=`)                                                               | equality, inequality                                               |
-|     6 | `and`  `or`                                                                        | logical conjunction and disjunction                                |
-|     7 | `iff` (also `<=>`, `⇔`)                                                            | biconditional                                                      |
-|     8 | `:`                                                                                | type annotation                                                    |
+`-x * y` means `(-x) * y`. Type annotation `:` is part of
+`logical_term`, so it is grouped left-to-right with `and` and `or`;
+use parentheses when mixing annotations with logical connectives.
 
 The ASCII aliases for `∪` and `∩` (the single characters used as the
 table separator and HTML-attribute character) are documented at
@@ -1857,9 +1862,9 @@ chaining the same comparison (e.g. `a < b < c`) is unusual and is *not*
 interpreted as a mathematical chained comparison — write it as
 `a < b and b < c` instead.
 
-The authoritative source for the precedence is the grammar in
-`Deduce.lark` and `rec_desc_parser.py`; the table above summarizes what
-those files implement.
+The authoritative sources for precedence are `Deduce.lark` and
+`rec_desc_parser.py`; the table above summarizes what those files
+implement and names the corresponding public Lark rules.
 
 
 ## Or  (logical disjunction)
@@ -1947,7 +1952,7 @@ or more identifiers (for the rest of the function parameters).
 ## Period (Proof of True)
 
 ```deduce-grammar
-proof_hi ::= "."
+atomic_proof ::= "."
 ```
 
 A period is a proof of the formula `true` in Deduce.
@@ -2110,7 +2115,7 @@ The output is `5`.
 ## Question Mark `?` (Proof)
 
 ```deduce-grammar
-proof_hi ::= "?"
+atomic_proof ::= "?"
 ```
 
 A proof can be left incomplete by placing a `?` in the part that you
@@ -2472,7 +2477,7 @@ sure that the given formula matches the current goal.
 ## Some (Formula)
 
 ```deduce-grammar
-term_hi ::= "some" type_annotation_list "." term
+atomic_term ::= "some" type_annotation_list "." term
 ```
 
 The formula `some x1:T1,...,xn:Tn. P` is true when there exists
@@ -2486,7 +2491,7 @@ To use a `some` formula, see the entry for [Obtain](#obtain-exists-elimination)
 ## Sorry (Proof)
 
 ```deduce-grammar
-proof_hi ::= "sorry"
+atomic_proof ::= "sorry"
 ```
 
 `sorry` is the get-out-of-jail free card. It can prove anything.
@@ -2609,7 +2614,7 @@ See the entry for [Assume](#assume).
 ## Switch (Term)
 
 ```deduce-grammar
-term_hi ::= "switch" term "{" switch_list "}"
+atomic_term ::= "switch" term "{" switch_list "}"
 ```
 
 ```deduce-grammar
@@ -2809,7 +2814,7 @@ terms `a`, `b`, and `c`.
 ## True (Formula)
 
 ```deduce-grammar
-term_hi ::= "true"
+atomic_term ::= "true"
 ```
 
 There's not much to say about `true`. It's true!

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -31,12 +31,12 @@ TOKEN_ALIASES = {
     "number": "INT",
     "unsigned_integer": "INT",
 }
-PASSTHROUGH_RULES = {"type_hi"}
+PASSTHROUGH_RULES = {"atomic_type"}
 SUBSET_RULES = {
     "statement",
-    "term_hi",
+    "atomic_term",
     "proof_stmt",
-    "proof_hi",
+    "atomic_proof",
     "conclusion",
     "visibility",
 }
@@ -101,7 +101,7 @@ def parse_lark_rules(path: Path) -> dict[str, set[str]]:
 def expand_passthrough_alternatives(rules: dict[str, set[str]]) -> dict[str, set[str]]:
     """Inline alternatives that are exactly another rule name.
 
-    The public reference often presents helper rules such as ``type_hi`` as
+    The public reference often presents helper rules such as ``atomic_type`` as
     alternatives of the user-facing ``type`` nonterminal. Deduce.lark keeps
     those helper rules separate for precedence and AST construction.
     """


### PR DESCRIPTION
## Summary

- Rename Lark helper grammar rules from internal names like `term_hi` and `term_med` to public names like `atomic_term` and `multiplicative_term`.
- Update checked Reference.md grammar blocks to use the public names.
- Add a precedence table column that maps each level to its `Deduce.lark` rule and corrects the documented placement of `:`.

## Tests

- `python3 gh_pages/scripts/reference_grammar.py`
- `python3 -m pytest test/unit/test_parser_associativity.py`
- `python3 test-deduce.py --site`
- `make tests`

## Codex session

codex://threads/019e8d26-3ef8-76c0-9a56-ddc8a200c4c7

```bash
open 'codex://threads/019e8d26-3ef8-76c0-9a56-ddc8a200c4c7'
```

Addresses #812
