### PR TITLE
Tighten lemma ranker so type-incompatible matches don't crowd out real ones (#896)

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -4453,6 +4453,75 @@ def _iter_subterms(node: "AST") -> list["AST"]:
     return out
 
 
+def _matching_respects_var_types(
+    vars: list["ResolvedVar"],
+    matching: dict[str, "Term"],
+) -> bool:
+    """True when matched substitutions are consistent with the declared
+    types of the lemma's ``all``-bound (or existential) variables.
+
+    ``formula_match`` is deliberately permissive about types -- it lets
+    a ``y:Nat`` pattern bind to a list-typed goal term so the matcher
+    can be reused by ``apply_at`` (which surfaces a "you instantiated y
+    at the wrong type" error after the fact). For ranking, that
+    permissiveness produces vacuous matches: on a list-reverse goal,
+    ``iff_equal: all P:bool, Q:bool. if P ⇔ Q then P = Q`` and the
+    ``X_injective`` family all conclude with a bare ``=`` and bind P/Q
+    to the list-typed sides, even though the binders' declared types
+    have no relationship to the goal's. Without a type check those
+    lemmas score ``premises_remain`` and crowd out the lemma users
+    actually need (issue #896).
+
+    We compare each matched term's ``typeof`` against the variable's
+    declared ``typ`` after substituting earlier-matched type variables.
+    A mismatch between two concrete types is rejected; if either side
+    still has free type-variable references (the matcher chose not to
+    bind a particular type-var) we stay permissive.
+    """
+    from abstract_syntax import TypeType
+    try:
+        for v in vars:
+            if v.name not in matching:
+                continue
+            expected = getattr(v, "typeof", None)
+            if expected is None:
+                continue
+            try:
+                expected = expected.substitute(matching)
+            except Exception:
+                continue
+            # Type-binders carry a Type as their match, not a Term;
+            # there's no ``.typeof`` to compare against.
+            if isinstance(expected, TypeType):
+                continue
+            matched = matching[v.name]
+            actual = getattr(matched, "typeof", None)
+            if actual is None:
+                continue
+            try:
+                if expected == actual:
+                    continue
+            except Exception:
+                continue
+            # Permissive only when the substituted expected still
+            # references one of the lemma's own pattern variables
+            # (the matcher chose not to bind that type-var). A free
+            # name that comes from the global environment -- a bare
+            # type-name like ``Nat`` -- is effectively a constant
+            # and a mismatch against it is real.
+            try:
+                free = expected.free_vars()
+            except Exception:
+                continue
+            lemma_var_names = {v.name for v in vars}
+            if free & lemma_var_names:
+                continue
+            return False
+        return True
+    except Exception:
+        return True
+
+
 def _typed_formula_index(env: Optional["Env"]) -> dict[str, "Formula"]:
     """Build a one-shot ``base_name -> typed_formula`` index over the
     proof bindings in ``env``.
@@ -4582,7 +4651,7 @@ def _unify_score(
     try:
         formula_match(location, vars, conc, goal_ast, matching, env)
         unmatched = [v for v in vars if v.name not in matching]
-        if not unmatched:
+        if not unmatched and _matching_respects_var_types(vars, matching):
             conc_matched = True
     except MatchFailed:
         pass
@@ -4679,13 +4748,16 @@ def _equation_subterm_match(
         lhs, rhs = conc.args
         subterms = _iter_subterms(goal_ast)
         for side in (lhs, rhs):
-            # When the side is a bare forall-var, ``formula_match`` binds
-            # it to the first subterm visited -- typically the whole goal
-            # -- which is a meaningless "instantiation" for the splice.
-            # Skip emitting instantiations in that case: a bare
-            # ``replace name`` lets the rewrite engine pattern-match
-            # across the goal as before.
-            side_is_bare_var = isinstance(side, VarRef) and side in vars
+            # Skip a side that's a bare forall-var: ``formula_match``
+            # binds it to the first subterm visited and reports
+            # success regardless of the equation's shape, which makes
+            # every ``X = bare_var`` lemma look like a ``rewrite_subterm``
+            # match for every goal. The structured side (if any) is
+            # what tells us a ``replace lemma`` could actually fire;
+            # if neither side has structure, the lemma isn't a useful
+            # rewrite to surface (issue #896).
+            if isinstance(side, VarRef) and side in vars:
+                continue
             for sub in subterms:
                 sub_matching: dict[str, "Term"] = {}
                 try:
@@ -4696,11 +4768,9 @@ def _equation_subterm_match(
                     continue
                 if [v for v in vars if v.name not in sub_matching]:
                     continue
-                return (
-                    ()
-                    if side_is_bare_var
-                    else _render_instantiations(vars, sub_matching)
-                )
+                if not _matching_respects_var_types(vars, sub_matching):
+                    continue
+                return _render_instantiations(vars, sub_matching)
     except Exception:
         pass
     return None

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -835,6 +835,66 @@ def test_unify_disjunctive_split_tier_fires_for_disjunction_lemma() -> None:
     assert by_name["g_left_or_right"].unify_tier == "disjunctive_split"
 
 
+def test_type_incompatible_match_does_not_outrank_real_match() -> None:
+    """Issue #896: a lemma whose conclusion only unifies because the
+    matcher ignores type annotations -- e.g. ``injective : all x:Nat,
+    y:Nat. if f(x) = f(y) then x = y`` matched against a list-equality
+    goal -- must not outrank the lemma the user actually needs.
+
+    Reproducer mirrors the ``reverse_involutive`` induction step from
+    the bug report. The goal is a list equation and ``reverse_append``
+    is the relevant lemma; before the fix, ``X_injective``-shaped
+    lemmas all scored ``premises_remain`` (their ``x = y`` conclusion
+    unifies bindings with arbitrary types) and the relevant lemma
+    dropped to relevance ~0.5.
+    """
+    source = (
+        "theorem n_injective: all x:Nat, y:Nat."
+        " if suc(x) = suc(y) then x = y\n"
+        "proof\n"
+        "  arbitrary x:Nat, y:Nat\n"
+        "  suppose h: suc(x) = suc(y)\n"
+        "  injective suc h\n"
+        "end\n"
+        "\n"
+        "theorem b_idem: all P:bool. (P and P) = P\n"
+        "proof\n  arbitrary P:bool\n  switch P { case true { . } case false { . } }\n"
+        "end\n"
+        "\n"
+        "theorem reverse_helper: all T:type. all xs:List<T>, ys:List<T>.\n"
+        "  reverse(xs ++ ys) = reverse(ys) ++ reverse(xs)\n"
+        "proof\n"
+        "  arbitrary T:type\n"
+        "  arbitrary xs:List<T>, ys:List<T>\n"
+        "  ?\n"
+        "end\n"
+    )
+    hole_line = source.split("\n").index("  ?") + 1
+    matches = available_lemmas_at(
+        "user.pf",
+        source,
+        Position(line=hole_line, column=3),
+        prelude=("Base", "Option", "NatDefs", "Pair", "List"),
+    )
+    by_name = {m.name: m for m in matches}
+    assert "n_injective" in by_name, (
+        "Sanity: lemma must still be in scope even if it's deprioritized"
+    )
+    assert "b_idem" in by_name
+    # A list-equality goal: ``n_injective`` and ``b_idem`` both have
+    # bare-var conclusions that match by ignoring binder types
+    # (Nat vs. List<T>, bool vs. List<T>). They must rank no higher
+    # than the unrelated catch-all noise.
+    assert by_name["n_injective"].unify_tier is None, (
+        "n_injective binds x:Nat to a list value -- its conclusion "
+        "shouldn't pretend to unify"
+    )
+    assert by_name["b_idem"].unify_tier is None, (
+        "b_idem's RHS is bare ``P:bool`` -- it shouldn't claim a "
+        "rewrite_subterm tier on a list-equality goal"
+    )
+
+
 def test_browse_mode_leaves_unify_tier_unset() -> None:
     """Browse mode (no goal, no query) doesn't run the unifier, so
     ``unify_tier`` stays ``None`` on every result."""


### PR DESCRIPTION
## Summary

Fixes #896.

On a list-reverse induction goal (`reverse(reverse(node(x, xs'))) = node(x, xs')`),
`available_lemmas_at` ranked five `X_injective` lemmas at the top — all carrying
`if X = Y then …` shapes whose conclusion `x = y` "unified" with the goal only
because `formula_match` is intentionally permissive about types. The same
permissiveness let `and_idempotent` / `double_neg` / `neg_involutive` / etc. claim
a `rewrite_subterm` tier via their bare-var RHS matching the whole `=`-typed goal.
`reverse_append`, the lemma the proof actually needs, sank to relevance 0.538.

Two changes in `lsp/query.py`:

- **Type-aware unify check.** New `_matching_respects_var_types` helper compares
  each matched substitution's `typeof` against the variable's declared type after
  substituting earlier-matched type variables. Mismatches between two concrete
  types are rejected; lemma-bound type vars the matcher didn't bind stay
  permissive (so a generic lemma's `xs:List<T>` still matches when `T` is
  unresolved). Plumbed into both the tier-1/2 conclusion match in `_unify_score`
  and the bare-var-aware loop in `_equation_subterm_match`.
- **No more bare-var `rewrite_subterm`.** A bare `P:bool` pattern unifies with
  the first subterm it sees and reports success, which made every `X = bare_var`
  lemma look like a `rewrite_subterm` match for every goal. The structured side
  (if any) carries the real evidence that `replace lemma` could fire; if neither
  side has structure, the lemma isn't a useful rewrite to surface.

After both changes, the same induction goal puts `reverse_append`,
`length_reverse`, and `intersperse_singleton` at relevance 1.0; the bogus
injective / idempotent matches drop to ≤0.857.

The "different result sets between `{hole_id}` and `{line, column}`" symptom from
the issue is a downstream UX issue (a cursor position one column off the `?` flips
the call into browse mode, which then surfaces the enclosing theorem). It's out of
scope for this PR — happy to file a follow-up.

## Test plan

- [x] `pytest test/lsp/test_available_lemmas.py` — adds
  `test_type_incompatible_match_does_not_outrank_real_match` and keeps the 27
  existing tests passing.
- [x] `make static` — ruff + mypy clean.
- [x] `pytest test/unit/` — 539 pass.
- [ ] `pytest test/lsp/` — full LSP suite (running locally; the rest of CI will
  cover this).
- [ ] `test-deduce.py` — running locally.

[Claude session](claude://resume?session=df7030af-66f0-4c9e-a67c-553244d6084c) — fallback UUID: `df7030af-66f0-4c9e-a67c-553244d6084c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
