### PR TITLE
Accept parenthesized multi-arg function type 'fn (A, B) -> C' (closes #858)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -263,6 +263,7 @@ identifier: IDENT              -> identifier
  | visibility "postulate" IDENT ":" term               -> postulate
 
 ?type: "fn" type_params_opt type_list "->" type        -> function_type
+ | "fn" type_params_opt "(" type "," type_list ")" "->" type   -> function_type_paren
  | IDENT "<" type_list ">"                             -> type_inst
  | atomic_type
 

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -1112,12 +1112,21 @@ assert interchange(pair(1,2)) = pair(2,1)
 
 ```
 type ::= "fn" type_params_opt type_list "->" type
+type ::= "fn" type_params_opt "(" type "," type_list ")" "->" type
 ```
 
 A function type classifies a function. This includes both recursive
 functions (`recursive`) and non-recursive functions (`fun` or `λ`).
 If the function is generic, its function type includes type parameters
 enclosed in `<` and `>`.
+
+Multi-argument parameter lists may be written bare (`fn A, B -> C`) or
+wrapped in parentheses (`fn (A, B) -> C`); both forms are equivalent.
+The parenthesized spelling matches the parameter syntax used in
+function declarations such as `recursive partition<T>(List<T>, fn (T)->bool) -> ...`.
+A single-argument paren type (`fn (A) -> B`) was already accepted via
+the existing parenthesized atomic type and continues to mean a unary
+function from `A` to `B`.
 
 ## Generic (Formula)
 
@@ -2847,6 +2856,7 @@ type ::= identifier                                    // type of a union or typ
 type ::= identifier "<" type_list ">"                  // type of a generic union or type alias
 type ::= "[" type "]"                                  // type of an array
 type ::= "fn" type_params_opt type_list "->" type      // type of a function 
+type ::= "fn" type_params_opt "(" type "," type_list ")" "->" type   // parenthesized multi-arg form
 type ::= "(" type ")"
 ```
 

--- a/parser.py
+++ b/parser.py
@@ -295,6 +295,13 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
                           parse_tree_to_list(e.children[0], e),
                           parse_tree_to_list(e.children[1], e),
                           parse_tree_to_ast(e.children[2], e))
+    elif e.data == 'function_type_paren':
+      first_param = parse_tree_to_ast(e.children[1], e)
+      rest_params = parse_tree_to_list(e.children[2], e)
+      return FunctionType(e.meta,
+                          parse_tree_to_list(e.children[0], e),
+                          [first_param] + rest_params,
+                          parse_tree_to_ast(e.children[3], e))
     elif e.data == 'type_inst':
       return TypeInst(e.meta, Var(e.meta, None, _token_text(e, 0)),
                       parse_tree_to_list(e.children[1], e))

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1869,12 +1869,26 @@ def parse_type() -> Type:
 
 def parse_function_type() -> Type:
   while_parsing = 'while parsing\n' \
-      + '\ttype ::= "fn" type_params_opt type_list "->" type\n'
+      + '\ttype ::= "fn" type_params_opt type_list "->" type\n' \
+      + '\t       | "fn" type_params_opt "(" type "," type_list ")" "->" type\n'
   try:
     start_token = current_token()
     advance()
     type_params = parse_type_parameters()
-    param_types = parse_type_list()
+    if current_token().type == 'LPAR':
+      advance()
+      first_type = parse_type()
+      if current_token().type == 'COMMA':
+        advance()
+        rest_types = parse_type_list()
+        param_types = [first_type] + rest_types
+        consume_token('RPAR', 'closing ")"',
+                      context='after parenthesized parameter types')
+      else:
+        consume_token('RPAR', 'closing ")"')
+        param_types = [first_type]
+    else:
+      param_types = parse_type_list()
     consume_token('ARROW', '"->"', context='after parameter types')
     return_type = parse_type()
     return FunctionType(meta_from_tokens(start_token, previous_token()),

--- a/test/should-error/fn_missing_arrow.pf.err
+++ b/test/should-error/fn_missing_arrow.pf.err
@@ -3,6 +3,7 @@
 
 ./test/should-error/fn_missing_arrow.pf:1.12-1.19: while parsing
 	type ::= "fn" type_params_opt type_list "->" type
+	       | "fn" type_params_opt "(" type "," type_list ")" "->" type
 
 
 define f : fn bool bool = fun x { not x }

--- a/test/should-validate/function_type_paren.pf
+++ b/test/should-validate/function_type_paren.pf
@@ -1,0 +1,44 @@
+import UInt
+
+theorem fn_paren_two_args: all g : fn (UInt, UInt) -> UInt. g = g
+proof
+  arbitrary g : fn (UInt, UInt) -> UInt
+  .
+end
+
+theorem fn_bare_two_args: all g : fn UInt, UInt -> UInt. g = g
+proof
+  arbitrary g : fn UInt, UInt -> UInt
+  .
+end
+
+theorem fn_paren_single: all g : fn (UInt) -> UInt. g = g
+proof
+  arbitrary g : fn (UInt) -> UInt
+  .
+end
+
+theorem fn_paren_three_args: all g : fn (UInt, UInt, UInt) -> UInt. g = g
+proof
+  arbitrary g : fn (UInt, UInt, UInt) -> UInt
+  .
+end
+
+theorem fn_paren_nested:
+  all g : fn (fn (UInt, UInt) -> UInt, UInt) -> UInt. g = g
+proof
+  arbitrary g : fn (fn (UInt, UInt) -> UInt, UInt) -> UInt
+  .
+end
+
+theorem fn_paren_generic:
+  <T> all g : fn (T, T) -> T. g = g
+proof
+  arbitrary T:type
+  arbitrary g : fn (T, T) -> T
+  .
+end
+
+fun apply_swap<T>(g : fn (T, T) -> T, x : T, y : T) {
+  g(y, x)
+}


### PR DESCRIPTION
## Summary

Both parsers now accept `fn (A, B) -> C` as an equivalent spelling of the bare-list form `fn A, B -> C`. This matches the parenthesized, comma-separated form used in function declarations (e.g. `recursive partition<T>(List<T>, fn (T)->bool) -> ...`), which is the natural form to reach for when quantifying over a function-typed variable. Closes #858.

The new grammar production requires at least one comma after the first type:

```
type ::= "fn" type_params_opt type_list "->" type
type ::= "fn" type_params_opt "(" type "," type_list ")" "->" type
```

The single-argument paren form `fn (A) -> B` continues to parse via the existing `atomic_type: "(" type ")"` route and yields the same unary `FunctionType` AST. Requiring a comma keeps the grammar LALR(1)-deterministic at `fn ( type .` — `)` continues to mean the inner type was a parenthesized atomic_type, while `,` commits to the new multi-arg production.

## Changes

- [Deduce.lark](Deduce.lark): add `"fn" type_params_opt "(" type "," type_list ")" "->" type -> function_type_paren` alternative to the `type` rule.
- [parser.py](parser.py): handle `function_type_paren` by flattening `(first, rest)` into a single `param_types` list and constructing the same `FunctionType` AST.
- [rec_desc_parser.py](rec_desc_parser.py): `parse_function_type()` now peeks for `LPAR` after the type-params and consumes a parenthesized type list when present; falls through to the existing bare list otherwise.
- [test/should-validate/function_type_paren.pf](test/should-validate/function_type_paren.pf): positive fixture covering 1/2/3-arg paren forms, the bare form, nested paren in a function-typed param, generic type params, and a polymorphic `fun` declaration whose first parameter has a parenthesized function type.
- [test/should-error/fn_missing_arrow.pf.err](test/should-error/fn_missing_arrow.pf.err): refresh fixture for the updated `while parsing` grammar quote (the rule now lists both alternatives).
- [gh_pages/doc/Reference.md](gh_pages/doc/Reference.md): document the new alternative in both the prose Function Type section and the strict `deduce-grammar` block (the latter is checked by `gh_pages/scripts/reference_grammar.py`).

## Test plan

- [x] `make static` — ruff + mypy (strict) clean.
- [x] `python3.13 test-deduce.py` — lib, should-validate (both parsers), should-error, prelude, parser equivalence (RD vs LALR ASTs + pretty-print round trip).
- [x] `python3.13 gh_pages/scripts/reference_grammar.py` — Reference.md strict grammar matches `Deduce.lark`.
- [x] Manual verification of the issue's reproducer (`theorem repro_fn_type: all g : fn (UInt, UInt) -> UInt. g = g`) under both parsers.
- [x] Confirmed nested form `fn (fn (A, B) -> C, X) -> D` parses identically under RD and LALR.

[Claude session](claude://resume?session=cc227a70-f069-4084-84ef-bf2b63b86c1f) — fallback UUID: `cc227a70-f069-4084-84ef-bf2b63b86c1f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
