### PR TITLE
Narrow residual Any in high-value modules (#681 part 3)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -730,7 +730,7 @@ class ViewRecFun(Declaration):
 
     def uniquify_case(c: SwitchCase) -> SwitchCase:
       case_env = copy_dict(body_env)
-      pattern = cast(Any, c.pattern)
+      pattern = c.pattern
       params = pattern.bindings()
       new_params = [generate_name(x, ctx) for x in params]
       for (old, new) in zip(params, new_params):
@@ -768,7 +768,7 @@ class ViewRecFun(Declaration):
       + ') -> ' + str(self.returns)
     ret = 'viewrec ' + header + '\nview ' + base_name(self.view_name) \
       + '(' + str(self.view_subject) + ')\n' \
-      + '\n'.join([cast(str, cast(Any, c).pretty_print(indent+2))
+      + '\n'.join([c.pretty_print(indent+2)
                    for c in self.cases]) + '\n'
     return indent*' ' + ret
 

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -509,7 +509,7 @@ class IndCase(AST):
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
     body_env = copy_dict(env_map)
-    pattern = cast(Any, self.pattern)
+    pattern = cast(PatternCons, self.pattern)
 
     new_params = [generate_name(x, uniq_ctx) for x in pattern.parameters]
     for (old, new) in zip(pattern.parameters, new_params):
@@ -672,7 +672,7 @@ class SwitchProofCase(AST):
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
     body_env = copy_dict(env_map)
-    pattern = cast(Any, self.pattern)
+    pattern = self.pattern
 
     new_params = [generate_name(x, uniq_ctx) for x in pattern.bindings()]
     for (old, new) in zip(pattern.bindings(), new_params):

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1170,7 +1170,7 @@ class Call(Term):
       if fast is not None:
         return auto_rewrites(fast, env)
     ret: Term | None = None
-    match cast(Any, fun):
+    match fun:
       case Var(loc, _, '=') | OverloadedVar(loc, _, ['=']) | ResolvedVar(loc, _, '='):
         if args[0] == args[1]:
           ret = Bool(loc, BoolType(loc), True)
@@ -1193,8 +1193,7 @@ class Call(Term):
         # name (e.g. a ``define f = λ ...``) rather than a generic
         # ``anonymous``; literal lambdas with no name fall back to
         # ``<lambda>``.
-        lambda_fun = cast(Lambda, fun)
-        call_env = lambda_fun.env if lambda_fun.env is not None else env
+        call_env = fun.env if fun.env is not None else env
         display_name = callable_name(self.rator) or '<lambda>'
         ret = self.do_call(loc, vars, body, args, call_env, name=display_name)
     
@@ -1210,7 +1209,7 @@ class Call(Term):
                                body, subst, env, None,
                                display_args=args)
 
-      case TermInst(loc, _, subject, type_args) if isinstance(cast(Any, subject), GenRecFun):
+      case TermInst(loc, _, subject, type_args) if isinstance(subject, GenRecFun):
         gen_fun = cast(GenRecFun, subject)
         name = gen_fun.name
         typarams = gen_fun.type_params
@@ -1224,7 +1223,7 @@ class Call(Term):
       case RecFun(loc, name, [], params, returns, cases):
         ret = self.do_recursive_call(loc, name, cast(Term | RecFun, fun), [], [], params, args,
                                      returns, cases, is_assoc, env)
-      case TermInst(loc, _, subject, type_args) if isinstance(cast(Any, subject), RecFun):
+      case TermInst(loc, _, subject, type_args) if isinstance(subject, RecFun):
         rec_fun = cast(RecFun, subject)
         name = rec_fun.name
         typarams = rec_fun.type_params

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -14,7 +14,7 @@ File charter:
 """
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, cast
+from typing import List, Optional, Tuple, cast
 
 from lark.tree import Meta
 
@@ -36,39 +36,20 @@ from checker_cache import (
     _is_global_barrier, _record_hit, _record_miss, _stmt_cache,
 )
 from checker_common import *
-# The remaining checker_* modules still carry ``# mypy: ignore-errors`` and
-# their functions are untyped from mypy's perspective. Importing them through
-# an ``Any``-typed indirection keeps cross-module calls compatible with
-# ``disallow_untyped_calls`` until those files are strictified in turn.
 from checker_predicates import (
-    _build_predicate_translation as _build_predicate_translation_raw,
-    _check_predicate_strict_positivity as _check_predicate_strict_positivity_raw,
-    _predicate_style_hint as _predicate_style_hint_raw,
-    _validate_predicate_rule_shape as _validate_predicate_rule_shape_raw,
-    _validate_predicate_signature as _validate_predicate_signature_raw,
+    _build_predicate_translation, _check_predicate_strict_positivity,
+    _predicate_style_hint, _validate_predicate_rule_shape,
+    _validate_predicate_signature,
 )
-from checker_induction import match_induction as match_induction_raw
-from checker_logic import pattern_to_term as pattern_to_term_raw
-from checker_proofs import (
-    _try_check_proof_of as _try_check_proof_of_raw,
-    generate_proof_name as generate_proof_name_raw,
-)
+from checker_induction import match_induction
+from checker_logic import pattern_to_term
+from checker_proofs import _try_check_proof_of, generate_proof_name
 from checker_types import (
-    check_constructor_pattern as check_constructor_pattern_raw,
-    check_formula as check_formula_raw,
-    check_no_recfun_escape as check_no_recfun_escape_raw,
-    check_pattern as check_pattern_raw,
-    check_strict_positivity as check_strict_positivity_raw,
-    check_type as check_type_raw,
-    dirty_files,
-    get_recursive_call_count as get_recursive_call_count_raw,
-    infer_param_polarities as infer_param_polarities_raw,
-    is_modified as is_modified_raw,
-    lookup_union as lookup_union_raw,
-    reset_recursive_call_count as reset_recursive_call_count_raw,
-    type_check_formula as type_check_formula_raw,
-    type_check_term as type_check_term_raw,
-    type_synth_term as type_synth_term_raw,
+    check_constructor_pattern, check_formula, check_no_recfun_escape,
+    check_pattern, check_strict_positivity, check_type, dirty_files,
+    get_recursive_call_count, infer_param_polarities, is_modified,
+    lookup_union, reset_recursive_call_count, type_check_formula,
+    type_check_term, type_synth_term,
 )
 from error import (
     Diagnostic, ErrorSink, MatchFailed, error_header, get_active_sink,
@@ -79,41 +60,13 @@ from flags import (
     get_target_hole_location, get_verbose, set_verbose,
 )
 
-# Any-typed re-exports so the cross-checker calls below pass
-# ``disallow_untyped_calls`` without adding signatures to the still-ratcheting
-# modules (those files are being strictified in parallel and any signature
-# added here would risk a merge conflict).
-_build_predicate_translation: Any = _build_predicate_translation_raw
-_check_predicate_strict_positivity: Any = _check_predicate_strict_positivity_raw
-_predicate_style_hint: Any = _predicate_style_hint_raw
-_validate_predicate_rule_shape: Any = _validate_predicate_rule_shape_raw
-_validate_predicate_signature: Any = _validate_predicate_signature_raw
-match_induction: Any = match_induction_raw
-pattern_to_term: Any = pattern_to_term_raw
-_try_check_proof_of: Any = _try_check_proof_of_raw
-generate_proof_name: Any = generate_proof_name_raw
-check_constructor_pattern: Any = check_constructor_pattern_raw
-check_formula: Any = check_formula_raw
-check_no_recfun_escape: Any = check_no_recfun_escape_raw
-check_pattern: Any = check_pattern_raw
-check_strict_positivity: Any = check_strict_positivity_raw
-check_type: Any = check_type_raw
-get_recursive_call_count: Any = get_recursive_call_count_raw
-infer_param_polarities: Any = infer_param_polarities_raw
-is_modified: Any = is_modified_raw
-lookup_union: Any = lookup_union_raw
-reset_recursive_call_count: Any = reset_recursive_call_count_raw
-type_check_formula: Any = type_check_formula_raw
-type_check_term: Any = type_check_term_raw
-type_synth_term: Any = type_synth_term_raw
-
 imported_modules: set[str] = set()
 checked_modules: set[str] = set()
 
 Substitution = dict[str, Term | Type | RecFun | GenRecFun]
 TypeMatching = dict[str, Type | VarRef | None]
 ViewInfo = tuple[ViewDecl, Type, Type]
-PatternCoverage = dict[str, object]
+PatternCoverage = dict[str, bool]
 ParamTypes = list[tuple[str, Type]]
 
 def process_declaration_visibility(decl: Declaration, env: Env,

--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -12,7 +12,7 @@ File charter:
   lowering or custom induction generation.
 """
 
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from lark.tree import Meta
 
@@ -129,7 +129,7 @@ def generate_proof_name(name: str) -> str:
 # ---------------------------------------------------------------------------
 #
 
-def _check_proof_recall(proof: Any, env: Env) -> Any:
+def _check_proof_recall(proof: PRecall, env: Env) -> CheckedFormula:
   loc = proof.location
   results = []
   for fact in proof.facts:
@@ -146,7 +146,7 @@ def _check_proof_recall(proof: Any, env: Env) -> Any:
       return results[0]
   user_error(loc, 'expected some facts after `recall`')
 
-def _check_proof_var(proof: Any, env: Env) -> Any:
+def _check_proof_var(proof: PVar, env: Env) -> CheckedFormula:
   loc = proof.location
   try:
     formula = env.get_formula_of_proof_var(proof)
@@ -156,10 +156,10 @@ def _check_proof_var(proof: Any, env: Env) -> Any:
   except UserError as e:
     user_error(loc, str(e))
 
-def _check_proof_true(proof: Any, env: Env) -> Any:
+def _check_proof_true(proof: PTrue, env: Env) -> CheckedFormula:
   return Bool(proof.location, BoolType(proof.location), True)
 
-def _check_proof_and_elim(proof: Any, env: Env) -> Any:
+def _check_proof_and_elim(proof: PAndElim, env: Env) -> CheckedFormula:
   loc = proof.location
   formula = check_proof(proof.subject, env)
   if isinstance(formula, TLet):
@@ -175,7 +175,7 @@ def _check_proof_and_elim(proof: Any, env: Env) -> Any:
     case _:
       user_error(loc, 'expected a conjunction, not ' + str(formula))
 
-def _check_proof_evaluate_fact(proof: Any, env: Env) -> Any:
+def _check_proof_evaluate_fact(proof: EvaluateFact, env: Env) -> CheckedFormula:
   formula = check_proof(proof.subject, env)
   set_reduce_all(True)
   try:
@@ -183,11 +183,11 @@ def _check_proof_evaluate_fact(proof: Any, env: Env) -> Any:
   finally:
     set_reduce_all(False)
 
-def _check_proof_apply_defs_fact(proof: Any, env: Env) -> Any:
+def _check_proof_apply_defs_fact(proof: ApplyDefsFact, env: Env) -> CheckedFormula:
   formula = check_proof(proof.subject, env)
   return expand_definitions(proof.location, formula, proof.definitions, env)
 
-def _check_proof_rewrite_fact(proof: Any, env: Env) -> Any:
+def _check_proof_rewrite_fact(proof: RewriteFact, env: Env) -> CheckedFormula:
   formula = check_proof(proof.subject, env)
   eqns = [check_proof(equation_proof, env)
           for equation_proof in proof.equations]
@@ -195,7 +195,7 @@ def _check_proof_rewrite_fact(proof: Any, env: Env) -> Any:
   return apply_rewrites(proof.location, red_formula, eqns, env,
                         display_formula=formula)
 
-def _check_proof_simplify_fact(proof: Any, env: Env) -> Any:
+def _check_proof_simplify_fact(proof: SimplifyFact, env: Env) -> CheckedFormula:
   formula = check_proof(proof.subject, env)
   preds = [check_proof(given, env) for given in proof.givens]
   equations = [pred_to_equality(proof.location, p) for p in preds]
@@ -203,23 +203,23 @@ def _check_proof_simplify_fact(proof: Any, env: Env) -> Any:
   new_formula = apply_rewrites(proof.location, formula, eqns, env)
   return new_formula.reduce(env)
 
-def _check_proof_hole(proof: Any, env: Env) -> Any:
+def _check_proof_hole(proof: PHole, env: Env) -> CheckedFormula:
   incomplete_error(proof.location, 'unfinished proof')
 
-def _check_proof_sorry(proof: Any, env: Env) -> Any:
+def _check_proof_sorry(proof: PSorry, env: Env) -> CheckedFormula:
   user_error(proof.location, "can't use sorry in context with unknown goal")
 
-def _check_proof_help_use(proof: Any, env: Env) -> Any:
+def _check_proof_help_use(proof: PHelpUse, env: Env) -> CheckedFormula:
   formula = check_proof(proof.proof, env)
   user_error(proof.location, proof_use_advice(proof.proof, formula, env))
 
-def _check_proof_tlet_new(proof: Any, env: Env) -> Any:
+def _check_proof_tlet_new(proof: PTLetNew, env: Env) -> CheckedFormula:
   new_rhs = type_synth_term(proof.rhs, env, None, [])
   body_env = env.define_term_var(proof.location, proof.var,
                                  new_rhs.typeof, new_rhs)
   return check_proof(proof.body, body_env)
 
-def _check_proof_let(proof: Any, env: Env) -> Any:
+def _check_proof_let(proof: PLet, env: Env) -> CheckedFormula:
   loc = proof.location
   new_frm = check_formula(proof.proved, env)
   match new_frm:
@@ -232,7 +232,7 @@ def _check_proof_let(proof: Any, env: Env) -> Any:
                                              remove_mark(new_frm))
       return check_proof(proof.body, body_env)
 
-def _check_proof_annot(proof: Any, env: Env) -> Any:
+def _check_proof_annot(proof: PAnnot, env: Env) -> CheckedFormula:
   loc = proof.location
   new_claim = check_formula(proof.claim, env)
   match new_claim:
@@ -243,12 +243,12 @@ def _check_proof_annot(proof: Any, env: Env) -> Any:
       _try_check_proof_of(proof.body, new_claim, env)
       return remove_mark(new_claim)
 
-def _check_proof_tuple(proof: Any, env: Env) -> Any:
+def _check_proof_tuple(proof: PTuple, env: Env) -> CheckedFormula:
   loc = proof.location
   frms = [check_proof(pf, env) for pf in proof.args]
   return And(loc, BoolType(loc), frms)
 
-def _check_proof_imp_intro(proof: Any, env: Env) -> Any:
+def _check_proof_imp_intro(proof: ImpIntro, env: Env) -> CheckedFormula:
   loc = proof.location
   if proof.premise is not None:
       new_prem = check_formula(proof.premise, env)
@@ -258,7 +258,7 @@ def _check_proof_imp_intro(proof: Any, env: Env) -> Any:
   conc = check_proof(proof.body, body_env)
   return IfThen(loc, BoolType(loc), new_prem, conc)
 
-def _check_proof_all_intro(proof: Any, env: Env) -> Any:
+def _check_proof_all_intro(proof: AllIntro, env: Env) -> CheckedFormula:
   loc = proof.location
   body_env = env
   x, ty = proof.var
@@ -271,7 +271,7 @@ def _check_proof_all_intro(proof: Any, env: Env) -> Any:
   formula = check_proof(proof.body, body_env)
   return All(loc, BoolType(loc), checked_var, proof.pos, formula)
 
-def _check_proof_all_elim(proof: Any, env: Env) -> Any:
+def _check_proof_all_elim(proof: AllElim, env: Env) -> CheckedFormula:
   loc = proof.location
   allfrm = check_proof(proof.univ, env)
 
@@ -301,7 +301,7 @@ def _check_proof_all_elim(proof: Any, env: Env) -> Any:
                  + '\n' + style.orange('Givens:') + '\n' + env.proofs_str())
   return instantiate(loc, allfrm, new_arg)
 
