### PR TITLE
Add examples/filter.pf: filter correctness (append homomorphism + length bound)

### DIFF
--- a/examples/filter.pf
+++ b/examples/filter.pf
@@ -1,0 +1,89 @@
+// filter.pf
+//
+// A classic introductory-functional-programming function: `filter`,
+// which keeps only the elements of a list that satisfy a predicate.
+//
+//     filter :: (a -> Bool) -> [a] -> [a]
+//     filter p []                 = []
+//     filter p (x:xs) | p x       = x : filter p xs
+//                     | otherwise = filter p xs
+//
+// `filter` is part of the Deduce standard library (lib/List.pf). Here we
+// prove two of its classic correctness properties:
+//
+//   1. filter_append:  filter distributes over append (++),
+//        filter(xs ++ ys, p) = filter(xs, p) ++ filter(ys, p)
+//   2. filter_length:  filtering never lengthens a list,
+//        length(filter(xs, p)) ≤ length(xs)
+//
+// Both proofs go by induction on the list, with a `switch` on the value
+// of the predicate `p(x)` in the `node` case.
+
+// A quick test of the definition.
+assert filter([1, 2, 3, 4], λx{ x % 2 = 0 }) = [2, 4]
+
+theorem filter_append: all T:type, p:fn (T)->bool, xs:List<T>, ys:List<T>.
+  filter(xs ++ ys, p) = filter(xs, p) ++ filter(ys, p)
+proof
+  arbitrary T:type, p:fn (T)->bool
+  induction List<T>
+  case empty {
+    arbitrary ys:List<T>
+    expand operator++ | filter.
+  }
+  case node(x, xs') assume IH: all ys:List<T>.
+      filter(xs' ++ ys, p) = filter(xs', p) ++ filter(ys, p) {
+    arbitrary ys:List<T>
+    switch p(x) {
+      case true assume px_true {
+        equations
+          filter(node(x, xs') ++ ys, p)
+              = filter(node(x, xs' ++ ys), p)            by expand operator++.
+          ... = node(x, filter(xs' ++ ys, p))            by expand filter simplify with px_true.
+          ... = node(x, filter(xs', p) ++ filter(ys, p)) by replace IH[ys].
+          ... = #node(x, filter(xs', p)) ++ filter(ys, p)# by expand operator++.
+          ... = #filter(node(x, xs'), p)# ++ filter(ys, p)
+                                                         by expand filter simplify with px_true.
+      }
+      case false assume px_false {
+        equations
+          filter(node(x, xs') ++ ys, p)
+              = filter(node(x, xs' ++ ys), p)            by expand operator++.
+          ... = filter(xs' ++ ys, p)                     by expand filter simplify with px_false.
+          ... = filter(xs', p) ++ filter(ys, p)          by replace IH[ys].
+          ... = #filter(node(x, xs'), p)# ++ filter(ys, p)
+                                                         by expand filter simplify with px_false.
+      }
+    }
+  }
+end
+
+theorem filter_length: all T:type, p:fn (T)->bool, xs:List<T>.
+  length(filter(xs, p)) ≤ length(xs)
+proof
+  arbitrary T:type, p:fn (T)->bool
+  induction List<T>
+  case empty {
+    evaluate
+  }
+  case node(x, xs') assume IH: length(filter(xs', p)) ≤ length(xs') {
+    switch p(x) {
+      case true assume px_true {
+        have e: length(filter(node(x, xs'), p)) = 1 + length(filter(xs', p))
+          by expand filter simplify with px_true expand length.
+        replace e
+        expand length
+        IH
+      }
+      case false assume px_false {
+        have e: length(filter(node(x, xs'), p)) = length(filter(xs', p))
+          by expand filter simplify with px_false.
+        replace e
+        expand length
+        have h: length(xs') ≤ 1 + length(xs') by uint_less_equal_add_left[1, length(xs')]
+        apply uint_less_equal_trans[length(filter(xs', p)), length(xs'), 1 + length(xs')]
+          to (IH, h)
+      }
+    }
+  }
+end


### PR DESCRIPTION
## What

Adds `examples/filter.pf`, a new introductory-functional-programming worked example. It defines no new functions; instead it proves two classic correctness properties of the standard-library `filter`:

1. **`filter_append`** — filter distributes over append (it's a `++`-homomorphism):
   `filter(xs ++ ys, p) = filter(xs, p) ++ filter(ys, p)`
2. **`filter_length`** — filtering never lengthens a list:
   `length(filter(xs, p)) ≤ length(xs)`

Both go by induction on the list with a `switch` on `p(x)` in the `node` case. `filter_length` is the first `examples/` proof to exercise `≤` reasoning (`uint_less_equal_trans`, `uint_less_equal_add_left`).

## Why

`filter` is a staple of intro FP courses, and these two properties (distributes over concatenation; output no longer than input) are the canonical "prove it correct" exercises. The existing examples cover `sum`, `concat`, `count_if`, `partition`, etc., but neither of these filter properties was in `lib/` or `examples/`.

## Testing

- `python3 deduce.py examples/filter.pf` — valid
- `python3 deduce.py --lalr examples/filter.pf` — valid (both parsers)
- `python3 test-deduce.py --examples` — all pass

## Friction found during this walkthrough

Written as a new-user acceptance pass; two friction items were filed as separate issues:

- #862 — `expand a | b` is order-sensitive when an `auto` rule collapses the goal (`expand length | filter.` works, `expand filter | length.` hard-errors on the identical base-case goal).
- #863 — cryptic parse error for Haskell-style `\x. ...` lambdas; no hint to use `fun` / `λ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Claude session](claude://resume?session=02d92316-bc64-4e04-b050-bc9ac0c65085)
