### PR TITLE
[codex] Add inverse proof support to views

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -313,6 +313,9 @@ identifier: IDENT              -> identifier
        | visibility "import" IDENT "hiding" import_filter_list -> import_hiding
 ?import_filter_list: identifier ("|" identifier)*            -> import_filter_list
 
+?view_inverse_opt:                                 -> no_view_inverse
+    | "inverse" identifier                         -> view_inverse
+
 ?statement: visibility "union" IDENT type_params_opt "{" constructor_list "}" -> union
  | visibility "type" IDENT type_params_opt "=" type -> type_alias
  | visibility "predicate" identifier type_params_opt ":" type "{" predicate_rule_list "}" -> predicate_declaration
@@ -320,7 +323,7 @@ identifier: IDENT              -> identifier
  | visibility "recursive" identifier type_params_opt "(" type_list ")" "->" type "{" fun_case_list "}" -> recursive_function
  | visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}" -> fun
  | visibility "recfun" identifier type_params_opt "(" variable_list ")" "->" type "measure" term "of" type "{" term "}" "terminates" proof -> general_recursive_function
- | visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}" -> view_declaration
+ | visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier view_inverse_opt "}" -> view_declaration
  | definition
  | "associative" identifier type_params_opt "in" type -> associative_declaration
  | "auto" proof_hi -> auto_declaration

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -780,6 +780,7 @@ class ViewDecl(Declaration):
   into: str
   out: str
   roundtrip: str
+  inverse: str | None = None
 
   def uniquify(self, env: object, ctx: object) -> ViewDecl:
     env = cast(dict[str, Any], env)
@@ -808,9 +809,11 @@ class ViewDecl(Declaration):
     new_into = resolve_name(self.into, "view function")
     new_out = resolve_name(self.out, "view function")
     new_roundtrip = resolve_name(self.roundtrip, "proof")
+    new_inverse = None if self.inverse is None \
+      else resolve_name(self.inverse, "proof")
     return ViewDecl(self.location, new_name, new_type_params,
                     new_source, new_target, new_into, new_out,
-                    new_roundtrip, visibility=self.visibility)
+                    new_roundtrip, new_inverse, visibility=self.visibility)
 
   def collect_exports(self, export_env: dict[str, Any], importing_module: str) -> None:
     if self.visibility == 'private' and (importing_module != get_current_module()):
@@ -839,6 +842,8 @@ class ViewDecl(Declaration):
       + '  into ' + base_name(self.into) + '\n' \
       + '  out ' + base_name(self.out) + '\n' \
       + '  roundtrip ' + base_name(self.roundtrip) + '\n' \
