### PR TITLE
MCP check_file: add parser argument (recursive-descent / lalr / both)

### DIFF
--- a/lsp/library.py
+++ b/lsp/library.py
@@ -156,6 +156,7 @@ def check_file(
     collect_errors: bool = False,
     debugger: Optional["Debugger"] = None,
     prewarm_modules: Sequence[str] = (),
+    parser: Optional[str] = None,
 ) -> CheckResult:
     """Run the Deduce pipeline on ``filename`` and return a CheckResult.
 
@@ -189,6 +190,21 @@ def check_file(
                             ``lsp.query.check`` opts in to this so
                             every error in the buffer becomes its own
                             editor diagnostic.
+        parser:             Optional parser override. ``None`` (default)
+                            uses whichever parser ``flags.recursive_descent``
+                            currently selects -- matches the CLI behaviour
+                            and is what every existing caller wants.
+                            ``"recursive-descent"`` and ``"lalr"`` force the
+                            user file to be parsed with that specific
+                            parser, regardless of the global flag.
+                            When an explicit parser is given, the
+                            user-file AST cache is bypassed (a cached
+                            entry could have been produced by the other
+                            parser; the whole point of asking for a
+                            specific parser is to actually run it).
+                            The prelude is still served from its
+                            existing snapshot -- prelude AST equivalence
+                            across parsers is verified by CI.
         prewarm_modules:    Module names to pre-load into the
                             ``uniquified_modules`` cache during prelude
                             bootstrap, but **not** prepended as imports
@@ -218,11 +234,17 @@ def check_file(
     machinery here assumes a single caller at a time. Callers that
     want to fan out should serialize.
     """
+    if parser is not None and parser not in ("recursive-descent", "lalr"):
+        raise ValueError(
+            f"check_file: parser must be None, 'recursive-descent', or "
+            f"'lalr'; got {parser!r}"
+        )
     with _check_file_lock:
         return _check_file_locked(
             filename, tracing_functions, prelude, content,
             collect_errors=collect_errors, debugger=debugger,
             prewarm_modules=prewarm_modules,
+            parser=parser,
         )
 
 
@@ -234,6 +256,7 @@ def _check_file_locked(
     collect_errors: bool,
     debugger: Optional["Debugger"],
     prewarm_modules: Sequence[str] = (),
+    parser: Optional[str] = None,
 ) -> CheckResult:
     """Body of ``check_file``, run under the global pipeline lock."""
     # Prelude bootstrap runs without a debugger attached -- the user
