### PR TITLE
Add MCP hole IDs and structured goals

### DIFF
--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -412,10 +412,17 @@ $ claude
 Claude will call the Deduce MCP server's `check_file` tool, see the
 diagnostics, and respond. The full tool list:
 
+For incomplete-proof diagnostics on a `?`, `check_file` includes a
+stable declaration-scoped `hole_id` (for example `my_theorem#0`) and
+the same structured goal payload that `goal_at` returns. The MCP
+position tools that expose `hole_id` can use `{path, hole_id}` instead
+of `{path, line, column}` when the caller has a fresh ID from
+`check_file`.
+
 | Tool                       | What it does                                                  |
 | -------------------------- | ------------------------------------------------------------- |
-| `check_file`               | Type-check and proof-check a `.pf` file, optionally with inline `content`; returns diagnostics. |
-| `goal_at`                  | Return the proof goal + givens at a cursor position.          |
+| `check_file`               | Type-check and proof-check a `.pf` file, optionally with inline `content`; returns diagnostics, hole IDs, and structured goals. |
+| `goal_at`                  | Return the proof goal + givens at a cursor position or `hole_id`. |
 | `definition_of`            | Jump from a symbol to its declaration.                        |
 | `list_symbols`             | Outline of top-level theorems / definitions in a file.        |
 | `refine_at`                | Refine a `?` based on the goal's shape.                       |
@@ -426,6 +433,12 @@ diagnostics, and respond. The full tool list:
 | `eliminable_vars_at`       | List in-scope hypotheses that `eliminate_at` can target.      |
 | `fill_from_given_at`       | Replace a `?` with `conclude <goal> by <label>`.              |
 | `matching_givens_at`       | List in-scope hypotheses whose formula equals the goal.       |
+| `preview_conclude_at`      | Preview whether a local given discharges the current goal.    |
+| `apply_at`                 | Preview `apply <theorem>[<args>] to ?` at a hole.             |
+| `preview_replace_at`       | Preview the goal after `replace <equation>`.                  |
+| `preview_expand_at`        | Preview the goal after `expand <names>`.                      |
+| `available_lemmas_at`      | Search ranked visible lemmas at a position, query, or `hole_id`. |
+| `auto_rules_at`            | List visible `auto` rewrite rules at a position.              |
 
 These are the same operations the Emacs mode binds to `C-c C-r`,
 `C-c C-c`, `C-c C-i`, `C-c C-e`, and `C-c C-f` — the assistant has

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -36,6 +36,7 @@ adapter (Step 9) goes through ``lsp.query``.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
@@ -177,6 +178,123 @@ def _read_file(path: str) -> str:
         return f.read()
 
 
