### PR TITLE
Hint at fun/λ when the parser sees `\` (closes #863)

### DIFF
--- a/error.py
+++ b/error.py
@@ -381,3 +381,38 @@ class ParseError(Exception):
 
     # return  self.error_str() #+ '\n\n' + error_program_text(self.loc)
 
+
+def lark_unexpected_chars_to_parse_error(exc: object, filename: str) -> 'ParseError':
+  """Turn a lark ``UnexpectedCharacters`` into a Deduce ``ParseError``.
+
+  The default lark message ("No terminal matches '\\' in the current
+  parser context...") drops the reader into the lark internals and
+  lists raw terminal names. For characters Deduce wants to call out
+  specifically -- ``\\`` is the obvious one, since Haskell-style
+  lambdas are reflex for incoming FP students -- we replace the
+  message with a hint that points at the supported syntax.
+  """
+  char = getattr(exc, 'char', '?')
+  line = getattr(exc, 'line', 1)
+  column = getattr(exc, 'column', 1)
+  pos_in_stream = getattr(exc, 'pos_in_stream', 0)
+  meta = Meta()  # type: ignore[no-untyped-call,unused-ignore]
+  meta.empty = False
+  setattr(meta, 'filename', filename)
+  meta.line = line
+  meta.column = column
+  meta.start_pos = pos_in_stream
+  meta.end_line = line
+  meta.end_column = column + 1
+  meta.end_pos = pos_in_stream + 1
+  if char == '\\':
+    msg = ("'\\' is not a valid character in Deduce. "
+           "Anonymous functions are written\n"
+           "\tfun x { ... }\n"
+           "or, equivalently,\n"
+           "\tλx{ ... }\n"
+           "e.g. `filter(xs, fun x { x % 2 = 0 })`.")
+  else:
+    msg = (f"unexpected character {char!r} in input "
+           "(no terminal matches it in the current parser context)")
+  return ParseError(meta, msg)

--- a/parser.py
+++ b/parser.py
@@ -23,7 +23,7 @@ from lark import Lark, Token, Tree, exceptions
 from lark.tree import Meta
 from typing import Any, TypeAlias as TypingTypeAlias, cast
 from flags import VerboseLevel
-from error import ParseError
+from error import ParseError, lark_unexpected_chars_to_parse_error
 
 filename: str = '???'
 
@@ -963,6 +963,15 @@ def parse(program_text: str,
         print('')
     return ast
 
+  except exceptions.UnexpectedCharacters as e:
+      if error_expected:
+          raise Exception()
+      # The default lark lexer message is parser-internal noise (and
+      # actively misleading for backslash: "Expected one of: DOT, ..."
+      # reads as "you forgot a period"). Route through the shared
+      # helper so `\` gets a Deduce-flavored hint and other stray
+      # characters at least get a clean header.
+      raise Exception(str(lark_unexpected_chars_to_parse_error(e, get_filename())))
   except exceptions.UnexpectedToken as t:
       if error_expected:
           raise Exception()

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -22,9 +22,9 @@ from abstract_syntax import (
     count_marks, extract_and, extract_or, extract_tuple, get_default_mark_LHS,
     intToNat, listToNodeList, mkEqual, mkIntLit, mkUIntLit, remove_mark,
 )
-from lark import Lark, Token
+from lark import Lark, Token, exceptions
 from lark.tree import Meta
-from error import ParseError, error_header
+from error import ParseError, error_header, lark_unexpected_chars_to_parse_error
 from flags import VerboseLevel
 from edit_distance import closest_keyword, edit_distance
 
@@ -123,10 +123,18 @@ def parse(program_text: str,
     lexed = lark_parser.lex(program_text)
     token_list = []
     current_position = 0
-    for token in lexed:
-      if trace:
-        print(repr(token))
-      token_list.append(token)
+    # ``lark_parser.lex`` is a generator -- ``UnexpectedCharacters``
+    # only surfaces once the bad char is reached during iteration. Wrap
+    # the consume loop (not the construction) so the default
+    # parser-internal message gets replaced with a Deduce hint (notably
+    # for ``\``, which Haskell-trained users reach for first).
+    try:
+      for token in lexed:
+        if trace:
+          print(repr(token))
+        token_list.append(token)
+    except exceptions.UnexpectedCharacters as e:
+      raise lark_unexpected_chars_to_parse_error(e, get_filename())
 
     stmts: list[Statement] = []
     while not end_of_file():

--- a/test/parse/backslash_lambda.pf
+++ b/test/parse/backslash_lambda.pf
@@ -1,0 +1,4 @@
+// Haskell-style backslash lambda is not Deduce syntax. The parser
+// should suggest `fun x { ... }` / `λx{ ... }` rather than dumping
+// the lark terminal set.
+assert (\x. x = x)(0)

--- a/test/parse/backslash_lambda.pf.err
+++ b/test/parse/backslash_lambda.pf.err
@@ -1,0 +1,9 @@
+
+
+assert (\x. x = x)(0)
+        ^
+./test/parse/backslash_lambda.pf:4.9-4.10: '\' is not a valid character in Deduce. Anonymous functions are written
+	fun x { ... }
+or, equivalently,
+	λx{ ... }
+e.g. `filter(xs, fun x { x % 2 = 0 })`.


### PR DESCRIPTION
## Summary

- Catches lark's `UnexpectedCharacters` in both parsers and replaces the parser-internal message with a Deduce-shaped hint.
- `\` gets a specific suggestion pointing at `fun x { ... }` / `λx{ ... }` — the syntax FP students reach for.
- Other stray characters get a clean `file:line.col-line.col: unexpected character 'X' in input` header instead of the lark terminal-set dump.

Closes #863.

## Why

The old error looked like this:

```
No terminal matches '\' in the current parser context, at line 1 col 26

assert filter([1,2,3,4], \x. x % 2 = 0) = [2,4]
                         ^
Expected one of:
	* DOT
	* "..."
	* "(="
```

The `DOT` line actively misleads ("you forgot a period"), and the whole format reads as a parser bug rather than a syntax suggestion. For a beginner who typed `\x.` by Haskell reflex, that's the wrong message.

The new message:

```
assert (\x. x = x)(0)
        ^
./test/parse/backslash_lambda.pf:1.9-1.10: '\' is not a valid character in Deduce. Anonymous functions are written
	fun x { ... }
or, equivalently,
	λx{ ... }
e.g. `filter(xs, fun x { x % 2 = 0 })`.
```

## Implementation

- New helper `error.lark_unexpected_chars_to_parse_error` builds a `ParseError` from a lark `UnexpectedCharacters`, with a `\`-specific message and a generic-character fallback.
- `parser.py` (LALR) and `rec_desc_parser.py` (RD) both catch the exception at their top-level `parse()` and route through the helper. RD wraps just the lexer-iteration loop (the lark `lex()` generator only raises on consume), so existing recovery paths are untouched.

## Test plan

- [x] `python test-deduce.py --parser` — `test/parse/backslash_lambda.pf{,.err}` fixture added, RD output matches.
- [x] `python test-deduce.py` — full suite (lib, should-validate × 2 parsers, should-error, parser equivalence) passes.
- [x] `python -m pytest test/lsp test/unit` — 998 tests pass.
- [x] `make static` — ruff + mypy (both passes) clean.
- [x] Manual: both `python deduce.py --recursive-descent file.pf` and `python deduce.py --lalr file.pf` produce the new hint on `\`.

[Claude session](claude://resume?session=2123cc0e-835b-43b7-9ba6-fe6275bc6b7b) — fallback UUID: `2123cc0e-835b-43b7-9ba6-fe6275bc6b7b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
