### PR TITLE
[codex] Document list HOF argument order

### DIFF
--- a/gh_pages/doc/FunctionalProgramming.md
+++ b/gh_pages/doc/FunctionalProgramming.md
@@ -469,6 +469,13 @@ recursive all_elements<T>(List<T>, fn T->bool) -> bool {
 }
 ```
 
+The list higher-order functions in `List.pf` put the list before the
+function argument: `map(xs, f)`, `filter(xs, P)`, `foldr(xs, u, c)`,
+and `foldl(xs, u, c)`. This differs from the order used in languages
+such as Haskell, where examples are often written with the function
+first, such as `map f xs` or `foldr f z xs`. When translating those
+examples to Deduce, move the list to the first argument position.
+
 ## Pairs
 
 Pairs are defined as a `union` type:

--- a/gh_pages/doc/StandardLib.md
+++ b/gh_pages/doc/StandardLib.md
@@ -7,7 +7,10 @@ Only the top-level module files (such as `UInt.pf`) are listed below. Each modul
 - ([`Base.thm`](../lib/Base.thm), [`Base.pf`](../lib/Base.pf)): Base proofs about propositional and predicate logic
 - ([`BigO.thm`](../lib/BigO.thm), [`BigO.pf`](../lib/BigO.pf)): Big-O asymptotic analysis on `fn UInt -> UInt`
 - ([`Int.thm`](../lib/Int.thm), [`Int.pf`](../lib/Int.pf)): Integers
-- ([`List.thm`](../lib/List.thm), [`List.pf`](../lib/List.pf)): Lists
+- ([`List.thm`](../lib/List.thm), [`List.pf`](../lib/List.pf)): Lists.
+  Higher-order list functions use collection-first order:
+  `map(xs, f)`, `filter(xs, P)`, `foldr(xs, u, c)`, and
+  `foldl(xs, u, c)`.
 - ([`Maps.thm`](../lib/Maps.thm), [`Maps.pf`](../lib/Maps.pf)): Functional maps
 - ([`MultiSet.thm`](../lib/MultiSet.thm), [`MultiSet.pf`](../lib/MultiSet.pf)): Multisets
 - ([`Nat.thm`](../lib/Nat.thm), [`Nat.pf`](../lib/Nat.pf)): Natural numbers


### PR DESCRIPTION
## Summary

- Document that Deduce list higher-order functions use collection-first order.
- Add the same `map` / `filter` / `foldr` / `foldl` argument-order cue to the standard-library index.

## Tests

- `make tests`

## Codex session

codex://threads/019e8fee-8dfd-7861-9c40-355077e06bbb

```bash
open 'codex://threads/019e8fee-8dfd-7861-9c40-355077e06bbb'
```

Closes #824.