+      + ('' if self.inverse is None
+         else '  inverse ' + base_name(self.inverse) + '\n') \
       + '}\n'
     return indent*' ' + ret
 

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -198,12 +198,14 @@ def process_declaration_visibility(decl: Declaration, env: Env,
       return (decl, env.declare_term_var(loc, name, fun_type,
                                          visibility=decl.visibility))
 
-    case ViewDecl(loc, name, typarams, source, target, into, out, roundtrip):
+    case ViewDecl(loc, name, typarams, source, target, into, out, roundtrip,
+                  inverse):
       body_env = env.declare_type_vars(loc, typarams)
       checked_source = check_type(source, body_env)
       checked_target = check_type(target, body_env)
       checked_decl = ViewDecl(loc, name, typarams, checked_source,
                               checked_target, into, out, roundtrip,
+                              inverse,
                               visibility=decl.visibility)
       _check_view_function_type(loc, into,
                                 FunctionType(loc, typarams,
@@ -639,6 +641,19 @@ def _view_roundtrip_formula(loc: Meta, view: Any) -> Formula:
                   (i, len(view.type_params)), formula)
   return formula
 
+def _view_inverse_formula(loc: Meta, view: Any) -> Formula:
+  value_name = generate_proof_name("v")
+  value = ResolvedVar(loc, view.source, value_name)
+  formula = mkEqual(loc,
+                    _view_call(loc, view.out,
+                               _view_call(loc, view.into, value)),
+                    value)
+  formula = All(loc, None, (value_name, view.source), (0, 1), formula)
+  for i, tp in enumerate(reversed(view.type_params)):
+    formula = All(loc, None, (tp, TypeType(loc)),
+                  (i, len(view.type_params)), formula)
+  return formula
+
 def _check_view_roundtrip(loc: Meta, view: Any, env: Env) -> None:
   expected = type_check_formula(_view_roundtrip_formula(loc, view), env)
   actual = env.get_formula_of_proof_var(PVar(loc, view.roundtrip))
@@ -647,6 +662,19 @@ def _check_view_roundtrip(loc: Meta, view: Any, env: Env) -> None:
                + base_name(view.roundtrip))
   if not alpha_equiv(actual, expected):
     user_error(loc, "view roundtrip proof " + base_name(view.roundtrip)
+               + " proves\n\t" + str(actual)
+               + "\nbut expected\n\t" + str(expected))
+
+def _check_view_inverse(loc: Meta, view: Any, env: Env) -> None:
+  if view.inverse is None:
+    return
+  expected = type_check_formula(_view_inverse_formula(loc, view), env)
+  actual = env.get_formula_of_proof_var(PVar(loc, view.inverse))
+  if actual is None:
+    user_error(loc, "undefined inverse proof for view: "
+               + base_name(view.inverse))
+  if not alpha_equiv(actual, expected):
+    user_error(loc, "view inverse proof " + base_name(view.inverse)
                + " proves\n\t" + str(actual)
                + "\nbut expected\n\t" + str(expected))
 
@@ -918,8 +946,9 @@ def collect_env(stmt: Statement, env: Env) -> Env:
       return env.define_term_var(loc, name, fun_type, stmt,
                                  stmt.visibility)
 
-    case ViewDecl(loc, name, _, _, _, _, _, _):
+    case ViewDecl(loc, name, _, _, _, _, _, _, _):
       _check_view_roundtrip(loc, stmt, env)
+      _check_view_inverse(loc, stmt, env)
       return env.declare_view(loc, stmt, stmt.visibility)
       
     case Union(loc, name, typarams, _):

--- a/gh_pages/doc/FunctionalProgramming.md
+++ b/gh_pages/doc/FunctionalProgramming.md
@@ -327,12 +327,22 @@ proof
   }
 end
 
+theorem unary_inverse: all n:Unary. unary_out(unary_into(n)) = n
+proof
+  arbitrary n:Unary
+  switch n {
+    case UZero { evaluate }
+    case USucc(p) { evaluate }
+  }
+end
+
 view UnaryPred {
   source Unary
   target UnaryView
   into unary_into
   out unary_out
   roundtrip unary_roundtrip
+  inverse unary_inverse
 }
 
 recursive replicate<T>(UnaryPred, T) -> List<T> {
@@ -342,8 +352,10 @@ recursive replicate<T>(UnaryPred, T) -> List<T> {
 ```
 
 The theorem `unary_roundtrip` is part of the declaration: Deduce checks
-that it proves `unary_into(unary_out(v)) = v`. The reverse equation is
-not required, so a view may hide details of the source representation.
+that it proves `unary_into(unary_out(v)) = v`. The optional `inverse`
+line names and checks the reverse equation, such as
+`unary_out(unary_into(n)) = n`; omit it when a view intentionally hides
+details of the source representation.
 
 ## Generic Functions
 

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -2961,7 +2961,9 @@ optionally be annotated with its type.
 ## View (Statement)
 
 ```deduce-grammar
-statement ::= visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}"
+statement ::= visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier view_inverse_opt "}"
+view_inverse_opt ::= ε
+view_inverse_opt ::= "inverse" identifier
 ```
 
 A `view` declaration describes how to pattern match on a value through
@@ -2985,10 +2987,19 @@ all T:type, v:Target<T>. into(out(v)) = v
 ```
 
 Deduce checks that the `into` and `out` functions have the expected
-types, and that the `roundtrip` theorem proves the expected formula.
-The opposite direction, `out(into(x)) = x`, is not required. This
-allows a view to forget representation details while still presenting
-a complete pattern-matching interface.
+types, that the `roundtrip` theorem proves the expected formula, and,
+when present, that the `inverse` theorem proves the reverse formula.
+The optional `inverse` name must refer to a theorem that proves the
+opposite direction:
+
+```
+all x:Source. out(into(x)) = x
+```
+
+For a generic view, the theorem must quantify the type parameters
+first. If the `inverse` line is omitted, the opposite direction is not
+required. This allows a view to forget representation details while
+still presenting a complete pattern-matching interface.
 
 The view name can be used wherever a type is expected. In ordinary type
 positions it stands for the view's source type. When it appears as the
@@ -3034,12 +3045,22 @@ proof
   }
 end
 
