### PR TITLE
Add complete-specification companion examples for four functions

### DIFF
--- a/examples/fast_reverse_spec.pf
+++ b/examples/fast_reverse_spec.pf
@@ -1,0 +1,214 @@
+// fast_reverse_spec.pf
+//
+// `fast_reverse.pf` proves `fast_reverse(xs) = reverse(xs)`: the
+// accumulator-passing implementation computes the same list as the naive
+// `reverse`.  That IS a specification — an *extensional* one: "behaves
+// like reverse".  But it only counts as a *complete* specification if
+// `reverse` is itself pinned down by something implementation-independent.
+// Otherwise "= reverse" just defers the question to another definition.
+//
+// So this file asks: what is the complete, implementation-independent
+// specification of a reversal function?  The answer is algebraic.  A
+// function f reverses lists exactly when:
+//
+//   (E) f([])        = []                       -- empty maps to empty
+//   (S) f([x])       = [x]                       -- singletons are fixed
+//   (H) f(xs ++ ys)  = f(ys) ++ f(xs)            -- anti-homomorphism of ++
+//
+// These three laws never mention recursion, accumulators, or how f is
+// built — yet they determine f completely (`reverse_unique`).  We then:
+//   * show `reverse` satisfies the laws (`reverse_satisfies_spec`);
+//   * show `fast_reverse` satisfies them too (`fast_reverse_satisfies_spec`),
+//     and conclude `fast_reverse = reverse` *via the spec* rather than via
+//     the accumulator lemma (`fast_reverse_is_the_reverse`);
+//   * re-derive a property — length preservation — from the laws alone
+//     (`reverse_length_from_spec`), with no reference to any definition.
+
+recursive fast_reverse_helper<T>(List<T>, List<T>) -> List<T> {
+  fast_reverse_helper(empty, acc) = acc
+  fast_reverse_helper(node(x, xs), acc) = fast_reverse_helper(xs, node(x, acc))
+}
+
+fun fast_reverse<T>(xs : List<T>) {
+  fast_reverse_helper(xs, @empty<T>)
+}
+
+assert fast_reverse([1, 2, 3, 4]) = [4, 3, 2, 1]
+assert fast_reverse(@[]<UInt>) = []
+
+// The accumulator lemma and correctness theorem, as in fast_reverse.pf;
+// repeated here so this file stands alone.
+theorem fast_reverse_helper_correct: all T:type. all xs:List<T>. all acc:List<T>.
+  fast_reverse_helper(xs, acc) = reverse(xs) ++ acc
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary acc:List<T>
+    expand fast_reverse_helper | reverse | operator++.
+  }
+  case node(x, xs') assume IH: all acc:List<T>.
+      fast_reverse_helper(xs', acc) = reverse(xs') ++ acc {
+    arbitrary acc:List<T>
+    equations
+      fast_reverse_helper(node(x, xs'), acc)
+          = fast_reverse_helper(xs', node(x, acc))  by expand fast_reverse_helper.
+      ... = reverse(xs') ++ node(x, acc)            by IH[node(x, acc)]
+      ... = # reverse(xs') ++ ([x] ++ acc) #        by expand 2*operator++.
+      ... = (reverse(xs') ++ [x]) ++ acc
+                  by symmetric append_assoc<T>[reverse(xs'), [x], acc]
+      ... = # reverse(node(x, xs')) ++ acc #        by expand reverse.
+  }
+end
+
+theorem fast_reverse_correct: all T:type. all xs:List<T>.
+  fast_reverse(xs) = reverse(xs)
+proof
+  arbitrary T:type, xs:List<T>
+  equations
+    fast_reverse(xs)
+        = fast_reverse_helper(xs, @empty<T>)  by expand fast_reverse.
+    ... = reverse(xs) ++ @empty<T>            by fast_reverse_helper_correct<T>[xs][@empty<T>]
+    ... = reverse(xs)                         by append_empty<T>[reverse(xs)]
+end
+
+// ============================================================
+// COMPLETENESS, part 1: the algebraic spec determines reverse uniquely.
+//
+// Any f satisfying (E), (S), (H) equals reverse, pointwise.  The proof is
+// a one-line induction: node(x, xs') is [x] ++ xs', so (H) peels the head
+// to the right, (S) fixes it, and the IH handles the tail.  No definition
+// of f is ever unfolded.
+// ============================================================
+
+theorem reverse_unique: all T:type. all f : fn List<T> -> List<T>.
+  if f(@empty<T>) = @empty<T>                                            // (E)
+     and (all x:T. f([x]) = [x])                                         // (S)
+     and (all xs:List<T>, ys:List<T>. f(xs ++ ys) = f(ys) ++ f(xs))      // (H)
+  then all xs:List<T>. f(xs) = reverse(xs)
+proof
+  arbitrary T:type
+  arbitrary f : fn List<T> -> List<T>
+  suppose spec
+  have E: f(@empty<T>) = @empty<T>                  by conjunct 0 of spec
+  have S: all x:T. f([x]) = [x]                     by conjunct 1 of spec
+  have H: all xs:List<T>, ys:List<T>. f(xs ++ ys) = f(ys) ++ f(xs)
+                                                    by conjunct 2 of spec
+  induction List<T>
+  case empty {
+    suffices f(@empty<T>) = @empty<T>  by expand reverse.
+    E
+  }
+  case node(x, xs') assume IH: f(xs') = reverse(xs') {
+    have cons_app: node(x, xs') = [x] ++ xs'  by expand 2*operator++.
+    equations
+      f(node(x, xs'))
+          = f([x] ++ xs')          by replace cons_app.
+      ... = f(xs') ++ f([x])       by H[[x], xs']
+      ... = reverse(xs') ++ [x]    by replace IH | S[x].
+      ... = #reverse(node(x, xs'))#  by expand reverse.
+  }
+end
+
+// ============================================================
+// reverse satisfies the spec (using the standard library lemmas).
+// ============================================================
+
+theorem reverse_satisfies_spec: all T:type.
+  reverse(@empty<T>) = @empty<T>
+  and (all x:T. reverse([x]) = [x])
+  and (all xs:List<T>, ys:List<T>. reverse(xs ++ ys) = reverse(ys) ++ reverse(xs))
+proof
+  arbitrary T:type
+  have rev_empty: reverse(@empty<T>) = @empty<T>  by expand reverse.
+  have rev_single: all x:T. reverse([x]) = [x] by {
+    arbitrary x:T
+    expand 2*reverse | operator++.
+  }
+  have rev_app: all xs:List<T>, ys:List<T>.
+      reverse(xs ++ ys) = reverse(ys) ++ reverse(xs) by {
+    arbitrary xs:List<T>, ys:List<T>
+    reverse_append<T>[xs, ys]
+  }
+  (rev_empty, rev_single, rev_app)
+end
+
+// ============================================================
+// fast_reverse satisfies the spec too, by transporting each law across
+// fast_reverse_correct.  Then uniqueness re-derives correctness — a
+// second proof of fast_reverse = reverse that goes entirely through the
+// algebraic specification.
+// ============================================================
+
+theorem fast_reverse_satisfies_spec: all T:type.
+  fast_reverse(@empty<T>) = @empty<T>
+  and (all x:T. fast_reverse([x]) = [x])
+  and (all xs:List<T>, ys:List<T>.
+         fast_reverse(xs ++ ys) = fast_reverse(ys) ++ fast_reverse(xs))
+proof
+  arbitrary T:type
+  have fr: all xs:List<T>. fast_reverse(xs) = reverse(xs) by {
+    arbitrary xs:List<T>
+    fast_reverse_correct<T>[xs]
+  }
+  have c_empty: fast_reverse(@empty<T>) = @empty<T> by {
+    replace fr[@empty<T>]
+    expand reverse.
+  }
+  have c_single: all x:T. fast_reverse([x]) = [x] by {
+    arbitrary x:T
+    replace fr[[x]]
+    expand 2*reverse | operator++.
+  }
+  have c_app: all xs:List<T>, ys:List<T>.
+      fast_reverse(xs ++ ys) = fast_reverse(ys) ++ fast_reverse(xs) by {
+    arbitrary xs:List<T>, ys:List<T>
+    replace fr[xs ++ ys] | fr[xs] | fr[ys]
+    reverse_append<T>[xs, ys]
+  }
+  (c_empty, c_single, c_app)
+end
+
+theorem fast_reverse_is_the_reverse: all T:type. all xs:List<T>.
+  fast_reverse(xs) = reverse(xs)
+proof
+  arbitrary T:type
+  apply reverse_unique<T>[@fast_reverse<T>] to fast_reverse_satisfies_spec<T>
+end
+
+// ============================================================
+// COMPLETENESS, part 2: sufficiency.  Length preservation follows from
+// the spec alone — no recursion, no accumulator, just (S) and (H).
+// ============================================================
+
+theorem reverse_length_from_spec: all T:type. all f : fn List<T> -> List<T>.
+  if f(@empty<T>) = @empty<T>
+     and (all x:T. f([x]) = [x])
+     and (all xs:List<T>, ys:List<T>. f(xs ++ ys) = f(ys) ++ f(xs))
+  then all xs:List<T>. length(f(xs)) = length(xs)
+proof
+  arbitrary T:type
+  arbitrary f : fn List<T> -> List<T>
+  suppose spec
+  have S: all x:T. f([x]) = [x]                     by conjunct 1 of spec
+  have H: all xs:List<T>, ys:List<T>. f(xs ++ ys) = f(ys) ++ f(xs)
+                                                    by conjunct 2 of spec
+  induction List<T>
+  case empty {
+    have E: f(@empty<T>) = @empty<T>  by conjunct 0 of spec
+    suffices length(@empty<T>) = length(@empty<T>)  by replace E.
+    .
+  }
+  case node(x, xs') assume IH: length(f(xs')) = length(xs') {
+    have cons_app: node(x, xs') = [x] ++ xs'  by expand 2*operator++.
+    equations
+      length(f(node(x, xs')))
+          = length(f([x] ++ xs'))                 by replace cons_app.
+      ... = length(f(xs') ++ f([x]))              by replace H[[x], xs'].
+      ... = length(f(xs')) + length(f([x]))       by length_append<T>[f(xs'), f([x])]
+      ... = length(xs') + length([x])             by replace IH | S[x].
+      ... = length(xs') + 1                        by expand 2*length.
+      ... = 1 + length(xs')                        by uint_add_commute
+      ... = #length(node(x, xs'))#                 by expand length.
+  }
+end

--- a/examples/maximum.pf
+++ b/examples/maximum.pf
@@ -13,6 +13,12 @@
 //
 // `maximum` returns 0 on the empty list, which makes it behave as a
 // fold of the commutative monoid (UInt, max, 0).
+//
+// The three theorems here are proved DIRECTLY from the recursive
+// definition. For the companion question -- what is the complete
+// *specification* of `maximum` (the property that characterizes it
+// without reference to how it is computed), and how do these properties
+// follow from that spec -- see `maximum_spec.pf`.
 
 recursive maximum(List<UInt>) -> UInt {
   maximum(empty) = 0

--- a/examples/maximum_spec.pf
+++ b/examples/maximum_spec.pf
@@ -1,0 +1,247 @@
+// maximum_spec.pf
+//
+// In `maximum.pf` we defined `maximum` and proved a handful of properties
+// of it (distributes over ++, invariant under reverse, bounds every
+// element).  Each of those was proved DIRECTLY from the recursive
+// definition.  This file asks a different question:
+//
+//   What is the *specification* of `maximum` — the property that says
+//   "this function computes the largest element" without reference to
+//   how it is computed — and is that specification *complete*?
+//
+// "Complete" here means two things:
+//
+//   1. ADEQUACY / UNIQUENESS.  The spec pins the function down: any
+//      function whatsoever that satisfies the spec is equal to `maximum`.
+//      (`maximum_unique` below.)  A spec that admitted other functions
+//      would be too weak to be called "the" specification.
+//
+//   2. SUFFICIENCY.  Every property we proved from the definition can be
+//      re-derived from the spec alone.  We demonstrate this for
+//      `maximum_append`: its proof below never expands `maximum`, it uses
+//      only the two spec clauses.  So the spec is strong enough to stand
+//      in for the definition.
+//
+// The specification: maximum(xs) is the LEAST UPPER BOUND of the elements
+// of xs.  Two clauses:
+//
+//   (UB)  maximum(xs) is an upper bound:  every element is ≤ maximum(xs).
+//   (LUB) maximum(xs) is the *least* upper bound:  any u that bounds all
+//         the elements also bounds maximum(xs).
+//
+// This is uniform — it needs no special case for the empty list.  Because
+// every UInt is ≥ 0, the only upper bound of the empty list that (LUB)
+// can force maximum(empty) below is 0 itself, so the spec already entails
+// maximum(empty) = 0 with no extra clause.  (The textbook alternative —
+// "maximum(xs) is an element of xs that bounds every element" — is
+// equivalent for non-empty lists but needs a separate maximum(empty) = 0
+// clause, because the empty list has no element to point at.)
+
+recursive maximum(List<UInt>) -> UInt {
+  maximum(empty) = 0
+  maximum(node(x, xs)) = max(x, maximum(xs))
+}
+
+assert maximum([3, 1, 4, 1, 5, 9, 2, 6]) = 9
+assert maximum(@[]<UInt>) = 0
+
+// ============================================================
+// Small helpers.
+// ============================================================
+
+// Associativity of `or` (not in the prelude).
+theorem bool_or_assoc: all P:bool, Q:bool, R:bool.
+  (P or (Q or R)) = ((P or Q) or R)
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  switch P {
+    case true { . }
+    case false { . }
+  }
+end
+
+// Membership distributes over append.
+theorem contains_append: all T:type. all xs:List<T>, ys:List<T>, e:T.
+  contains(xs ++ ys, e) = (contains(xs, e) or contains(ys, e))
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary ys:List<T>, e:T
+    expand operator++ | contains.
+  }
+  case node(x, xs') assume IH: all ys:List<T>, e:T.
+      contains(xs' ++ ys, e) = (contains(xs', e) or contains(ys, e)) {
+    arbitrary ys:List<T>, e:T
+    expand operator++ | contains
+    replace IH[ys, e]
+    bool_or_assoc[(x = e), contains(xs', e), contains(ys, e)]
+  }
+end
+
+// ============================================================
+// The specification, proved of `maximum`.
+// ============================================================
+
+// (UB) maximum is an upper bound of the elements.
+//   (This is the property `maximum_upper_bound` from maximum.pf.)
+theorem maximum_upper_bound: all xs:List<UInt>. all x:UInt.
+  if contains(xs, x) then x ≤ maximum(xs)
+proof
+  induction List<UInt>
+  case empty {
+    arbitrary x:UInt
+    suppose cf: contains(@empty<UInt>, x)
+    expand contains in cf
+  }
+  case node(y, xs') assume IH: all x:UInt. if contains(xs', x) then x ≤ maximum(xs') {
+    arbitrary x:UInt
+    suppose cn: contains(node(y, xs'), x)
+    have disj: y = x or contains(xs', x) by expand contains in cn
+    cases disj
+    case yx: y = x {
+      suffices x ≤ max(y, maximum(xs'))  by expand maximum.
+      replace yx
+      uint_max_greater_left[x, maximum(xs')]
+    }
+    case cxs: contains(xs', x) {
+      suffices x ≤ max(y, maximum(xs'))  by expand maximum.
+      apply uint_less_equal_trans[x, maximum(xs'), max(y, maximum(xs'))]
+        to (apply IH[x] to cxs), uint_max_greater_right[y, maximum(xs')]
+    }
+  }
+end
+
+// (LUB) maximum is the least upper bound: it sits below any other bound.
+theorem maximum_least: all xs:List<UInt>, u:UInt.
+  if (all x:UInt. if contains(xs, x) then x ≤ u)
+  then maximum(xs) ≤ u
+proof
+  induction List<UInt>
+  case empty {
+    arbitrary u:UInt
+    suppose _ub: all x:UInt. if contains(@empty<UInt>, x) then x ≤ u
+    // maximum(empty) = 0 ≤ u holds for every u.
+    expand maximum.
+  }
+  case node(y, xs') assume IH: all u:UInt.
+      (if (all x:UInt. if contains(xs', x) then x ≤ u) then maximum(xs') ≤ u) {
+    arbitrary u:UInt
+    suppose ub: all x:UInt. if contains(node(y, xs'), x) then x ≤ u
+    suffices max(y, maximum(xs')) ≤ u  by expand maximum.
+    // y is an element, so it is bounded by u.
+    have cy: contains(node(y, xs'), y)  by expand contains.
+    have y_le_u: y ≤ u  by apply ub[y] to cy
+    // every element of xs' is also an element of node(y, xs'), so u
+    // bounds them too; the IH then bounds maximum(xs').
+    have rest_ub: all x:UInt. if contains(xs', x) then x ≤ u by {
+      arbitrary x:UInt
+      suppose cx: contains(xs', x)
+      have cn: contains(node(y, xs'), x) by {
+        suffices (y = x) or contains(xs', x)  by expand contains.
+        cx
+      }
+      apply ub[x] to cn
+    }
+    have rest_le_u: maximum(xs') ≤ u  by apply IH[u] to rest_ub
+    apply uint_max_less_equal[y, maximum(xs'), u] to y_le_u, rest_le_u
+  }
+end
+
+// ============================================================
+// COMPLETENESS, part 1: adequacy / uniqueness.
+//
+// Any function f that satisfies the spec is equal to maximum, pointwise.
+// The argument is pure lattice reasoning: each of f and maximum is an
+// upper bound, each is least, so antisymmetry forces them equal.  Note
+// the proof never mentions the recursive definition of either function.
+// ============================================================
+
+theorem maximum_unique:
+  all f : fn List<UInt> -> UInt.
+  if (all xs:List<UInt>, x:UInt. if contains(xs, x) then x ≤ f(xs))           // f is (UB)
+     and (all xs:List<UInt>, u:UInt.                                          // f is (LUB)
+            if (all x:UInt. if contains(xs, x) then x ≤ u) then f(xs) ≤ u)
+  then all xs:List<UInt>. f(xs) = maximum(xs)
+proof
+  arbitrary f : fn List<UInt> -> UInt
+  suppose spec
+  have f_ub: all xs:List<UInt>, x:UInt. if contains(xs, x) then x ≤ f(xs)
+    by spec
+  have f_lub: all xs:List<UInt>, u:UInt.
+       if (all x:UInt. if contains(xs, x) then x ≤ u) then f(xs) ≤ u
+    by spec
+  arbitrary xs:List<UInt>
+  // maximum is least and f(xs) bounds every element, so maximum(xs) ≤ f(xs).
+  have max_le_f: maximum(xs) ≤ f(xs)
+    by apply maximum_least[xs, f(xs)] to f_ub[xs]
+  // f is least and maximum(xs) bounds every element, so f(xs) ≤ maximum(xs).
+  have f_le_max: f(xs) ≤ maximum(xs)
+    by apply f_lub[xs, maximum(xs)] to maximum_upper_bound[xs]
+  apply uint_less_equal_antisymmetric[f(xs), maximum(xs)] to f_le_max, max_le_f
+end
+
+// ============================================================
+// COMPLETENESS, part 2: sufficiency.
+//
+// We re-prove `maximum_append` from maximum.pf, but this time using ONLY
+// the spec clauses (maximum_upper_bound, maximum_least) and the lattice
+// lemmas — never `expand maximum`.  This shows the spec is strong enough
+// to entail the definition-derived properties.
+// ============================================================
+
+theorem maximum_append_from_spec: all xs:List<UInt>, ys:List<UInt>.
+  maximum(xs ++ ys) = max(maximum(xs), maximum(ys))
+proof
+  arbitrary xs:List<UInt>, ys:List<UInt>
+  // (≤) max(maximum(xs), maximum(ys)) is an upper bound of xs ++ ys,
+  //     so maximum(xs ++ ys), being least, is below it.
+  have left: maximum(xs ++ ys) ≤ max(maximum(xs), maximum(ys)) by {
+    apply maximum_least[xs ++ ys, max(maximum(xs), maximum(ys))] to {
+      arbitrary e:UInt
+      suppose ce: contains(xs ++ ys, e)
+      have e_in: contains(xs, e) or contains(ys, e)
+        by replace contains_append<UInt>[xs, ys, e] in ce
+      cases e_in
+      case in_xs: contains(xs, e) {
+        apply uint_less_equal_trans[e, maximum(xs), max(maximum(xs), maximum(ys))]
+          to (apply maximum_upper_bound[xs][e] to in_xs),
+             uint_max_greater_left[maximum(xs), maximum(ys)]
+      }
+      case in_ys: contains(ys, e) {
+        apply uint_less_equal_trans[e, maximum(ys), max(maximum(xs), maximum(ys))]
+          to (apply maximum_upper_bound[ys][e] to in_ys),
+             uint_max_greater_right[maximum(xs), maximum(ys)]
+      }
+    }
+  }
+  // (≥) maximum(xs ++ ys) bounds every element of xs and of ys, hence it
+  //     bounds maximum(xs) and maximum(ys), hence their max.
+  have max_xs_le: maximum(xs) ≤ maximum(xs ++ ys) by {
+    apply maximum_least[xs, maximum(xs ++ ys)] to {
+      arbitrary e:UInt
+      suppose ce: contains(xs, e)
+      have in_app: contains(xs ++ ys, e) by {
+        replace contains_append<UInt>[xs, ys, e]
+        ce
+      }
+      apply maximum_upper_bound[xs ++ ys][e] to in_app
+    }
+  }
+  have max_ys_le: maximum(ys) ≤ maximum(xs ++ ys) by {
+    apply maximum_least[ys, maximum(xs ++ ys)] to {
+      arbitrary e:UInt
+      suppose ce: contains(ys, e)
+      have in_app: contains(xs ++ ys, e) by {
+        replace contains_append<UInt>[xs, ys, e]
+        ce
+      }
+      apply maximum_upper_bound[xs ++ ys][e] to in_app
+    }
+  }
+  have right: max(maximum(xs), maximum(ys)) ≤ maximum(xs ++ ys)
+    by apply uint_max_less_equal[maximum(xs), maximum(ys), maximum(xs ++ ys)]
+       to max_xs_le, max_ys_le
+  apply uint_less_equal_antisymmetric[maximum(xs ++ ys), max(maximum(xs), maximum(ys))]
+    to left, right
+end

--- a/examples/partition_spec.pf
+++ b/examples/partition_spec.pf
@@ -1,0 +1,228 @@
+// partition_spec.pf
+//
+// `partition.pf` defines `partition` and proves three properties directly
+// from the definition: the two output lengths sum to the input length
+// (`length_partition`), and the two components equal the corresponding
+// filters (`partition_filter_first`, `partition_filter_second`).
+//
+// This file makes the *specification* explicit and shows it is complete.
+// The specification IS the filter characterization: a partitioner g is
+// correct exactly when, for every list and predicate,
+//
+//   (G1) first(g(xs, p))  = filter(xs, p)                  -- the kept part
+//   (G2) second(g(xs, p)) = filter(xs, fun y { not p(y) }) -- the rest
+//
+// These say "the first output is the p-elements in order, the second is
+// the non-p-elements in order" — membership AND order are pinned down by
+// `filter`.  Completeness then means:
+//
+//   1. ADEQUACY (`partition_unique`): any g satisfying (G1),(G2) equals
+//      partition.  A pair is its two projections (the `pair_first_second`
+//      law), and (G1),(G2) fix both projections, so g(xs,p) has nowhere
+//      left to vary.
+//   2. SUFFICIENCY (`length_partition_from_spec`): the length property
+//      follows from the spec — the two filters of a list cover it exactly
+//      (`length_filter_complement`).
+
+recursive partition<T>(List<T>, fn (T)->bool) -> Pair< List<T>, List<T> > {
+  partition(empty, p) = pair(@empty<T>, @empty<T>)
+  partition(node(x, xs), p) =
+    define rest = partition(xs, p);
+    if p(x) then pair(node(x, first(rest)), second(rest))
+    else         pair(first(rest), node(x, second(rest)))
+}
+
+define is_even : fn UInt -> bool = fun n { n % 2 = 0 }
+assert partition([1, 2, 3, 4, 5], is_even) = pair([2, 4], [1, 3, 5])
+
+// ============================================================
+// partition satisfies the filter spec.  (These are the theorems
+// partition_filter_first / partition_filter_second from partition.pf,
+// repeated so this file stands alone.)
+// ============================================================
+
+theorem partition_filter_first: all T:type. all xs:List<T>. all p:fn(T)->bool.
+  first(partition(xs, p)) = filter(xs, p)
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary p:fn(T)->bool
+    expand partition | filter | first.
+  }
+  case node(x, xs') assume IH: all p:fn(T)->bool.
+      first(partition(xs', p)) = filter(xs', p) {
+    arbitrary p:fn(T)->bool
+    switch p(x) {
+      case true assume px_true {
+        equations
+          first(partition(node(x, xs'), p))
+              = node(x, first(partition(xs', p)))
+                  by expand partition simplify with px_true expand first.
+          ... = node(x, filter(xs', p))   by replace IH[p].
+          ... = #filter(node(x, xs'), p)#
+                  by expand filter simplify with px_true.
+      }
+      case false assume px_false {
+        equations
+          first(partition(node(x, xs'), p))
+              = first(partition(xs', p))
+                  by expand partition simplify with px_false expand first.
+          ... = filter(xs', p)            by IH[p]
+          ... = #filter(node(x, xs'), p)#
+                  by expand filter simplify with px_false.
+      }
+    }
+  }
+end
+
+theorem partition_filter_second: all T:type. all xs:List<T>. all p:fn(T)->bool.
+  second(partition(xs, p)) = filter(xs, fun y:T { not p(y) })
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary p:fn(T)->bool
+    expand partition | filter | second.
+  }
+  case node(x, xs') assume IH: all p:fn(T)->bool.
+      second(partition(xs', p)) = filter(xs', fun y:T { not p(y) }) {
+    arbitrary p:fn(T)->bool
+    switch p(x) {
+      case true assume px_true {
+        equations
+          second(partition(node(x, xs'), p))
+              = second(partition(xs', p))
+                  by expand partition simplify with px_true expand second.
+          ... = filter(xs', fun y:T { not p(y) })   by IH[p]
+          ... = #filter(node(x, xs'), fun y:T { not p(y) })#
+                  by expand filter simplify with px_true.
+      }
+      case false assume px_false {
+        equations
+          second(partition(node(x, xs'), p))
+              = node(x, second(partition(xs', p)))
+                  by expand partition simplify with px_false expand second.
+          ... = node(x, filter(xs', fun y:T { not p(y) }))   by replace IH[p].
+          ... = #filter(node(x, xs'), fun y:T { not p(y) })#
+                  by expand filter simplify with px_false.
+      }
+    }
+  }
+end
+
+// ============================================================
+// COMPLETENESS, part 1: adequacy / uniqueness.
+//
+// Any g whose projections are the two filters equals partition.  The
+// proof rebuilds each pair from its projections and rewrites with the
+// spec; partition's own filter laws close the loop.
+// ============================================================
+
+theorem partition_unique:
+  all T:type. all g : fn List<T>, (fn (T)->bool) -> Pair< List<T>, List<T> >.
+  if (all xs:List<T>, p:fn(T)->bool. first(g(xs, p)) = filter(xs, p))           // (G1)
+     and (all xs:List<T>, p:fn(T)->bool.                                        // (G2)
+            second(g(xs, p)) = filter(xs, fun y:T { not p(y) }))
+  then all xs:List<T>, p:fn(T)->bool. g(xs, p) = partition(xs, p)
+proof
+  arbitrary T:type
+  arbitrary g : fn List<T>, (fn (T)->bool) -> Pair< List<T>, List<T> >
+  suppose spec
+  have G1: all xs:List<T>, p:fn(T)->bool. first(g(xs, p)) = filter(xs, p)
+    by conjunct 0 of spec
+  have G2: all xs:List<T>, p:fn(T)->bool.
+       second(g(xs, p)) = filter(xs, fun y:T { not p(y) })
+    by conjunct 1 of spec
+  arbitrary xs:List<T>, p:fn(T)->bool
+  equations
+    g(xs, p)
+        = pair(first(g(xs, p)), second(g(xs, p)))
+              by symmetric pair_first_second<List<T>, List<T>>[g(xs, p)]
+    ... = pair(filter(xs, p), filter(xs, fun y:T { not p(y) }))
+              by replace G1[xs, p] | G2[xs, p].
+    ... = pair(first(partition(xs, p)), second(partition(xs, p)))
+              by replace symmetric partition_filter_first<T>[xs][p]
+                       | symmetric partition_filter_second<T>[xs][p].
+    ... = partition(xs, p)
+              by pair_first_second<List<T>, List<T>>[partition(xs, p)]
+end
+
+// ============================================================
+// COMPLETENESS, part 2: sufficiency.
+//
+// The two filters of any list partition it by length.  This is the core
+// fact behind `length_partition`, stated about `filter` alone.
+// ============================================================
+
+theorem length_filter_complement: all T:type. all xs:List<T>. all p:fn(T)->bool.
+  length(filter(xs, p)) + length(filter(xs, fun y:T { not p(y) })) = length(xs)
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary p:fn(T)->bool
+    expand filter | length.
+  }
+  case node(x, xs') assume IH: all p:fn(T)->bool.
+      length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })) = length(xs') {
+    arbitrary p:fn(T)->bool
+    switch p(x) {
+      case true assume px_true {
+        have keep_eq: filter(node(x, xs'), p) = node(x, filter(xs', p))
+          by expand filter simplify with px_true.
+        have drop_eq: filter(node(x, xs'), fun y:T { not p(y) })
+                   = filter(xs', fun y:T { not p(y) })
+          by expand filter simplify with px_true.
+        equations
+          length(filter(node(x, xs'), p)) + length(filter(node(x, xs'), fun y:T { not p(y) }))
+              = (1 + length(filter(xs', p))) + length(filter(xs', fun y:T { not p(y) }))
+                  by replace keep_eq | drop_eq expand length.
+          ... = 1 + (length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })))
+                  by .
+          ... = 1 + length(xs')         by replace IH[p].
+          ... = #length(node(x, xs'))#  by expand length.
+      }
+      case false assume px_false {
+        have drop_eq: filter(node(x, xs'), p) = filter(xs', p)
+          by expand filter simplify with px_false.
+        have keep_eq: filter(node(x, xs'), fun y:T { not p(y) })
+                   = node(x, filter(xs', fun y:T { not p(y) }))
+          by expand filter simplify with px_false.
+        equations
+          length(filter(node(x, xs'), p)) + length(filter(node(x, xs'), fun y:T { not p(y) }))
+              = length(filter(xs', p)) + (1 + length(filter(xs', fun y:T { not p(y) })))
+                  by replace keep_eq | drop_eq expand length.
+          ... = (length(filter(xs', p)) + 1) + length(filter(xs', fun y:T { not p(y) }))
+                  by .
+          ... = (1 + length(filter(xs', p))) + length(filter(xs', fun y:T { not p(y) }))
+                  by replace uint_add_commute[length(filter(xs', p)), 1].
+          ... = 1 + (length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })))
+                  by .
+          ... = 1 + length(xs')         by replace IH[p].
+          ... = #length(node(x, xs'))#  by expand length.
+      }
+    }
+  }
+end
+
+theorem length_partition_from_spec:
+  all T:type. all g : fn List<T>, (fn (T)->bool) -> Pair< List<T>, List<T> >.
+  if (all xs:List<T>, p:fn(T)->bool. first(g(xs, p)) = filter(xs, p))
+     and (all xs:List<T>, p:fn(T)->bool.
+            second(g(xs, p)) = filter(xs, fun y:T { not p(y) }))
+  then all xs:List<T>, p:fn(T)->bool.
+         length(first(g(xs, p))) + length(second(g(xs, p))) = length(xs)
+proof
+  arbitrary T:type
+  arbitrary g : fn List<T>, (fn (T)->bool) -> Pair< List<T>, List<T> >
+  suppose spec
+  have G1: all xs:List<T>, p:fn(T)->bool. first(g(xs, p)) = filter(xs, p)
+    by conjunct 0 of spec
+  have G2: all xs:List<T>, p:fn(T)->bool.
+       second(g(xs, p)) = filter(xs, fun y:T { not p(y) })
+    by conjunct 1 of spec
+  arbitrary xs:List<T>, p:fn(T)->bool
+  replace G1[xs, p] | G2[xs, p]
+  length_filter_complement<T>[xs][p]
+end

--- a/examples/sum_spec.pf
+++ b/examples/sum_spec.pf
@@ -1,0 +1,146 @@
+// sum_spec.pf
+//
+// `sum_correct.pf` defines `sum` over a list of UInts and proves two
+// properties directly from the definition: it distributes over append
+// (`sum_append`) and is invariant under reversal (`sum_reverse`).
+//
+// This file gives the *specification* of `sum` and shows it is complete.
+// The specification is algebraic: `sum` is the unique MONOID HOMOMORPHISM
+// from (List<UInt>, ++, []) to (UInt, +, 0) that sends each singleton to
+// its element.  A function f qualifies exactly when:
+//
+//   (E) f([])        = 0                          -- preserves the unit
+//   (S) f([x])       = x                          -- fixes singletons
+//   (H) f(xs ++ ys)  = f(xs) + f(ys)              -- homomorphism of ++/+
+//
+// As with the other *_spec files, "complete" means:
+//
+//   1. ADEQUACY (`sum_unique`): any f satisfying (E),(S),(H) equals sum.
+//      Generators ([x]) plus the homomorphism law leave no freedom.
+//   2. SUFFICIENCY (`sum_reverse_from_spec`): the reversal invariance
+//      proved in sum_correct.pf follows from the spec alone — it needs
+//      only (S), (H) and commutativity of +, never the recursion.
+
+recursive sum(List<UInt>) -> UInt {
+  sum(empty) = 0
+  sum(node(x, xs)) = x + sum(xs)
+}
+
+assert sum([1, 2, 3]) = 6
+assert sum(@[]<UInt>) = 0
+
+// The homomorphism law (clause H), proved directly — this is `sum_append`
+// from sum_correct.pf, repeated so the file stands alone.
+theorem sum_append: all xs:List<UInt>, ys:List<UInt>.
+  sum(xs ++ ys) = sum(xs) + sum(ys)
+proof
+  induction List<UInt>
+  case empty {
+    arbitrary ys:List<UInt>
+    expand sum | operator++.
+  }
+  case node(x, xs') assume IH: (all ys:List<UInt>. sum(xs' ++ ys) = sum(xs') + sum(ys)) {
+    arbitrary ys:List<UInt>
+    equations
+      sum(node(x, xs') ++ ys)
+          = x + sum(xs' ++ ys)              by expand operator++ | sum.
+      ... = x + (sum(xs') + sum(ys))        by replace IH[ys].
+      ... = #sum(node(x, xs'))# + sum(ys)   by expand sum.
+  }
+end
+
+// ============================================================
+// COMPLETENESS, part 1: adequacy / uniqueness.
+//
+// Any homomorphism f that fixes singletons equals sum.  node(x, xs') is
+// [x] ++ xs', so (H) splits off the head, (S) evaluates it, and the IH
+// handles the tail.  The definition of f is never unfolded.
+// ============================================================
+
+theorem sum_unique: all f : fn List<UInt> -> UInt.
+  if f(@empty<UInt>) = 0                                                  // (E)
+     and (all x:UInt. f([x]) = x)                                         // (S)
+     and (all xs:List<UInt>, ys:List<UInt>. f(xs ++ ys) = f(xs) + f(ys))  // (H)
+  then all xs:List<UInt>. f(xs) = sum(xs)
+proof
+  arbitrary f : fn List<UInt> -> UInt
+  suppose spec
+  have E: f(@empty<UInt>) = 0                       by conjunct 0 of spec
+  have S: all x:UInt. f([x]) = x                    by conjunct 1 of spec
+  have H: all xs:List<UInt>, ys:List<UInt>. f(xs ++ ys) = f(xs) + f(ys)
+                                                    by conjunct 2 of spec
+  induction List<UInt>
+  case empty {
+    suffices f(@empty<UInt>) = 0  by expand sum.
+    E
+  }
+  case node(x, xs') assume IH: f(xs') = sum(xs') {
+    have cons_app: node(x, xs') = [x] ++ xs'  by expand 2*operator++.
+    equations
+      f(node(x, xs'))
+          = f([x] ++ xs')        by replace cons_app.
+      ... = f([x]) + f(xs')      by H[[x], xs']
+      ... = x + sum(xs')         by replace S[x] | IH.
+      ... = #sum(node(x, xs'))#  by expand sum.
+  }
+end
+
+// ============================================================
+// sum satisfies the spec.
+// ============================================================
+
+theorem sum_satisfies_spec:
+  sum(@empty<UInt>) = 0
+  and (all x:UInt. sum([x]) = x)
+  and (all xs:List<UInt>, ys:List<UInt>. sum(xs ++ ys) = sum(xs) + sum(ys))
+proof
+  have e: sum(@empty<UInt>) = 0  by expand sum.
+  have s: all x:UInt. sum([x]) = x by {
+    arbitrary x:UInt
+    expand sum | sum.
+  }
+  have h: all xs:List<UInt>, ys:List<UInt>. sum(xs ++ ys) = sum(xs) + sum(ys) by {
+    arbitrary xs:List<UInt>, ys:List<UInt>
+    sum_append[xs, ys]
+  }
+  (e, s, h)
+end
+
+// ============================================================
+// COMPLETENESS, part 2: sufficiency.
+//
+// Reversal invariance, proved from the spec alone.  The head element x
+// that reverse moves to the far end contributes the same summand x in
+// either position — that is exactly commutativity of +.
+// ============================================================
+
+theorem sum_reverse_from_spec: all f : fn List<UInt> -> UInt.
+  if f(@empty<UInt>) = 0
+     and (all x:UInt. f([x]) = x)
+     and (all xs:List<UInt>, ys:List<UInt>. f(xs ++ ys) = f(xs) + f(ys))
+  then all xs:List<UInt>. f(reverse(xs)) = f(xs)
+proof
+  arbitrary f : fn List<UInt> -> UInt
+  suppose spec
+  have S: all x:UInt. f([x]) = x                    by conjunct 1 of spec
+  have H: all xs:List<UInt>, ys:List<UInt>. f(xs ++ ys) = f(xs) + f(ys)
+                                                    by conjunct 2 of spec
+  induction List<UInt>
+  case empty {
+    expand reverse.
+  }
+  case node(x, xs') assume IH: f(reverse(xs')) = f(xs') {
+    // f(node(x, xs')) = f([x] ++ xs') = f([x]) + f(xs') = x + f(xs').
+    have head_eq: f(node(x, xs')) = x + f(xs') by {
+      have cons_app: node(x, xs') = [x] ++ xs'  by expand 2*operator++.
+      replace cons_app | H[[x], xs'] | S[x].
+    }
+    equations
+      f(reverse(node(x, xs')))
+          = f(reverse(xs') ++ [x])    by expand reverse.
+      ... = f(reverse(xs')) + f([x])  by H[reverse(xs'), [x]]
+      ... = f(xs') + x                by replace IH | S[x].
+      ... = x + f(xs')                by uint_add_commute
+      ... = f(node(x, xs'))           by symmetric head_eq
+  }
+end


### PR DESCRIPTION
## What

Adds, for four `examples/` functions, a companion `*_spec.pf` that states the function's **complete specification** and demonstrates completeness — answering "should we prove these functions satisfy a spec, and can that spec be complete enough to imply the directly-proven properties?"

Each spec file shows completeness in two senses:

1. **Adequacy / uniqueness** — quantifies over an *arbitrary* function satisfying the spec clauses and proves it equals the real function, pointwise, **without unfolding any definition**. Nothing else satisfies the spec.
2. **Sufficiency** — re-derives a property that the original `*.pf` proved from the definition, using **only** the spec clauses. The spec is strong enough to stand in for the definition.

| File | Spec | Re-derived from spec |
|---|---|---|
| `maximum_spec.pf` | least upper bound of the elements (uniform — no empty special case) | `maximum_append` |
| `sum_spec.pf` | unique monoid homomorphism `(List,++,[]) → (UInt,+,0)` fixing singletons | `sum_reverse` |
| `fast_reverse_spec.pf` | algebraic laws of reversal (empty, fixes singletons, anti-homomorphism) — gives a spec-based proof of `fast_reverse = reverse` distinct from the accumulator lemma | length preservation |
| `partition_spec.pf` | the filter characterization (`first = filter p`, `second = filter ¬p`) | `length_partition` |

`maximum.pf` gains a one-line header note pointing at `maximum_spec.pf`.

## Testing

All four validate under **both** parsers (`deduce.py` and `deduce.py --lalr`) and `python test-deduce.py --examples`.

## Issues discovered while writing these

Filed separately (not fixed here):

- #857 — `equations` steps reject `or` on the RHS (worked around by transforming the goal directly).
- #858 — parenthesized multi-arg function types `fn (A, B) -> C` are rejected; must use `fn A, B -> C`.
- #859 — MCP `check_file` can't validate under LALR / both parsers, so the both-parsers rule still requires the CLI.

[Claude session](claude://resume?session=6d6d571b-183a-4de4-9827-e3e0d5a8cd1c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update:** added `maximum_specs_equivalent.pf` — proves the least-upper-bound characterization of `maximum` (used in `maximum_spec.pf`) is equivalent, for non-empty lists, to the textbook "greatest member" characterization (`is_lub(m, xs) ⇔ is_greatest_member(m, xs)`). The bridge is `maximum` itself: each side forces `m = maximum(xs)` by antisymmetry, since `maximum` is provably both the lub and a member (new `maximum_member` lemma). Validated under both parsers and `--examples`.
