### PR TITLE
Allow and/or/iff on both sides of an equations step (closes #857)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -175,9 +175,22 @@ identifier: IDENT              -> identifier
 ?switch_proof_case_list: switch_proof_case               -> single
     | switch_proof_case switch_proof_case_list           -> push
 
-?equation: comparison_term "=" additive_term reason    -> equation
+?equation: equation_side "=" equation_side reason    -> equation
 
-?half_equation:  "..." "=" additive_term reason     -> half_equation
+?half_equation:  "..." "=" equation_side reason     -> half_equation
+
+// An equation step's `=` is the step separator, which would otherwise be
+// shadowed by the `=` boolean-equality operator (higher precedence than the
+// `and`/`or`/`iff` connectives). So each side parses the logical connectives
+// directly on top of comparison terms, leaving the top-level `=` for the step.
+?equation_side: eqs_iff_term
+?eqs_iff_term: eqs_iff_term "iff" eqs_logical_term     -> iff_formula
+    | eqs_iff_term "<=>" eqs_logical_term              -> iff_formula
+    | eqs_iff_term "⇔" eqs_logical_term                -> iff_formula
+    | eqs_logical_term
+?eqs_logical_term: eqs_logical_term "and" comparison_term  -> and_formula
+    | eqs_logical_term "or" comparison_term            -> or_formula
+    | comparison_term
 
 ?equation_list: half_equation                      -> single
     | half_equation equation_list                  -> push

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -945,8 +945,8 @@ conclusion ::= "equations" equation equation_list
 ```
 
 ```deduce-grammar
-equation ::= comparison_term "=" additive_term reason
-half_equation ::= "..." "=" additive_term reason
+equation ::= equation_side "=" equation_side reason
+half_equation ::= "..." "=" equation_side reason
 equation_list ::= half_equation
 equation_list ::= half_equation equation_list
 equation_list ::= "$" equation equation_list
@@ -957,6 +957,12 @@ so Deduce provides `equations` to streamline this process.  After the
 first equation, the left-hand side of each equation is written as
 `...` because it is just a repetition of the right-hand side of the
 previous equation.
+
+Each `equation_side` may use the logical connectives `and`, `or`, and
+`iff` without parentheses (for example, `P or Q = Q or P`); the `=`
+that separates the two sides of a step still binds the whole step
+together, even though the `=` operator normally binds more tightly than
+those connectives.
 
 When using `replace` or `expand` for one of the reasoning steps in
 `equations`, the transformation is, by default, applied to the

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1317,10 +1317,44 @@ def parse_rule_induction_case() -> RuleInductionCase:
     raise ParseError(meta_from_tokens(start_token, previous_token()),
                      "Unexpected error while parsing:\n\t" + str(e))
 
+def parse_equation_side_logic() -> Term:
+  # `and`/`or` directly on top of comparison terms (left-associative, to
+  # match the LALR `eqs_logical_term` rule). The equality level is skipped so
+  # the step-separator `=` is not consumed here.
+  token = current_token()
+  term = parse_term_compare()
+  while (not end_of_file()) and (current_token().type == 'AND'
+                                 or current_token().type == 'OR'):
+    opr = current_token().type
+    advance()
+    right = parse_term_compare()
+    loc = meta_from_tokens(token, previous_token())
+    if opr == 'AND':
+      term = And(loc, None, extract_and(term) + extract_and(right))
+    else:
+      term = Or(loc, None, extract_or(term) + extract_or(right))
+  return term
+
+def parse_equation_side() -> Term:
+  # One side of an `equations` step. Allows the logical connectives
+  # `iff`/`and`/`or` (which sit below `=` in the normal precedence ladder) by
+  # parsing them on top of comparison terms, leaving the top-level `=` to
+  # separate the two sides of the step. See Deduce.lark `equation_side`.
+  token = current_token()
+  term = parse_equation_side_logic()
+  while (not end_of_file()) and (current_token().value in iff_operators):
+    advance()
+    right = parse_equation_side_logic()
+    loc = meta_from_tokens(token, previous_token())
+    left_right = IfThen(loc, None, term.copy(), right.copy())
+    right_left = IfThen(loc, None, right.copy(), term.copy())
+    term = And(loc, None, [left_right, right_left])
+  return term
+
 def parse_equation() -> tuple[Term, Term, Proof]:
-  lhs = parse_term_compare()
+  lhs = parse_equation_side()
   consume_token('EQUAL', '"="', context='after left-hand side of equation')
-  rhs = parse_term_compare()
+  rhs = parse_equation_side()
   reason = parse_reason()
   return (lhs, rhs, reason)
 
@@ -1328,7 +1362,7 @@ def parse_half_equation() -> tuple[Term | None, Term, Proof]:
   if current_token().value == '...':
     advance()
     consume_token('EQUAL', '"="', context='after "..."')
-    rhs = parse_term_compare()
+    rhs = parse_equation_side()
     reason = parse_reason()
     return (None, rhs, reason)
   elif current_token().value == '$':

--- a/test/should-validate/equation-logic-connectives.pf
+++ b/test/should-validate/equation-logic-connectives.pf
@@ -1,0 +1,38 @@
+// An `equations` step may carry the low-precedence logical connectives
+// `or`, `and`, and `iff` on either side, unparenthesized. The step-separator
+// `=` still binds the two sides together (it is not read as the boolean `=`
+// operator that normally binds tighter than these connectives).
+// Regression test for https://github.com/jsiek/deduce/issues/857
+
+theorem equation_or_on_both_sides: all P:bool, Q:bool, R:bool.
+  (P or (Q or R)) = ((P or Q) or R)
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  equations
+    P or (Q or R)        = (P or Q) or R    by .
+end
+
+theorem equation_and_on_both_sides: all P:bool, Q:bool, R:bool.
+  (P and (Q and R)) = ((P and Q) and R)
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  equations
+    P and (Q and R)      = (P and Q) and R  by .
+end
+
+theorem equation_iff_on_both_sides: all P:bool, Q:bool.
+  (P iff Q) = (P iff Q)
+proof
+  arbitrary P:bool, Q:bool
+  equations
+    P iff Q              = P iff Q          by .
+end
+
+theorem equation_chained_or: all P:bool.
+  (P or true) = true
+proof
+  arbitrary P:bool
+  equations
+    P or true            = true or P        by .
+                     ... = true             by .
+end


### PR DESCRIPTION
## Summary

Fixes #857. Inside an `equations` block, neither side of a step could carry a low-precedence logical connective (`or`, `and`, `iff`) without parentheses — the parser stopped at the connective expecting `=`/`by`:

```deduce
equations
  P or (Q or R)  = (P or Q) or R   by .   // previously a parse error
```

The root cause is that the step-separator `=` shares its token with the boolean-equality `=` operator, which binds *more tightly* than `and`/`or`/`iff`. So there was no precedence level that included those connectives but excluded the separator `=`.

## Fix

Introduce an `equation_side` nonterminal that parses `iff`/`and`/`or` directly on top of comparison terms, leaving the top-level `=` to separate the two sides of the step:

```
?equation: equation_side "=" equation_side reason
?equation_side: eqs_iff_term
?eqs_iff_term:     eqs_iff_term ("iff"|"<=>"|"⇔") eqs_logical_term | eqs_logical_term
?eqs_logical_term: eqs_logical_term ("and"|"or") comparison_term  | comparison_term
```

Both parsers implement this (LALR grammar + recursive-descent `parse_equation_side`), left-associatively, and produce **identical ASTs** (checked by `test-deduce.py --equiv`). The change also removes a latent RD/LALR asymmetry: the LALR grammar previously restricted the equation RHS to `additive_term` while recursive-descent allowed `comparison_term`; both now use `equation_side`.

No new keywords or tokens are introduced (the connectives already existed), so the highlighting/keyword files are unaffected. The Reference.md equation grammar is updated to match (verified by `gh_pages/scripts/reference_grammar.py`).

## Testing

- New `test/should-validate/equation-logic-connectives.pf` exercises `or`, `and`, and `iff` on both sides plus a chained `... =` step; validates under both parsers.
- `make static` clean; full `test-deduce.py` green (lib + should-validate + should-error + prelude + equiv); `--parser` and `--site` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)