### PR TITLE
Promote mult_suc, add_suc, mult_zero to public theorems (closes #881)

### DIFF
--- a/lib/NatAdd.pf
+++ b/lib/NatAdd.pf
@@ -140,7 +140,7 @@ proof
 end
 
 // `suc` on the right of `+` factors out.
-lemma add_suc: all m:Nat. all n:Nat.
+theorem add_suc: all m:Nat. all n:Nat.
   m + suc(n) = suc(m + n)
 proof
   induction Nat

--- a/lib/NatMult.pf
+++ b/lib/NatMult.pf
@@ -38,7 +38,7 @@ end
 auto nat_zero_mult
 
 // Right zero of multiplication.
-lemma mult_zero: all n:Nat.
+theorem mult_zero: all n:Nat.
   n * zero = zero
 proof
   induction Nat
@@ -72,7 +72,7 @@ end
 auto lit_suc_mult
 
 // Step the right operand of `*` through `suc`.
-lemma mult_suc: all m:Nat. all n:Nat.
+theorem mult_suc: all m:Nat. all n:Nat.
   m * suc(n) = m + m * n
 proof
   induction Nat

--- a/test/should-validate/public-mult-suc.pf
+++ b/test/should-validate/public-mult-suc.pf
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/jsiek/deduce/issues/881
+// `mult_suc`, `add_suc`, and `mult_zero` were module-private `lemma`s,
+// so a user file could not cite them. They are now public `theorem`s.
+
+import Nat
+
+theorem mult_suc_is_public: all m:Nat, n:Nat.
+  m * suc(n) = m + m * n
+proof
+  arbitrary m:Nat, n:Nat
+  mult_suc[m][n]
+end
+
+theorem add_suc_is_public: all m:Nat, n:Nat.
+  m + suc(n) = suc(m + n)
+proof
+  arbitrary m:Nat, n:Nat
+  add_suc[m][n]
+end
+
+theorem mult_zero_is_public: all n:Nat.
+  n * zero = zero
+proof
+  arbitrary n:Nat
+  mult_zero[n]
+end


### PR DESCRIPTION
## Summary

Fixes #881. There was no **public** general theorem for stepping a `suc` through `Nat` multiplication/addition. `mult_suc` (`m * suc(n) = m + m * n`) existed in `lib/NatMult.pf` but was declared `lemma`, so it was module-private:

```
'mult_suc' is declared as a `lemma` in module Nat; lemmas are
module-private and not accessible from other modules.
```

The only public variants (`lit_mult_suc`, `lit_mult_lit_suc`) require the **left** factor to be a literal, so they don't apply to a goal like `suc(n') * suc(suc(n'))` that arises naturally in induction — forcing a non-obvious commute + `expand operator*` workaround.

## Change

Promote three building blocks from `lemma` to `theorem` (visibility-only — no proof changes):

- `mult_suc`: `m * suc(n) = m + m * n` (the primary ask; not an auto rule, so previously unreachable).
- `add_suc`: `m + suc(n) = suc(m + n)` (exact parallel — general form, not auto; only `lit_add_suc` was public).
- `mult_zero`: `n * zero = zero` (the issue's other suggestion; stays an `auto` rule and now also citable, matching the public `uint_mult_zero` / `int_mult_zero`).

This is consistent with the already-public `dist_mult_add`, `dist_mult_add_right`, and `mult_commute`. The `auto mult_zero` registration and all internal references still resolve unchanged.

## Testing

- New `test/should-validate/public-mult-suc.pf` cites all three from a user file via `import Nat`; validates under both parsers.
- `test-deduce.py --lib` (full stdlib, both parsers), `--passable`, and `--equiv` all green; `make static` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)