-def _check_proof_all_elim_types(proof: Any, env: Env) -> Any:
+def _check_proof_all_elim_types(proof: AllElimTypes, env: Env) -> CheckedFormula:
   loc = proof.location
   allfrm = check_proof(proof.univ, env)
 
@@ -320,7 +320,7 @@ def _check_proof_all_elim_types(proof: Any, env: Env) -> Any:
       user_error(loc, 'expected all formula to instantiate, not ' + str(allfrm))
   return instantiate(loc, allfrm, type_arg)
 
-def _check_proof_modus_ponens(proof: Any, env: Env) -> Any:
+def _check_proof_modus_ponens(proof: ModusPonens, env: Env) -> CheckedFormula:
   loc = proof.location
   ifthen = check_proof(proof.implication, env)
   match ifthen:
@@ -358,7 +358,7 @@ def _check_proof_modus_ponens(proof: Any, env: Env) -> Any:
       arg_frm = check_proof(proof.arg, env)
       for prem, conc in imps:
         try:
-          matching: dict[str, Any] = {}
+          matching: dict[str, Term] = {}
           formula_match(loc, vars, prem, arg_frm, matching, env,
                         numeric_literals=True)
           type_vars = [x for x in vars if isinstance(x.typeof, TypeType)]
@@ -389,7 +389,7 @@ def _check_proof_modus_ponens(proof: Any, env: Env) -> Any:
     case _:
       user_error(loc, "in 'apply', expected an if-then formula, not " + str(ifthen))
 