@@ -254,6 +277,7 @@ def _check_file_locked(
         return _check_file_impl(
             filename, tracing_functions, prelude, content, ctx,
             collect_errors=collect_errors,
+            parser=parser,
         )
     # Attach the debugger only for the user-file check; detach in a
     # ``finally`` so a quit/crash mid-session leaves the next check_file
@@ -267,6 +291,7 @@ def _check_file_locked(
         return _check_file_impl(
             filename, tracing_functions, prelude, content, ctx,
             collect_errors=collect_errors,
+            parser=parser,
         )
     except DebuggerQuit as e:
         module_name = Path(filename).stem
@@ -289,6 +314,7 @@ def _check_file_impl(
     content: Optional[str],
     ctx: UniquifyContext,
     collect_errors: bool = False,
+    parser: Optional[str] = None,
 ) -> CheckResult:
     """The original ``check_file`` body.
 
@@ -308,7 +334,14 @@ def _check_file_impl(
         # may be stale. MCP tools, however, read the file from disk and
         # pass that exact text through this same API; those calls are
         # cacheable because they match the cache's on-disk contract.
-        use_cache = content is None or _content_matches_file(filename, content)
+        # When an explicit ``parser`` is requested, skip the cache: a
+        # cached entry may have been produced by the *other* parser,
+        # and the whole point of the explicit choice is to actually
+        # run that parser on this file.
+        use_cache = (
+            parser is None
+            and (content is None or _content_matches_file(filename, content))
+        )
         if use_cache and module_name in cached:
             ast = cached[module_name]
         else:
@@ -318,8 +351,13 @@ def _check_file_impl(
             else:
                 program_text = content
 
+            if parser is None:
+                use_rd = get_recursive_descent()
+            else:
+                use_rd = parser == "recursive-descent"
+
             deduce_dir = os.path.dirname(sys.argv[0])
-            if get_recursive_descent():
+            if use_rd:
                 _rd_parser.set_deduce_directory(deduce_dir)
                 _rd_parser.set_filename(filename)
                 _rd_parser.init_parser()

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -178,7 +178,11 @@ def _read_file(path: str) -> str:
 
 
 @mcp.tool()
-def check_file(path: str, content: Optional[str] = None) -> JSONDict:
+def check_file(
+    path: str,
+    content: Optional[str] = None,
+    parser: str = "recursive-descent",
+) -> JSONDict:
     """Run the Deduce pipeline on ``path`` and return diagnostics.
 
     The standard library at ``lib/`` is auto-prepended unless the
@@ -189,9 +193,43 @@ def check_file(path: str, content: Optional[str] = None) -> JSONDict:
     ``code``. When ``content`` is given, validate that text as if it
     were the contents of ``path``; ``path`` is still used for imports,
     prelude selection, and diagnostic locations.
+
+    ``parser`` selects which parser validates the file:
+
+    - ``"recursive-descent"`` (default) -- the hand-written
+      recursive-descent parser, matching Deduce's default CLI mode.
+    - ``"lalr"`` -- the lark-based LALR parser, matching
+      ``deduce.py --lalr``.
+    - ``"both"`` -- run both parsers and merge their diagnostics.
+      Each entry in the result has an extra ``parser`` field
+      (``"recursive-descent"`` or ``"lalr"``) so the caller can tell
+      which parser produced which message. Use this to satisfy the
+      both-parsers-must-pass contributor rule in one call.
     """
     text = _read_file(path) if content is None else content
-    diagnostics = query.check(path, text, prelude=_prelude_for(path))
+    if parser == "both":
+        rd_diags = query.check(
+            path, text, prelude=_prelude_for(path),
+            parser="recursive-descent",
+        )
+        lalr_diags = query.check(
+            path, text, prelude=_prelude_for(path),
+            parser="lalr",
+        )
+        merged: list[JSONDict] = []
+        for d in _to_list_of_dicts(rd_diags):
+            merged.append({**d, "parser": "recursive-descent"})
+        for d in _to_list_of_dicts(lalr_diags):
+            merged.append({**d, "parser": "lalr"})
+        return {"diagnostics": merged}
+    if parser not in ("recursive-descent", "lalr"):
+        raise ValueError(
+            f"check_file: parser must be 'recursive-descent', 'lalr', "
+            f"or 'both'; got {parser!r}"
+        )
+    diagnostics = query.check(
+        path, text, prelude=_prelude_for(path), parser=parser,
+    )
     return {"diagnostics": _to_serializable(diagnostics)}
 
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -563,7 +563,8 @@ class AutoRule:
 
 
 def check(
-    path: str, content: str, prelude: Sequence[str] = ()
+    path: str, content: str, prelude: Sequence[str] = (),
+    parser: Optional[str] = None,
 ) -> list[Diagnostic]:
     """Run the full Deduce pipeline on ``content`` (treated as if it
     were the contents of ``path``) and return all diagnostics found.
@@ -588,13 +589,23 @@ def check(
     ``prelude`` is the list of module names auto-imported in front of
     the file (matching ``deduce.py``'s ``--no-stdlib`` flag: empty by
     default; the MCP / LSP server passes the standard library here).
+
+    ``parser`` selects which parser checks the user file: ``None``
+    (default) uses whatever ``flags.recursive_descent`` selects --
+    matches CLI behaviour. ``"recursive-descent"`` and ``"lalr"``
+    force that specific parser, bypassing the AST cache so the
+    requested parser actually runs. The prelude is served from its
+    existing snapshot regardless (parser-equivalent by CI).
     """
     # Imported here, not at module top, so this module stays free of
     # any pipeline import while it is just a stub at module-load time.
     # That keeps the protocol-neutral boundary cheap to enforce.
     from lsp.library import check_file
 
-    result = check_file(path, content=content, prelude=prelude, collect_errors=True)
+    result = check_file(
+        path, content=content, prelude=prelude,
+        collect_errors=True, parser=parser,
+    )
     if result.ok:
         return []
 

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -131,6 +131,26 @@ def test_unsaved_content_bypasses_module_cache(tmp_path: Path) -> None:
     assert path.stem not in get_uniquified_modules()
 
 
+@pytest.mark.parametrize("parser", ["recursive-descent", "lalr"])
+def test_parser_argument_validates_with_each(parser: str) -> None:
+    """``check_file(parser=...)`` runs the requested parser on the user
+    file. Either parser should accept a simple valid file."""
+    path = PASS_DIR / "empty_file.pf"
+    result = check_file(str(path), prelude=(), parser=parser)
+    assert result.ok, (
+        f"{path.name} should validate under {parser} but check_file "
+        f"reported: {result.error_message}"
+    )
+
+
+def test_parser_argument_rejects_unknown_value() -> None:
+    """An unknown parser name is a programming error and must fail
+    loudly rather than silently falling back to the default."""
+    path = PASS_DIR / "empty_file.pf"
+    with pytest.raises(ValueError, match="parser"):
+        check_file(str(path), prelude=(), parser="bogus")
+
+
 def test_collect_errors_includes_expand_residual_hint() -> None:
     """Regression test for issue #745: the ``expand_residual_hint``
     appended by ``_check_proof_of_apply_defs_goal`` must reach the

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -171,6 +171,59 @@ async def test_check_file_accepts_inline_content(server, tmp_path):
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("parser", ["recursive-descent", "lalr"])
+async def test_check_file_accepts_parser_argument(server, parser):
+    """The MCP wrapper plumbs ``parser`` through to ``query.check`` and
+    each parser accepts a known-valid file."""
+    payload = await _call(
+        server, "check_file", {"path": str(VALID_FILE), "parser": parser}
+    )
+    assert payload == {"diagnostics": []}
+
+
+@pytest.mark.anyio
+async def test_check_file_parser_both_labels_each_diagnostic(server):
+    """With ``parser="both"`` the wrapper runs RD and LALR and tags
+    every returned diagnostic with which parser produced it. For a
+    valid file the merged list is empty but the call still succeeds."""
+    payload = await _call(
+        server, "check_file", {"path": str(VALID_FILE), "parser": "both"}
+    )
+    assert payload == {"diagnostics": []}
+
+
+@pytest.mark.anyio
+async def test_check_file_parser_both_merges_error_diagnostics(server):
+    """``parser="both"`` returns one entry per parser per problem, each
+    tagged with the parser that produced it."""
+    payload = await _call(
+        server, "check_file", {"path": str(ERROR_FILE), "parser": "both"}
+    )
+    diags = payload["diagnostics"]
+    parsers_seen = sorted({d["parser"] for d in diags})
+    assert parsers_seen == ["lalr", "recursive-descent"]
+    # Both parsers agree on the same incomplete-proof hole.
+    rd = next(d for d in diags if d["parser"] == "recursive-descent")
+    lalr = next(d for d in diags if d["parser"] == "lalr")
+    assert "incomplete proof" in rd["message"]
+    assert "incomplete proof" in lalr["message"]
+
+
+@pytest.mark.anyio
+async def test_check_file_rejects_unknown_parser(server):
+    """An unknown ``parser`` value must surface as a tool error rather
+    than silently defaulting."""
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        await session.initialize()
+        result = await session.call_tool(
+            "check_file", {"path": str(VALID_FILE), "parser": "bogus"}
+        )
+        assert result.isError
+
+
+@pytest.mark.anyio
 async def test_check_file_on_stdlib_file_does_not_prepend_stdlib(
     server, monkeypatch
 ):

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -197,7 +197,9 @@ def _check_sig(func, expected_params, expected_return):
 
 
 def test_check_signature():
-    _check_sig(check, ["path", "content", "prelude"], list[Diagnostic])
+    _check_sig(
+        check, ["path", "content", "prelude", "parser"], list[Diagnostic]
+    )
 
 
 def test_goal_at_signature():


### PR DESCRIPTION
## Summary

Closes #859.

Adds an optional `parser` argument to the MCP `check_file` tool so callers can validate a file under the recursive-descent parser, the LALR parser, or both in a single call. The new default (`"recursive-descent"`) preserves today's behaviour; `"lalr"` mirrors `deduce.py --lalr`; `"both"` runs each parser and merges diagnostics, tagging each entry with which parser produced it. With `"both"`, a single MCP call satisfies the contributor rule that both parsers must accept any file touching parsing or the AST -- no more dropping back to the `deduce.py --lalr` CLI for the second half of validation.

## Changes

- `lsp/library.py`: thread `parser` through `check_file` -> `_check_file_locked` -> `_check_file_impl`. When the parameter is non-`None`, the requested parser is used for the user file and the AST cache is bypassed (a cached entry may have been produced by the other parser; the whole point of the explicit choice is to actually run it). When `None`, behaviour matches before: use whichever parser `flags.recursive_descent` selects.
- `lsp/query.py`: surface the same parameter on `check`. The MCP tool calls `query.check` once per parser when `"both"` is requested.
- `lsp/mcp_server.py`: add `parser: str = "recursive-descent"` to the MCP `check_file` tool. `"both"` returns a `diagnostics` list with a `parser` field on each entry; unknown values raise `ValueError`.
- Tests: cover each parser value at the library and MCP layers; verify `"both"` returns diagnostics tagged by parser on an error file; refresh the parameter-name signature test in `test_query.py`.

## Test plan

- [x] `make static` (ruff + mypy, including `--no-site-packages`).
- [x] `pytest test/lsp/test_library.py test/lsp/test_mcp_server.py test/lsp/test_query.py` -- all green.
- [x] Full `pytest test/lsp/` sweep -- 465 passing on the second run (one earlier `test_dap_server` timeout was flaky and passed on retry).
- [ ] CI: `make` and the full Deduce test corpus on push.

[Claude session](claude://resume?session=2bcc05ce-133a-48f5-8a73-6fc66c9c033b) — fallback UUID: `2bcc05ce-133a-48f5-8a73-6fc66c9c033b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
