### PR TITLE
Check more Reference grammar snippets (Bool, Braces, FnType, Ident, Parens)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -490,7 +490,7 @@ The biconditional formula `P ⇔ Q` is syntactic sugar for
 
 ## Bool (Type)
 
-```
+```deduce-grammar
 type ::= "bool"
 ```
 
@@ -499,8 +499,8 @@ A *formula* is a term of type `bool`.
 
 ## Braces (Proof)
 
-```
-proof ::= "{" proof "}"
+```deduce-grammar
+atomic_proof ::= "{" proof "}"
 ```
 
 A proof may be surrounded in curly braces.
@@ -1118,7 +1118,7 @@ assert interchange(pair(1,2)) = pair(2,1)
 
 ## Function Type
 
-```
+```deduce-grammar
 type ::= "fn" type_params_opt type_list "->" type
 type ::= "fn" type_params_opt "(" type "," type_list ")" "->" type
 ```
@@ -1283,10 +1283,9 @@ given.
 
 ## Identifier 
 
-```
-term ::= identifier
-formula ::= identifier
-conclusion ::= identifier
+```deduce-grammar
+atomic_term ::= identifier
+atomic_proof ::= identifier
 ```
 
 Identifiers are used in Deduce to give names to functions and values and
@@ -1930,10 +1929,9 @@ To use a given of the form `P or Q`, use
 
 ## Parentheses
 
-```
-term ::= "(" term ")"
-formula ::= "(" formula ")"
-proof ::= "(" proof ")"
+```deduce-grammar
+atomic_term ::= "(" term ")"
+atomic_proof ::= "(" proof ")"
 ```
 
 A term, formula, or a proof may be surrounded in parentheses.

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -47,6 +47,7 @@ SUBSET_RULES = {
     "multiplicative_term",
     "proof_stmt",
     "statement",
+    "type",
     "visibility",
 }
 


### PR DESCRIPTION
## Summary

- Migrate the last six unmarked grammar fragments in `Reference.md` to
  strict checked `deduce-grammar` blocks: **Bool Type**, **Braces (Proof)**,
  **Function Type**, **Identifier**, and **Parentheses**.
- Allow `type` to be subset-checked in `reference_grammar.py` so a single
  entry (e.g. `Bool Type` or `Function Type`) can document one alternative
  without having to repeat the whole rule — same treatment the precedence
  term/proof nonterminals already get.
- For Identifier and Parentheses, drop the `formula ::= …` lines: there
  is no `formula` nonterminal in `Deduce.lark`, and the surrounding prose
  already states that a formula is a `bool`-typed term, so the line is
  redundant.

Six rules added to the strict check, total goes from 133 to 139.

## Validation

- `python3 gh_pages/scripts/reference_grammar.py`
- `python3 -m ruff check gh_pages/scripts/reference_grammar.py`
- `python3 -m mypy gh_pages/scripts/reference_grammar.py`
- `make static` (ruff + mypy across the repo)
- `python3 test-deduce.py --site --serial` (planned — kicked off after pushing this draft)

## Issue

Refs #473.

This is another Reference grammar-fragment migration slice. The umbrella
issue remains open for remaining items (the `formula ::= term` block in
the **Formula** section is intentionally left unmarked since `formula`
is not a real grammar nonterminal, plus `should-error` parser-equivalence
policy and parser round-trip expansion).

## Test plan

- [ ] `python3 gh_pages/scripts/reference_grammar.py` reports the new
      checked-rule count.
- [ ] CI green on `make tests` and the static-site grammar gates.

[Claude session](claude://resume?session=a8f41b3f-09ea-444a-9b4e-1b3c8033a064) — fallback UUID: `a8f41b3f-09ea-444a-9b4e-1b3c8033a064`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