-def _check_proof_injective(proof: Any, env: Env) -> Any:
+def _check_proof_injective(proof: PInjective, env: Env) -> CheckedFormula:
   loc = proof.location
   check_type(proof.constr, env)
   if not is_constructor(proof.constr.name, env):
@@ -424,13 +424,13 @@ def _check_proof_injective(proof: Any, env: Env) -> Any:
     case _:
       user_error(loc, 'in injective, non-applicable formula: ' + str(formula))
 
-def _check_proof_symmetric(proof: Any, env: Env) -> Any:
+def _check_proof_symmetric(proof: PSymmetric, env: Env) -> CheckedFormula:
   loc = proof.location
   frm = check_proof(proof.body, env)
   (a,b) = split_equation(loc, frm, env)
   return mkEqual(loc, b, a)
 
-def _check_proof_transitive(proof: Any, env: Env) -> Any:
+def _check_proof_transitive(proof: PTransitive, env: Env) -> CheckedFormula:
   loc = proof.location
   eq1 = check_proof(proof.first, env)
   eq2 = check_proof(proof.second, env)
@@ -960,12 +960,12 @@ def pred_to_equality(meta: Meta, pred: CheckedFormula) -> CheckedFormula:
           return Call(meta, None, ResolvedVar(meta, None, '='),
                       [pred , Bool(meta, None, True)])
 
-def _check_rule_induction(proof: Any, goal: CheckedFormula, env: Env) -> None:
+def _check_rule_induction(proof: RuleInduction, goal: CheckedFormula, env: Env) -> None:
   """See `_check_rule_inversion`: same shape, applies the
   `<pred>_rule_induction` theorem instead of the inversion theorem."""
   _check_rule_induction_or_inversion(proof, goal, env, is_inversion=False)
 
