### PR TITLE
Move or_assoc, contains_append, length_filter_complement into prelude (closes #864)

### DIFF
--- a/examples/maximum_spec.pf
+++ b/examples/maximum_spec.pf
@@ -46,40 +46,6 @@ assert maximum([3, 1, 4, 1, 5, 9, 2, 6]) = 9
 assert maximum(@[]<UInt>) = 0
 
 // ============================================================
-// Small helpers.
-// ============================================================
-
-// Associativity of `or` (not in the prelude).
-theorem bool_or_assoc: all P:bool, Q:bool, R:bool.
-  (P or (Q or R)) = ((P or Q) or R)
-proof
-  arbitrary P:bool, Q:bool, R:bool
-  switch P {
-    case true { . }
-    case false { . }
-  }
-end
-
-// Membership distributes over append.
-theorem contains_append: all T:type. all xs:List<T>, ys:List<T>, e:T.
-  contains(xs ++ ys, e) = (contains(xs, e) or contains(ys, e))
-proof
-  arbitrary T:type
-  induction List<T>
-  case empty {
-    arbitrary ys:List<T>, e:T
-    expand operator++ | contains.
-  }
-  case node(x, xs') assume IH: all ys:List<T>, e:T.
-      contains(xs' ++ ys, e) = (contains(xs', e) or contains(ys, e)) {
-    arbitrary ys:List<T>, e:T
-    expand operator++ | contains
-    replace IH[ys, e]
-    bool_or_assoc[(x = e), contains(xs', e), contains(ys, e)]
-  }
-end
-
-// ============================================================
 // The specification, proved of `maximum`.
 // ============================================================
 

--- a/examples/partition_spec.pf
+++ b/examples/partition_spec.pf
@@ -151,60 +151,9 @@ end
 // ============================================================
 // COMPLETENESS, part 2: sufficiency.
 //
-// The two filters of any list partition it by length.  This is the core
-// fact behind `length_partition`, stated about `filter` alone.
+// The two filters of any list partition it by length (the prelude lemma
+// `length_filter_complement` is the core fact behind `length_partition`).
 // ============================================================
-
-theorem length_filter_complement: all T:type. all xs:List<T>. all p:fn(T)->bool.
-  length(filter(xs, p)) + length(filter(xs, fun y:T { not p(y) })) = length(xs)
-proof
-  arbitrary T:type
-  induction List<T>
-  case empty {
-    arbitrary p:fn(T)->bool
-    expand filter | length.
-  }
-  case node(x, xs') assume IH: all p:fn(T)->bool.
-      length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })) = length(xs') {
-    arbitrary p:fn(T)->bool
-    switch p(x) {
-      case true assume px_true {
-        have keep_eq: filter(node(x, xs'), p) = node(x, filter(xs', p))
-          by expand filter simplify with px_true.
-        have drop_eq: filter(node(x, xs'), fun y:T { not p(y) })
-                   = filter(xs', fun y:T { not p(y) })
-          by expand filter simplify with px_true.
-        equations
-          length(filter(node(x, xs'), p)) + length(filter(node(x, xs'), fun y:T { not p(y) }))
-              = (1 + length(filter(xs', p))) + length(filter(xs', fun y:T { not p(y) }))
-                  by replace keep_eq | drop_eq expand length.
-          ... = 1 + (length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })))
-                  by .
-          ... = 1 + length(xs')         by replace IH[p].
-          ... = #length(node(x, xs'))#  by expand length.
-      }
-      case false assume px_false {
-        have drop_eq: filter(node(x, xs'), p) = filter(xs', p)
-          by expand filter simplify with px_false.
-        have keep_eq: filter(node(x, xs'), fun y:T { not p(y) })
-                   = node(x, filter(xs', fun y:T { not p(y) }))
-          by expand filter simplify with px_false.
-        equations
-          length(filter(node(x, xs'), p)) + length(filter(node(x, xs'), fun y:T { not p(y) }))
-              = length(filter(xs', p)) + (1 + length(filter(xs', fun y:T { not p(y) })))
-                  by replace keep_eq | drop_eq expand length.
-          ... = (length(filter(xs', p)) + 1) + length(filter(xs', fun y:T { not p(y) }))
-                  by .
-          ... = (1 + length(filter(xs', p))) + length(filter(xs', fun y:T { not p(y) }))
-                  by replace uint_add_commute[length(filter(xs', p)), 1].
-          ... = 1 + (length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })))
-                  by .
-          ... = 1 + length(xs')         by replace IH[p].
-          ... = #length(node(x, xs'))#  by expand length.
-      }
-    }
-  }
-end
 
 theorem length_partition_from_spec:
   all T:type. all g : fn List<T>, (fn (T)->bool) -> Pair< List<T>, List<T> >.

--- a/lib/Base.pf
+++ b/lib/Base.pf
@@ -44,6 +44,17 @@ proof
   }
 end
 
+// Disjunction is associative.
+theorem or_assoc: all P:bool, Q:bool, R:bool.
+  (P or (Q or R)) = ((P or Q) or R)
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  switch P {
+    case true { . }
+    case false { . }
+  }
+end
+
 // Conjunction is symmetric.
 theorem and_sym: all P:bool, Q:bool.  (P and Q) = (Q and P)
 proof

--- a/lib/List.pf
+++ b/lib/List.pf
@@ -334,6 +334,26 @@ proof
   }
 end
 
+// Membership distributes over append: an element belongs to xs ++ ys
+// iff it belongs to xs or to ys.
+theorem contains_append: all T:type. all xs:List<T>, ys:List<T>, e:T.
+  contains(xs ++ ys, e) = (contains(xs, e) or contains(ys, e))
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary ys:List<T>, e:T
+    expand operator++ | contains.
+  }
+  case node(x, xs') assume IH: all ys:List<T>, e:T.
+      contains(xs' ++ ys, e) = (contains(xs', e) or contains(ys, e)) {
+    arbitrary ys:List<T>, e:T
+    expand operator++ | contains
+    replace IH[ys, e]
+    or_assoc[(x = e), contains(xs', e), contains(ys, e)]
+  }
+end
+
 // Reversing a list preserves its length.
 theorem length_reverse: all U :type, xs :List<U>.
   length(reverse(xs)) = length(xs)
@@ -533,6 +553,59 @@ proof
   }
 end
 */
+
+// `filter` and its complement partition the input by length: the kept
+// and dropped sublists' lengths sum to the original.
+theorem length_filter_complement: all T:type. all xs:List<T>. all p:fn(T)->bool.
+  length(filter(xs, p)) + length(filter(xs, fun y:T { not p(y) })) = length(xs)
+proof
+  arbitrary T:type
+  induction List<T>
+  case empty {
+    arbitrary p:fn(T)->bool
+    expand filter | length.
+  }
+  case node(x, xs') assume IH: all p:fn(T)->bool.
+      length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })) = length(xs') {
+    arbitrary p:fn(T)->bool
+    switch p(x) {
+      case true assume px_true {
+        have keep_eq: filter(node(x, xs'), p) = node(x, filter(xs', p))
+          by expand filter simplify with px_true.
+        have drop_eq: filter(node(x, xs'), fun y:T { not p(y) })
+                   = filter(xs', fun y:T { not p(y) })
+          by expand filter simplify with px_true.
+        equations
+          length(filter(node(x, xs'), p)) + length(filter(node(x, xs'), fun y:T { not p(y) }))
+              = (1 + length(filter(xs', p))) + length(filter(xs', fun y:T { not p(y) }))
+                  by replace keep_eq | drop_eq expand length.
+          ... = 1 + (length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })))
+                  by .
+          ... = 1 + length(xs')         by replace IH[p].
+          ... = #length(node(x, xs'))#  by expand length.
+      }
+      case false assume px_false {
+        have drop_eq: filter(node(x, xs'), p) = filter(xs', p)
+          by expand filter simplify with px_false.
+        have keep_eq: filter(node(x, xs'), fun y:T { not p(y) })
+                   = node(x, filter(xs', fun y:T { not p(y) }))
+          by expand filter simplify with px_false.
+        equations
+          length(filter(node(x, xs'), p)) + length(filter(node(x, xs'), fun y:T { not p(y) }))
+              = length(filter(xs', p)) + (1 + length(filter(xs', fun y:T { not p(y) })))
+                  by replace keep_eq | drop_eq expand length.
+          ... = (length(filter(xs', p)) + 1) + length(filter(xs', fun y:T { not p(y) }))
+                  by .
+          ... = (1 + length(filter(xs', p))) + length(filter(xs', fun y:T { not p(y) }))
+                  by replace uint_add_commute[length(filter(xs', p)), 1].
+          ... = 1 + (length(filter(xs', p)) + length(filter(xs', fun y:T { not p(y) })))
+                  by .
+          ... = 1 + length(xs')         by replace IH[p].
+          ... = #length(node(x, xs'))#  by expand length.
+      }
+    }
+  }
+end
 
 // A list whose `set_of` is empty must itself be empty.
 theorem set_of_empty: all T:type, xs:List<T>.


### PR DESCRIPTION
## Summary

Move three helpers from `examples/*_spec.pf` files into the standard library so they're available across proofs:

- `or_assoc` → `lib/Base.pf` (was `bool_or_assoc` in `examples/maximum_spec.pf`). Renamed to match the existing `or_sym`/`and_sym` naming pattern in `Base.pf` (which omits the `bool_` prefix for propositional lemmas).
- `contains_append` → `lib/List.pf` (was in `examples/maximum_spec.pf`). Sits with the other `*_append` theorems just after `append_empty`. Its proof now uses the prelude's `or_assoc`.
- `length_filter_complement` → `lib/List.pf` (was in `examples/partition_spec.pf`). Purely about `filter`/`length` from the prelude — a natural fit. Placed near the other `filter` theorems.

The example files lose the helper definitions but keep their call sites (`contains_append<UInt>[...]`, `length_filter_complement<T>[...]`) — they now resolve to the prelude versions.

I surveyed the other `_spec.pf` files (`fast_reverse_spec.pf`, `sum_spec.pf`, `maximum_specs_equivalent.pf`) and they contain only theorems about locally-defined functions (`fast_reverse`, `sum`, `maximum`), so nothing else from them belongs in the prelude.

Addresses #864.

## Test plan

- [x] `make static` (ruff + mypy)
- [x] `python deduce.py lib/Base.pf`
- [x] `python deduce.py lib/List.pf`
- [x] `python deduce.py examples/maximum_spec.pf`
- [x] `python deduce.py examples/partition_spec.pf`
- [x] `python deduce.py --lalr` smoke check on the three above
- [ ] CI: `make tests` + `make tests-lib` (running)

[Claude session](claude://resume?session=68aed6a1-193d-44d5-82d8-5995de3c277c) — fallback UUID: `68aed6a1-193d-44d5-82d8-5995de3c277c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
