### PR TITLE
Add named MCP hole support

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -11,6 +11,7 @@ OPERATOR: /[\-\+∸*%=≠<>≤≥&∘∪∩⊆∈⨄⊝\^≲≈]/
 // a lambda followed by an identifier, even without a space, and exclude
 // the subscript digits `₀`–`₉` from the first character so they only
 // appear as modifiers on a preceding letter (matches the previous rule).
+NAMED_HOLE.2: "?" /[^\W\dλ₀₁₂₃₄₅₆₇₈₉]/ /([^\Wλ]|[₀₁₂₃₄₅₆₇₈₉!?'])*/
 IDENT: /[^\W\dλ₀₁₂₃₄₅₆₇₈₉]/ /([^\Wλ]|[₀₁₂₃₄₅₆₇₈₉!?'])*/
 NEWLINE: (/\r/? /\n/)+
 WS: /[ \t\f\r\n]/+
@@ -115,6 +116,7 @@ identifier: IDENT              -> identifier
     | "<" identifier_list ">" term                      -> alltype_formula
     | "some" type_annotation_list "." term              -> some_formula
     | "define" IDENT "=" term ";" term             -> define_term
+    | NAMED_HOLE                                  -> named_hole_term
     | "?"                                          -> hole_term
     | "─"                                          -> omitted_term
     | "__"                                         -> omitted_term
@@ -232,6 +234,7 @@ identifier: IDENT              -> identifier
 
 ?atomic_proof: IDENT                                              -> proof_var
     | "."                                                -> true_proof
+    | NAMED_HOLE                                      -> named_hole_proof
     | "?"                                                -> hole_proof
     | "(" proof ")"                                      -> paren
     | atomic_proof "[" term_list "]"                         -> all_elim

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -412,17 +412,18 @@ $ claude
 Claude will call the Deduce MCP server's `check_file` tool, see the
 diagnostics, and respond. The full tool list:
 
-For incomplete-proof diagnostics on a `?`, `check_file` includes a
-stable declaration-scoped `hole_id` (for example `my_theorem#0`) and
-the same structured goal payload that `goal_at` returns. The MCP
-position tools that expose `hole_id` can use `{path, hole_id}` instead
-of `{path, line, column}` when the caller has a fresh ID from
-`check_file`.
+For incomplete-proof diagnostics on a `?` or named `?goal`, `check_file`
+includes a stable declaration-scoped `hole_id` (for example
+`my_theorem#0`) and the same structured goal payload that `goal_at`
+returns. Named holes also include a `hole` field, such as `"goal"`.
+The MCP position tools that expose `hole_id` and `hole` can use
+`{path, hole_id}` or `{path, hole}` instead of `{path, line, column}`
+when the caller has a fresh handle from `check_file`.
 
 | Tool                       | What it does                                                  |
 | -------------------------- | ------------------------------------------------------------- |
-| `check_file`               | Type-check and proof-check a `.pf` file, optionally with inline `content`; returns diagnostics, hole IDs, and structured goals. |
-| `goal_at`                  | Return the proof goal + givens at a cursor position or `hole_id`. |
+| `check_file`               | Type-check and proof-check a `.pf` file, optionally with inline `content`; returns diagnostics, hole IDs/names, and structured goals. |
+| `goal_at`                  | Return the proof goal + givens at a cursor position, `hole_id`, or named hole. |
 | `definition_of`            | Jump from a symbol to its declaration.                        |
 | `list_symbols`             | Outline of top-level theorems / definitions in a file.        |
 | `refine_at`                | Refine a `?` based on the goal's shape.                       |
@@ -437,7 +438,7 @@ of `{path, line, column}` when the caller has a fresh ID from
 | `apply_at`                 | Preview `apply <theorem>[<args>] to ?` at a hole.             |
 | `preview_replace_at`       | Preview the goal after `replace <equation>`.                  |
 | `preview_expand_at`        | Preview the goal after `expand <names>`.                      |
-| `available_lemmas_at`      | Search ranked visible lemmas at a position, query, or `hole_id`. |
+| `available_lemmas_at`      | Search ranked visible lemmas at a position, query, `hole_id`, or named hole. |
 | `auto_rules_at`            | List visible `auto` rewrite rules at a position.              |
 
 These are the same operations the Emacs mode binds to `C-c C-r`,

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -2135,12 +2135,16 @@ The output is `5`.
 
 ```deduce-grammar
 atomic_proof ::= "?"
+               | NAMED_HOLE
 ```
 
 A proof can be left incomplete by placing a `?` in the part that you
-don't know. Deduce halts at the `?` and prints an error message with
-the location of the `?` and the formula that needs to be proved, as
-well as some advice about how to prove it.
+don't know. You can also name the hole with `?name`, where `name` uses
+identifier characters. Deduce halts at the hole and prints an error
+message with the location of the hole and the formula that needs to be
+proved, as well as some advice about how to prove it. Named holes are
+useful for editor and MCP tools because `?name` can be addressed by its
+name even if nearby edits move the line and column.
 
 ## Reason
 

--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -75,6 +75,7 @@ known_tokens = {
     'MINUS': 'operator',
     'MODULE': 'keyword',
     'MORETHAN': 'operator',
+    'NAMED_HOLE': 'operator',
     'NOT': 'keyword',
     'NAT': 'keyword',
     'OBTAIN': 'keyword',

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import os
 import re
 import sys
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
 from typing import Optional, TypeAlias, cast
 
@@ -183,6 +183,19 @@ _DECL_RE = re.compile(
     r"(?:theorem|lemma|postulate|define|recursive|fun|union|predicate)\s+"
     r"(?P<name>[^\s:{(<]+)"
 )
+_IDENT_START_RE = r"[^\W\dλ₀₁₂₃₄₅₆₇₈₉]"
+_IDENT_CONTINUE_RE = r"(?:[^\Wλ]|[₀₁₂₃₄₅₆₇₈₉!?'])*"
+_HOLE_TOKEN_RE = re.compile(
+    rf"(?<![^\Wλ])(?<![₀₁₂₃₄₅₆₇₈₉!?'])"
+    rf"\?(?P<name>{_IDENT_START_RE}{_IDENT_CONTINUE_RE})?"
+)
+
+
+@dataclass(frozen=True)
+class _HoleSite:
+    hole_id: str
+    range: query.Range
+    name: Optional[str] = None
 
 
 def _mask_comments(
@@ -223,12 +236,12 @@ def _mask_comments(
     return "".join(chars), in_block_comment
 
 
-def _hole_sites_by_id(content: str, path: str) -> dict[str, query.Range]:
-    """Return declaration-scoped IDs for every literal ``?`` hole."""
+def _hole_sites(content: str, path: str) -> list[_HoleSite]:
+    """Return source sites for every literal ``?`` / ``?name`` hole."""
     fallback_scope = Path(path).stem or "file"
     current_scope = fallback_scope
     next_ordinal: dict[str, int] = {}
-    sites: dict[str, query.Range] = {}
+    sites: list[_HoleSite] = []
     in_block_comment = False
 
     for line_no, raw_line in enumerate(content.splitlines(keepends=True), 1):
@@ -239,29 +252,42 @@ def _hole_sites_by_id(content: str, path: str) -> dict[str, query.Range]:
         if decl_match is not None:
             current_scope = decl_match.group("name")
 
-        for match in re.finditer(r"\?", code_line):
+        for match in _HOLE_TOKEN_RE.finditer(code_line):
             ordinal = next_ordinal.get(current_scope, 0)
             next_ordinal[current_scope] = ordinal + 1
             hole_id = f"{current_scope}#{ordinal}"
             col = match.start() + 1
-            sites[hole_id] = query.Range(
+            rng = query.Range(
                 start=query.Position(line=line_no, column=col),
-                end=query.Position(line=line_no, column=col + 1),
+                end=query.Position(
+                    line=line_no, column=col + len(match.group(0))
+                ),
+            )
+            sites.append(
+                _HoleSite(
+                    hole_id=hole_id, range=rng, name=match.group("name")
+                )
             )
     return sites
 
 
-def _hole_ids_by_start(content: str, path: str) -> dict[tuple[int, int], str]:
+def _hole_sites_by_id(content: str, path: str) -> dict[str, _HoleSite]:
+    return {site.hole_id: site for site in _hole_sites(content, path)}
+
+
+def _hole_sites_by_start(
+    content: str, path: str
+) -> dict[tuple[int, int], _HoleSite]:
     return {
-        (rng.start.line, rng.start.column): hole_id
-        for hole_id, rng in _hole_sites_by_id(content, path).items()
+        (site.range.start.line, site.range.start.column): site
+        for site in _hole_sites(content, path)
     }
 
 
 def _diagnostic_payloads(
     diagnostics: object, content: str, path: str
 ) -> list[JSONDict]:
-    hole_ids = _hole_ids_by_start(content, path)
+    hole_sites = _hole_sites_by_start(content, path)
     payloads = _to_list_of_dicts(diagnostics)
     for payload in payloads:
         rng = cast(JSONDict, payload.get("range"))
@@ -269,10 +295,23 @@ def _diagnostic_payloads(
             payload.pop("goal", None)
         start = cast(JSONDict, rng.get("start"))
         key = (cast(int, start.get("line")), cast(int, start.get("column")))
-        hole_id = hole_ids.get(key)
-        if hole_id is not None:
-            payload["hole_id"] = hole_id
+        site = hole_sites.get(key)
+        if site is not None:
+            payload["hole_id"] = site.hole_id
+            if site.name is not None:
+                payload["hole"] = site.name
     return payloads
+
+
+def _hole_site_by_name(
+    tool_name: str, content: str, path: str, hole: str
+) -> _HoleSite:
+    matches = [site for site in _hole_sites(content, path) if site.name == hole]
+    if not matches:
+        raise ValueError(f"{tool_name}: unknown hole {hole!r}")
+    if len(matches) > 1:
+        raise ValueError(f"{tool_name}: ambiguous hole {hole!r}")
+    return matches[0]
 
 
 def _position_from_args(
@@ -282,15 +321,22 @@ def _position_from_args(
     line: Optional[int],
     column: Optional[int],
     hole_id: Optional[str],
+    hole: Optional[str],
 ) -> query.Position:
+    if hole_id is not None and hole is not None:
+        raise ValueError(
+            f"{tool_name}: provide only one of hole_id or hole"
+        )
     if hole_id is not None:
-        rng = _hole_sites_by_id(content, path).get(hole_id)
-        if rng is None:
+        site = _hole_sites_by_id(content, path).get(hole_id)
+        if site is None:
             raise ValueError(f"{tool_name}: unknown hole_id {hole_id!r}")
-        return rng.start
+        return site.range.start
+    if hole is not None:
+        return _hole_site_by_name(tool_name, content, path, hole).range.start
     if line is None or column is None:
         raise ValueError(
-            f"{tool_name}: provide line and column, or hole_id"
+            f"{tool_name}: provide line and column, hole_id, or hole"
         )
     return query.Position(line=line, column=column)
 
@@ -357,6 +403,7 @@ def goal_at(
     line: Optional[int] = None,
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
+    hole: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Return the proof obligation visible at ``line``:``column``.
 
@@ -376,7 +423,7 @@ def goal_at(
     """
     content = _read_file(path)
     pos = _position_from_args(
-        "goal_at", path, content, line, column, hole_id
+        "goal_at", path, content, line, column, hole_id, hole
     )
     goal = query.goal_at(path, content, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(goal)
@@ -388,6 +435,7 @@ def definition_of(
     line: Optional[int] = None,
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
+    hole: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Return the source location of the symbol at ``line``:``column``.
 
@@ -397,7 +445,7 @@ def definition_of(
     """
     content = _read_file(path)
     pos = _position_from_args(
-        "definition_of", path, content, line, column, hole_id
+        "definition_of", path, content, line, column, hole_id, hole
     )
     loc = query.definition_of(path, content, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(loc)
@@ -409,6 +457,7 @@ def refine_at(
     line: Optional[int] = None,
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
+    hole: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Propose a refinement template for the hole at ``line``:``column``.
 
@@ -435,7 +484,7 @@ def refine_at(
     """
     content = _read_file(path)
     pos = _position_from_args(
-        "refine_at", path, content, line, column, hole_id
+        "refine_at", path, content, line, column, hole_id, hole
     )
     edit = query.refine_at(path, content, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(edit)
@@ -617,6 +666,7 @@ def matching_givens_at(
     line: Optional[int] = None,
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
+    hole: Optional[str] = None,
 ) -> list[str]:
     """Return labels of in-scope local proof bindings whose formula
     equals the goal at ``line``:``column``.
@@ -627,7 +677,7 @@ def matching_givens_at(
     """
     content = _read_file(path)
     pos = _position_from_args(
-        "matching_givens_at", path, content, line, column, hole_id
+        "matching_givens_at", path, content, line, column, hole_id, hole
     )
     return list(
         query.matching_givens_at(path, content, pos, prelude=_prelude_for(path))
@@ -740,6 +790,7 @@ def preview_replace_at(
     line: Optional[int] = None,
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
+    hole: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Preview the result of ``replace <equation>`` at the hole at
     ``line``:``column``.
@@ -771,7 +822,7 @@ def preview_replace_at(
     """
     content = _read_file(path)
     pos = _position_from_args(
-        "preview_replace_at", path, content, line, column, hole_id
+        "preview_replace_at", path, content, line, column, hole_id, hole
     )
     preview = query.preview_replace_at(
         path, content, pos, equation, prelude=_prelude_for(path)
@@ -823,6 +874,7 @@ def available_lemmas_at(
     query: Optional[str] = None,
     limit: int = 50,
     hole_id: Optional[str] = None,
+    hole: Optional[str] = None,
 ) -> list[JSONDict]:
     """Search for theorems/lemmas/postulates relevant at a position.
 
@@ -858,7 +910,7 @@ def available_lemmas_at(
 
     content = _read_file(path)
     pos = _position_from_args(
-        "available_lemmas_at", path, content, line, column, hole_id
+        "available_lemmas_at", path, content, line, column, hole_id, hole
     )
     matches = _q.available_lemmas_at(
         path,

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -888,6 +888,12 @@ def _line_col_to_offset(content: str, pos: Position) -> Optional[int]:
 
 
 _END_RE = re.compile(r"\bend\b")
+_IDENT_START_RE = r"[^\W\dλ₀₁₂₃₄₅₆₇₈₉]"
+_IDENT_CONTINUE_RE = r"(?:[^\Wλ]|[₀₁₂₃₄₅₆₇₈₉!?'])*"
+_HOLE_TOKEN_RE = re.compile(
+    rf"(?<![^\Wλ])(?<![₀₁₂₃₄₅₆₇₈₉!?'])"
+    rf"\?(?:{_IDENT_START_RE}{_IDENT_CONTINUE_RE})?"
+)
 
 
 def _goal_from_exception(
@@ -1866,19 +1872,28 @@ def refine_at(
 
 
 def _find_hole_at(content: str, pos: Position) -> Optional[Range]:
-    """Return the source range of a ``?`` token at or adjacent to ``pos``.
+    """Return the source range of a ``?`` / ``?name`` token at ``pos``.
 
-    Tries the cursor offset itself, then one position to the left
-    (cursor sits just after the ``?``). Returns ``None`` when neither
-    matches.
+    The cursor may sit anywhere inside the token or just after it.
+    Returns ``None`` when no hole token matches.
     """
     offset = _line_col_to_offset(content, pos)
     if offset is None:
         return None
-    for try_off in (offset, offset - 1):
-        if 0 <= try_off < len(content) and content[try_off] == "?":
-            return _char_range_at(content, try_off)
+    for match in _HOLE_TOKEN_RE.finditer(content):
+        if match.start() <= offset <= match.end():
+            return _range_for_offsets(content, match.start(), match.end())
     return None
+
+
+def _range_for_offsets(content: str, start: int, end: int) -> Range:
+    """Return a 1-indexed Range for ``content[start:end]``."""
+    start_line, start_col = _offset_to_line_col(content, start)
+    end_line, end_col = _offset_to_line_col(content, end)
+    return Range(
+        start=Position(line=start_line, column=start_col),
+        end=Position(line=end_line, column=end_col),
+    )
 
 
 def _char_range_at(content: str, offset: int) -> Range:

--- a/parser.py
+++ b/parser.py
@@ -349,6 +349,8 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
         return Call(e.meta, None, Var(e.meta, None, '-'), [arg])
     elif e.data == 'hole_term':
         return Hole(e.meta, None)
+    elif e.data == 'named_hole_term':
+        return Hole(e.meta, None)
     elif e.data == 'omitted_term':
         return Omitted(e.meta, None)
     elif e.data == 'identifier':
@@ -458,6 +460,8 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
     elif e.data == 'true_proof':
         return PTrue(e.meta)
     elif e.data == 'hole_proof':
+        return PHole(e.meta)
+    elif e.data == 'named_hole_proof':
         return PHole(e.meta)
     elif e.data == 'sorry_proof':
         return PSorry(e.meta)

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -356,6 +356,11 @@ def parse_term_hi() -> Term:
     meta = meta_from_tokens(token,token)
     return Hole(meta, None)
 
+  elif token.type == 'NAMED_HOLE':
+    advance()
+    meta = meta_from_tokens(token,token)
+    return Hole(meta, None)
+
   elif token.type == 'SOME':
     advance()
     vars = parse_type_annot_list()
@@ -810,6 +815,11 @@ def parse_proof_hi() -> Proof:
     return proof
 
   elif token.type == 'QMARK':
+    advance()
+    meta = meta_from_tokens(token, token)
+    return PHole(meta)
+
+  elif token.type == 'NAMED_HOLE':
     advance()
     meta = meta_from_tokens(token, token)
     return PHole(meta)

--- a/test/lsp/test_goal_at.py
+++ b/test/lsp/test_goal_at.py
@@ -245,6 +245,23 @@ def test_goal_at_cursor_immediately_after_existing_hole() -> None:
     assert g.range.end == Position(line=4, column=4)
 
 
+def test_goal_at_cursor_after_named_hole() -> None:
+    source = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?goal\n"
+        "end\n"
+    )
+
+    g = goal_at("test.pf", source, Position(line=4, column=8))
+
+    assert g is not None
+    assert g.formula == "P = P"
+    assert g.range.start == Position(line=4, column=3)
+    assert g.range.end == Position(line=4, column=8)
+
+
 def test_goal_at_cursor_on_hole_matches_synthetic_hole_path() -> None:
     """Sanity: the cursor-on-`?` path and the synthesise-a-hole path
     return the same formula and givens for matching positions.

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -143,6 +143,26 @@ def test_parser_argument_validates_with_each(parser: str) -> None:
     )
 
 
+@pytest.mark.parametrize("parser", ["recursive-descent", "lalr"])
+def test_named_hole_parses_with_each_parser(
+    tmp_path: Path, parser: str
+) -> None:
+    path = tmp_path / "NamedHole.pf"
+    path.write_text(
+        "theorem named_hole: true\n"
+        "proof\n"
+        "  ?goal\n"
+        "end\n",
+        encoding="utf-8",
+    )
+
+    result = check_file(str(path), prelude=(), parser=parser)
+
+    assert not result.ok
+    assert result.error_message is not None
+    assert "incomplete proof" in result.error_message
+
+
 def test_parser_argument_rejects_unknown_value() -> None:
     """An unknown parser name is a programming error and must fail
     loudly rather than silently falling back to the default."""

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -207,6 +207,36 @@ async def test_check_file_hole_diagnostics_include_ids_and_goals(
 
 
 @pytest.mark.anyio
+async def test_check_file_named_hole_diagnostics_include_names(
+    server, tmp_path
+):
+    src = (
+        "theorem named: all P:bool, Q:bool. P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  ?left, ?right\n"
+        "end\n"
+    )
+    fp = tmp_path / "named-holes.pf"
+    fp.write_text(src)
+
+    payload = await _call(server, "check_file", {"path": str(fp)})
+
+    diags = payload["diagnostics"]
+    assert len(diags) == 2
+    by_name = {diag["hole"]: diag for diag in diags}
+    assert set(by_name) == {"left", "right"}
+    assert by_name["left"]["hole_id"] == "named#0"
+    assert by_name["left"]["goal"]["formula"] == "P"
+    assert by_name["left"]["range"]["start"] == {"line": 4, "column": 3}
+    assert by_name["left"]["range"]["end"] == {"line": 4, "column": 8}
+    assert by_name["right"]["hole_id"] == "named#1"
+    assert by_name["right"]["goal"]["formula"] == "Q"
+    assert by_name["right"]["range"]["start"] == {"line": 4, "column": 10}
+    assert by_name["right"]["range"]["end"] == {"line": 4, "column": 16}
+
+
+@pytest.mark.anyio
 async def test_hole_id_resolves_goal_after_lines_shift(server, tmp_path):
     src = (
         "// Later edits can add lines above the declaration.\n"
@@ -227,6 +257,31 @@ async def test_hole_id_resolves_goal_after_lines_shift(server, tmp_path):
     assert payload is not None
     assert payload["formula"] == "P = P"
     assert payload["range"]["start"] == {"line": 6, "column": 3}
+
+
+@pytest.mark.anyio
+async def test_named_hole_resolves_goal(server, tmp_path):
+    src = (
+        "// Later edits can move this declaration without invalidating"
+        " the name.\n"
+        "\n"
+        "theorem named_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?target\n"
+        "end\n"
+    )
+    fp = tmp_path / "named-goal.pf"
+    fp.write_text(src)
+
+    payload = await _call(
+        server, "goal_at", {"path": str(fp), "hole": "target"}
+    )
+
+    assert payload is not None
+    assert payload["formula"] == "P = P"
+    assert payload["range"]["start"] == {"line": 6, "column": 3}
+    assert payload["range"]["end"] == {"line": 6, "column": 10}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Add `?name` named-hole syntax to the LALR and recursive-descent parsers while keeping existing `?` holes unchanged.
- Surface named holes from MCP `check_file` diagnostics as `hole` alongside the generated `hole_id`.
- Let MCP position tools resolve `{path, hole}` in addition to `{path, hole_id}` and `{path, line, column}`.
- Update Getting Started and Reference docs for named holes.

## Tests

- `python3 -m pytest test/lsp/test_library.py::test_named_hole_parses_with_each_parser test/lsp/test_goal_at.py::test_goal_at_cursor_after_named_hole test/lsp/test_mcp_server.py::test_check_file_named_hole_diagnostics_include_names test/lsp/test_mcp_server.py::test_named_hole_resolves_goal`
- `python3 gh_pages/scripts/reference_grammar.py`
- `python3 -m ruff check parser.py rec_desc_parser.py lsp/query.py lsp/mcp_server.py test/lsp/test_library.py test/lsp/test_goal_at.py test/lsp/test_mcp_server.py`
- `python3 -m mypy lsp/mcp_server.py lsp/query.py parser.py rec_desc_parser.py`
- `make tests`

## Codex session

codex://threads/019e9a05-bc6c-7770-aae5-39039c9970ff

```bash
open 'codex://threads/019e9a05-bc6c-7770-aae5-39039c9970ff'
```
