### PR TITLE
[codex] Narrow numeric literal comparison types

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -488,14 +488,16 @@ def try_fast_lit_nat_arith(loc: Meta, rator: Term, args: list[Term],
     lit_var = Var(loc, None, lit_name)
   return Call(loc, ty, lit_var, [inner])
 
-def _same_numeric_literal(t1: Any, t2: Any) -> bool:
+def _same_numeric_literal(t1: AST, t2: AST) -> bool:
+  if not isinstance(t1, Term) or not isinstance(t2, Term):
+    return False
   if isNat(t1) and isNat(t2):
     return natToInt(t1) == natToInt(t2)
   if isUInt(t1) and isUInt(t2):
     return uintToInt(t1) == uintToInt(t2)
   return False
 
-def formulas_equal_modulo_numeric_literals(frm1: Any, frm2: Any) -> bool:
+def formulas_equal_modulo_numeric_literals(frm1: AST, frm2: AST) -> bool:
   if frm1 == frm2 or _same_numeric_literal(frm1, frm2):
     return True
   match (frm1, frm2):


### PR DESCRIPTION
## Summary

- Narrow `abstract_syntax/literals.py` numeric-literal comparison helpers from `Any` to `AST`.
- Keep numeric literal recognition guarded to term nodes while preserving ordinary AST equality behavior.
- Remove the remaining explicit `Any` mentions from `abstract_syntax/literals.py`.

## Tests

- `python3 -m ruff check abstract_syntax/literals.py abstract_syntax/rewrite.py`
- `python3 -m mypy --strict abstract_syntax/literals.py abstract_syntax/rewrite.py --follow-imports=silent`
- `make tests`

## Codex session

codex://threads/019e8ea4-ea88-7bc1-931c-ecd313c86e54

```bash
open 'codex://threads/019e8ea4-ea88-7bc1-931c-ecd313c86e54'
```
