### PR TITLE
Add --help and reject unknown flags in deduce.py (closes #898)

### DIFF
--- a/deduce.py
+++ b/deduce.py
@@ -133,6 +133,40 @@ def deduce_directory(directory: str, recursive_directories: bool,
         elif recursive_directories and os.path.isdir(fpath):
             deduce_directory(fpath, recursive_directories, tracing_functions, prelude, debugger=debugger)
     
+USAGE = """\
+Usage: python deduce.py [options] file_or_directory [...]
+
+Check the given Deduce (.pf) files. Multiple files or directories may be
+supplied; directories are scanned for *.pf (use -r to recurse).
+
+Options:
+  -h, --help                show this help message and exit
+  -v, --version             print version and exit
+  --dir <directory>         add <directory> to the import search path
+  --no-stdlib               do not auto-include the standard library
+  --recursive-descent       use the recursive descent parser (default)
+  --lalr                    use the Lark LALR parser
+  -r, --recursive-directories
+                            descend into subdirectories of supplied paths
+  --quiet                   suppress informational output
+  --verbose [full]          enable debug output ('full' includes imports)
+  --unique-names            print every name with its unique suffix
+  --trace <function>        trace calls to <function> (may be repeated)
+  --traceback               include the Python traceback on error
+  --suppress-theorems       do not write .thm files
+  --error                   expect each file to error (exit 255 if not)
+  --no-check-imports        do not check proofs of imported files
+  --color / --no-color      force or disable ANSI color output
+  --compile                 compile to a self-contained C program
+  --compile-module          compile as a single module (.c + .h)
+  --no-main                 (with --compile-module) library module, no main
+  -o <path>                 output path for --compile / --compile-module
+  --no-prune                with --compile, keep all lowered declarations
+  --debug                   enable the interactive debugger
+
+See gh_pages/doc/GettingStarted.md for the full reference.
+"""
+
 def check_in_prelude(deducable : str, stdlib_dir : str) -> bool:
     deducable_path = Path(deducable)
     stdlib_path = Path(stdlib_dir)
@@ -177,7 +211,10 @@ if __name__ == "__main__":
             continue
     
         argument = sys.argv[i]
-        if argument == '--error':
+        if argument == '--help' or argument == '-h':
+            print(USAGE, end='')
+            exit(0)
+        elif argument == '--error':
             error_expected = True
         elif argument == '--unique-names':
             set_unique_names(True)
@@ -233,6 +270,11 @@ if __name__ == "__main__":
             color_mode = 'never'
         elif argument == '--color':
             color_mode = 'always'
+        elif argument.startswith('-'):
+            print(f"unknown option: {argument}", file=sys.stderr)
+            print("Run 'python deduce.py --help' for a list of options.",
+                  file=sys.stderr)
+            exit(1)
         else:
             deducables.append(argument)
     

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -382,7 +382,14 @@ the same proof-editing toolkit you do.
 The `deduce.py` script supports command line arguments which are
 documented below. If an argument is not preceded by one of the
 keywords listed below, then it is treated as the name of a file or
-directory and will be processed by Deduce.
+directory and will be processed by Deduce. An argument starting with
+`-` that does not match a known flag is reported as `unknown option:
+<flag>` and Deduce exits with a non-zero status.
+
+`--help` or `-h`
+
+Prints a concise summary of the supported command line arguments and
+exits.
 
 `--dir directory-name`
 


### PR DESCRIPTION
## Summary

Fixes #898 by making `deduce.py`'s CLI behave the way a new user
expects.

- `--help` / `-h` now prints a concise listing of every supported
  command-line flag and exits 0.
- Any argument that starts with `-` and doesn't match a known flag is
  rejected with `unknown option: <flag>` on stderr and a non-zero exit
  status (instead of being silently treated as a filename and producing
  the misleading `<flag> was not found!` error).
- Updated `gh_pages/doc/GettingStarted.md` to document the new `--help`
  flag and the unknown-option behavior.

### Before
```
$ python3 deduce.py --help
--help was not found!

$ python3 deduce.py --quite example.pf
--quite was not found!
```

### After
```
$ python3 deduce.py --help
Usage: python deduce.py [options] file_or_directory [...]
  ...
  -h, --help                show this help message and exit
  ...

$ python3 deduce.py --quite example.pf
unknown option: --quite
Run 'python deduce.py --help' for a list of options.
```

Real-file paths (and `-r`, the only legitimate single-dash flag) still
work as before; only unrecognized dash-prefixed arguments error out.

## Test plan

- [x] `make static` (ruff + mypy, both passes) — clean
- [x] `python test-deduce.py --passable` — all green (RD + LALR)
- [x] `python test-deduce.py --errors` — all green
- [x] `python test-deduce.py --parser` — all green
- [x] `python test-deduce.py --lib` — all green
- [x] `python -m pytest test/unit` — 539 passed
- [x] Manual: `--help`, `-h`, `--version`, `--quite foo.pf`, `-X foo.pf`,
      `nonexistent.pf`, and `example.pf` (normal run with prelude) all
      behave as expected.

[Claude session](claude://resume?session=0b0e7ee8-618f-4a82-912e-2b730b72fbd5) — fallback UUID: `0b0e7ee8-618f-4a82-912e-2b730b72fbd5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
