### PR TITLE
Account for boundary Any: narrow equations proof, comment SDK/lark/facade (#681 part 3)

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -12,8 +12,8 @@ from abstract_syntax import (
     Postulate, Predicate, Print, RecFun, RewriteFact, RewriteGoal,
     Rule, RuleInduction, RuleInductionCase, RuleInversion, SimplifyFact,
     SimplifyGoal, Some, SomeElim, SomeIntro, Statement, Suffices, Switch,
-    SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, TermInst,
-    Theorem, Trace, TypeAlias, TypeInst, TypeType, Union, Var,
+    SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, Term, TermInst,
+    Theorem, Trace, Proof, TypeAlias, TypeInst, TypeType, Union, Var,
     ViewDecl, count_marks, extract_and, extract_or, extract_tuple,
     get_default_mark_LHS, intToNat, listToNodeList, mkEqual, mkIntLit,
     mkUIntLit, remove_mark,
@@ -192,6 +192,8 @@ def next_impl_num() -> int:
     impl_num += 1
     return ret
 
+# Any: statement is any declaration node carrying a `visibility` attribute;
+# this is a duck-typed setter over the heterogeneous declaration kinds.
 def set_visibility(statement: Any, visibility: str) -> None:
     if visibility == 'private':
         statement.visibility = 'private'
@@ -203,8 +205,8 @@ def set_visibility(statement: Any, visibility: str) -> None:
     else:
         statement.visibility = 'public'
         
-def build_equations_proof(loc: Meta, eqs: list[Any]) -> Any:
-    result = None
+def build_equations_proof(loc: Meta, eqs: list[tuple[Term, Term, Proof]]) -> Proof:
+    result: Proof | None = None
     for (lhs, rhs, reason) in reversed(eqs):
         num_marks = count_marks(lhs) + count_marks(rhs)
         if num_marks == 0 and get_default_mark_LHS():
@@ -217,8 +219,15 @@ def build_equations_proof(loc: Meta, eqs: list[Any]) -> Any:
             result = eq_proof
         else:
             result = PTransitive(loc, eq_proof, result)
+    assert result is not None  # the equations grammar yields >= 1 step
     return result
         
+# Any: the lark-tree -> AST dispatch boundary. This is dispatched on the
+# grammar rule name and so is polymorphic over every node kind the grammar
+# can produce (Term/Formula/Proof/Type/Pattern/Statement, plus bare str
+# identifiers and tuples), with no single static return type. The
+# parse_tree_to_{list,case,case_list} helpers and set_visibility below
+# inherit that same dynamic boundary.
 def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
     if isinstance(e, Token):
         return e

--- a/proof_checker.py
+++ b/proof_checker.py
@@ -47,6 +47,10 @@ _STATE_ATTRS = {
 }
 
 
+# Any: the re-export surface is intentionally dynamic. These helpers copy the
+# heterogeneous public objects of the checker_* modules (functions, classes,
+# module-level state) across a shared namespace, so the values and the
+# __getattr__/__setattr__ that expose them are necessarily typed Any.
 def _public_items(module: ModuleType) -> dict[str, Any]:
     return {
         name: value

--- a/tools/claude_fill_hole/anthropic_backend.py
+++ b/tools/claude_fill_hole/anthropic_backend.py
@@ -70,7 +70,7 @@ class AnthropicBackend(Backend):
     def __init__(
         self,
         *,
-        client: Any,
+        client: Any,  # Any: the anthropic SDK client (optional dependency, untyped here)
         model: str = _DEFAULT_MODEL,
         max_tokens: int = _DEFAULT_MAX_TOKENS,
         effort: str = "high",
@@ -368,6 +368,10 @@ class AnthropicBackend(Backend):
 # ---------------------------------------------------------------------------
 
 
+# Any: SDK-response accessor boundary. `block` is an Anthropic content block,
+# either a Pydantic model from the optional `anthropic` package or a plain dict;
+# its concrete type isn't available here, so the duck-typed reads stay Any and
+# each helper's isinstance guards produce the typed result.
 def _is_tool_use(block: Any) -> bool:
     return _block_type(block) == "tool_use"
 

--- a/tools/claude_fill_hole/openai_backend.py
+++ b/tools/claude_fill_hole/openai_backend.py
@@ -105,7 +105,7 @@ class OpenAICompatBackend(Backend):
     def __init__(
         self,
         *,
-        client: Any,
+        client: Any,  # Any: the openai SDK client (optional dependency, untyped here)
         model: str,
         max_tokens: int = _DEFAULT_MAX_TOKENS,
     ) -> None:
@@ -444,6 +444,11 @@ def _query_payload(outcome: QueryOutcome) -> dict[str, object]:
     return {"error": outcome.error or "unknown"}
 
 
+# Any: SDK-response accessor boundary. The helpers below read fields off
+# OpenAI response objects (Pydantic models, or plain dicts from OpenAI-compatible
+# servers); their concrete types live in the optional `openai` package and vary
+# by server, so the duck-typed reads stay Any and the typed results are produced
+# by the isinstance guards inside each helper.
 def _first_choice(response: Any) -> Any:
     choices = _attr(response, "choices", default=[]) or []
     if not choices:
@@ -504,6 +509,7 @@ def _extract_proof_text(args_raw: str) -> Optional[str]:
     return proof
 
 
+# Any: tool_call objects are SDK Pydantic models or plain dicts (see above).
 def _serialize_tool_calls(tool_calls: list[Any]) -> list[dict[str, object]]:
     """Re-serialise a list of tool_call objects (Pydantic models or dicts)
     into a plain list of dicts safe to round-trip through the request.
@@ -585,6 +591,7 @@ def _strip_trailing_turn_with_synthetic_note(
 
 
 def _attr(obj: Any, name: str, default: Any = None) -> Any:
+    # Any: the generic SDK-shape reader underlying the accessors above.
     """Read ``name`` off ``obj`` whether it's a dict or attribute object."""
     if obj is None:
         return default


### PR DESCRIPTION
The final mop-up of #681 part 3: every residual `Any` in the source tree is now either narrowed or a genuine boundary with an explanatory `# Any:` comment. This finishes the issue's stated success metric — "every Any is either at a real protocol boundary or has a comment explaining why" — not "zero Any".

## Changes

- **`parser.py`** — narrow `build_equations_proof` (`eqs -> list[tuple[Term, Term, Proof]]`, returns `Proof`), mirroring the recursive-descent equations builder. Comment the genuine lark-tree → AST boundary: `parse_tree_to_ast` dispatches on the grammar rule name and is polymorphic over every node kind it can build (plus bare `str` identifiers and tuples), so it — and the `parse_tree_to_{list,case,case_list}` / `set_visibility` helpers that inherit it — stay `Any`.
- **`tools/claude_fill_hole/{openai,anthropic}_backend.py`** — comment the SDK-response accessor clusters and the `client` params. These read fields off optional-dependency SDK objects (Pydantic models or plain dicts) whose concrete types aren't available here; each helper's `isinstance` guards produce the typed result.
- **`proof_checker.py`** — comment the dynamic re-export facade helpers, whose values (and the `__getattr__`/`__setattr__` exposing them) are necessarily `Any`.

`abstract_syntax/{core,__init__}.py` already carried explanatory comments on their remaining `Any` (`UniquifyEnv`, the facade `__getattr__`), so they're unchanged.

## Verification

`ruff check .`, `mypy .`, `mypy . --no-site-packages`, `test-deduce.py` (both parsers), and `pytest test/claude_fill_hole` (67 passed) all pass.

## Scope

Completes the last of #681 part 3. With the closing-criteria PR (#844) and the high-value narrowing PR (#848) already merged, this resolves the remaining work on #681.

Closes #681

[Claude session](claude://resume?session=$CLAUDE_CODE_SESSION_ID)