-def _check_rule_inversion(proof: Any, goal: CheckedFormula, env: Env) -> None:
+def _check_rule_inversion(proof: RuleInversion, goal: CheckedFormula, env: Env) -> None:
   """Desugar `rule inversion <pred> case <r1> { ... } ...` to
      `apply <pred>_rule_inversion[<motive>] to (<case_1>, ..., <case_k>)`.
   Same goal shape as `rule induction`, but each case proves the rule's
@@ -974,7 +974,7 @@ def _check_rule_inversion(proof: Any, goal: CheckedFormula, env: Env) -> None:
   _check_rule_induction_or_inversion(proof, goal, env, is_inversion=True)
 
 def _check_rule_induction_or_inversion(
-    proof: Any,
+    proof: RuleInduction | RuleInversion,
     goal: CheckedFormula,
     env: Env,
     is_inversion: bool,
@@ -1076,7 +1076,7 @@ def _check_rule_induction_or_inversion(
 
   _try_check_proof_of(desugared, goal, env)
 
-def _check_proof_of_hole(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_hole(proof: PHole, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_formula = check_formula(remove_mark(formula), env)
   # Uncommented by i ran into a proof where I had to prove
@@ -1096,10 +1096,10 @@ def _check_proof_of_hole(proof: Any, formula: CheckedFormula, env: Env) -> None:
                    + givens,
                    formula=new_formula, env=env)
 
-def _check_proof_of_sorry(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_sorry(proof: PSorry, formula: CheckedFormula, env: Env) -> None:
   warning(proof.location, 'unfinished proof')
 
-def _check_proof_of_reflexive(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_reflexive(proof: PReflexive, formula: CheckedFormula, env: Env) -> None:
   match formula:
     case Call(_, _, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
       lhsNF = lhs.reduce(env)
@@ -1119,13 +1119,13 @@ def _check_proof_of_reflexive(proof: Any, formula: CheckedFormula, env: Env) -> 
                      + str(formula) \
                      + givens_str(env))
 
-def _check_proof_of_symmetric(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_symmetric(proof: PSymmetric, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   (a,b) = split_equation(loc, formula, env)
   flip_formula = mkEqual(loc, b, a)
   _try_check_proof_of(proof.body, flip_formula, env)
 
-def _check_proof_of_transitive(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_transitive(proof: PTransitive, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   (a1,c) = split_equation(loc, formula, env)
 
@@ -1145,7 +1145,7 @@ def _check_proof_of_transitive(proof: Any, formula: CheckedFormula, env: Env) ->
           + 'but that does not match the goal\n\t' + str(formula) + '\n'
           + givens_str(env))
 
-def _check_proof_of_extensionality(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_extensionality(proof: PExtensionality, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   (lhs,rhs) = split_equation(loc, formula, env)
   match lhs.typeof:
@@ -1165,7 +1165,7 @@ def _check_proof_of_extensionality(proof: Any, formula: CheckedFormula, env: Env
       add_diagnostic(loc, 'extensionality expects a function, not ' + str(lhs.typeof)
             + givens_str(env))
 
-def _check_proof_of_evaluate_goal(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_evaluate_goal(proof: EvaluateGoal, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   set_reduce_all(True)
   set_dont_reduce_opaque(True)
@@ -1177,7 +1177,7 @@ def _check_proof_of_evaluate_goal(proof: Any, formula: CheckedFormula, env: Env)
           + str(red_formula)
           + givens_str(env))
 
-def _check_proof_of_rewrite_goal(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_rewrite_goal(proof: RewriteGoal, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   equations = [check_proof(proof, env) for proof in proof.equations]
   eqns = [equation.reduce(env) for equation in equations]
@@ -1186,7 +1186,7 @@ def _check_proof_of_rewrite_goal(proof: Any, formula: CheckedFormula, env: Env) 
                                display_formula=formula)
   _try_check_proof_of(proof.body, new_formula, env)
 
-def _check_proof_of_simplify_goal(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_simplify_goal(proof: SimplifyGoal, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   preds = [check_proof(proof, env) for proof in proof.givens]
   equations = [pred_to_equality(loc, p) for p in preds]
@@ -1195,7 +1195,7 @@ def _check_proof_of_simplify_goal(proof: Any, formula: CheckedFormula, env: Env)
   new_formula = new_formula.reduce(env)
   _try_check_proof_of(proof.body, new_formula, env)
 
-def _check_proof_of_apply_defs_goal(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_apply_defs_goal(proof: ApplyDefsGoal, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_formula = expand_definitions(loc, formula, proof.definitions, env)
   red_formula = new_formula.reduce(env)
@@ -1222,7 +1222,7 @@ def _check_proof_of_apply_defs_goal(proof: Any, formula: CheckedFormula, env: En
         if isinstance(entry, UserError):
           sink.errors[i] = wrap_user_error(entry, hint)
 
-def _check_proof_of_all_intro(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_all_intro(proof: AllIntro, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   var = proof.var
   body = proof.body
@@ -1255,7 +1255,7 @@ def _check_proof_of_all_intro(proof: Any, formula: CheckedFormula, env: Env) -> 
             + str(formula)
             + givens_str(env))
 
-def _check_proof_of_some_intro(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_some_intro(proof: SomeIntro, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   # room for improvement, if var has type annotation, could type_check the witness
   witnesses = [type_synth_term(trm, env, None, []) for trm in proof.witnesses]
@@ -1272,7 +1272,7 @@ def _check_proof_of_some_intro(proof: Any, formula: CheckedFormula, env: Env) ->
       add_diagnostic(loc, "choose expects the goal to start with 'some', not " + str(formula)
             + givens_str(env))
 
-def _check_proof_of_some_elim(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_some_elim(proof: SomeElim, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   someFormula = check_proof(proof.some, env)
 
@@ -1297,7 +1297,7 @@ def _check_proof_of_some_elim(proof: Any, formula: CheckedFormula, env: Env) -> 
       add_diagnostic(loc, "obtain expects 'from' to be a proof of a 'some' formula, not " + str(someFormula)
             + givens_str(env))
 
-def _check_proof_of_imp_intro(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_imp_intro(proof: ImpIntro, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
 
   if proof.premise is None:
@@ -1331,7 +1331,7 @@ def _check_proof_of_imp_intro(proof: Any, formula: CheckedFormula, env: Env) -> 
       add_diagnostic(proof.location, 'the assume statement is for if-then formula, not ' + str(formula)
             + givens_str(env))
 
-def _check_proof_of_tlet_new(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_tlet_new(proof: PTLetNew, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_rhs = type_synth_term(proof.rhs, env, None, [])
   body_env = env.define_term_var(loc, proof.var, new_rhs.typeof, new_rhs)
@@ -1348,7 +1348,7 @@ def _check_proof_of_tlet_new(proof: Any, formula: CheckedFormula, env: Env) -> N
                        for (k,b) in body_env.dict.items()})
   _try_check_proof_of(proof.body, frm, new_body_env)
 
-def _check_proof_of_let(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_let(proof: PLet, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_frm = check_formula(proof.proved, env)
   match new_frm:
@@ -1361,7 +1361,7 @@ def _check_proof_of_let(proof: Any, formula: CheckedFormula, env: Env) -> None:
       body_env = env.declare_local_proof_var(loc, proof.label, remove_mark(new_frm))
   _try_check_proof_of(proof.body, formula, body_env)
 
-def _check_proof_of_annot(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_annot(proof: PAnnot, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_claim = check_formula(proof.claim, env)
   match new_claim:
@@ -1376,7 +1376,7 @@ def _check_proof_of_annot(proof: Any, formula: CheckedFormula, env: Env) -> None
                     remove_mark(formula_red).reduce(env))
       _try_check_proof_of(proof.body, claim_red, env)
 
-def _check_proof_of_tuple(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_tuple(proof: PTuple, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   try:
     with speculative_probe():
@@ -1407,7 +1407,7 @@ def _check_proof_of_tuple(proof: Any, formula: CheckedFormula, env: Env) -> None
             + str(ex2)
             + givens_str(env))
 
-def _check_proof_of_cases(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_cases(proof: Cases, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   sub_frm = check_proof(proof.subject, env)
 
@@ -1433,7 +1433,7 @@ def _check_proof_of_cases(proof: Any, formula: CheckedFormula, env: Env) -> None
       add_diagnostic(proof.location, "expected 'or', not " + str(sub_red)
             + givens_str(env))
 
-def _check_proof_of_suffices(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_suffices(proof: Suffices, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   claim = proof.claim
   reason = proof.reason
@@ -1496,7 +1496,7 @@ def _check_proof_of_suffices(proof: Any, formula: CheckedFormula, env: Env) -> N
       _try_check_proof_of(reason, imp, env)
       _try_check_proof_of(rest, claim_red, env)
 
-def _check_proof_of_induction(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_induction(proof: Induction, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   typ = check_type(proof.typ, env)
   cases = proof.cases
@@ -1577,7 +1577,7 @@ def _check_proof_of_induction(proof: Any, formula: CheckedFormula, env: Env) -> 
           add_diagnostic(loc, 'expected ' + str(len(alts)) + ' cases for induction' \
                 + ', but only have ' + str(len(cases))
                 + givens_str(env))
-        cases_present: dict[str, Any] = {}
+        cases_present: dict[str, bool] = {}
         for (constr,indcase) in zip(alts, cases):
           check_pattern(indcase.pattern, typ, env, cases_present)
           if get_verbose():
@@ -1637,7 +1637,7 @@ def _check_proof_of_induction(proof: Any, formula: CheckedFormula, env: Env) -> 
         add_diagnostic(loc, "induction expected name of union, not " + str(typ)
               + '\nwhich resolves to\n' + str(blah) + '\nin ' + str(env))
 
-def _check_proof_of_switch(proof: Any, formula: CheckedFormula, env: Env) -> None:
+def _check_proof_of_switch(proof: SwitchProof, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_subject = type_synth_term(proof.subject, env, None, [])
   cases = proof.cases
@@ -1742,7 +1742,7 @@ def _check_proof_of_switch(proof: Any, formula: CheckedFormula, env: Env) -> Non
             add_diagnostic(loc, 'expected ' + str(len(alts)) + ' cases in switch ('
                   + ', '.join(alt_name_list) + '), ' + '; '.join(suffix_parts)
                   + givens_str(env))
-          cases_present: dict[str, Any] = {}
+          cases_present: dict[str, bool] = {}
           for (constr,scase) in zip(alts, cases):
             check_pattern(scase.pattern, ty, env, cases_present)
             if scase.pattern.constructor.name != constr.name:

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -45,7 +45,21 @@ import traceback as _traceback
 from dataclasses import dataclass
 from enum import Enum
 from lark.tree import Meta
-from typing import Any, Callable, Iterator, Optional, Sequence, Union, cast
+from typing import (
+    TYPE_CHECKING, Any, Callable, Iterator, Optional, Sequence, Union, cast,
+)
+
+if TYPE_CHECKING:
+    # Type-only imports.  The runtime body keeps its lazy ``from
+    # abstract_syntax import ...`` pattern so this module stays free of
+    # any pipeline import at module-load time (the protocol-neutral
+    # boundary the docstring guarantees); these names exist only for
+    # annotations and never execute.
+    from abstract_syntax import (
+        AST, All, And, Auto, Env, Formula, IfThen, Import, Or,
+        ResolvedVar, Some, Statement, Term, Type,
+    )
+    from abstract_syntax import Union as UnionDecl
 
 
 __all__ = [
@@ -97,7 +111,11 @@ __all__ = [
 
 # TODO: remove the _call_untyped function.
 def _call_untyped(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-    """Typed boundary for calls into not-yet-strict Deduce core modules."""
+    # Any: dynamic-dispatch boundary into lazily-imported pipeline
+    # helpers (set_reduce_all, instantiate, collect_all_if_then,
+    # formula_match, split_equation, apply_rewrites, expand_definitions,
+    # ...). The call site casts the result to the concrete type it
+    # expects; the variadic signature can't express that per-callee.
     return fn(*args, **kwargs)
 
 
@@ -659,7 +677,7 @@ def _format_unstructured_exception(
     return f"internal error in Deduce: {msg}"
 
 
-def _format_incomplete_proof_message(formula: Any) -> str:
+def _format_incomplete_proof_message(formula: "Formula") -> str:
     """Render an ``IncompleteProof`` as a one-line diagnostic.
 
     LSP diagnostic messages land in space-constrained UI: the echo
@@ -904,7 +922,9 @@ def _goal_from_exception(
     )
 
 
-def _normalize_formula(formula_ast: Any, env: Any, rendered: str) -> Optional[str]:
+def _normalize_formula(
+    formula_ast: Optional["Formula"], env: Optional["Env"], rendered: str
+) -> Optional[str]:
     """Render the auto-reduced form of ``formula_ast`` under ``env``.
 
     Returns ``None`` when reduction is unavailable (missing AST or env)
@@ -924,7 +944,7 @@ def _normalize_formula(formula_ast: Any, env: Any, rendered: str) -> Optional[st
 
 
 def _attach_normalized_givens(
-    givens: tuple[Given, ...], env: Any
+    givens: tuple[Given, ...], env: Optional["Env"]
 ) -> tuple[Given, ...]:
     """Add ``formula_normalized`` to each given when env exposes its AST.
 
