### PR TITLE
Reorder Getting Started docs

### DIFF
--- a/gh_pages/doc/Emacs.md
+++ b/gh_pages/doc/Emacs.md
@@ -1,0 +1,96 @@
+# Emacs Mode
+
+The [Getting Started guide](./GettingStarted.md#emacs) covers installing
+Deduce's Emacs mode and trying the core keybindings. This page collects
+the longer Emacs-specific setup notes.
+
+For full editor details — including troubleshooting, customization, and
+a manual smoke test — see
+[`editor/emacs/README.md`](https://github.com/jsiek/deduce/blob/main/editor/emacs/README.md).
+
+## AI-assisted proof completion in Emacs
+
+`C-c C-a` asks a language model to fill the `?` at point. The Emacs
+mode spawns the
+[`tools/claude_fill_hole`](https://github.com/jsiek/deduce/tree/main/tools/claude_fill_hole)
+sidecar, which requests a candidate proof, validates it against
+`deduce.py`, and splices the first valid one back into your buffer.
+Emacs stays interactive while the model iterates (up to five
+attempts; the first valid proof wins).
+
+The binding comes from `deduce-fill-hole` — make sure your init file
+has `(require 'deduce-fill-hole)` from the
+[Emacs setup](./GettingStarted.md#emacs). You'll also need an API key
+for whichever model provider you point the sidecar at.
+
+**1. Install the sidecar's Python dependencies:**
+
+```sh
+cd /path/to/deduce
+python3 -m pip install -r requirements-fill-hole.txt
+```
+
+This pulls in `anthropic` and `openai`; the sidecar picks one at run
+time based on your backend choice.
+
+**2. Pick a backend and set its API key.** Three common setups:
+
+*Anthropic / Claude (default; best quality, paid):*
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+*Indiana University REALLMs (free for IU researchers/faculty/staff,
+hosted on-prem):*
+
+```sh
+export REALLMS_API_KEY=...
+```
+
+```elisp
+;; In your init.el, after (require 'deduce-fill-hole):
+(setq deduce-fill-hole-backend 'openai-compat
+      deduce-fill-hole-base-url "https://reallms.rescloud.iu.edu/direct/v1"
+      deduce-fill-hole-api-key-env "REALLMS_API_KEY"
+      deduce-fill-hole-model "Qwen3-Coder-Next")
+```
+
+*OpenAI (paid):*
+
+```sh
+export OPENAI_API_KEY=sk-...
+```
+
+```elisp
+(setq deduce-fill-hole-backend 'openai-compat
+      deduce-fill-hole-model "gpt-4o")
+```
+
+Add the `export` line to your shell init file (`~/.zshrc`,
+`~/.bashrc`, ...) so the variable is available in every Emacs session.
+On macOS GUI Emacs, where shell variables sometimes fail to propagate
+into the GUI environment, the
+[`exec-path-from-shell`](https://github.com/purcell/exec-path-from-shell)
+package is a reliable fix.
+
+**3. (Optional) Pin the model and tune attempts.** By default the
+sidecar uses `claude-opus-4-7` (Anthropic backend) or
+`gemma-4-31B-it` (OpenAI-compat). To override:
+
+```elisp
+(setq deduce-fill-hole-model "claude-sonnet-4-6")  ; cheaper Claude
+(setq deduce-fill-hole-max-attempts 3)             ; default is 5
+(setq deduce-fill-hole-timeout 60)                 ; per validate_proof, seconds
+```
+
+The full set of `defcustom`s (with defaults) is reachable via `M-x
+customize-group RET deduce-fill-hole RET`, and documented in the
+[`editor/emacs/README.md`](https://github.com/jsiek/deduce/blob/main/editor/emacs/README.md#deduce-fill-hole)
+customization table.
+
+**4. Try it.** Open a `.pf` file with a `?` to fill, place point on
+the `?`, and press `C-c C-a`. The mode line shows progress; when the
+model returns a valid proof, it replaces the `?` automatically. If
+every attempt fails validation, the sidecar surfaces its last error
+in the echo area and leaves the buffer as it was.

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -4,9 +4,8 @@ Here are some resources to help you get started with Deduce.
 
 * [Installing Deduce](#installation)
 * [Running Programs](#running-deduce-programs)
-* [AI-assisted proof completion in Emacs (`C-c C-a`)](#ai-assisted-proof-completion-in-emacs)
-* [Calling Deduce from an AI assistant (MCP)](#calling-deduce-from-an-ai-assistant-mcp)
 * [Learning Deduce](#deduce-introduction)
+* [Calling Deduce from an AI assistant (MCP)](#calling-deduce-from-an-ai-assistant-mcp)
 
 ## Installation
 
@@ -115,8 +114,9 @@ python3 -m pip install -r requirements-lsp.txt
 ```
 
 This installs `pygls` (for the LSP server) and `mcp` (for the MCP
-server documented in the next section). Skip this if you only want
-syntax highlighting.
+server documented in
+[Calling Deduce from an AI assistant](#calling-deduce-from-an-ai-assistant-mcp)).
+Skip this if you only want syntax highlighting.
 
 **2. Add to your Emacs init file.** Without `use-package`:
 
@@ -152,7 +152,7 @@ Opening any `.pf` file then enters `deduce-mode` automatically. With
 `deduce-lsp` loaded, `eglot` connects on first save (the first
 connection bootstraps the standard library; subsequent calls are warm).
 `deduce-fill-hole` is independent — see
-[Set up an AI Assistant](#using-deduce-with-an-ai-assistant) below
+[AI-assisted proof completion in Emacs](./Emacs.md#ai-assisted-proof-completion-in-emacs)
 for its API-key / model configuration.
 
 **3. Try the keybindings.** Inside a `.pf` buffer:
@@ -167,7 +167,7 @@ for its API-key / model configuration.
 | `C-c C-i` | Induction skeleton. Cursor on a `?` whose goal is `all x:T. P(x)` with `T` a union; replaces the `?` with `induction T` and one case per constructor, including `IH<N>` bindings on recursive arguments. |
 | `C-c C-e` | Eliminate / use-fact. Cursor on a `?`; prompts for a hypothesis label and replaces the `?` with a tactic chosen by the hypothesis's shape (destructure for `and`, `cases` for `or`, `apply ... to ?` for `if then`, `H[?]` for `all`, `obtain ... from H` for `some`, `replace H` for equality). |
 | `C-c C-f` | Fill hole with a given. Cursor on a `?`; replaces it with `conclude <goal> by <label>` for an in-scope hypothesis whose formula equals the goal. Auto-applies on a single match; otherwise prompts. |
-| `C-c C-a` | **Ask AI** to fill the `?` at point. Spawns an LLM-driven proof-completion sidecar; emacs stays interactive while the model iterates (up to 5 attempts, first valid proof wins). Requires API-key configuration — see [AI-assisted proof completion in Emacs](#ai-assisted-proof-completion-in-emacs) below. |
+| `C-c C-a` | **Ask AI** to fill the `?` at point. Spawns an LLM-driven proof-completion sidecar; Emacs stays interactive while the model iterates (up to 5 attempts, first valid proof wins). Requires API-key configuration — see [AI-assisted proof completion in Emacs](./Emacs.md#ai-assisted-proof-completion-in-emacs). |
 
 For full details — including troubleshooting, customization, and a
 manual smoke test — see
@@ -230,93 +230,24 @@ hello.pf is valid
 ```
 
 
-## AI-assisted proof completion in Emacs
+## Deduce Introduction
 
-`C-c C-a` asks a language model to fill the `?` at point. The Emacs
-mode spawns the
-[`tools/claude_fill_hole`](https://github.com/jsiek/deduce/tree/main/tools/claude_fill_hole)
-sidecar, which requests a candidate proof, validates it against
-`deduce.py`, and splices the first valid one back into your buffer.
-Emacs stays interactive while the model iterates (up to five
-attempts; the first valid proof wins).
+This introduction to Deduce has two parts. The first part gives a tutorial on how to write programs in Deduce. The second part shows how to write proofs in Deduce.
 
-The binding comes from `deduce-fill-hole` — make sure your init file
-has `(require 'deduce-fill-hole)` from the [Emacs setup](#emacs)
-above. You'll also need an API key for whichever model provider you
-point the sidecar at.
+* [Programming in Deduce](./FunctionalProgramming.md)
+* [Writing Proofs in Deduce](./ProofIntro.md)
 
-**1. Install the sidecar's Python dependencies:**
+I recommend that you work through the examples in this introduction. Create a file named `examples.pf` in the top `deduce` directory and add the examples one at a time. To check the file, run the `deduce.py` script on the file from the `deduce` directory.
 
-```sh
-cd /path/to/deduce
-python3 -m pip install -r requirements-fill-hole.txt
-```
+When working through the programming examples, note that bare numeric
+literals such as `5` are `UInt` values. `Nat` literals use the `ℕ`
+prefix, for example `ℕ5`.
 
-This pulls in `anthropic` and `openai`; the sidecar picks one at run
-time based on your backend choice.
+The Deduce Reference manual is linked below. It provides an alphabetical list of all the features in Deduce. The Cheat Sheet gives some advice regarding proof strategy and which Deduce keyword to use next in a proof. The Syntax Overview page provides a brief overview of the syntax structure of deduce.
 
-**2. Pick a backend and set its API key.** Three common setups:
-
-*Anthropic / Claude (default; best quality, paid):*
-
-```sh
-export ANTHROPIC_API_KEY=sk-ant-…
-```
-
-*Indiana University REALLMs (free for IU researchers/faculty/staff,
-hosted on-prem):*
-
-```sh
-export REALLMS_API_KEY=…
-```
-
-```elisp
-;; In your init.el, after (require 'deduce-fill-hole):
-(setq deduce-fill-hole-backend 'openai-compat
-      deduce-fill-hole-base-url "https://reallms.rescloud.iu.edu/direct/v1"
-      deduce-fill-hole-api-key-env "REALLMS_API_KEY"
-      deduce-fill-hole-model "Qwen3-Coder-Next")
-```
-
-*OpenAI (paid):*
-
-```sh
-export OPENAI_API_KEY=sk-…
-```
-
-```elisp
-(setq deduce-fill-hole-backend 'openai-compat
-      deduce-fill-hole-model "gpt-4o")
-```
-
-Add the `export` line to your shell init file (`~/.zshrc`,
-`~/.bashrc`, …) so the variable is available in every Emacs session.
-On macOS GUI Emacs, where shell variables sometimes fail to propagate
-into the GUI environment, the
-[`exec-path-from-shell`](https://github.com/purcell/exec-path-from-shell)
-package is a reliable fix.
-
-**3. (Optional) Pin the model and tune attempts.** By default the
-sidecar uses `claude-opus-4-7` (Anthropic backend) or
-`gemma-4-31B-it` (OpenAI-compat). To override:
-
-```elisp
-(setq deduce-fill-hole-model "claude-sonnet-4-6")  ; cheaper Claude
-(setq deduce-fill-hole-max-attempts 3)             ; default is 5
-(setq deduce-fill-hole-timeout 60)                 ; per validate_proof, seconds
-```
-
-The full set of `defcustom`s (with defaults) is reachable via `M-x
-customize-group RET deduce-fill-hole RET`, and documented in the
-[`editor/emacs/README.md`](https://github.com/jsiek/deduce/blob/main/editor/emacs/README.md#deduce-fill-hole)
-customization table.
-
-**4. Try it.** Open a `.pf` file with a `?` to fill, place point on
-the `?`, and press `C-c C-a`. The mode line shows progress; when the
-model returns a valid proof, it replaces the `?` automatically. If
-every attempt fails validation, the sidecar surfaces its last error
-in the echo area and leaves the buffer as it was.
-
+* [Reference Manual](./Reference.md)
+* [Cheat Sheet](./CheatSheet.md)
+* [Syntax Overview](./SyntaxGrammar.md)
 
 ## Calling Deduce from an AI assistant (MCP)
 
@@ -445,26 +376,7 @@ These are the same operations the Emacs mode binds to `C-c C-r`,
 the same proof-editing toolkit you do.
 
 
-## Deduce Introduction
-
-This introduction to Deduce has two parts. The first part gives a tutorial on how to write programs in Deduce. The second part shows how to write proofs in Deduce.
-
-* [Programming in Deduce](./FunctionalProgramming.md)
-* [Writing Proofs in Deduce](./ProofIntro.md)
-
-I recommend that you work through the examples in this introduction. Create a file named `examples.pf` in the top `deduce` directory and add the examples one at a time. To check the file, run the `deduce.py` script on the file from the `deduce` directory.
-
-When working through the programming examples, note that bare numeric
-literals such as `5` are `UInt` values. `Nat` literals use the `ℕ`
-prefix, for example `ℕ5`.
-
-The Deduce Reference manual is linked below. It provides an alphabetical list of all the features in Deduce. The Cheat Sheet gives some advice regarding proof strategy and which Deduce keyword to use next in a proof. The Syntax Overview page provides a brief overview of the syntax structure of deduce.
-
-* [Reference Manual](./Reference.md)
-* [Cheat Sheet](./CheatSheet.md)
-* [Syntax Overview](./SyntaxGrammar.md)
-
-### Command Line Arguments
+## Command Line Arguments
 
 The `deduce.py` script supports command line arguments which are
 documented below. If an argument is not preceded by one of the

--- a/gh_pages/scripts/convert.py
+++ b/gh_pages/scripts/convert.py
@@ -24,6 +24,7 @@ mdToHtmlName = {
     'StandardLib' : 'stdlib',
     'Compiler' : 'compiler',
     'Debugger' : 'debugger',
+    'Emacs' : 'emacs',
     'Index' : 'index',
 }
 
@@ -39,6 +40,7 @@ mdToTitle = {
     'StandardLib' : 'Standard Library',
     'Compiler' : 'Compiler',
     'Debugger' : 'Debugger',
+    'Emacs' : 'Emacs Mode',
     'Index' : 'Home',
 }
 
@@ -54,6 +56,7 @@ mdToDescription = {
     'StandardLib' : 'Documentation for the deduce standard library.',
     'Compiler' : 'Compile Deduce programs to a self-contained C binary.',
     'Debugger' : 'Step through Deduce programs with the gdb-style debugger.',
+    'Emacs' : 'Setup and AI-assisted proof completion for Deduce\'s Emacs mode.',
     'Index' : 'Deduce is an automated proof checker meant for use in education to help students',
 }
 
@@ -69,6 +72,7 @@ mdToDeduceCode = {
     'StandardLib' : 'stdlib',
     'Compiler' : 'compiler',
     'Debugger' : 'debugger',
+    'Emacs' : 'emacs',
     'Index' : 'index',
 }
 


### PR DESCRIPTION
## Summary

- reorder Getting Started so Learning Deduce comes before the MCP assistant section
- move the long Emacs `C-c C-a` AI proof-completion setup into a separate Emacs page linked from the Emacs setup
- register the new Emacs page with the site converter metadata

Closes #886.

## Tests

- `python3 test-deduce.py --site --serial`
- `git diff --check`
- `make tests`

## Codex session

codex://threads/019e99ce-4fdc-7751-a735-a554cba61d7a

```bash
open 'codex://threads/019e99ce-4fdc-7751-a735-a554cba61d7a'
```
