### PR TITLE
docs: document Nat literal syntax

### DIFF
--- a/gh_pages/doc/FunctionalProgramming.md
+++ b/gh_pages/doc/FunctionalProgramming.md
@@ -47,6 +47,11 @@ Optionally, the type can be specified after the name, following a
 colon.  In the above, `six` holds a natural number, so its type is
 `UInt`.
 
+Bare numeric literals such as `5` and `12` have type `UInt`. If you
+need a literal of type `Nat`, write the `ℕ` prefix before the digits,
+for example `ℕ0`, `ℕ5`, or `ℕ12`. You can copy and paste the `ℕ`
+symbol if your keyboard does not have a direct way to enter it.
+
 ## Printing Values
 
 You can ask Deduce to print a value to standard output using the

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -454,6 +454,10 @@ This introduction to Deduce has two parts. The first part gives a tutorial on ho
 
 I recommend that you work through the examples in this introduction. Create a file named `examples.pf` in the top `deduce` directory and add the examples one at a time. To check the file, run the `deduce.py` script on the file from the `deduce` directory.
 
+When working through the programming examples, note that bare numeric
+literals such as `5` are `UInt` values. `Nat` literals use the `ℕ`
+prefix, for example `ℕ5`.
+
 The Deduce Reference manual is linked below. It provides an alphabetical list of all the features in Deduce. The Cheat Sheet gives some advice regarding proof strategy and which Deduce keyword to use next in a proof. The Syntax Overview page provides a brief overview of the syntax structure of deduce.
 
 * [Reference Manual](./Reference.md)


### PR DESCRIPTION
Fixes #882.

## Summary
- document that bare numeric literals have type `UInt`
- add examples of `ℕ`-prefixed `Nat` literals in the programming tutorial
- add a short Getting Started pointer for new users

## Verification
- `git diff --check`
- `python ./gh_pages/scripts/keywords.py`
- `python ./gh_pages/scripts/reference_grammar.py`