### PR TITLE
[codex] Narrow hole-fill CLI boundary types

### DIFF
--- a/tools/claude_fill_hole/__main__.py
+++ b/tools/claude_fill_hole/__main__.py
@@ -26,7 +26,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, IO, Optional
+from typing import IO, Optional
 
 from .agent import AgentResult, Backend
 from .prompt import build_system_prompt, build_user_message, slice_around_hole
@@ -343,10 +343,10 @@ def _build_backend(args: argparse.Namespace, api_key: str) -> Backend:
             ) from e
         from .openai_backend import OpenAICompatBackend
 
-        client_kwargs: dict[str, Any] = {"api_key": api_key}
         if args.base_url:
-            client_kwargs["base_url"] = args.base_url
-        openai_client = openai.OpenAI(**client_kwargs)
+            openai_client = openai.OpenAI(api_key=api_key, base_url=args.base_url)
+        else:
+            openai_client = openai.OpenAI(api_key=api_key)
         return OpenAICompatBackend(client=openai_client, model=args.model)
 
     raise _BackendBuildError(f"unknown backend: {args.backend!r}")
@@ -586,7 +586,7 @@ def _emit_response(stream: IO[str], response: HoleFillResponse) -> None:
     stream.flush()
 
 
-def _emit_progress(event: str, **fields: Any) -> None:
+def _emit_progress(event: str, **fields: object) -> None:
     sys.stderr.write(progress_event(event, **fields))
     sys.stderr.write("\n")
     sys.stderr.flush()

--- a/tools/claude_fill_hole/validator.py
+++ b/tools/claude_fill_hole/validator.py
@@ -22,7 +22,7 @@ import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Optional, Sequence
 
 
 @dataclass(frozen=True)
@@ -219,7 +219,7 @@ class LspValidator(Validator):
     the LSP daemon's ``deduce/validateProof`` becomes the cheap path.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         raise NotImplementedError(
             "LspValidator is a follow-up; use SubprocessValidator for now"
         )


### PR DESCRIPTION
## Summary

- Remove the remaining explicit `Any` annotations from the hole-fill sidecar CLI and validator placeholder files.
- Replace the OpenAI client dynamic kwargs dict with explicit constructor calls so the boundary stays precisely typed.
- Type progress-event passthrough fields and unused LSP validator placeholder args as `object`.

Part of #681.

## Tests

- `python3 -m ruff check tools/claude_fill_hole/__main__.py tools/claude_fill_hole/validator.py`
- `MYPYPATH=tools python3 -m mypy --strict tools/claude_fill_hole/__main__.py tools/claude_fill_hole/validator.py --follow-imports=silent`
- `make tests`

## Codex session

codex://threads/019e8edc-5a84-7df1-af07-7910c9ec05e7

```bash
open 'codex://threads/019e8edc-5a84-7df1-af07-7910c9ec05e7'
```
