### PR TITLE
[codex] Align Python 3.12 prerequisite docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Deduce is a proof checker and small functional language for teaching logic, written in Python. Source `.pf` files contain definitions, theorems, and proofs; running `deduce.py file.pf` either prints `... is valid` or fails with an error. The standard library lives in `lib/` and is auto-imported as a prelude unless `--no-stdlib` is passed.
 
-Single dependency: `lark==1.2.2` (Python 3.11+, CI uses 3.12, Makefile uses 3.13).
+Single dependency: `lark==1.2.2` (Python 3.12+, Makefile uses 3.13).
 
 ## Code style
 
@@ -49,7 +49,7 @@ python test-deduce.py --generate-error test/should-error/foo.pf
 python test-deduce.py --regenerate-errors      # all of them
 ```
 
-The test harness auto-discovers a python3.11–3.14 with `lark` installed. Both parsers must pass — when changing parsing or AST, run with `--lalr` and `--recursive-descent`.
+The test harness runs under the active Python interpreter, which must be Python 3.12+ with `lark` installed. Both parsers must pass — when changing parsing or AST, run with `--lalr` and `--recursive-descent`.
 
 Useful `deduce.py` flags while debugging: `--verbose` (or `--verbose full`), `--unique-names`, `--trace <function>`, `--traceback`, `--quiet`, `--suppress-theorems`, `-r` (recurse into directories).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A proof checker and small functional language for teaching logic.
 
 ## Quick start
 
-Deduce needs Python 3.10+ and the [Lark](https://github.com/lark-parser/lark)
+Deduce needs Python 3.12+ and the [Lark](https://github.com/lark-parser/lark)
 parsing library. From a fresh clone:
 
 ```sh

--- a/editor/emacs/README.md
+++ b/editor/emacs/README.md
@@ -28,7 +28,7 @@ Three layers, each independently usable:
 - **Emacs 29.1 or newer.** Install via `brew install emacs` or your
   distro package. Emacs 29 is the minimum because eglot ships in
   Emacs from version 29 onward; older Emacs is not supported.
-- **Python 3.11+ with `lark`.** Required to run `deduce.py` itself:
+- **Python 3.12+ with `lark`.** Required to run `deduce.py` itself:
   `pip install lark==1.2.2`.
 
 ### For LSP capabilities (`deduce-lsp`)

--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -112,7 +112,7 @@ lockstep with it.
 ## Prerequisites
 
 - VS Code 1.80 or newer.
-- Python 3.11+ with `lark==1.2.2` installed (the same prerequisites
+- Python 3.12+ with `lark==1.2.2` installed (the same prerequisites
   as `deduce.py` itself).  See *Settings* below if your default
   `python3` doesn't have `lark`.
 - For the LSP features (diagnostics, go-to-def, outline, code

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -18,7 +18,7 @@ To get started with Deduce, follow these steps:
 
 ### Install Prerequisites
 
-You will need [Python](https://www.python.org/) version 3.10 or later. Here are some [instructions](https://wiki.python.org/moin/BeginnersGuide/Download) and links to download Python for many computer systems.
+You will need [Python](https://www.python.org/) version 3.12 or later. Here are some [instructions](https://wiki.python.org/moin/BeginnersGuide/Download) and links to download Python for many computer systems.
 
 You will also need the [Lark](https://github.com/lark-parser/lark) parsing library, which you can install by running the following command in the same directory as `deduce.py`
 

--- a/gh_pages/scripts/lib_generate.py
+++ b/gh_pages/scripts/lib_generate.py
@@ -363,13 +363,13 @@ def select_definees(definees, imports, name):
 
 def call_deduce_lib():
     python_path = ""
-    for i in range(14, 10, -1):
+    for i in range(14, 11, -1):
         python_path = os.popen("command -v python3." + str(i)).read()[0: -1] # strip the newline character with the splicing
         if python_path != "" and os.system(python_path + " -m pip list | grep lark > /dev/null") == 0:
             break
     
     if python_path == "":
-        print("Could not find a python version at or above 3.11 with lark installed")
+        print("Could not find a python version at or above 3.12 with lark installed")
         exit(1)
     
     subprocess.run([python_path, './deduce.py', './lib'], capture_output=True)


### PR DESCRIPTION
## Summary

- Update install-facing docs to require Python 3.12+, matching `pyproject.toml`.
- Align editor prerequisites and local agent guidance with the same interpreter floor.
- Restrict the docs library-generation helper to search Python 3.12+ interpreters.

Fixes #822.

## Tests

- `make tests`

## Codex session

codex://threads/019e8f13-40af-73e3-98c1-ab27667023a0

```bash
open 'codex://threads/019e8f13-40af-73e3-98c1-ab27667023a0'
```