+theorem unary_inverse: all n:Unary. unary_out(unary_into(n)) = n
+proof
+  arbitrary n:Unary
+  switch n {
+    case UZero { evaluate }
+    case USucc(p) { evaluate }
+  }
+end
+
 view UnaryPred {
   source Unary
   target UnaryView
   into unary_into
   out unary_out
   roundtrip unary_roundtrip
+  inverse unary_inverse
 }
 
 recursive unary_length(UnaryPred) -> UInt {

--- a/gh_pages/doc/TacticsCheatSheet.md
+++ b/gh_pages/doc/TacticsCheatSheet.md
@@ -18,7 +18,7 @@ If a name on this page is unfamiliar, follow the link in the Reference column fo
 | `postulate name: P` | Assume `P` without proof. |
 | `auto name` | Register an equation `name : LHS = RHS` as an automatic rewrite. Subsequent goals are simplified silently using it. |
 | `associative operator* in T` | Register `*` as associative for `T`; `replace` and `evaluate` will renormalize accordingly. |
-| `view V { source S target T into f out g roundtrip thm }` | Declare a checked pattern-matching view. `thm` must prove `f(g(v)) = v` for all viewed values. |
+| `view V { source S target T into f out g roundtrip thm inverse inv }` | Declare a checked pattern-matching view. `thm` must prove `f(g(v)) = v`; optional `inv` names `g(f(x)) = x`. |
 | `recursive f(V, A) -> R { f(C(args), y) = ... }` | If `V` is a view, define a terminating recursive function by matching on `V`'s target constructors. |
 
 ## Proof structure
@@ -107,7 +107,7 @@ Use these when `apply lemma to p` doesn't typecheck because `p` is a wider conju
 
 7. **Numeric literals don't always reduce eagerly.** `0:UInt` parses as `fromNat(lit(zero))`, so `toNat(0:UInt)` is not definitionally `ℕ0` — it requires `evaluate` or `expand` to bridge. A common pattern: stash `have toNat_zero: toNat((0:UInt)) = ℕ0 by evaluate` near the top of the proof.
 
-8. **Views need their law before use.** A `view` declaration checks the supplied `roundtrip` theorem exactly. For a target type `T`, prove `all v:T. into(out(v)) = v` before the `view` declaration; for generic views, quantify type parameters first.
+8. **Views need their law before use.** A `view` declaration checks the supplied `roundtrip` theorem exactly. For a target type `T`, prove `all v:T. into(out(v)) = v` before the `view` declaration; for generic views, quantify type parameters first. If the declaration includes `inverse inv`, `inv` names the reverse law `all x:Source. out(into(x)) = x`.
 
 9. **Inside `equations`, `expand`/`replace` only touch the LHS.** Each step's left-hand side is implicitly marked as the target; the right-hand side is invisible to `expand`/`replace`. The fix is to wrap the part of the RHS you want to transform in hash marks: `... = # f(x) + y # by expand f.`. The error message "could not find a place to expand definition of `f` in: ..." with the RHS shown is usually this — see [Equations](./Reference.md#equations) for the full rule.
 

--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -100,6 +100,7 @@ known_tokens = {
     'INTO': 'keyword',
     'OUT': 'keyword',
     'ROUNDTRIP': 'keyword',
+    'INVERSE': 'keyword',
     'INVERSION': 'keyword',
     'REFLEXIVE': 'keyword',
     'RELATION': 'keyword',

--- a/parser.py
+++ b/parser.py
@@ -132,6 +132,13 @@ def parse_tree_to_case_list(e: Any) -> list[tuple[str, Any]]:
             + parse_tree_to_case_list(e.children[1])
     else:
         raise Exception('unrecognized as a type list ' + repr(e))
+
+def parse_tree_to_optional_identifier(e: Any) -> str | None:
+    if e.data == 'no_view_inverse':
+        return None
+    if e.data == 'view_inverse':
+        return cast(str, parse_tree_to_ast(e.children[0], e))
+    raise Exception('parse_tree_to_optional_identifier, unexpected ' + str(e))
     
 infix_ops = {'add', 'sub', 'nat_sub', 'o_sub', 'mul', 'div', 'mod', 'circ', 'pow',
              'and', 'or','equal', 'not_equal',
@@ -813,7 +820,8 @@ def parse_tree_to_ast(e: Any, parent: Any) -> Any:
                              parse_tree_to_ast(e.children[4], e),
                              parse_tree_to_ast(e.children[5], e),
                              parse_tree_to_ast(e.children[6], e),
-                             parse_tree_to_ast(e.children[7], e))
+                             parse_tree_to_ast(e.children[7], e),
+                             parse_tree_to_optional_identifier(e.children[8]))
         set_visibility(statement, visibility)
         return statement
         

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1534,7 +1534,7 @@ def parse_gen_rec_function(visibility):
 
 def parse_view_decl(visibility):
   while_parsing = 'while parsing\n' \
-      + '\tstatement ::= "view" identifier type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier "}"\n'
+      + '\tstatement ::= "view" identifier type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier [ "inverse" identifier ] "}"\n'
   try:
     start_token = current_token()
     advance()
@@ -1552,11 +1552,15 @@ def parse_view_decl(visibility):
     out = parse_identifier()
     consume_token('ROUNDTRIP', '"roundtrip"', context='inside view declaration')
     roundtrip = parse_identifier()
+    inverse = None
+    if current_token().type == 'INVERSE':
+      advance()
+      inverse = parse_identifier()
     consume_token('RBRACE', '"}"', context='after view declaration')
 
     meta = meta_from_tokens(start_token, previous_token())
     return ViewDecl(meta, name, typarams, source, target, into, out,
-                    roundtrip, visibility=visibility)
+                    roundtrip, inverse, visibility=visibility)
 
   except ParseError as e:
     raise e.extend(meta_from_tokens(start_token, previous_token()),

--- a/test/should-error/view_inverse_bad.pf
+++ b/test/should-error/view_inverse_bad.pf
@@ -1,0 +1,44 @@
+union NInv {
+  NInvZero
+  NInvSucc(NInv)
+}
+
+union NInvView {
+  NInvViewZero
+  NInvViewSucc(NInv)
+}
+
+fun n_inv_view(n:NInv) {
+  switch n {
+    case NInvZero { NInvViewZero }
+    case NInvSucc(p) { NInvViewSucc(p) }
+  }
+}
+
+fun n_inv_unview(v:NInvView) {
+  switch v {
+    case NInvViewZero { NInvZero }
+    case NInvViewSucc(p) { NInvSucc(p) }
+  }
+}
+
+theorem n_inv_roundtrip: all v:NInvView. n_inv_view(n_inv_unview(v)) = v
+proof
+  arbitrary v:NInvView
+  switch v {
+    case NInvViewZero { evaluate }
+    case NInvViewSucc(p) { evaluate }
+  }
+end
+
+postulate not_the_inverse_law:
+  all n:NInv. n_inv_unview(n_inv_view(n)) = n_inv_unview(n_inv_view(n))
+
+view NInvPred {
+  source NInv
+  target NInvView
+  into n_inv_view
+  out n_inv_unview
+  roundtrip n_inv_roundtrip
+  inverse not_the_inverse_law
+}

--- a/test/should-error/view_inverse_bad.pf.err
+++ b/test/should-error/view_inverse_bad.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/view_inverse_bad.pf:37.1-44.2: view inverse proof not_the_inverse_law proves
+	(all n:NInvPred. n_inv_unview(n_inv_view(n)) = n_inv_unview(n_inv_view(n)))
+but expected
+	(all v:NInvPred. n_inv_unview(n_inv_view(v)) = v)

--- a/test/should-validate/view_inverse_decl.pf
+++ b/test/should-validate/view_inverse_decl.pf
@@ -1,0 +1,59 @@
+import UInt
+
+union UnaryInverse {
+  UInvZero
+  UInvSucc(UnaryInverse)
+}
+
+union UnaryInverseView {
+  UInvViewZero
+  UInvViewSucc(UnaryInverse)
+}
+
+fun unary_inverse_into(n:UnaryInverse) {
+  switch n {
+    case UInvZero { UInvViewZero }
+    case UInvSucc(p) { UInvViewSucc(p) }
+  }
+}
+
+fun unary_inverse_out(v:UnaryInverseView) {
+  switch v {
+    case UInvViewZero { UInvZero }
+    case UInvViewSucc(p) { UInvSucc(p) }
+  }
+}
+
+theorem unary_inverse_roundtrip:
+  all v:UnaryInverseView. unary_inverse_into(unary_inverse_out(v)) = v
+proof
+  arbitrary v:UnaryInverseView
+  switch v {
+    case UInvViewZero { evaluate }
+    case UInvViewSucc(p) { evaluate }
+  }
+end
+
+theorem unary_inverse_inverse:
+  all n:UnaryInverse. unary_inverse_out(unary_inverse_into(n)) = n
+proof
+  arbitrary n:UnaryInverse
+  switch n {
+    case UInvZero { evaluate }
+    case UInvSucc(p) { evaluate }
+  }
+end
+
+view UnaryInversePred {
+  source UnaryInverse
+  target UnaryInverseView
+  into unary_inverse_into
+  out unary_inverse_out
+  roundtrip unary_inverse_roundtrip
+  inverse unary_inverse_inverse
+}
+
+recursive unary_inverse_length(UnaryInversePred) -> UInt {
+  unary_inverse_length(UInvViewZero) = 0
+  unary_inverse_length(UInvViewSucc(p)) = 1 + unary_inverse_length(p)
+}


### PR DESCRIPTION
## Summary

- Add optional `inverse <proof>` syntax to `view` declarations in both parsers and `ViewDecl`.
- Check the supplied inverse proof against `all v:Source. out(into(v)) = v` when present.
- Document the new view field and add positive/negative parser/checker fixtures.

This is a partial slice of #795: it covers the parser/AST/checking foundation for bijective views. The later view-based `switch`/`induction` dispatch and stdlib migration work remains open.

## Validation

- `make tests`
- `python3 test-deduce.py --site`
- `python3 gh_pages/scripts/reference_grammar.py`
- `git diff --check`

## Codex session

codex://threads/019e8a23-bc78-78c0-bb0b-6d42147c3662

```bash
open 'codex://threads/019e8a23-bc78-78c0-bb0b-6d42147c3662'
```