### PR TITLE
Narrow SDK-boundary Any to object in claude_fill_hole backends (#852)

### DIFF
--- a/tools/claude_fill_hole/anthropic_backend.py
+++ b/tools/claude_fill_hole/anthropic_backend.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from .agent import (
     AgentResult,
@@ -368,37 +368,49 @@ class AnthropicBackend(Backend):
 # ---------------------------------------------------------------------------
 
 
-# Any: SDK-response accessor boundary. `block` is an Anthropic content block,
-# either a Pydantic model from the optional `anthropic` package or a plain dict;
-# its concrete type isn't available here, so the duck-typed reads stay Any and
-# each helper's isinstance guards produce the typed result.
-def _is_tool_use(block: Any) -> bool:
+# SDK-response accessor boundary. ``block`` is an Anthropic content block --
+# either a Pydantic model from the optional `anthropic` package or a plain dict.
+# We accept the input as ``object`` (consistent with schema.py's parsed-JSON
+# boundary) and produce typed results via local isinstance guards.
+def _is_tool_use(block: object) -> bool:
     return _block_type(block) == "tool_use"
 
 
-def _block_type(block: Any) -> str:
-    val = block.get("type", "") if isinstance(block, dict) else getattr(block, "type", "")
+def _block_type(block: object) -> str:
+    val = (
+        cast(dict[object, object], block).get("type", "")
+        if isinstance(block, dict)
+        else getattr(block, "type", "")
+    )
     return val if isinstance(val, str) else ""
 
 
-def _block_id(block: Any) -> str:
-    val = block.get("id", "") if isinstance(block, dict) else getattr(block, "id", "")
+def _block_id(block: object) -> str:
+    val = (
+        cast(dict[object, object], block).get("id", "")
+        if isinstance(block, dict)
+        else getattr(block, "id", "")
+    )
     return val if isinstance(val, str) else ""
 
 
-def _tool_use_name(block: Any) -> str:
-    val = block.get("name", "") if isinstance(block, dict) else getattr(block, "name", "")
+def _tool_use_name(block: object) -> str:
+    val = (
+        cast(dict[object, object], block).get("name", "")
+        if isinstance(block, dict)
+        else getattr(block, "name", "")
+    )
     return val if isinstance(val, str) else ""
 
 
-def _extract_proof_text(block: Any) -> Optional[str]:
+def _extract_proof_text(block: object) -> Optional[str]:
     if isinstance(block, dict):
-        inp = block.get("input", {})
+        inp = cast(dict[object, object], block).get("input", {})
     else:
         inp = getattr(block, "input", {})
     if not isinstance(inp, dict):
         return None
-    proof = inp.get("proof_text")
+    proof = cast(dict[object, object], inp).get("proof_text")
     if not isinstance(proof, str):
         return None
     return proof

--- a/tools/claude_fill_hole/openai_backend.py
+++ b/tools/claude_fill_hole/openai_backend.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from .agent import (
     AgentResult,
@@ -444,44 +444,46 @@ def _query_payload(outcome: QueryOutcome) -> dict[str, object]:
     return {"error": outcome.error or "unknown"}
 
 
-# Any: SDK-response accessor boundary. The helpers below read fields off
-# OpenAI response objects (Pydantic models, or plain dicts from OpenAI-compatible
+# SDK-response accessor boundary. The helpers below read fields off OpenAI
+# response objects (Pydantic models, or plain dicts from OpenAI-compatible
 # servers); their concrete types live in the optional `openai` package and vary
-# by server, so the duck-typed reads stay Any and the typed results are produced
-# by the isinstance guards inside each helper.
-def _first_choice(response: Any) -> Any:
-    choices = _attr(response, "choices", default=[]) or []
-    if not choices:
+# by server. We accept the input as `object` (consistent with schema.py's
+# parsed-JSON boundary) and produce typed results via local isinstance guards.
+def _first_choice(response: object) -> object:
+    choices_raw = _attr(response, "choices", default=None)
+    if not isinstance(choices_raw, list) or not choices_raw:
         # Surface a structured error rather than crashing.
         raise RuntimeError("OpenAI response has no choices")
-    return choices[0]
+    return cast(list[object], choices_raw)[0]
 
 
-def _choice_message(choice: Any) -> Any:
+def _choice_message(choice: object) -> object:
     return _attr(choice, "message")
 
 
-def _message_content(msg: Any) -> Any:
+def _message_content(msg: object) -> object:
     return _attr(msg, "content")
 
 
-def _tool_calls(msg: Any) -> list[Any]:
-    calls = _attr(msg, "tool_calls", default=None) or []
-    return list(calls)
+def _tool_calls(msg: object) -> list[object]:
+    calls = _attr(msg, "tool_calls", default=None)
+    if not isinstance(calls, list):
+        return []
+    return list(cast(list[object], calls))
 
 
-def _tool_call_id(tc: Any) -> str:
+def _tool_call_id(tc: object) -> str:
     val = _attr(tc, "id", default="")
     return val if isinstance(val, str) else ""
 
 
-def _tool_call_function_name(tc: Any) -> str:
+def _tool_call_function_name(tc: object) -> str:
     fn = _attr(tc, "function")
     val = _attr(fn, "name", default="")
     return val if isinstance(val, str) else ""
 
 
-def _tool_call_function_arguments(tc: Any) -> str:
+def _tool_call_function_arguments(tc: object) -> str:
     """Return the JSON-string ``arguments`` field for a tool call."""
     fn = _attr(tc, "function")
     val = _attr(fn, "arguments", default="")
@@ -509,8 +511,9 @@ def _extract_proof_text(args_raw: str) -> Optional[str]:
     return proof
 
 
-# Any: tool_call objects are SDK Pydantic models or plain dicts (see above).
-def _serialize_tool_calls(tool_calls: list[Any]) -> list[dict[str, object]]:
+# tool_call entries are SDK Pydantic models or plain dicts (see above); each
+# accessor below narrows internally.
+def _serialize_tool_calls(tool_calls: list[object]) -> list[dict[str, object]]:
     """Re-serialise a list of tool_call objects (Pydantic models or dicts)
     into a plain list of dicts safe to round-trip through the request.
 
@@ -590,11 +593,14 @@ def _strip_trailing_turn_with_synthetic_note(
     return messages[:cut] + [note]
 
 
-def _attr(obj: Any, name: str, default: Any = None) -> Any:
-    # Any: the generic SDK-shape reader underlying the accessors above.
-    """Read ``name`` off ``obj`` whether it's a dict or attribute object."""
+def _attr(obj: object, name: str, default: object = None) -> object:
+    """Read ``name`` off ``obj`` whether it's a dict or attribute object.
+
+    The generic SDK-shape reader underlying the accessors above. Returns
+    ``object``; callers refine via ``isinstance`` to a concrete type.
+    """
     if obj is None:
         return default
     if isinstance(obj, dict):
-        return obj.get(name, default)
+        return cast(dict[object, object], obj).get(name, default)
     return getattr(obj, name, default)


### PR DESCRIPTION
## Summary

Addresses #852. Narrows the residual SDK-boundary `Any` in the `claude_fill_hole` backends to `object`, matching the style already used in `schema.py:_expect_object` for the parsed-JSON boundary.

### What changed

- **`tools/claude_fill_hole/openai_backend.py`** — `_first_choice`, `_choice_message`, `_message_content`, `_tool_calls`, `_tool_call_id`, `_tool_call_function_name`, `_tool_call_function_arguments`, `_serialize_tool_calls`, and `_attr` now take `object` and return `object`/concrete types. The `_first_choice` body now uses an `isinstance(..., list)` guard + `cast(list[object], ...)` for indexing; `_tool_calls` does the same for its list materialisation; `_attr` casts to `dict[object, object]` after `isinstance(obj, dict)` so `.get(...)` typechecks.
- **`tools/claude_fill_hole/anthropic_backend.py`** — `_is_tool_use`, `_block_type`, `_block_id`, `_tool_use_name`, and `_extract_proof_text` now take `object`. Each conditional dict-vs-attribute read uses `cast(dict[object, object], block)` after `isinstance(block, dict)` so `.get(...)` typechecks.

### What stayed Any (intentionally)

The `client: Any` constructor params on both backends — per the issue, the SDK client itself is the weakest narrowing candidate (it's the opaque optional dependency). Comments retained.

### Why Option A and not Option B

Option B (Protocols) would have required `Mapping` fallbacks for the Pydantic-vs-dict duality of every SDK shape, plus a Protocol per access pattern (choice / message / tool_call / function). That's more code with no real precision win, because every helper already narrows internally via `isinstance` before returning — the type-level guarantee Option B provides is something the runtime guards already enforce.

## Test plan

- [x] `ruff check tools/claude_fill_hole/` — clean
- [x] `mypy .` — 51 files, no issues
- [x] `mypy . --no-site-packages` — 51 files, no issues (the secondary mypy pass called out in the issue checklist)
- [x] `pytest test/claude_fill_hole/` — 67 passed
- [x] Broader `pytest test/ --ignore=test/lsp` — 694 passed
- [ ] CI (`make tests` + dual-parser + lib equiv) — to be confirmed by the GitHub Actions run on this PR

[Claude session](claude://resume?session=1d855222-70e9-47a3-9494-44322807e41c) — fallback UUID: `1d855222-70e9-47a3-9494-44322807e41c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
