### PR TITLE
[codex] Narrow abstract syntax facade typing

### DIFF
--- a/abstract_syntax/__init__.py
+++ b/abstract_syntax/__init__.py
@@ -87,7 +87,7 @@ for _module in _MODULES:
 # Many migrated methods still resolve peer classes and helper functions as
 # module globals, matching their former single-file lookup behavior.  Populate
 # each submodule with the complete public surface after all modules import.
-_SHARED_GLOBALS: dict[str, Any] = {}
+_SHARED_GLOBALS: dict[str, object] = {}
 for _module in _MODULES:
     for _name in _shared_names(_module):
         _SHARED_GLOBALS[_name] = getattr(_module, _name)
@@ -115,6 +115,8 @@ _DYNAMIC_OWNERS = {
 }
 
 def __getattr__(name: str) -> Any:
+    # The compatibility facade exposes names injected after import; mypy needs
+    # module __getattr__ to stay dynamically typed for those re-exported classes.
     if name in _DYNAMIC_OWNERS:
         return getattr(_DYNAMIC_OWNERS[name], name)
     for module in reversed(_MODULES):

--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -86,6 +86,8 @@ def set_current_module(name: str) -> None:
     global current_module
     current_module = name
 
+UniquifyEnv = dict[str, Any]
+
 ############ AST Base Classes ###########
 
 @dataclass
@@ -114,8 +116,8 @@ class AST:
     # to `self` after construction. New post-hoc attributes are
     # discouraged — declare an `Optional[...]` field on the dataclass
     # instead (see issue #480) — but the loop is kept as a safety net.
-    cls = cast(Any, type(self))
-    non_struct = cls._NON_STRUCTURAL_FIELDS
+    cls = cast(Callable[..., Self], type(self))
+    non_struct = self._NON_STRUCTURAL_FIELDS
     new_args: dict[str, object] = {}
     field_names = set()
     for fld in dc_fields(self):
@@ -136,7 +138,7 @@ class AST:
   def copy(self) -> Self:
     return self._map_children(lambda x: x.copy())
 
-  def uniquify(self, env: dict[str, Any], ctx: UniquifyContext) -> Self:
+  def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Self:
     return self._map_children(lambda x: x.uniquify(env, ctx))
 
   def substitute(self, sub: Mapping[str, Term | Type | RecFun | GenRecFun]) -> AST:
@@ -167,7 +169,7 @@ class Type(AST):
   def free_vars(self) -> Set[str]:
     internal_error(self.location, 'free_vars not implemented')
 
-  def uniquify(self, env: dict[str, Any], ctx: UniquifyContext) -> Type:
+  def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Type:
     return super().uniquify(env, ctx)
 
   def substitute(self, sub: Mapping[str, Term | Type | RecFun | GenRecFun]) -> Type:


### PR DESCRIPTION
## Summary

- Replace the AST base dynamic constructor `cast(Any, type(self))` with a typed `Callable[..., Self]` cast.
- Centralize the AST uniquify environment annotation behind `UniquifyEnv` while preserving the existing `dict[str, Any]` contract used by split submodules.
- Type the abstract-syntax facade shared-global cache as `dict[str, object]` and document why module `__getattr__` must remain dynamically typed for compatibility re-exports.

## Issue

Progress on #681. This does not complete the umbrella issue; `rec_desc_parser.py`, larger checker/parser narrowing, and final global strict cleanup remain.

## Validation

- `python3 -m ruff check abstract_syntax/core.py abstract_syntax/__init__.py`
- `python3 -m mypy --strict abstract_syntax/core.py abstract_syntax/__init__.py --follow-imports=silent`
- `make tests`

## Codex session

codex://threads/019e9283-26f3-7ad0-bb59-4c4c8f1b457b

```bash
open 'codex://threads/019e9283-26f3-7ad0-bb59-4c4c8f1b457b'
```
