### PR TITLE
Allow Unicode letters in identifiers (closes #846)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -1,10 +1,17 @@
 DIGIT: /[0-9]/
 INT: DIGIT+
-NAT: /[ℕ]/DIGIT+
-UPPER: /[A-Z]/
-LOWER: /[a-z]/
+// Higher priority than IDENT so that "ℕ0" stays a Nat literal even
+// though "ℕ" is now allowed as an identifier letter.
+NAT.2: /[ℕ]/DIGIT+
 OPERATOR: /[\-\+∸*%=≠<>≤≥&∘∪∩⊆∈⨄⊝\^≲≈]/
-IDENT: (/_/|UPPER|LOWER) (/_/|UPPER|LOWER|DIGIT|/[₀₁₂₃₄₅₆₇₈₉!?']/)*
+// Identifier characters: any Unicode letter (or `_`) to start; the same
+// set plus digits, the existing subscript digits, and `!?'` to continue.
+// Operators and punctuation are naturally excluded because they fall
+// outside `\w`. We also exclude `λ` so that `λx:T{x}` still tokenises as
+// a lambda followed by an identifier, even without a space, and exclude
+// the subscript digits `₀`–`₉` from the first character so they only
+// appear as modifiers on a preceding letter (matches the previous rule).
+IDENT: /[^\W\dλ₀₁₂₃₄₅₆₇₈₉]/ /([^\Wλ]|[₀₁₂₃₄₅₆₇₈₉!?'])*/
 NEWLINE: (/\r/? /\n/)+
 WS: /[ \t\f\r\n]/+
 LINECOMMENT: "//" /[^\n]*/ 

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -1275,13 +1275,16 @@ conclusion ::= identifier
 Identifiers are used in Deduce to give names to functions and values and
 to label theorems and facts.
 
-An identifier is a sequence of characters that starts with an upper or
-lower-case letter or an underscore, and is followed by letters,
-digits, or the special characters `!`, `?`, and `'`.  An identifier
-can also be an operator, which starts with the keyword
-`operator` and is then followed by one of the following operators:
-`+`, `-`, `*`, `/`, `%`, `=`, `≠`, `/=`, `<`, `≤`, `<=`, `≥`, `>=`
-`++`, `∩`, `&`, `∈`, `in`, `∪`, `|`, `⨄`, `.+.`, `⊆`, `(=`, `∘`, `.o.`.
+An identifier is a sequence of characters that starts with a Unicode
+letter or an underscore, and is followed by letters, digits, or the
+special characters `!`, `?`, and `'`. Subscript digits (`₀`–`₉`) are
+also allowed in continuation. The character `λ` is excluded because it
+introduces a lambda expression; `ℕ` followed by a digit sequence is a
+Nat literal rather than an identifier. An identifier can also be an
+operator, which starts with the keyword `operator` and is then
+followed by one of the following operators: `+`, `-`, `*`, `/`, `%`,
+`=`, `≠`, `/=`, `<`, `≤`, `<=`, `≥`, `>=` `++`, `∩`, `&`, `∈`, `in`,
+`∪`, `|`, `⨄`, `.+.`, `⊆`, `(=`, `∘`, `.o.`.
 
 
 ## Identifier List

--- a/parser.py
+++ b/parser.py
@@ -974,7 +974,7 @@ def parse(program_text: str,
           hint = ''
           if t.token.type == 'LESSTHAN':
               preceding = program_text[:t.token.start_pos]
-              m = re.search(r'\bdefine\s+([A-Za-z_]\w*)\s*\Z', preceding)
+              m = re.search(r'\bdefine\s+([^\W\d]\w*)\s*\Z', preceding)
               if m:
                   name = m.group(1)
                   hint = ('\n`define` does not take type parameters.'

--- a/test/should-validate/unicode_idents.pf
+++ b/test/should-validate/unicode_idents.pf
@@ -1,0 +1,32 @@
+import Nat
+
+// Unicode identifiers: Greek letters, accented Latin letters, and ℕ
+// can appear inside an identifier. ℕ followed by a digit is still a
+// Nat literal, but ℕ followed by a non-digit letter is part of the
+// identifier.
+
+theorem reflexivity_αβ : all αβ : bool. αβ = αβ
+proof
+  arbitrary αβ:bool
+  conclude αβ = αβ by .
+end
+
+theorem café_implies_itself : all café : bool. if café then café
+proof
+  arbitrary café:bool
+  assume h
+  conclude café by h
+end
+
+theorem reflexivity_ℕmax : all ℕmax : bool. ℕmax = ℕmax
+proof
+  arbitrary ℕmax:bool
+  conclude ℕmax = ℕmax by .
+end
+
+define ψ : bool = true
+define φ_max : bool = ψ
+assert φ_max
+
+// Nat literal still parses even though ℕ is now an identifier letter.
+assert ℕ0 = ℕ0


### PR DESCRIPTION
## Summary

- Extend the `IDENT` terminal in `Deduce.lark` so identifiers may contain any Unicode letter, in addition to the existing ASCII letters, underscore, digits, subscript digits, and `!?'`.
- Bump the `NAT` terminal to priority 2 so `ℕ0` still tokenises as a Nat literal even though `ℕ` is now a valid identifier letter (`ℕmax` becomes an identifier, `ℕ0` remains a Nat).
- Exclude `λ` from identifier characters so `λx:T{x}` continues to tokenise as a lambda followed by an identifier without a space, matching how the stdlib already writes lambdas.
- Exclude subscript digits `₀`–`₉` from the first character (they are still allowed in continuation), so the only way they appear is as modifiers on a preceding letter — matching the previous behaviour.
- Update the `Reference.md` identifier description and a small `define` hint regex in `parser.py` that used `[A-Za-z_]\w*` to match an identifier.
- Add `test/should-validate/unicode_idents.pf` exercising Greek-letter, accented-Latin, and `ℕ`-containing identifiers.

Closes #846.

## Test plan

- [x] `make` (ruff + mypy + token check + lib + should-validate × 2 parsers + should-error + parser equivalence + pretty-print round trip)
- [x] `python -m pytest test/lsp test/unit` (998 passed)
- [x] `make tests-tokens`
- [x] Manual lex check: `αβγ`, `café`, `ℕ0`, `ℕmax`, `λx:T{x}`, `Λ_special`, `αλβ`, `foo₀bar` all tokenise as expected.

## Notes

The `gh_pages/js/sandbox.js` and `gh_pages/js/codeUtils.js` web syntax highlighters still use ASCII-only identifier regexes; Unicode identifiers will appear unhighlighted on the website. That's a cosmetic gap, separate from the language change, and can be addressed in a follow-up.

[Claude session](claude://resume?session=367d01b5-e5b1-412b-acfc-aa120e38de38) — fallback UUID: `367d01b5-e5b1-412b-acfc-aa120e38de38`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
