### PR TITLE
[codex] Narrow uniquify seed env type

### DIFF
--- a/abstract_syntax/ops.py
+++ b/abstract_syntax/ops.py
@@ -266,7 +266,7 @@ def uniquify_deduce(ast: Sequence[Statement], ctx: UniquifyContext) -> list[Stat
   -- without it, the structural hash of every downstream statement
   drifts on every edit and the cache is useless.
   """
-  env: dict[str, Any] = {}
+  env: dict[str, object] = {}
   env['≠'] = ['≠']
   env['='] = ['=']
   # Using a space in the name to not collide with deduce identifiers


### PR DESCRIPTION
## Summary

- Replace `uniquify_deduce`'s local seed environment annotation with `dict[str, object]`.
- Remove the remaining `Any` mention from `abstract_syntax/ops.py` without changing runtime behavior.

## Tests

- `python3 -m ruff check abstract_syntax/ops.py`
- `python3 -m mypy --strict abstract_syntax/ops.py --follow-imports=silent`
- `make tests`

## Codex session

codex://threads/019e8fb8-13a4-7d32-bb83-2f85d41fe0c4

```bash
open 'codex://threads/019e8fb8-13a4-7d32-bb83-2f85d41fe0c4'
```
