### PR TITLE
[codex] Drop redundant List imports from examples

### DIFF
--- a/examples/all_any.pf
+++ b/examples/all_any.pf
@@ -19,8 +19,6 @@
 //   3. list_all_any_de_morgan:  the De Morgan duality between them,
 //        not list_all(xs, p) = list_any(xs, fun x { not p(x) })
 
-import List
-
 recursive list_all<T>(List<T>, fn T->bool) -> bool {
   list_all(empty, p) = true
   list_all(node(x, xs), p) = p(x) and list_all(xs, p)

--- a/examples/concat.pf
+++ b/examples/concat.pf
@@ -11,8 +11,6 @@
 //
 //   concat(xss ++ yss) = concat(xss) ++ concat(yss)
 
-import List
-
 recursive concat<T>(List< List<T> >) -> List<T> {
   concat(empty) = empty
   concat(node(xs, xss)) = xs ++ concat(xss)

--- a/examples/count.pf
+++ b/examples/count.pf
@@ -11,8 +11,6 @@
 //   3. count_le_length: number of occurrences cannot exceed length,
 //        count(xs, x) ≤ length(xs)
 
-import List
-
 recursive count<T>(List<T>, T) -> UInt {
   count(empty, x) = 0
   count(node(y, ys), x) = (if y = x then 1 + count(ys, x) else count(ys, x))
@@ -119,4 +117,3 @@ proof
     }
   }
 end
-

--- a/examples/count_if.pf
+++ b/examples/count_if.pf
@@ -9,8 +9,6 @@
 //     countIf :: (a -> Bool) -> [a] -> Int
 //     countIf p xs = length (filter p xs)
 
-import List
-
 recursive count_if<T>(List<T>, fn (T) -> bool) -> UInt {
   count_if(empty, p) = 0
   count_if(node(x, xs), p) =

--- a/examples/fast_reverse.pf
+++ b/examples/fast_reverse.pf
@@ -15,8 +15,6 @@
 //   2. fast_reverse_correct:
 //        fast_reverse(xs) = reverse(xs)
 
-import List
-
 // Tail-recursive reverse-helper: walks `xs` left-to-right, building
 // up the reversed list in the accumulator `acc`.
 recursive fast_reverse_helper<T>(List<T>, List<T>) -> List<T> {

--- a/examples/foldr_foldl.pf
+++ b/examples/foldr_foldl.pf
@@ -15,8 +15,6 @@
 // which is `foldl_shift` below. The main theorem then specializes
 // `a := e` and uses the left-identity law.
 
-import List
-
 theorem foldl_shift: all T:type, op:fn T,T->T, e:T.
   if (all x:T,y:T,z:T. op(op(x,y),z) = op(x,op(y,z)))
      and (all x:T. op(e,x) = x)

--- a/examples/partition.pf
+++ b/examples/partition.pf
@@ -18,8 +18,6 @@
 //      with the negated predicate,
 //        second(partition(xs, p)) = filter(xs, fun y { not p(y) })
 
-import List
-
 recursive partition<T>(List<T>, fn (T)->bool) -> Pair< List<T>, List<T> > {
   partition(empty, p) = pair(@empty<T>, @empty<T>)
   partition(node(x, xs), p) =

--- a/examples/replicate.pf
+++ b/examples/replicate.pf
@@ -11,7 +11,6 @@
 //   2. length_replicate:   length(replicate(n, x)) = n
 
 import UInt
-import List
 
 recfun replicate<T>(n : UInt, x : T) -> List<T>
   measure n of UInt

--- a/examples/take_while.pf
+++ b/examples/take_while.pf
@@ -15,8 +15,6 @@
 //                                 = length(xs)
 //   3. take_while_all:         every element of take_while(xs, p) satisfies p
 
-import List
-
 recursive take_while<T>(List<T>, fn (T)->bool) -> List<T> {
   take_while(empty, p) = empty
   take_while(node(x, xs), p) =


### PR DESCRIPTION
## Summary

- Remove redundant `import List` lines from the examples that still had them.
- Align all `examples/` files with the standard-library prelude behavior.

## Tests

- `make tests`

## Codex session

codex://threads/019e905c-e2e6-7221-99df-340610d20ecc

```bash
open 'codex://threads/019e905c-e2e6-7221-99df-340610d20ecc'
```
