### PR TITLE
MCP check_file: accept inline content

### DIFF
--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -414,7 +414,7 @@ diagnostics, and respond. The full tool list:
 
 | Tool                       | What it does                                                  |
 | -------------------------- | ------------------------------------------------------------- |
-| `check_file`               | Type-check and proof-check a `.pf` file; returns diagnostics. |
+| `check_file`               | Type-check and proof-check a `.pf` file, optionally with inline `content`; returns diagnostics. |
 | `goal_at`                  | Return the proof goal + givens at a cursor position.          |
 | `definition_of`            | Jump from a symbol to its declaration.                        |
 | `list_symbols`             | Outline of top-level theorems / definitions in a file.        |

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -178,7 +178,7 @@ def _read_file(path: str) -> str:
 
 
 @mcp.tool()
-def check_file(path: str) -> JSONDict:
+def check_file(path: str, content: Optional[str] = None) -> JSONDict:
     """Run the Deduce pipeline on ``path`` and return diagnostics.
 
     The standard library at ``lib/`` is auto-prepended unless the
@@ -186,10 +186,12 @@ def check_file(path: str) -> JSONDict:
     with a ``diagnostics`` list; an empty list means the file is
     valid. Diagnostic entries have ``severity``, ``range`` (with
     1-indexed line/column positions), ``message``, and an optional
-    ``code``.
+    ``code``. When ``content`` is given, validate that text as if it
+    were the contents of ``path``; ``path`` is still used for imports,
+    prelude selection, and diagnostic locations.
     """
-    content = _read_file(path)
-    diagnostics = query.check(path, content, prelude=_prelude_for(path))
+    text = _read_file(path) if content is None else content
+    diagnostics = query.check(path, text, prelude=_prelude_for(path))
     return {"diagnostics": _to_serializable(diagnostics)}
 
 

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -139,6 +139,38 @@ async def test_check_file_on_error_file_returns_one_diagnostic(server):
 
 
 @pytest.mark.anyio
+async def test_check_file_accepts_inline_content(server, tmp_path):
+    disk_src = (
+        "theorem from_disk: true\n"
+        "proof\n"
+        "  .\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem from_inline: true\n"
+        "proof\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "inline-content.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "check_file",
+        {"path": str(fp), "content": inline_src},
+    )
+
+    assert "diagnostics" in payload
+    diags = payload["diagnostics"]
+    assert len(diags) == 1
+    diag = diags[0]
+    assert diag["severity"] == "error"
+    assert diag["range"]["start"]["line"] == 3
+    assert "incomplete proof" in diag["message"]
+
+
+@pytest.mark.anyio
 async def test_check_file_on_stdlib_file_does_not_prepend_stdlib(
     server, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- Add an optional `content` argument to the MCP `check_file` tool.
- Validate inline text as the contents of `path` while preserving `path` for imports, prelude selection, and diagnostic locations.
- Document the inline `content` option in the MCP tool list.

Closes #861.

## Tests

- `python3 -m pytest test/lsp/test_mcp_server.py`
- `make tests`
- `git diff --check`

## Codex session

codex://threads/019e943a-98f2-7cd1-9eee-38821b54a91c

```bash
open 'codex://threads/019e943a-98f2-7cd1-9eee-38821b54a91c'
```