@@ -941,7 +961,7 @@ def _attach_normalized_givens(
     except Exception:
         return givens
 
-    by_label: dict[str, Any] = {}
+    by_label: dict[str, "Formula"] = {}
     for unique, binding in env.dict.items():
         if not isinstance(binding, ProofBinding):
             continue
@@ -1215,7 +1235,7 @@ def completions_at(
 
 def _completion_env_and_goal(
     path: str, content: str, pos: Position, prelude: Sequence[str],
-) -> tuple[Any, Any]:
+) -> tuple[Optional["Env"], Optional["Formula"]]:
     """Return ``(env, goal)`` visible at ``pos``, or ``(None, None)``.
 
     Two paths:
@@ -1305,7 +1325,7 @@ def _strip_partial_word(
 
 
 def _local_completion_candidates(
-    env: Any, seen: set[str]
+    env: "Env", seen: set[str]
 ) -> Iterator[CompletionCandidate]:
     """Yield :class:`CompletionCandidate` items for in-scope bindings
     in ``env`` whose base name isn't already in ``seen``.
@@ -1362,9 +1382,9 @@ def _bump_priority(cand: CompletionCandidate, priority: int) -> CompletionCandid
 
 
 def _collect_completion_names_from_ast(
-    ast_nodes: Any,
-    _seen: Optional[set[Any]] = None,
-) -> Any:
+    ast_nodes: Sequence["Statement"],
+    _seen: Optional[set[str]] = None,
+) -> Iterator[CompletionCandidate]:
     """Yield a :class:`CompletionCandidate` per named top-level decl.
 
     Walks the user file's top-level statements plus ``Import.ast``
@@ -1464,7 +1484,7 @@ def _meta_contains(meta: Meta, pos: Position) -> bool:
 
 
 def _find_reference_at(
-    ast_nodes: Sequence[Any], pos: Position, path: str
+    ast_nodes: Sequence["Statement"], pos: Position, path: str
 ) -> Optional[str]:
     """Locate the smallest reference node whose range contains ``pos``.
 
