### PR TITLE
[codex] Narrow backend payload typing

### DIFF
--- a/tools/claude_fill_hole/agent.py
+++ b/tools/claude_fill_hole/agent.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional, Protocol
 
 from .validator import HoleQuerier, Validator, ValidationOutcome
 
@@ -112,10 +112,11 @@ class AgentResult:
     error: Optional[str] = None  # hard-failure top-level message
 
 
-# Type alias for the progress callback.  Matches what __main__.py uses
+# Protocol for the progress callback.  Matches what __main__.py uses
 # to write NDJSON events to stderr; backends call back through this so
 # they stay decoupled from the protocol layer.
-ProgressFn = Callable[..., None]
+class ProgressFn(Protocol):
+    def __call__(self, event: str, **fields: object) -> None: ...
 
 
 class Backend(ABC):

--- a/tools/claude_fill_hole/anthropic_backend.py
+++ b/tools/claude_fill_hole/anthropic_backend.py
@@ -92,7 +92,7 @@ class AnthropicBackend(Backend):
     ) -> AgentResult:
         started = time.monotonic()
 
-        def _progress(event: str, **fields: Any) -> None:
+        def _progress(event: str, **fields: object) -> None:
             if on_progress is not None:
                 on_progress(event, **fields)
 
@@ -108,7 +108,9 @@ class AnthropicBackend(Backend):
         if querier is not None:
             tools = [_VALIDATE_TOOL, _QUERY_GOAL_TOOL]
 
-        messages: list[dict[str, Any]] = [{"role": "user", "content": user_message}]
+        messages: list[dict[str, object]] = [
+            {"role": "user", "content": user_message}
+        ]
         history: list[AttemptRecord] = []
 
         _progress("start", maxAttempts=max_attempts)
@@ -176,7 +178,7 @@ class AnthropicBackend(Backend):
                 {"role": "assistant", "content": response.content}
             )
 
-            tool_results: list[dict[str, Any]] = []
+            tool_results: list[dict[str, object]] = []
             success_proof: Optional[str] = None
 
             for block in tool_uses:
