### PR TITLE
Make multi-target expand order-independent under early auto-collapse (closes #862)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"62352481-dca6-4417-ad7e-43679e5cb8b4","pid":90103,"procStart":"Fri Jun  5 14:27:04 2026","acquiredAt":1780669636162}

--- a/checker_logic.py
+++ b/checker_logic.py
@@ -754,6 +754,10 @@ def expand_definitions(loc: Meta, formula: Formula, defs: Sequence[Term],
                      + str(formula))
   if get_verbose():
       print('expand definitions to formula: ' + str(new_formula))
+  # True once an earlier target in this `expand a | b | ...` collapsed the
+  # goal to `true` (e.g. via an auto rewrite). Later targets then have nothing
+  # left to unfold; we treat that as a no-op so `expand` is order-independent.
+  collapsed_by_earlier = False
   for var in defs:
     if not env.term_var_is_defined(var):
       user_error(loc, f"Expected a term or a type variable when attempting to expand {var}." +\
@@ -802,7 +806,9 @@ def expand_definitions(loc: Meta, formula: Formula, defs: Sequence[Term],
                       print('expanded definition ' + var_name)
       if get_verbose():
           print('new_formula = ' + str(new_formula))
-      if not reduced_one:
+      if reduced_one and is_true(new_formula):
+          collapsed_by_earlier = True
+      if not reduced_one and not collapsed_by_earlier:
           user_error(loc, 'could not find a place to expand definition of ' \
                 + name2str(var.name) \
                 + ' in:\n' + '\t' + str(new_formula) \

--- a/checker_logic.py
+++ b/checker_logic.py
@@ -67,7 +67,7 @@ from checker_common import *
 if TYPE_CHECKING:
     from checker_proofs import update_all_head
 from checker_types import check_formula
-from error import MatchFailed, UserError, internal_error, user_error, wrap_user_error
+from error import MatchFailed, UserError, internal_error, user_error, warning, wrap_user_error
 from flags import get_verbose, print_verbose
 
 SubstitutionValue: TypeAlias = Term | Type | RecFun | GenRecFun
@@ -808,12 +808,22 @@ def expand_definitions(loc: Meta, formula: Formula, defs: Sequence[Term],
           print('new_formula = ' + str(new_formula))
       if reduced_one and is_true(new_formula):
           collapsed_by_earlier = True
-      if not reduced_one and not collapsed_by_earlier:
-          user_error(loc, 'could not find a place to expand definition of ' \
-                + name2str(var.name) \
-                + ' in:\n' + '\t' + str(new_formula) \
-                + auto_simplified_hint(new_formula) \
-                + expand_backward_mark_hint(formula, var, env))
+      if not reduced_one:
+          if collapsed_by_earlier:
+              # An earlier clause already reduced the goal to `true`, so this
+              # clause has nothing left to unfold. Allow it (expand stays
+              # order-independent w.r.t. early collapse) but warn that it is
+              # dead weight so the user can tidy the proof.
+              warning(loc, "warning: unused clause '" + name2str(var.name) \
+                    + "' in expand: the goal was already simplified to `true` " \
+                    + "by an earlier clause, so there is nothing left to " \
+                    + "expand. Drop this clause from the expand.")
+          else:
+              user_error(loc, 'could not find a place to expand definition of ' \
+                    + name2str(var.name) \
+                    + ' in:\n' + '\t' + str(new_formula) \
+                    + auto_simplified_hint(new_formula) \
+                    + expand_backward_mark_hint(formula, var, env))
 
   if num_marks == 0:          
       return check_formula(new_formula, env)

--- a/test/should-validate/expand-order-collapse.pf
+++ b/test/should-validate/expand-order-collapse.pf
@@ -5,6 +5,9 @@
 // remaining `| length` then has nothing to unfold and must be a no-op.
 // Regression test for https://github.com/jsiek/deduce/issues/862
 
+import UInt
+import List
+
 theorem expand_collapse_filter_first: all T:type, p:fn (T)->bool.
   length(filter(@[]<T>, p)) <= length(@[]<T>)
 proof

--- a/test/should-validate/expand-order-collapse.pf
+++ b/test/should-validate/expand-order-collapse.pf
@@ -2,7 +2,8 @@
 // earlier target collapses the goal to `true` via an auto rewrite rule.
 // Here `expand filter` reduces the goal to `length(@[]) <= length(@[])`,
 // which the `uint_less_equal_refl_true` auto rule collapses to `true`; the
-// remaining `| length` then has nothing to unfold and must be a no-op.
+// remaining `| length` then has nothing to unfold. That clause is allowed
+// (the proof still validates) but Deduce emits an "unused clause" warning.
 // Regression test for https://github.com/jsiek/deduce/issues/862
 
 import UInt

--- a/test/should-validate/expand-order-collapse.pf
+++ b/test/should-validate/expand-order-collapse.pf
@@ -1,0 +1,20 @@
+// A multi-target `expand a | b` must be order-independent even when an
+// earlier target collapses the goal to `true` via an auto rewrite rule.
+// Here `expand filter` reduces the goal to `length(@[]) <= length(@[])`,
+// which the `uint_less_equal_refl_true` auto rule collapses to `true`; the
+// remaining `| length` then has nothing to unfold and must be a no-op.
+// Regression test for https://github.com/jsiek/deduce/issues/862
+
+theorem expand_collapse_filter_first: all T:type, p:fn (T)->bool.
+  length(filter(@[]<T>, p)) <= length(@[]<T>)
+proof
+  arbitrary T:type, p:fn (T)->bool
+  expand filter | length.
+end
+
+theorem expand_collapse_length_first: all T:type, p:fn (T)->bool.
+  length(filter(@[]<T>, p)) <= length(@[]<T>)
+proof
+  arbitrary T:type, p:fn (T)->bool
+  expand length | filter.
+end


### PR DESCRIPTION
## Summary

Fixes #862. A multi-target `expand a | b | ...` was order-sensitive when an earlier clause collapsed the goal to `true` via an auto rewrite rule.

In the issue's repro, the empty-case goal is `length(filter(@[], p)) ≤ length(@[])`:

- `expand length | filter.` succeeds.
- `expand filter | length.` hard-errors: `expand filter` reduces the goal to `length(@[]) ≤ length(@[])`, the `uint_less_equal_refl_true` auto rule collapses it to `true`, and the trailing `| length` then has nothing to unfold → `could not find a place to expand definition of length in: true`.

The failing order is the one every worked example in `examples/` teaches ("expand the function under study first, helpers after"), so following the convention broke a working proof.

## Fix

`expand_definitions` now tracks whether an earlier clause *in the same expand chain* reduced the goal to `true`. If so, a later clause that finds no match is allowed instead of erroring, making `expand` order-independent w.r.t. early collapse.

Rather than silently ignoring such a dead clause, Deduce emits an **"unused clause" warning** naming the clause and suggesting it be dropped:

```
…: warning: unused clause 'length' in expand: the goal was already simplified
to `true` by an earlier clause, so there is nothing left to expand. Drop this
clause from the expand.
```

A single-target `expand foo` on an already-`true` goal still errors with the existing "drop it / use `evaluate`" hint — that case is unchanged and covered by `test/should-error/expand_after_auto_simplify.pf`.

## Testing

- New `test/should-validate/expand-order-collapse.pf` proves the same lemma with both orderings; both validate under recursive-descent and LALR (the filter-first order also emits the unused-clause warning).
- `test/should-error/expand_after_auto_simplify.pf` (single-target, already-true goal) still errors as before.
- `make static` clean (ruff + mypy); full `test-deduce.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)