### PR TITLE
Add UInt view inverse proof

### DIFF
--- a/lib/UIntDefs.pf
+++ b/lib/UIntDefs.pf
@@ -163,6 +163,23 @@ proof
   }
 end
 
+lemma inc_dub_is_inc_dub: all x:Binary. inc(dub(x)) = inc_dub(x)
+proof
+  induction Binary
+  case bzero {
+    evaluate
+  }
+  case dub_inc(x) assume IH {
+    evaluate
+  }
+  case inc_dub(x) assume IH {
+    expand dub
+    expand inc
+    replace IH
+    .
+  }
+end
+
 lemma inc_add_one_raw: all x:Binary. inc(x) = 1 + x
 proof
   induction Binary
@@ -195,12 +212,31 @@ proof
   }
 end
 
+lemma uint_unview_view: all x:Binary. uint_unview(uint_view(x)) = x
+proof
+  induction Binary
+  case bzero {
+    evaluate
+  }
+  case dub_inc(x) assume IH {
+    expand uint_view | pred | uint_unview
+    replace symmetric inc_add_one_raw[inc_dub(x)]
+    evaluate
+  }
+  case inc_dub(x) assume IH {
+    expand uint_view | pred | uint_unview
+    replace symmetric inc_add_one_raw[dub(x)]
+    inc_dub_is_inc_dub[x]
+  }
+end
+
 view UInt {
   source Binary
   target UIntView
   into uint_view
   out uint_unview
   roundtrip uint_view_unview
+  inverse uint_unview_view
 }
 
 opaque fun div2(b : UInt) {

--- a/test/should-error/predicate_signature_not_bool.pf.err
+++ b/test/should-error/predicate_signature_not_bool.pf.err
@@ -1,1 +1,1 @@
-./lib/UIntDefs.pf:199.10-199.16: the result type of a predicate must be 'bool', not 'UInt'
+./lib/UIntDefs.pf:234.10-234.16: the result type of a predicate must be 'bool', not 'UInt'


### PR DESCRIPTION
## Summary

- prove the UInt view inverse direction `uint_unview(uint_view(x)) = x`
- add `inverse uint_unview_view` to the `view UInt` declaration
- update the affected should-error golden line number after the inserted proof

Refs #795.

## Validation

- `make tests`

## Codex session

codex://threads/019e9327-780c-76f3-8986-5b7c701a3a67

```bash
open 'codex://threads/019e9327-780c-76f3-8986-5b7c701a3a67'
```