@@ -400,7 +402,7 @@ def _extract_proof_text(block: Any) -> Optional[str]:
 
 def _tool_result_block(
     tool_use_id: str, *, ok: bool, error: Optional[str]
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """Format a tool_result the API will accept, carrying our outcome."""
     if ok:
         content = "ok"
@@ -414,14 +416,16 @@ def _tool_result_block(
     }
 
 
-def _query_result_block(tool_use_id: str, outcome: QueryOutcome) -> dict[str, Any]:
+def _query_result_block(
+    tool_use_id: str, outcome: QueryOutcome
+) -> dict[str, object]:
     """Format a tool_result carrying a structured query response.
 
     JSON-encode the {goal, givens} (or {error}) payload so the model
     sees it as a parseable structure rather than a free-form string.
     """
     if outcome.ok:
-        payload = {
+        payload: dict[str, object] = {
             "goal": outcome.goal,
             "givens": [
                 {"label": g.label, "formula": g.formula}

--- a/tools/claude_fill_hole/openai_backend.py
+++ b/tools/claude_fill_hole/openai_backend.py
@@ -125,7 +125,7 @@ class OpenAICompatBackend(Backend):
     ) -> AgentResult:
         started = time.monotonic()
 
-        def _progress(event: str, **fields: Any) -> None:
+        def _progress(event: str, **fields: object) -> None:
             if on_progress is not None:
                 on_progress(event, **fields)
 
@@ -134,7 +134,7 @@ class OpenAICompatBackend(Backend):
         # explicit cache breakpoints; servers that support implicit
         # prefix caching (real OpenAI, some LiteLLM deployments) get
         # it for free, others pay full price each attempt.
-        messages: list[dict[str, Any]] = [
+        messages: list[dict[str, object]] = [
             {"role": "system", "content": system_text},
             {"role": "user", "content": user_message},
         ]
@@ -414,7 +414,9 @@ class OpenAICompatBackend(Backend):
 # ---------------------------------------------------------------------------
 
 
-def _tool_message(tool_call_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+def _tool_message(
+    tool_call_id: str, payload: dict[str, object]
+) -> dict[str, object]:
     """Format a `role: tool' message carrying a JSON-encoded payload.
 
     Centralised here so the validate_proof and query_goal paths
@@ -427,7 +429,7 @@ def _tool_message(tool_call_id: str, payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _query_payload(outcome: QueryOutcome) -> dict[str, Any]:
+def _query_payload(outcome: QueryOutcome) -> dict[str, object]:
     """Convert a QueryOutcome into the JSON shape the model sees in
     the tool_result message: `{goal, givens}` on success, `{error}`
     on failure."""
@@ -502,7 +504,7 @@ def _extract_proof_text(args_raw: str) -> Optional[str]:
     return proof
 
 
-def _serialize_tool_calls(tool_calls: list[Any]) -> list[dict[str, Any]]:
+def _serialize_tool_calls(tool_calls: list[Any]) -> list[dict[str, object]]:
     """Re-serialise a list of tool_call objects (Pydantic models or dicts)
     into a plain list of dicts safe to round-trip through the request.
 
@@ -513,7 +515,7 @@ def _serialize_tool_calls(tool_calls: list[Any]) -> list[dict[str, Any]]:
     request and reject malformed bytes from a prior turn.  See
     https://github.com/jsiek/deduce/issues/376.
     """
-    out: list[dict[str, Any]] = []
+    out: list[dict[str, object]] = []
     for tc in tool_calls:
         name = _tool_call_function_name(tc)
         args_raw = _tool_call_function_arguments(tc)
@@ -559,7 +561,9 @@ def _is_recoverable_malformed_args_error(exc: BaseException) -> bool:
     return any(marker in msg for marker in _RECOVERABLE_BAD_REQUEST_MARKERS)
 
 
-def _strip_trailing_turn_with_synthetic_note(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _strip_trailing_turn_with_synthetic_note(
+    messages: list[dict[str, object]]
+) -> list[dict[str, object]]:
     """Walk back to the last ``role: assistant`` entry, drop it (and
     any tool messages that followed it), and replace it with a plain
     synthetic note pointing the model at what went wrong.
@@ -573,9 +577,11 @@ def _strip_trailing_turn_with_synthetic_note(messages: list[dict[str, Any]]) -> 
         if messages[i].get("role") == "assistant":
             cut = i
             break
-    return messages[:cut] + [
-        {"role": "assistant", "content": _MALFORMED_RETRY_NOTE}
-    ]
+    note: dict[str, object] = {
+        "role": "assistant",
+        "content": _MALFORMED_RETRY_NOTE,
+    }
+    return messages[:cut] + [note]
 
 
 def _attr(obj: Any, name: str, default: Any = None) -> Any:


### PR DESCRIPTION
## Summary

- Replace the fill-hole progress callback alias with a protocol that accepts object-typed progress fields.
- Type the Anthropic and OpenAI-compatible backend internal message/tool-result payload containers as `dict[str, object]`.
- Leave `Any` only at the SDK client and duck-typed response introspection boundary for these backend adapters.

## Tests

- `python3 -m ruff check tools/claude_fill_hole/agent.py tools/claude_fill_hole/anthropic_backend.py tools/claude_fill_hole/openai_backend.py`
- `MYPYPATH=tools python3 -m mypy --strict tools/claude_fill_hole/agent.py tools/claude_fill_hole/anthropic_backend.py tools/claude_fill_hole/openai_backend.py --follow-imports=silent`
- `python3 -m pytest test/claude_fill_hole/test_anthropic_backend.py test/claude_fill_hole/test_openai_backend.py`
- `make tests`

## Codex session

codex://threads/019e8f81-9b15-7a63-ac62-502326074e9a

```bash
open 'codex://threads/019e8f81-9b15-7a63-ac62-502326074e9a'
```
