### PR TITLE
fix(mcp): honor content override in hole_id position tools (#895)

### DIFF
--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -349,7 +349,10 @@ includes a stable declaration-scoped `hole_id` (for example
 returns. Named holes also include a `hole` field, such as `"goal"`.
 The MCP position tools that expose `hole_id` and `hole` can use
 `{path, hole_id}` or `{path, hole}` instead of `{path, line, column}`
-when the caller has a fresh handle from `check_file`.
+when the caller has a fresh handle from `check_file`. Editors that
+operate on unsaved buffers should pass the same `content` they passed
+to `check_file` so the `hole_id` resolves against that buffer (without
+`content`, the handle is looked up in the on-disk file).
 
 | Tool                       | What it does                                                  |
 | -------------------------- | ------------------------------------------------------------- |

--- a/lsp/mcp_server.py
+++ b/lsp/mcp_server.py
@@ -404,6 +404,7 @@ def goal_at(
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
     hole: Optional[str] = None,
+    content: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Return the proof obligation visible at ``line``:``column``.
 
@@ -420,12 +421,17 @@ def goal_at(
     after serialization) when it would equal ``formula`` -- i.e. no
     auto rule fired -- so callers can compare cheaply by presence
     alone.
+
+    When ``content`` is given, that text is used in place of the
+    on-disk file -- both for resolving ``hole_id`` and for the query
+    itself -- so editor flows can query unsaved buffers with the
+    fresh IDs returned by ``check_file(path, content=...)``.
     """
-    content = _read_file(path)
+    text = _read_file(path) if content is None else content
     pos = _position_from_args(
-        "goal_at", path, content, line, column, hole_id, hole
+        "goal_at", path, text, line, column, hole_id, hole
     )
-    goal = query.goal_at(path, content, pos, prelude=_prelude_for(path))
+    goal = query.goal_at(path, text, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(goal)
 
 
@@ -436,18 +442,23 @@ def definition_of(
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
     hole: Optional[str] = None,
+    content: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Return the source location of the symbol at ``line``:``column``.
 
     Returns ``None`` when the cursor isn't on a resolvable symbol or
     when the definition lives outside the file (an imported module,
     a built-in). The result has ``path`` and ``range``.
+
+    When ``content`` is given, that text is used in place of the
+    on-disk file -- both for resolving ``hole_id`` and for the query
+    itself.
     """
-    content = _read_file(path)
+    text = _read_file(path) if content is None else content
     pos = _position_from_args(
-        "definition_of", path, content, line, column, hole_id, hole
+        "definition_of", path, text, line, column, hole_id, hole
     )
-    loc = query.definition_of(path, content, pos, prelude=_prelude_for(path))
+    loc = query.definition_of(path, text, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(loc)
 
 
@@ -458,6 +469,7 @@ def refine_at(
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
     hole: Optional[str] = None,
+    content: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Propose a refinement template for the hole at ``line``:``column``.
 
@@ -481,12 +493,16 @@ def refine_at(
     - ``all x:T. body`` -> ``arbitrary x:T\\n?``
     - ``some x:T. body`` -> ``choose ?\\n?``
     - reducible ``e1 = e2`` -> ``reflexive``
+
+    When ``content`` is given, that text is used in place of the
+    on-disk file -- both for resolving ``hole_id`` and for the query
+    itself.
     """
-    content = _read_file(path)
+    text = _read_file(path) if content is None else content
     pos = _position_from_args(
-        "refine_at", path, content, line, column, hole_id, hole
+        "refine_at", path, text, line, column, hole_id, hole
     )
-    edit = query.refine_at(path, content, pos, prelude=_prelude_for(path))
+    edit = query.refine_at(path, text, pos, prelude=_prelude_for(path))
     return _to_dict_or_none(edit)
 
 
@@ -667,6 +683,7 @@ def matching_givens_at(
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
     hole: Optional[str] = None,
+    content: Optional[str] = None,
 ) -> list[str]:
     """Return labels of in-scope local proof bindings whose formula
     equals the goal at ``line``:``column``.
@@ -674,13 +691,17 @@ def matching_givens_at(
     The cursor must sit on a ``?`` token.  Names are sorted and
     deduplicated.  Returns ``[]`` when the cursor isn't on a ``?``,
     the goal AST isn't available, or no local binding matches.
+
+    When ``content`` is given, that text is used in place of the
+    on-disk file -- both for resolving ``hole_id`` and for the query
+    itself.
     """
-    content = _read_file(path)
+    text = _read_file(path) if content is None else content
     pos = _position_from_args(
-        "matching_givens_at", path, content, line, column, hole_id, hole
+        "matching_givens_at", path, text, line, column, hole_id, hole
     )
     return list(
-        query.matching_givens_at(path, content, pos, prelude=_prelude_for(path))
+        query.matching_givens_at(path, text, pos, prelude=_prelude_for(path))
     )
 
 
@@ -791,6 +812,7 @@ def preview_replace_at(
     column: Optional[int] = None,
     hole_id: Optional[str] = None,
     hole: Optional[str] = None,
+    content: Optional[str] = None,
 ) -> Optional[JSONDict]:
     """Preview the result of ``replace <equation>`` at the hole at
     ``line``:``column``.
@@ -819,13 +841,17 @@ def preview_replace_at(
     ``goal_at`` for the inner loop where the agent picks an equation,
     previews the rewrite, and only commits when the after-text matches
     its plan.
+
+    When ``content`` is given, that text is used in place of the
+    on-disk file -- both for resolving ``hole_id`` and for the query
+    itself.
     """
-    content = _read_file(path)
+    text = _read_file(path) if content is None else content
     pos = _position_from_args(
-        "preview_replace_at", path, content, line, column, hole_id, hole
+        "preview_replace_at", path, text, line, column, hole_id, hole
     )
     preview = query.preview_replace_at(
-        path, content, pos, equation, prelude=_prelude_for(path)
+        path, text, pos, equation, prelude=_prelude_for(path)
     )
     return _to_dict_or_none(preview)
 
@@ -875,6 +901,7 @@ def available_lemmas_at(
     limit: int = 50,
     hole_id: Optional[str] = None,
     hole: Optional[str] = None,
+    content: Optional[str] = None,
 ) -> list[JSONDict]:
     """Search for theorems/lemmas/postulates relevant at a position.
 
@@ -905,16 +932,20 @@ def available_lemmas_at(
 
     Returns ``[]`` only when nothing is in scope at the position or
     a given ``query`` matches nothing.
+
+    When ``content`` is given, that text is used in place of the
+    on-disk file -- both for resolving ``hole_id`` and for the query
+    itself.
     """
     from lsp import query as _q
 
-    content = _read_file(path)
+    text = _read_file(path) if content is None else content
     pos = _position_from_args(
-        "available_lemmas_at", path, content, line, column, hole_id, hole
+        "available_lemmas_at", path, text, line, column, hole_id, hole
     )
     matches = _q.available_lemmas_at(
         path,
-        content,
+        text,
         pos,
         query=query,
         prelude=_prelude_for(path),

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -285,6 +285,79 @@ async def test_named_hole_resolves_goal(server, tmp_path):
 
 
 @pytest.mark.anyio
+async def test_goal_at_resolves_hole_id_against_content(server, tmp_path):
+    """``goal_at`` must honor ``content`` when resolving ``hole_id`` --
+    the documented editor flow is ``check_file(path, content=...)``
+    returns a fresh ID and the follow-up position queries pass that
+    ID back along with the same ``content``. The on-disk file has
+    no hole, so resolving against disk would 404."""
+    disk_src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "content-override.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "goal_at",
+        {
+            "path": str(fp),
+            "hole_id": "hole_owner#0",
+            "content": inline_src,
+        },
+    )
+
+    assert payload is not None
+    assert payload["formula"] == "P = P"
+    assert payload["range"]["start"] == {"line": 4, "column": 3}
+
+
+@pytest.mark.anyio
+async def test_goal_at_content_override_uses_inline_for_query(
+    server, tmp_path
+):
+    """The ``content`` override must drive the *query*, not just hole
+    resolution -- otherwise the goal payload would describe a hole the
+    on-disk file doesn't even have. Use line/column (not hole_id) so
+    the test isolates that the query itself runs against ``content``."""
+    disk_src = "// empty on disk\n"
+    inline_src = (
+        "theorem t: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "content-query.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "goal_at",
+        {
+            "path": str(fp),
+            "line": 4,
+            "column": 3,
+            "content": inline_src,
+        },
+    )
+
+    assert payload is not None
+    assert payload["formula"] == "P = P"
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("parser", ["recursive-descent", "lalr"])
 async def test_check_file_accepts_parser_argument(server, parser):
     """The MCP wrapper plumbs ``parser`` through to ``query.check`` and
@@ -503,6 +576,42 @@ async def test_definition_of_accepts_hole_id(server, tmp_path):
     assert payload is None
 
 
+@pytest.mark.anyio
+async def test_definition_of_resolves_hole_id_against_content(
+    server, tmp_path
+):
+    """``content`` override unlocks ``hole_id`` resolution for an
+    unsaved buffer where the on-disk file has no hole."""
+    disk_src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "definition-content.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "definition_of",
+        {
+            "path": str(fp),
+            "hole_id": "hole_owner#0",
+            "content": inline_src,
+        },
+    )
+
+    assert payload is None
+
+
 # --------------------------------------------------------------------------
 # list_symbols
 # --------------------------------------------------------------------------
@@ -583,6 +692,43 @@ async def test_refine_at_accepts_hole_id(server, tmp_path):
 
     assert payload is not None
     assert payload["path"] == str(fp)
+    assert payload["new_text"] == "reflexive"
+    assert payload["range"]["start"] == {"line": 4, "column": 3}
+    assert payload["range"]["end"] == {"line": 4, "column": 4}
+
+
+@pytest.mark.anyio
+async def test_refine_at_resolves_hole_id_against_content(
+    server, tmp_path
+):
+    disk_src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem hole_owner: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "refine-content.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "refine_at",
+        {
+            "path": str(fp),
+            "hole_id": "hole_owner#0",
+            "content": inline_src,
+        },
+    )
+
+    assert payload is not None
     assert payload["new_text"] == "reflexive"
     assert payload["range"]["start"] == {"line": 4, "column": 3}
     assert payload["range"]["end"] == {"line": 4, "column": 4}
@@ -889,6 +1035,42 @@ async def test_matching_givens_at_accepts_hole_id(server, tmp_path):
     )
 
     assert payload == ["H"]
+
+
+@pytest.mark.anyio
+async def test_matching_givens_at_resolves_hole_id_against_content(
+    server, tmp_path
+):
+    disk_src = (
+        "theorem hole_owner: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  H\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem hole_owner: all P:bool. if P then P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  assume H: P\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "matching-content.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "matching_givens_at",
+        {
+            "path": str(fp),
+            "hole_id": "hole_owner#0",
+            "content": inline_src,
+        },
+    )
+
+    assert payload == ["H"]
 # --------------------------------------------------------------------------
 # apply_at
 # --------------------------------------------------------------------------
@@ -1042,6 +1224,47 @@ async def test_preview_replace_at_accepts_hole_id(server, tmp_path):
 
 
 @pytest.mark.anyio
+async def test_preview_replace_at_resolves_hole_id_against_content(
+    server, tmp_path
+):
+    disk_src = (
+        "theorem hole_owner: all P:bool, Q:bool. if P = Q then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P = Q\n"
+        "  replace H\n"
+        "  H\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem hole_owner: all P:bool, Q:bool. if P = Q then P\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume H: P = Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "preview-replace-content.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "preview_replace_at",
+        {
+            "path": str(fp),
+            "hole_id": "hole_owner#0",
+            "equation": "H",
+            "content": inline_src,
+        },
+    )
+
+    assert payload is not None
+    assert payload["outcome"] == "ok"
+    assert payload["before"] == "P"
+    assert payload["after"] == "Q"
+
+
+@pytest.mark.anyio
 async def test_preview_replace_at_returns_unbound(server, tmp_path):
     src = (
         "theorem t: all P:bool. P\n"
@@ -1175,6 +1398,66 @@ async def test_available_lemmas_at_accepts_hole_id(server, tmp_path):
     assert "and_intro" in names
     entry = next(m for m in payload if m["name"] == "and_intro")
     assert entry["kind"] == "theorem"
+
+
+@pytest.mark.anyio
+async def test_available_lemmas_at_resolves_hole_id_against_content(
+    server, tmp_path
+):
+    """``content`` override must work for the lemma-search position
+    tool too -- it's the headline goal-driven entry point for editor
+    flows operating on unsaved buffers."""
+    disk_src = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume pP: P\n"
+        "  assume qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume pP: P\n"
+        "  assume qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+    )
+    inline_src = (
+        "theorem and_intro: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume pP: P\n"
+        "  assume qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool. if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  assume pP: P\n"
+        "  assume qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    fp = tmp_path / "available-content.pf"
+    fp.write_text(disk_src)
+
+    payload = await _call(
+        server,
+        "available_lemmas_at",
+        {
+            "path": str(fp),
+            "hole_id": "with_hole#0",
+            "limit": 10,
+            "content": inline_src,
+        },
+    )
+
+    assert isinstance(payload, list)
+    names = [m["name"] for m in payload]
+    assert "and_intro" in names
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes [#895](https://github.com/jsiek/deduce/issues/895): the MCP position tools that accept a `hole_id` resolved that ID against the on-disk file, so the documented editor flow — `check_file(path, content=<buffer>)` returns a fresh `hole_id`, follow-up calls pass the same `content` — failed on unsaved buffers.

Each of these tools now accepts an optional `content` parameter; when given, the same text drives both `hole_id` resolution and the underlying query (matching `check_file`'s existing semantics). Without `content`, behavior is unchanged (reads from disk).

Tools updated:
- `goal_at`
- `definition_of`
- `refine_at`
- `matching_givens_at`
- `preview_replace_at`
- `available_lemmas_at`

## Changes

- `lsp/mcp_server.py`: add `content: Optional[str] = None` to each tool; use `text = _read_file(path) if content is None else content` consistently.
- `test/lsp/test_mcp_server.py`: one content-override test per fixed tool. Disk file has no hole; inline buffer has one — verifies both that the `hole_id` resolves against `content` and that the query runs on `content`.
- `gh_pages/doc/GettingStarted.md`: clarify the editor `content` workflow in the MCP section so the documented contract matches the implementation.

## Test plan

- [x] `python3.13 -m pytest test/lsp/test_mcp_server.py` — 52 passed (6 new tests for the content-override case).
- [x] `make static` — ruff + mypy (with and without `--no-site-packages`) clean.
- [ ] CI passes.

[Claude session](claude://resume?session=1ac6a375-c2b9-482a-9832-59a39a2b8a8e) — fallback UUID: `1ac6a375-c2b9-482a-9832-59a39a2b8a8e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