+_DECL_RE = re.compile(
+    r"^\s*(?:private\s+|public\s+|opaque\s+)*"
+    r"(?:theorem|lemma|postulate|define|recursive|fun|union|predicate)\s+"
+    r"(?P<name>[^\s:{(<]+)"
+)
+
+
+def _mask_comments(
+    line: str, in_block_comment: bool
+) -> tuple[str, bool]:
+    """Replace comment text with spaces while preserving columns."""
+    chars = list(line)
+    i = 0
+    while i < len(line):
+        if in_block_comment:
+            end = line.find("*/", i)
+            stop = len(line) if end < 0 else end + 2
+            for j in range(i, stop):
+                if chars[j] not in "\r\n":
+                    chars[j] = " "
+            if end < 0:
+                return "".join(chars), True
+            i = stop
+            in_block_comment = False
+            continue
+
+        if line.startswith("//", i):
+            for j in range(i, len(line)):
+                if chars[j] not in "\r\n":
+                    chars[j] = " "
+            break
+        if line.startswith("/*", i):
+            end = line.find("*/", i + 2)
+            stop = len(line) if end < 0 else end + 2
+            for j in range(i, stop):
+                if chars[j] not in "\r\n":
+                    chars[j] = " "
+            if end < 0:
+                return "".join(chars), True
+            i = stop
+            continue
+        i += 1
+    return "".join(chars), in_block_comment
+
+
+def _hole_sites_by_id(content: str, path: str) -> dict[str, query.Range]:
+    """Return declaration-scoped IDs for every literal ``?`` hole."""
+    fallback_scope = Path(path).stem or "file"
+    current_scope = fallback_scope
+    next_ordinal: dict[str, int] = {}
+    sites: dict[str, query.Range] = {}
+    in_block_comment = False
+
+    for line_no, raw_line in enumerate(content.splitlines(keepends=True), 1):
+        code_line, in_block_comment = _mask_comments(
+            raw_line, in_block_comment
+        )
+        decl_match = _DECL_RE.match(code_line)
+        if decl_match is not None:
+            current_scope = decl_match.group("name")
+
+        for match in re.finditer(r"\?", code_line):
+            ordinal = next_ordinal.get(current_scope, 0)
+            next_ordinal[current_scope] = ordinal + 1
+            hole_id = f"{current_scope}#{ordinal}"
+            col = match.start() + 1
+            sites[hole_id] = query.Range(
+                start=query.Position(line=line_no, column=col),
+                end=query.Position(line=line_no, column=col + 1),
+            )
+    return sites
+
+
+def _hole_ids_by_start(content: str, path: str) -> dict[tuple[int, int], str]:
+    return {
+        (rng.start.line, rng.start.column): hole_id
+        for hole_id, rng in _hole_sites_by_id(content, path).items()
+    }
+
+
+def _diagnostic_payloads(
+    diagnostics: object, content: str, path: str
+) -> list[JSONDict]:
+    hole_ids = _hole_ids_by_start(content, path)
+    payloads = _to_list_of_dicts(diagnostics)
+    for payload in payloads:
+        rng = cast(JSONDict, payload.get("range"))
+        if payload.get("goal") is None:
+            payload.pop("goal", None)
+        start = cast(JSONDict, rng.get("start"))
+        key = (cast(int, start.get("line")), cast(int, start.get("column")))
+        hole_id = hole_ids.get(key)
+        if hole_id is not None:
+            payload["hole_id"] = hole_id
+    return payloads
+
+
+def _position_from_args(
+    tool_name: str,
+    path: str,
+    content: str,
+    line: Optional[int],
+    column: Optional[int],
+    hole_id: Optional[str],
+) -> query.Position:
+    if hole_id is not None:
+        rng = _hole_sites_by_id(content, path).get(hole_id)
+        if rng is None:
+            raise ValueError(f"{tool_name}: unknown hole_id {hole_id!r}")
+        return rng.start
+    if line is None or column is None:
+        raise ValueError(
+            f"{tool_name}: provide line and column, or hole_id"
+        )
+    return query.Position(line=line, column=column)
+
+
 @mcp.tool()
 def check_file(
     path: str,
@@ -217,9 +335,9 @@ def check_file(
             parser="lalr",
         )
         merged: list[JSONDict] = []
-        for d in _to_list_of_dicts(rd_diags):
+        for d in _diagnostic_payloads(rd_diags, text, path):
             merged.append({**d, "parser": "recursive-descent"})
-        for d in _to_list_of_dicts(lalr_diags):
+        for d in _diagnostic_payloads(lalr_diags, text, path):
             merged.append({**d, "parser": "lalr"})
         return {"diagnostics": merged}
     if parser not in ("recursive-descent", "lalr"):
@@ -230,11 +348,16 @@ def check_file(
     diagnostics = query.check(
         path, text, prelude=_prelude_for(path), parser=parser,
     )
-    return {"diagnostics": _to_serializable(diagnostics)}
+    return {"diagnostics": _diagnostic_payloads(diagnostics, text, path)}
 
 
 @mcp.tool()
-def goal_at(path: str, line: int, column: int) -> Optional[JSONDict]:
+def goal_at(
+    path: str,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    hole_id: Optional[str] = None,
+) -> Optional[JSONDict]:
     """Return the proof obligation visible at ``line``:``column``.
 
     Lines and columns are 1-indexed (matching the location text in
@@ -252,13 +375,20 @@ def goal_at(path: str, line: int, column: int) -> Optional[JSONDict]:
     alone.
     """
     content = _read_file(path)
-    pos = query.Position(line=line, column=column)
+    pos = _position_from_args(
+        "goal_at", path, content, line, column, hole_id
+    )
     goal = query.goal_at(path, content, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(goal)
 
 
 @mcp.tool()
-def definition_of(path: str, line: int, column: int) -> Optional[JSONDict]:
+def definition_of(
+    path: str,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    hole_id: Optional[str] = None,
+) -> Optional[JSONDict]:
     """Return the source location of the symbol at ``line``:``column``.
 
     Returns ``None`` when the cursor isn't on a resolvable symbol or
@@ -266,13 +396,20 @@ def definition_of(path: str, line: int, column: int) -> Optional[JSONDict]:
     a built-in). The result has ``path`` and ``range``.
     """
     content = _read_file(path)
-    pos = query.Position(line=line, column=column)
+    pos = _position_from_args(
+        "definition_of", path, content, line, column, hole_id
+    )
     loc = query.definition_of(path, content, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(loc)
 
 
 @mcp.tool()
-def refine_at(path: str, line: int, column: int) -> Optional[JSONDict]:
+def refine_at(
+    path: str,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    hole_id: Optional[str] = None,
+) -> Optional[JSONDict]:
     """Propose a refinement template for the hole at ``line``:``column``.
 
     The cursor must sit on (or immediately adjacent to) a ``?`` token.
@@ -297,7 +434,9 @@ def refine_at(path: str, line: int, column: int) -> Optional[JSONDict]:
     - reducible ``e1 = e2`` -> ``reflexive``
     """
     content = _read_file(path)
-    pos = query.Position(line=line, column=column)
+    pos = _position_from_args(
+        "refine_at", path, content, line, column, hole_id
+    )
     edit = query.refine_at(path, content, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(edit)
 
@@ -474,7 +613,10 @@ def fill_from_given_at(
 
 @mcp.tool()
 def matching_givens_at(
-    path: str, line: int, column: int
+    path: str,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    hole_id: Optional[str] = None,
 ) -> list[str]:
     """Return labels of in-scope local proof bindings whose formula
     equals the goal at ``line``:``column``.
@@ -484,7 +626,9 @@ def matching_givens_at(
     the goal AST isn't available, or no local binding matches.
     """
     content = _read_file(path)
-    pos = query.Position(line=line, column=column)
+    pos = _position_from_args(
+        "matching_givens_at", path, content, line, column, hole_id
+    )
     return list(
         query.matching_givens_at(path, content, pos, prelude=_prelude_for(path))
     )
@@ -591,7 +735,11 @@ def apply_at(
 
 @mcp.tool()
 def preview_replace_at(
-    path: str, line: int, column: int, equation: str
+    path: str,
+    equation: str,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    hole_id: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Preview the result of ``replace <equation>`` at the hole at
     ``line``:``column``.
@@ -622,7 +770,9 @@ def preview_replace_at(
     its plan.
     """
     content = _read_file(path)
-    pos = query.Position(line=line, column=column)
+    pos = _position_from_args(
+        "preview_replace_at", path, content, line, column, hole_id
+    )
     preview = query.preview_replace_at(
         path, content, pos, equation, prelude=_prelude_for(path)
     )
@@ -668,10 +818,11 @@ def preview_expand_at(
 @mcp.tool()
 def available_lemmas_at(
     path: str,
-    line: int,
-    column: int,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
     query: Optional[str] = None,
     limit: int = 50,
+    hole_id: Optional[str] = None,
 ) -> list[JSONDict]:
     """Search for theorems/lemmas/postulates relevant at a position.
 
@@ -706,7 +857,9 @@ def available_lemmas_at(
     from lsp import query as _q
 
     content = _read_file(path)
-    pos = _q.Position(line=line, column=column)
+    pos = _position_from_args(
+        "available_lemmas_at", path, content, line, column, hole_id
+    )
     matches = _q.available_lemmas_at(
         path,
         content,

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -185,6 +185,10 @@ class Diagnostic:
     # so adapters can plumb it through; the checker does not yet emit
     # codes.
     code: Optional[str] = None
+    # Structured goal payload for incomplete-proof diagnostics. Protocol
+    # adapters can expose this alongside the compact diagnostic message
+    # without forcing callers to re-run ``goal_at`` for each hole.
+    goal: Optional["Goal"] = None
 
 
 @dataclass(frozen=True)
@@ -659,13 +663,17 @@ def _diagnostic_from_exception(
 
     formula = getattr(exc, "formula", None)
     body: str
+    goal: Optional[Goal] = None
     if formula is not None:
         body = _format_incomplete_proof_message(formula)
+        goal = _goal_from_exception(exc, rng)
     else:
         msg = getattr(exc, "message_body", None)
         body = msg if msg is not None else _format_unstructured_exception(exc, str_fallback)
 
-    return Diagnostic(severity=Severity.ERROR, range=rng, message=body)
+    return Diagnostic(
+        severity=Severity.ERROR, range=rng, message=body, goal=goal
+    )
 
 
 def _format_unstructured_exception(

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -171,6 +171,65 @@ async def test_check_file_accepts_inline_content(server, tmp_path):
 
 
 @pytest.mark.anyio
+async def test_check_file_hole_diagnostics_include_ids_and_goals(
+    server, tmp_path
+):
+    src = (
+        "theorem first: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+        "\n"
+        "theorem second: all P:bool, Q:bool. P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  ?, ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "hole-ids.pf"
+    fp.write_text(src)
+
+    payload = await _call(server, "check_file", {"path": str(fp)})
+
+    diags = payload["diagnostics"]
+    assert len(diags) == 3
+    by_id = {diag["hole_id"]: diag for diag in diags}
+    assert set(by_id) == {"first#0", "second#0", "second#1"}
+
+    first = by_id["first#0"]
+    assert first["goal"]["formula"] == "P = P"
+    assert first["goal"]["range"] == first["range"]
+    assert first["goal"]["givens"] == []
+
+    assert by_id["second#0"]["goal"]["formula"] == "P"
+    assert by_id["second#1"]["goal"]["formula"] == "Q"
+
+
+@pytest.mark.anyio
+async def test_hole_id_resolves_goal_after_lines_shift(server, tmp_path):
+    src = (
+        "// Later edits can add lines above the declaration.\n"
+        "\n"
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "shifted-goal.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server, "goal_at", {"path": str(fp), "hole_id": "hole_owner#0"}
+    )
+
+    assert payload is not None
+    assert payload["formula"] == "P = P"
+    assert payload["range"]["start"] == {"line": 6, "column": 3}
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("parser", ["recursive-descent", "lalr"])
 async def test_check_file_accepts_parser_argument(server, parser):
     """The MCP wrapper plumbs ``parser`` through to ``query.check`` and
@@ -368,6 +427,27 @@ async def test_definition_of_returns_null_for_whitespace(server, tmp_path):
     assert payload is None
 
 
+@pytest.mark.anyio
+async def test_definition_of_accepts_hole_id(server, tmp_path):
+    src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "definition-hole-id.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server,
+        "definition_of",
+        {"path": str(fp), "hole_id": "hole_owner#0"},
+    )
+
+    assert payload is None
+
+
 # --------------------------------------------------------------------------
 # list_symbols
 # --------------------------------------------------------------------------
@@ -421,6 +501,31 @@ async def test_refine_at_returns_workspace_edit(server, tmp_path):
         "refine_at",
         {"path": str(fp), "line": 4, "column": 3},
     )
+    assert payload is not None
+    assert payload["path"] == str(fp)
+    assert payload["new_text"] == "reflexive"
+    assert payload["range"]["start"] == {"line": 4, "column": 3}
+    assert payload["range"]["end"] == {"line": 4, "column": 4}
+
+
+@pytest.mark.anyio
+async def test_refine_at_accepts_hole_id(server, tmp_path):
+    src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "refine-hole-id.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server,
+        "refine_at",
+        {"path": str(fp), "hole_id": "hole_owner#0"},
+    )
+
     assert payload is not None
     assert payload["path"] == str(fp)
     assert payload["new_text"] == "reflexive"
@@ -702,6 +807,33 @@ async def test_eliminable_vars_at_returns_candidates(server, tmp_path):
     assert "H" in payload
 
 
+
+
+# --------------------------------------------------------------------------
+# matching_givens_at
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_matching_givens_at_accepts_hole_id(server, tmp_path):
+    src = (
+        "theorem hole_owner: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "matching-hole-id.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server,
+        "matching_givens_at",
+        {"path": str(fp), "hole_id": "hole_owner#0"},
+    )
+
+    assert payload == ["H"]
 # --------------------------------------------------------------------------
 # apply_at
 # --------------------------------------------------------------------------
@@ -826,6 +958,35 @@ async def test_preview_replace_at_returns_ok_outcome(server, tmp_path):
 
 
 @pytest.mark.anyio
+async def test_preview_replace_at_accepts_hole_id(server, tmp_path):
+    src = (
+        "theorem hole_owner: all P:bool, Q:bool. if P = Q then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P = Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "preview-replace-hole-id.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server,
+        "preview_replace_at",
+        {
+            "path": str(fp),
+            "hole_id": "hole_owner#0",
+            "equation": "H",
+        },
+    )
+
+    assert payload is not None
+    assert payload["outcome"] == "ok"
+    assert payload["before"] == "P"
+    assert payload["after"] == "Q"
+
+
+@pytest.mark.anyio
 async def test_preview_replace_at_returns_unbound(server, tmp_path):
     src = (
         "theorem t: all P:bool. P\n"
@@ -924,6 +1085,41 @@ async def test_available_lemmas_at_query_pattern(server, tmp_path):
     assert entry["kind"] == "theorem"
     assert entry["module"] == "lemmas"
     assert 0.0 <= entry["relevance"] <= 1.0
+
+
+@pytest.mark.anyio
+async def test_available_lemmas_at_accepts_hole_id(server, tmp_path):
+    src = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume pP: P\n"
+        "  assume qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume pP: P\n"
+        "  assume qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "available-hole-id.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server,
+        "available_lemmas_at",
+        {"path": str(fp), "hole_id": "with_hole#0", "limit": 10},
+    )
+
+    assert isinstance(payload, list)
+    names = [m["name"] for m in payload]
+    assert "and_intro" in names
+    entry = next(m for m in payload if m["name"] == "and_intro")
+    assert entry["kind"] == "theorem"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Add declaration-scoped MCP hole IDs to `check_file` diagnostics, such as `my_theorem#0`.
- Carry structured `goal` payloads on incomplete-proof diagnostics so callers do not need a separate `goal_at` round trip for each hole.
- Let the named MCP position tools resolve `{path, hole_id}` as an alternative to `{path, line, column}` for stable post-edit hole targeting.
- Update MCP docs and wrapper coverage for hole IDs and structured goals.

## Tests
- `python3 -m pytest test/lsp/test_mcp_server.py`
- `make tests`

## Follow-up
- This covers #870 items 1 and 2. Named holes (`?name`) remain later syntax-level work.

## Codex session
codex://threads/019e986b-423a-75e0-897d-7dd57bc05d51

```bash
open 'codex://threads/019e986b-423a-75e0-897d-7dd57bc05d51'
```
