### PR TITLE
Snap-to-hole + drop enclosing theorem in browse mode (closes #903)

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -1875,15 +1875,26 @@ def _find_hole_at(content: str, pos: Position) -> Optional[Range]:
     """Return the source range of a ``?`` / ``?name`` token at ``pos``.
 
     The cursor may sit anywhere inside the token or just after it.
-    Returns ``None`` when no hole token matches.
+    When the cursor isn't on a token but the line contains one or more
+    ``?`` tokens, snap to the closest one on that line -- a near-miss
+    cursor shouldn't flip goal-driven MCP tools into browse mode
+    (issue #903).  Returns ``None`` when no hole token is on the cursor
+    or on the cursor's line.
     """
     offset = _line_col_to_offset(content, pos)
     if offset is None:
         return None
+    same_line: list[tuple[int, int]] = []
     for match in _HOLE_TOKEN_RE.finditer(content):
         if match.start() <= offset <= match.end():
             return _range_for_offsets(content, match.start(), match.end())
-    return None
+        start_line, _ = _offset_to_line_col(content, match.start())
+        if start_line == pos.line:
+            same_line.append((match.start(), match.end()))
+    if not same_line:
+        return None
+    start, end = min(same_line, key=lambda se: abs(se[0] - offset))
+    return _range_for_offsets(content, start, end)
 
 
 def _range_for_offsets(content: str, start: int, end: int) -> Range:
@@ -3748,14 +3759,11 @@ def available_lemmas_at(
 
     # A proof can't cite the theorem it's proving -- circularity --
     # so drop the enclosing theorem from candidates before ranking.
-    # Only applies when the cursor is at a hole inside a proof body;
-    # browse mode (cursor anywhere else) keeps every declaration
-    # visible, including the theorem that happens to start at pos.
-    exclude = (
-        _enclosing_theorem_name(ast_nodes, pos)
-        if hole_range is not None
-        else None
-    )
+    # Applies in browse mode too: surfacing the theorem currently
+    # being edited as a top recommendation reproduces the visible
+    # weirdness from issue #903 (the user-file theorem ranks at 1.0
+    # alongside browse-mode "alphabetical soup").
+    exclude = _enclosing_theorem_name(ast_nodes, pos)
     candidates = _collect_lemma_candidates(
         path, ast_nodes, prelude, exclude_name=exclude
     )
@@ -3930,11 +3938,13 @@ def _enclosing_theorem_name(
     encloses ``pos``, or ``None`` when ``pos`` isn't inside one.
 
     Theorems don't nest at the top level, so the enclosing one is the
-    last ``Theorem`` whose start ``location`` is at or before ``pos``
-    and which has no later top-level statement starting at or before
-    ``pos``. The intent is to skip the theorem currently being proved
-    when surfacing lemmas at one of its holes -- the proof can't
-    refer to itself.
+    last ``Theorem`` whose start ``location`` is strictly before
+    ``pos`` and which has no later top-level statement starting at or
+    before ``pos``. The intent is to skip the theorem currently being
+    proved when surfacing lemmas at one of its holes -- the proof
+    can't refer to itself. The strict comparison handles the edge
+    case where ``pos`` sits exactly on the ``theorem`` keyword: the
+    cursor isn't yet inside the proof body.
     """
     if ast_nodes is None:
         return None
@@ -3949,12 +3959,14 @@ def _enclosing_theorem_name(
             # ``ast_nodes`` is in source order; no later sibling can be
             # at-or-before ``pos`` either.
             break
-        if isinstance(stmt, Theorem):
+        if isinstance(stmt, Theorem) and _meta_strictly_before(loc, pos):
             enclosing = base_name(stmt.name)
         else:
-            # A non-Theorem starts at-or-before pos, which means any
-            # earlier Theorem ended before this stmt -- pos is outside
-            # it. Reset.
+            # Either a non-Theorem starts at-or-before pos (an earlier
+            # Theorem closed before it, so pos is outside that
+            # Theorem), or a Theorem starts exactly at pos (we're on
+            # its ``theorem`` keyword, not yet inside its body).
+            # Either way, reset.
             enclosing = None
     return enclosing
 
@@ -5378,6 +5390,23 @@ def _meta_at_or_before(meta: Meta, pos: Position) -> bool:
     if meta.line < pos.line:
         return True
     if meta.line == pos.line and meta.column <= pos.column:
+        return True
+    return False
+
+
+def _meta_strictly_before(meta: Meta, pos: Position) -> bool:
+    """True iff ``meta`` starts strictly before 1-indexed ``pos``.
+
+    Same convention as :func:`_meta_at_or_before` for empty meta
+    (treated as "before"), but rejects ``pos == meta.start`` so a
+    cursor exactly on the statement's keyword isn't counted as
+    "inside" it.
+    """
+    if getattr(meta, "empty", True):
+        return True
+    if meta.line < pos.line:
+        return True
+    if meta.line == pos.line and meta.column < pos.column:
         return True
     return False
 

--- a/test/lsp/test_available_lemmas.py
+++ b/test/lsp/test_available_lemmas.py
@@ -86,7 +86,9 @@ def test_goal_drives_ranking_by_head_symbol() -> None:
 def test_no_hole_no_query_returns_browse_results() -> None:
     """Cursor not on a `?` and no `query`: browse mode surfaces every
     in-scope lemma so off-hole exploration works without inserting a
-    synthetic `?` (issue #418)."""
+    synthetic `?` (issue #418). The enclosing theorem (the one the
+    cursor sits inside) is excluded -- it can't be cited from its
+    own proof (issue #903)."""
     source = (
         "theorem alpha: true\n"
         "proof\n  .\nend\n"
@@ -100,13 +102,15 @@ def test_no_hole_no_query_returns_browse_results() -> None:
         "  reflexive\n"
         "end\n"
     )
-    # Cursor on `reflexive` (line 12), not a `?`. Browse mode returns
-    # every user-file lemma in scope at that point.
+    # Cursor on the `reflexive` line (line 14), not a `?`. Browse
+    # mode returns sibling user-file lemmas but not `gamma`, which
+    # the cursor is inside.
     matches = available_lemmas_at(
-        "lemmas.pf", source, Position(line=12, column=3)
+        "lemmas.pf", source, Position(line=14, column=3)
     )
     names = {m.name for m in matches}
-    assert {"alpha", "beta", "gamma"} <= names
+    assert {"alpha", "beta"} <= names
+    assert "gamma" not in names
 
 
 def test_user_lemmas_get_module_set_to_file_stem() -> None:
@@ -849,3 +853,127 @@ def test_browse_mode_leaves_unify_tier_unset() -> None:
     assert matches  # browse mode surfaces everything
     assert all(m.unify_tier is None for m in matches)
     assert all(m.discharged_premises == () for m in matches)
+
+
+# ---------------------------------------------------------------------------
+# Snap-to-hole (issue #903): an off-cursor (line, column) on the same line
+# as a ``?`` token snaps to that hole rather than silently falling through
+# to browse mode.
+# ---------------------------------------------------------------------------
+
+
+def test_off_cursor_same_line_snaps_to_hole() -> None:
+    """Cursor a few columns to the left of a ``?`` on the same line
+    drives goal-mode ranking, not browse mode -- the enclosing
+    theorem doesn't surface at 1.0 and ranking remains goal-shape
+    driven (issue #903)."""
+    source = (
+        "theorem and_helper: all P:bool, Q:bool."
+        " if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  pP, qQ\n"
+        "end\n"
+        "\n"
+        "theorem with_hole: all P:bool, Q:bool."
+        " if P then if Q then P and Q\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  suppose pP: P\n"
+        "  suppose qQ: Q\n"
+        "  ?\n"
+        "end\n"
+    )
+    # The `?` sits at (line=14, column=3).
+    on_hole = available_lemmas_at(
+        "lemmas.pf", source, Position(line=14, column=3)
+    )
+    # A few columns to the left of the `?`, same line.
+    off_cursor = available_lemmas_at(
+        "lemmas.pf", source, Position(line=14, column=1)
+    )
+    on_names = [m.name for m in on_hole]
+    off_names = [m.name for m in off_cursor]
+    # Snap brings the off-cursor call back to the goal-driven result
+    # set: same names, same order.
+    assert on_names == off_names
+    # And it does NOT include the enclosing theorem (with_hole).
+    assert "with_hole" not in off_names
+
+
+def test_off_cursor_closest_hole_wins() -> None:
+    """When multiple ``?`` sit on the same line, snap to the one
+    whose start column is closest to the cursor (issue #903)."""
+    # Two `?` holes on the same line; the cursor is closer to the
+    # first one's start column.
+    source = (
+        "theorem with_two_holes: all P:bool, Q:bool. P or Q or true\n"
+        "proof\n"
+        "  arbitrary P:bool, Q:bool\n"
+        "  ?       ?\n"
+        "end\n"
+    )
+    # The two `?` are at columns 3 and 11 on line 4. The cursor sits
+    # at column 4 (between them but closer to the first).
+    near_first = available_lemmas_at(
+        "lemmas.pf", source, Position(line=4, column=4)
+    )
+    # Compare against an exact-hit call at column 3.
+    exact = available_lemmas_at(
+        "lemmas.pf", source, Position(line=4, column=3)
+    )
+    assert [m.name for m in near_first] == [m.name for m in exact]
+
+
+def test_off_cursor_no_hole_on_line_stays_browse_mode() -> None:
+    """Cursor on a line without any ``?`` token doesn't snap -- the
+    call still falls through to browse mode, just like before issue
+    #903. This preserves the off-hole exploration contract."""
+    source = (
+        "theorem alpha: true\nproof\n  .\nend\n"
+        "\n"
+        "theorem beta: all P:bool. P = P\n"
+        "proof\n  arbitrary P:bool\n  reflexive\nend\n"
+        "\n"
+        "theorem with_hole: true\nproof\n  ?\nend\n"
+    )
+    # Cursor at line=8 sits on `arbitrary P:bool` -- inside `beta`,
+    # nowhere near the `?` in `with_hole`. Browse mode applies.
+    matches = available_lemmas_at(
+        "lemmas.pf", source, Position(line=8, column=3)
+    )
+    names = {m.name for m in matches}
+    # Sibling theorems still appear; `beta` (enclosing) is dropped.
+    assert "alpha" in names
+    assert "with_hole" in names
+    assert "beta" not in names
+
+
+# ---------------------------------------------------------------------------
+# Enclosing theorem exclusion in browse mode (issue #903 part 4).
+# ---------------------------------------------------------------------------
+
+
+def test_enclosing_theorem_excluded_in_browse_mode() -> None:
+    """Browse mode also drops the enclosing theorem from candidates
+    -- a proof can't cite the theorem it's editing, even when no
+    hole is present at the cursor (issue #903)."""
+    source = (
+        "theorem helper: true\nproof\n  .\nend\n"
+        "\n"
+        "theorem reverse_involutive: all P:bool. P = P\n"
+        "proof\n"
+        "  arbitrary P:bool\n"
+        "  reflexive\n"
+        "end\n"
+    )
+    # Cursor on the `reflexive` line (line 8), no `?` on that line,
+    # so browse mode applies via the no-snap fallback.
+    matches = available_lemmas_at(
+        "lemmas.pf", source, Position(line=8, column=3)
+    )
+    names = {m.name for m in matches}
+    assert "helper" in names
+    assert "reverse_involutive" not in names

--- a/test/lsp/test_mcp_server.py
+++ b/test/lsp/test_mcp_server.py
@@ -1180,7 +1180,8 @@ async def test_available_lemmas_at_accepts_hole_id(server, tmp_path):
 @pytest.mark.anyio
 async def test_available_lemmas_at_no_signal_browses(server, tmp_path):
     """No `?` and no `query`: browse mode surfaces every in-scope
-    lemma so off-hole exploration works (issue #418)."""
+    lemma so off-hole exploration works (issue #418). The enclosing
+    theorem is excluded -- a proof can't cite itself (issue #903)."""
     fp = tmp_path / "browse.pf"
     fp.write_text(
         "theorem alpha: true\nproof\n  .\nend\n"
@@ -1193,14 +1194,17 @@ async def test_available_lemmas_at_no_signal_browses(server, tmp_path):
         "  reflexive\n"
         "end\n"
     )
+    # Cursor on the `reflexive` line (line 14): inside `gamma`, so
+    # `gamma` is dropped; sibling theorems remain.
     payload = await _call(
         server,
         "available_lemmas_at",
-        {"path": str(fp), "line": 9, "column": 3},
+        {"path": str(fp), "line": 14, "column": 3},
     )
     assert isinstance(payload, list)
     names = {m["name"] for m in payload}
-    assert {"alpha", "beta", "gamma"} <= names
+    assert {"alpha", "beta"} <= names
+    assert "gamma" not in names
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes for the off-cursor MCP behavior reported in #903.

- `_find_hole_at` (in [lsp/query.py](lsp/query.py)) now snaps the cursor to the closest `?` token on the same line. An off-cursor `(line=9, column=3)` when the hole is at `(line=9, column=5)` no longer silently flips every goal-driven MCP tool (`available_lemmas_at`, `refine_at`, `case_split_at`, …) into browse mode.
- `available_lemmas_at` now excludes the enclosing theorem in browse mode too. Editing the body of `reverse_involutive` should never surface `reverse_involutive` itself as a top recommendation. To stay safe at file boundaries the enclosing-theorem detection is gated on the cursor being **strictly** past the theorem's start position (a new `_meta_strictly_before` helper), so a cursor at the very top of the file (the common test position) still gets browse-mode results that include the first theorem.

This is the issue's recommended "minimum" of suggestions (1) + (4); the snap is the closest-by-column policy for multi-hole lines.

## Test plan

- [x] `python3.13 -m pytest test/lsp/test_available_lemmas.py` (31 passed)
- [x] `python3.13 -m pytest test/lsp/ --ignore=test/lsp/test_dap_server.py --ignore=test/lsp/test_debugger*.py` (421 passed)
- [x] `python3.13 -m pytest test/unit/` (539 passed)
- [x] `make static` (ruff + mypy clean)
- [x] Reproducer from the issue: off-cursor `(line=N, col=hole_col-2)` now returns the same goal-driven result set as the on-cursor call, and `reverse_involutive` no longer ranks at 1.0 against its own body.

New regression tests:

- `test_off_cursor_same_line_snaps_to_hole` — off-cursor and on-cursor yield identical ranked lists.
- `test_off_cursor_closest_hole_wins` — multi-hole line snaps to the nearest `?`.
- `test_off_cursor_no_hole_on_line_stays_browse_mode` — no `?` on the line ⇒ still browse mode.
- `test_enclosing_theorem_excluded_in_browse_mode` — browse mode also drops the enclosing theorem.

Updated tests that previously asserted the enclosing theorem stayed in browse-mode results:

- `test_no_hole_no_query_returns_browse_results` (in `test/lsp/test_available_lemmas.py`)
- `test_available_lemmas_at_no_signal_browses` (in `test/lsp/test_mcp_server.py`)

Closes #903. Builds on #902 (the original goal-driven ranking fix).

[Claude session](claude://resume?session=90e82950-b0ee-4818-ad72-6ab78a3f1b50) — fallback UUID: `90e82950-b0ee-4818-ad72-6ab78a3f1b50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