@@ -1493,7 +1513,7 @@ def _find_reference_at(
     best: list[Optional[str]] = [None]
     best_span: list[Optional[int]] = [None]
 
-    def visit(node: Any) -> None:
+    def visit(node: "AST") -> None:
         if isinstance(node, VarRef):
             resolved = node.get_name()
         elif isinstance(node, PVar):
@@ -1559,7 +1579,8 @@ def _meta_span(meta: Meta) -> int:
 
 
 def _find_declaration(
-    ast_nodes: Sequence[Any], target_name: str, _seen: Optional[set[str]] = None
+    ast_nodes: Sequence["Statement"], target_name: str,
+    _seen: Optional[set[str]] = None,
 ) -> Optional[Meta]:
     """Find a declaration whose uniquified ``name`` field equals
     ``target_name``.  Returns its ``Meta`` location, or ``None``.
@@ -1630,9 +1651,9 @@ def _find_declaration(
 
 
 def _walk_ast(
-    node: Any,
-    visit: Callable[[Any], None],
-    ast_class: type[Any],
+    node: "AST",
+    visit: Callable[["AST"], None],
+    ast_class: type["AST"],
     seen: Optional[set[int]] = None,
 ) -> None:
     """Recursively visit every AST descendant of ``node``.
@@ -1663,7 +1684,7 @@ def _walk_ast(
                     _walk_ast(item, visit, ast_class, seen)
 
 
-def _symbol_info_for(stmt: Any, path: str) -> Optional[SymbolInfo]:
+def _symbol_info_for(stmt: "Statement", path: str) -> Optional[SymbolInfo]:
     """Build a ``SymbolInfo`` for a top-level statement, or ``None``
     if the node isn't a kind we surface (e.g. ``Auto``)."""
     from abstract_syntax import (
@@ -1891,7 +1912,7 @@ def _offset_to_line_col(content: str, offset: int) -> tuple[int, int]:
     return (line, offset - line_start + 1)
 
 
-def _refine_template(formula: Any, env: Any) -> Optional[str]:
+def _refine_template(formula: "Formula", env: Optional["Env"]) -> Optional[str]:
     """Select a refinement template based on the goal AST.
 
     Imports the AST node classes lazily so this module's import-time
@@ -1937,7 +1958,7 @@ def _refine_template(formula: Any, env: Any) -> Optional[str]:
     return None
 
 
-def _fresh_assume_label(env: Any) -> str:
+def _fresh_assume_label(env: Optional["Env"]) -> str:
     """Return the lowest ``H<N>`` (N >= 1) not already bound in ``env``.
 
     Successive ``assume H1: ...``, ``assume H2: ...`` invocations
@@ -2075,7 +2096,7 @@ def splittable_vars_at(
     return _splittable_vars(env)
 
 
-def _splittable_vars(env: Any) -> tuple[str, ...]:
+def _splittable_vars(env: "Env") -> tuple[str, ...]:
     """Names of bindings whose ``case_split`` would succeed.
 
     Excludes constructor names: the env stores each union's
@@ -2132,7 +2153,7 @@ def _splittable_vars(env: Any) -> tuple[str, ...]:
     return tuple(sorted(seen))
 
 
-def _case_split_template(name: str, env: Any) -> Optional[str]:
+def _case_split_template(name: str, env: "Env") -> Optional[str]:
     """Render a switch/cases skeleton for the variable named ``name``.
 
     Looks up ``name`` in ``env`` by base name (the dict is keyed by
@@ -2186,7 +2207,7 @@ def _case_split_template(name: str, env: Any) -> Optional[str]:
     return None
 
 
-def _cases_template(var_name: str, formula: Any, env: Any) -> str:
+def _cases_template(var_name: str, formula: "Or", env: "Env") -> str:
     """Render a ``cases <var> ...`` block for an ``Or`` formula.
 
     Each disjunct gets a fresh per-branch label so successive
@@ -2210,7 +2231,7 @@ def _cases_template(var_name: str, formula: Any, env: Any) -> str:
     return f"cases {var_name}\n" + "\n".join(case_lines)
 
 
-def _switch_template(var_name: str, union_def: Any, env: Any) -> str:
+def _switch_template(var_name: str, union_def: "UnionDecl", env: "Env") -> str:
     """Render a ``switch <var> { ... }`` block for a ``Union`` type.
 
     Each constructor's parameters get fresh names against the
@@ -2251,7 +2272,7 @@ def _switch_template(var_name: str, union_def: Any, env: Any) -> str:
     return f"switch {var_name} {{\n" + "\n".join(case_lines) + "\n}"
 
 
-def _type_first_letter(ty: Any) -> str:
+def _type_first_letter(ty: "Type") -> str:
     """First letter of a type's printed form, lowercased.
 
     Mirrors the naming convention in ``proof_advice``: a parameter of
@@ -2334,7 +2355,7 @@ def induction_skeleton_at(
     return WorkspaceEdit(path=path, range=hole_range, new_text=template)
 
 
-def _induction_template(formula: Any, env: Any) -> Optional[str]:
+def _induction_template(formula: "Formula", env: "Env") -> Optional[str]:
     """Render an ``induction T`` skeleton if ``formula`` is
     ``all x:T. P(x)`` with T a multi-alternative union."""
     from abstract_syntax import (
@@ -2367,7 +2388,7 @@ def _induction_template(formula: Any, env: Any) -> Optional[str]:
 
 
 def _render_induction(
-    var_x: str, var_ty: Any, body: Any, union_def: Any, env: Any
+    var_x: str, var_ty: "Type", body: "Formula", union_def: "UnionDecl", env: "Env"
 ) -> str:
     """Build the ``induction T\\n  case ... { ? }\\n  ...`` text."""
     from abstract_syntax import ResolvedVar, base_name
@@ -2384,7 +2405,7 @@ def _render_induction(
     for alt in union_def.alternatives:
         cons_name = base_name(alt.name)
         used = set(env_used)
-        params: list[tuple[str, Any]] = []  # (name, type) pairs for this case
+        params: list[tuple[str, Type]] = []  # (name, type) pairs for this case
         for i, p_ty in enumerate(alt.parameters):
             stem = _type_first_letter(p_ty)
             candidate = f"{stem}{i + 1}"
@@ -2541,7 +2562,7 @@ def eliminable_vars_at(
     return _eliminable_vars(env)
 
 
-def _eliminable_vars(env: Any) -> tuple[str, ...]:
+def _eliminable_vars(env: "Env") -> tuple[str, ...]:
     """Names of local proof bindings whose ``eliminate'' would
     produce a meaningful edit."""
     from abstract_syntax import (
@@ -2572,7 +2593,7 @@ def _eliminable_vars(env: Any) -> tuple[str, ...]:
     return tuple(sorted(seen))
 
 
-def _eliminate_template(label: str, env: Any) -> Optional[str]:
+def _eliminate_template(label: str, env: "Env") -> Optional[str]:
     """Look up ``label'' in ``env'' and dispatch to the appropriate
     template.
 
@@ -2593,7 +2614,7 @@ def _eliminate_template(label: str, env: Any) -> Optional[str]:
 
 
 def _eliminate_template_for_formula(
-    formula: Any, binding_name: str, env: Any, dry_run: bool
+    formula: "Formula", binding_name: str, env: "Env", dry_run: bool
 ) -> Optional[str]:
     """Pick a template for ``formula''.
 
@@ -2651,7 +2672,7 @@ def _eliminate_template_for_formula(
     return None
 
 
-def _fresh_h_labels(env: Any, count: int) -> list[str]:
+def _fresh_h_labels(env: "Env", count: int) -> list[str]:
     """Generate ``count`` fresh ``H<N>``-style labels not in env."""
     from abstract_syntax import base_name
     used = {base_name(k) for k in env.dict.keys()}
@@ -2666,7 +2687,7 @@ def _fresh_h_labels(env: Any, count: int) -> list[str]:
     return out
 
 
-def _eliminate_and(label: str, formula: Any, env: Any) -> str:
+def _eliminate_and(label: str, formula: "And", env: "Env") -> str:
     """``have h1: P by conjunct 1 of H\\nhave h2: Q by conjunct 2
     of H\\n?''"""
     labels = _fresh_h_labels(env, len(formula.args))
@@ -2678,7 +2699,7 @@ def _eliminate_and(label: str, formula: Any, env: Any) -> str:
     return "\n".join(lines)
 
 
-def _eliminate_or(label: str, formula: Any, env: Any) -> str:
+def _eliminate_or(label: str, formula: "Or", env: "Env") -> str:
     """``cases H\\n  case h1: P { ? }\\n  case h2: Q { ? } ...''"""
     from abstract_syntax import base_name
 
@@ -2697,13 +2718,13 @@ def _eliminate_or(label: str, formula: Any, env: Any) -> str:
     return f"cases {label}\n" + "\n".join(case_lines)
 
 
-def _eliminate_ifthen(label: str, formula: Any, env: Any) -> str:
+def _eliminate_ifthen(label: str, formula: "IfThen", env: "Env") -> str:
     """``have h: Q by apply H to ?\\n?''"""
     h = _fresh_h_labels(env, 1)[0]
     return f"have {h}: {formula.conclusion} by apply {label} to ?\n?"
 
 
-def _eliminate_all(label: str, formula: Any, env: Any) -> str:
+def _eliminate_all(label: str, formula: "All", env: "Env") -> str:
     """``H[?, ?, ...]'' (term args) or ``H<?, ?, ...>'' (type args).
 
     Handles a single all-block: ``all x:T1, y:T2. P'' yields
@@ -2712,8 +2733,8 @@ def _eliminate_all(label: str, formula: Any, env: Any) -> str:
     """
     from abstract_syntax import All, TypeType
 
-    vars_in_block: list[tuple[str, Any]] = []
-    cur = formula
+    vars_in_block: list[tuple[str, Type]] = []
+    cur: "Formula" = formula
     while isinstance(cur, All):
         x, ty = cur.var
         vars_in_block.append((x, ty))
@@ -2733,13 +2754,13 @@ def _eliminate_all(label: str, formula: Any, env: Any) -> str:
     return f"{label}{open_b}{placeholders}{close_b}"
 
 
-def _eliminate_some(label: str, formula: Any, env: Any) -> str:
+def _eliminate_some(label: str, formula: "Some", env: "Env") -> str:
     """``obtain x1, ... where h: <body[subst]> from H\\n?''"""
     from abstract_syntax import ResolvedVar, base_name
 
     used = {base_name(k) for k in env.dict.keys()}
     fresh_witnesses: list[str] = []
-    sub: dict[str, Any] = {}
+    sub: dict[str, "Term"] = {}
     for (x, ty) in formula.vars:
         stem = _type_first_letter(ty)
         n = 1
@@ -2877,7 +2898,7 @@ def matching_givens_at(
     return _matching_given_names(goal, env)
 
 
-def _implies(frm1: Any, frm2: Any) -> bool:
+def _implies(frm1: "Formula", frm2: "Formula") -> bool:
     """Side-effect-free wrapper around ``proof_checker.check_implies``.
 
     ``check_implies`` raises ``UserError`` (or ``MatchFailed``) on failure
@@ -2899,7 +2920,7 @@ def _implies(frm1: Any, frm2: Any) -> bool:
         flags.verbose = saved
 
 
-def _matching_given_names(goal: Any, env: Any) -> tuple[str, ...]:
+def _matching_given_names(goal: "Formula", env: "Env") -> tuple[str, ...]:
     """Names of local proof bindings that discharge ``goal``.
 
     Exact equality matches come first (alphabetical), followed by
@@ -2929,7 +2950,7 @@ def _matching_given_names(goal: Any, env: Any) -> tuple[str, ...]:
     return tuple(sorted(exact)) + tuple(sorted(implies))
 
 
-def _fill_from_given_template(label: str, goal: Any, env: Any) -> Optional[str]:
+def _fill_from_given_template(label: str, goal: "Formula", env: "Env") -> Optional[str]:
     """Return a proof of ``goal`` using ``label`` when ``label`` names
     a local proof binding in ``env`` whose formula equals or implies
     ``goal``.
@@ -3004,6 +3025,9 @@ def preview_conclude_at(
     path: str, content: str, pos: Position,
     label: str,
     prelude: Sequence[str] = (),
+    # Any: MCP tool-result payload -- a discriminated dict whose value
+    # types vary by ``outcome`` (str fields, ``label``, etc.); the
+    # adapter serializes it straight to JSON.
 ) -> Optional[dict[str, Any]]:
     """Preview ``conclude <goal> by <label>`` modulo auto-rule
     normalization.
@@ -3120,6 +3144,9 @@ def apply_at(
     theorem: str,
     args: Optional[Sequence[str]] = None,
     prelude: Sequence[str] = (),
+    # Any: MCP tool-result payload -- a discriminated dict keyed on
+    # ``outcome`` with heterogeneous values (rendered formulas, the
+    # ``remaining_premises`` list, int counts); serialized to JSON.
 ) -> Optional[dict[str, Any]]:
     """Preview ``apply <theorem>[<args>] to ?`` at the cursor's hole.
 
@@ -3287,7 +3314,8 @@ def _splice_apply_args(
 
 
 def _apply_match_manual(
-    formula: Any, goal: Any, env: Any, goal_str: str
+    formula: "Formula", goal: "Formula", env: "Env", goal_str: str
+    # Any: MCP tool-result payload -- discriminated dict (see apply_at).
 ) -> dict[str, Any]:
     """Compute the result of ``apply <formula> to ?`` against ``goal``.
 
@@ -3346,7 +3374,7 @@ def _apply_match_manual(
                 }
             reasons = []
             for prem, conc in imps:
-                matching: dict[str, Any] = {}
+                matching: dict[str, "Term"] = {}
                 try:
                     _call_untyped(
                         formula_match,
@@ -3391,7 +3419,7 @@ def _apply_match_manual(
         _call_untyped(set_reduce_all, False)
 
 
-def _split_premise_on_and(formula: Any) -> list[str]:
+def _split_premise_on_and(formula: "Formula") -> list[str]:
     """If ``formula`` is a top-level conjunction, render each conjunct
     separately so the result maps to what the user would put after
     ``to`` (Deduce desugars ``to A, B`` into a tuple proof of an
@@ -3483,7 +3511,7 @@ def hole_context_at(
 
 
 def _collect_lemmas_in_scope(
-    ast_nodes: Any, prelude: Sequence[str]
+    ast_nodes: Optional[Sequence["Statement"]], prelude: Sequence[str]
 ) -> tuple[LemmaInfo, ...]:
     """Build the ``lemmas_in_scope`` tuple for :class:`HoleContext`.
 
@@ -3541,7 +3569,7 @@ def _collect_lemmas_in_scope(
     return tuple(out)
 
 
-def _lemma_info_for(stmt: Any, public_only: bool = False) -> Optional[LemmaInfo]:
+def _lemma_info_for(stmt: "Statement", public_only: bool = False) -> Optional[LemmaInfo]:
     """Build a :class:`LemmaInfo` from a top-level statement, or
     ``None`` if the node isn't surfaced (``Import``, etc.).
 
@@ -3662,8 +3690,8 @@ def available_lemmas_at(
 
     hole_range = _find_hole_at(content, pos)
     goal_text: Optional[str] = None
-    goal_ast: Any = None
-    env: Any = None
+    goal_ast: Optional["Formula"] = None
+    env: Optional["Env"] = None
     if hole_range is not None:
         target = (hole_range.start.line, hole_range.start.column)
         with _target_hole(target):
@@ -3756,8 +3784,8 @@ def insert_lemma_at(
 
     hole_range = _find_hole_at(content, pos)
     goal_text: Optional[str] = None
-    goal_ast: Any = None
-    env: Any = None
+    goal_ast: Optional["Formula"] = None
+    env: Optional["Env"] = None
 
     if hole_range is not None:
         target = (hole_range.start.line, hole_range.start.column)
@@ -3776,7 +3804,7 @@ def insert_lemma_at(
         ast_nodes = result.ast
 
     candidates = _collect_lemma_candidates(path, ast_nodes, prelude)
-    target_formula: Any = None
+    target_formula: Optional["Formula"] = None
     for info, formula, _module in candidates:
         if info.name == name:
             target_formula = formula
@@ -3809,7 +3837,7 @@ def insert_lemma_at(
 
 def _insert_lemma_template(
     name: str,
-    formula: Any,
+    formula: "Formula",
     tier: Optional[str],
     discharged: tuple[tuple[str, str], ...],
     goal_text: Optional[str],
@@ -3852,7 +3880,9 @@ def _module_for_path(path: str) -> str:
     return Path(path).stem
 
 
-def _enclosing_theorem_name(ast_nodes: Any, pos: Position) -> Optional[str]:
+def _enclosing_theorem_name(
+    ast_nodes: Optional[Sequence["Statement"]], pos: Position
+) -> Optional[str]:
     """Return the base name of the user-file ``Theorem`` whose body
     encloses ``pos``, or ``None`` when ``pos`` isn't inside one.
 
@@ -3888,10 +3918,10 @@ def _enclosing_theorem_name(ast_nodes: Any, pos: Position) -> Optional[str]:
 
 def _collect_lemma_candidates(
     path: str,
-    ast_nodes: Any,
+    ast_nodes: Optional[Sequence["Statement"]],
     prelude: Sequence[str],
     exclude_name: Optional[str] = None,
-) -> tuple[tuple[LemmaInfo, Any, str], ...]:
+) -> tuple[tuple[LemmaInfo, "Formula", str], ...]:
     """Build the ranking input: theorems/lemmas/postulates with their
     formula AST and module of origin.
 
@@ -3928,7 +3958,8 @@ def _collect_lemma_candidates(
     seen_modules: set[str] = set()
 
     def _collect_from_module(
-        module_ast: Optional[Sequence[Any]], module_name: str, importer: Any
+        module_ast: Optional[Sequence["Statement"]], module_name: str,
+        importer: Optional["Import"],
     ) -> None:
         if module_ast is None:
             return
@@ -4139,7 +4170,7 @@ def _goal_tokens(text: Optional[str]) -> frozenset[str]:
     return frozenset(tokens)
 
 
-def _formula_head_symbol(formula: Any) -> Optional[str]:
+def _formula_head_symbol(formula: "Formula") -> Optional[str]:
     """Head operator of a lemma's formula (peeling outer ``All`` and
     ``IfThen``).  Returns the rator's base name for a ``Call``, or a
     string token for non-Call shapes (``and``/``or``/``not``/etc.).
@@ -4175,7 +4206,7 @@ def _formula_head_symbol(formula: Any) -> Optional[str]:
     return None
 
 
-def _formula_symbols(formula: Any) -> frozenset[str]:
+def _formula_symbols(formula: "Formula") -> frozenset[str]:
     """Set of all rator names appearing in ``formula`` (recursively).
 
     Drives the symbol-overlap signal in lemma ranking.  Bound
@@ -4189,7 +4220,7 @@ def _formula_symbols(formula: Any) -> frozenset[str]:
 
     out: set[str] = set()
 
-    def visit(node: Any) -> None:
+    def visit(node: "AST") -> None:
         if isinstance(node, Call):
             rator = node.rator
             if isinstance(rator, TermInst):
@@ -4251,7 +4282,7 @@ _UNIFY_TIER_SCORE: dict[str, float] = {
 }
 
 
-def _collect_local_givens(env: Any) -> tuple[tuple[str, Any], ...]:
+def _collect_local_givens(env: Optional["Env"]) -> tuple[tuple[str, "Formula"], ...]:
     """``(label, formula_ast)`` for local proof bindings in ``env``.
 
     Mirrors how :func:`_matching_given_names` walks ``env.dict``, but
@@ -4265,7 +4296,7 @@ def _collect_local_givens(env: Any) -> tuple[tuple[str, Any], ...]:
     from abstract_syntax import ProofBinding, base_name
 
     seen: set[str] = set()
-    out: list[tuple[str, Any]] = []
+    out: list[tuple[str, Formula]] = []
     try:
         items = env.dict.items()
     except AttributeError:
@@ -4284,8 +4315,8 @@ def _collect_local_givens(env: Any) -> tuple[tuple[str, Any], ...]:
 
 
 def _peel_quantified_implication(
-    formula: Any,
-) -> Optional[tuple[list[Any], list[Any], Any]]:
+    formula: Optional["Formula"],
+) -> Optional[tuple[list["ResolvedVar"], list["Formula"], "Formula"]]:
     """Peel outer ``All`` and ``IfThen`` to ``(vars, premises, conc)``.
 
     Returns the list of all-bound variables (as :class:`VarRef`), the
@@ -4300,13 +4331,13 @@ def _peel_quantified_implication(
     if f is None:
         return None
 
-    vars: list[Any] = []
+    vars: list["ResolvedVar"] = []
     while isinstance(f, All):
         name, ty = f.var
         vars.append(ResolvedVar(f.location, ty, name))
         f = f.body
 
-    premises: list[Any] = []
+    premises: list["Formula"] = []
     while isinstance(f, IfThen):
         prem = f.premise
         if isinstance(prem, And):
@@ -4318,7 +4349,9 @@ def _peel_quantified_implication(
     return vars, premises, f
 
 
-def _formulas_match_modulo_env(frm1: Any, frm2: Any, env: Any) -> bool:
+def _formulas_match_modulo_env(
+    frm1: "Formula", frm2: "Formula", env: Optional["Env"]
+) -> bool:
     """Best-effort equality of two formulas under ``env`` reduction.
 
     Used to ask "does this substituted premise match a given?".
@@ -4341,7 +4374,7 @@ def _formulas_match_modulo_env(frm1: Any, frm2: Any, env: Any) -> bool:
         return False
 
 
-def _iter_subterms(node: Any) -> Any:
+def _iter_subterms(node: "AST") -> list["AST"]:
     """Yield ``node`` and every AST descendant (depth-first).
 
     Used by the ``rewrite_subterm`` tier: walk the goal's subterms
@@ -4350,12 +4383,12 @@ def _iter_subterms(node: Any) -> Any:
     """
     from abstract_syntax import AST
 
-    out: list[Any] = []
+    out: list[AST] = []
     _walk_ast(node, out.append, ast_class=AST)
     return out
 
 
-def _typed_formula_index(env: Any) -> dict[str, Any]:
+def _typed_formula_index(env: Optional["Env"]) -> dict[str, "Formula"]:
     """Build a one-shot ``base_name -> typed_formula`` index over the
     proof bindings in ``env``.
 
@@ -4391,7 +4424,7 @@ def _typed_formula_index(env: Any) -> dict[str, Any]:
         return {}
     from abstract_syntax import ProofBinding, base_name
 
-    out: dict[str, Any] = {}
+    out: dict[str, "Formula"] = {}
     for key, binding in env.dict.items():
         if not isinstance(binding, ProofBinding):
             continue
@@ -4403,7 +4436,7 @@ def _typed_formula_index(env: Any) -> dict[str, Any]:
 
 
 def _render_instantiations(
-    vars: Sequence[Any], matching: dict[str, Any]
+    vars: Sequence["ResolvedVar"], matching: dict[str, "Term"]
 ) -> tuple[str, ...]:
     """Render ``matching[v.name]`` for each ``v`` in ``vars``.
 
@@ -4424,10 +4457,10 @@ def _render_instantiations(
 
 
 def _unify_score(
-    formula: Any,
-    goal_ast: Any,
-    env: Any,
-    given_pairs: tuple[tuple[str, Any], ...],
+    formula: Optional["Formula"],
+    goal_ast: Optional["Formula"],
+    env: Optional["Env"],
+    given_pairs: tuple[tuple[str, "Formula"], ...],
 ) -> tuple[
     float,
     Optional[str],
@@ -4476,7 +4509,7 @@ def _unify_score(
     location = getattr(formula, "location", None)
 
     # Tier 1/2: try to unify the conclusion against the goal.
-    matching: dict[str, Any] = {}
+    matching: dict[str, "Term"] = {}
     conc_matched = False
     try:
         formula_match(location, vars, conc, goal_ast, matching, env)
@@ -4541,7 +4574,7 @@ def _unify_score(
                     # goal as before.
                     side_is_bare_var = isinstance(side, VarRef) and side in vars
                     for sub in subterms:
-                        sub_matching: dict[str, Any] = {}
+                        sub_matching: dict[str, "Term"] = {}
                         try:
                             formula_match(
                                 location, vars, side, sub, sub_matching, env
@@ -4573,14 +4606,14 @@ def _unify_score(
 
 
 def _rank_lemmas(
-    candidates: tuple[tuple[LemmaInfo, Any, str], ...],
+    candidates: tuple[tuple[LemmaInfo, "Formula", str], ...],
     goal_text: Optional[str],
     query: Optional[str],
     user_module: str,
-    goal_ast: Any = None,
-    env: Any = None,
-    given_pairs: tuple[tuple[str, Any], ...] = (),
-    typed_formula_by_name: Optional[dict[str, Any]] = None,
+    goal_ast: Optional["Formula"] = None,
+    env: Optional["Env"] = None,
+    given_pairs: tuple[tuple[str, "Formula"], ...] = (),
+    typed_formula_by_name: Optional[dict[str, "Formula"]] = None,
 ) -> list[LemmaMatch]:
     """Score and sort candidate lemmas.
 
@@ -4637,7 +4670,7 @@ def _rank_lemmas(
     # that actually unify (which always share head/operator tokens
     # with the goal) in the considered set.
     prelim: list[
-        tuple[float, LemmaInfo, Any, str, float]
+        tuple[float, LemmaInfo, "Formula", str, float]
     ] = []  # (cheap_raw, info, formula, module, proximity-marker)
     for info, formula, module in candidates:
         proximity = 1.0 if module == user_module else 0.0
@@ -4932,9 +4965,9 @@ def _preview_replace(
     name: str,
     is_symmetric: bool,
     original_input: str,
-    formula: Any,
-    env: Any,
-    loc: Any,
+    formula: "Formula",
+    env: "Env",
+    loc: Optional[Meta],
 ) -> RewritePreview:
     """Look up ``name`` and apply the rewrite (or report a structured
     failure). ``loc`` is the hole's source location, used for the
@@ -5057,7 +5090,7 @@ def preview_expand_at(
 
 
 def _preview_expand(
-    names: list[str], formula: Any, env: Any, loc: Any
+    names: list[str], formula: "Formula", env: "Env", loc: Optional[Meta]
 ) -> ExpandPreview:
     """Resolve each name then call ``expand_definitions`` with the
     constructed var list. Pre-checks unknown / all-opaque names so the
@@ -5174,7 +5207,7 @@ def auto_rules_at(
     # know about, then the user file's own AST (which overrides any
     # cached entry that happens to share a unique name -- shouldn't
     # happen in practice, but the cache could be slightly stale).
-    formula_by_name: dict[str, Any] = {}
+    formula_by_name: dict[str, "Formula"] = {}
     for module_name, module_ast in cached_modules.items():
         if module_name == user_module:
             continue
@@ -5220,7 +5253,7 @@ def _meta_at_or_before(meta: Meta, pos: Position) -> bool:
 
 
 def _auto_rule_from_stmt(
-    stmt: Any, module_name: str, formula_by_name: dict[str, Any]
+    stmt: "Auto", module_name: str, formula_by_name: dict[str, "Formula"]
 ) -> "AutoRule":
     """Render an ``Auto`` AST node into an :class:`AutoRule`.
 


### PR DESCRIPTION
Part 3 of #681: narrow residual `Any` to real types across the modules that already pass strict but leaned on `Any` at AST/JSON boundaries. Targets the high-value interiors (per the choice to skip the SDK/lark boundary modules, where `Any` is mostly legitimate). Bundled into one PR rather than per-module.

Produced by a per-module fan-out (one agent per file, each self-verified `mypy --strict`); every change is annotation-only or a behavior-preserving shim removal.

## `Any` reduction in targeted modules

| Module | before | after | note |
|---|---:|---:|---|
| `checker_proofs.py` | 53 | 0 | `Any` import dropped |
| `checker_pipeline.py` | 23 | 1 | the 1 is a prose word in a comment |
| `lsp/query.py` | 93 | 9 | 9 residual are commented JSON/dispatch boundaries |
| `abstract_syntax/{terms,proofs,declarations,core}` | 11 | 4 | |

## Highlights

- **`checker_proofs.py`** — the two proof-handler dispatch tables drive the narrowing: each `_check_proof_*` handler takes its specific `Proof` subclass (the table key) and returns `CheckedFormula`; `_check_proof_of_*` handlers take their dispatch-key type and return `None`.
- **`checker_pipeline.py`** — the `<name>: Any = <name>_raw` cross-checker re-export shims existed only to satisfy `disallow_untyped_calls` while sibling `checker_*` modules still carried `# mypy: ignore-errors`. They're all strict now, so the indirection is **deleted** and the functions imported directly under their real signatures. This surfaced a latent bug the `Any` was hiding: the module-local `PatternCoverage` alias was `dict[str, object]` but the real type is `dict[str, bool]`.
- **`lsp/query.py`** — interior helpers narrowed (`Env` / `Formula` / `Type` / `AST` / `Sequence[Statement]` / `dict[str, Term]` …) via a `TYPE_CHECKING` block with quoted annotations, so the module still loads without importing any pipeline module — preserving the protocol-neutral boundary it guarantees. The 9 residual `Any` at LSP/MCP JSON-payload and dynamic-dispatch boundaries are kept with `# Any:` notes.
- **`abstract_syntax/*`** — drop now-redundant `cast(Any, …)` / `cast(Lambda|PatternCons, …)` sites where the value already has a precise base type with the needed methods.

## Verification

`ruff check .`, `mypy .`, `mypy . --no-site-packages`, `test-deduce.py` (both parsers), `pytest test/unit` (539 passed), and `pytest test/lsp` (459 passed) all pass.

## Scope

Addresses #681 part 3 for the high-value modules. Lower-value `Any` at genuine SDK boundaries (`tools/claude_fill_hole/*`) and the `parser.py` lark boundary remain — mostly legitimate, comment-only follow-ups.

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)