### PR TITLE
Better diagnostic when a tactic leaves a `true` residual (closes #905)

### DIFF
--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -1428,6 +1428,34 @@ def _check_proof_of_evaluate_goal(proof: EvaluateGoal, formula: CheckedFormula, 
           + str(red_formula)
           + givens_str(env))
 
+def _missing_period_after_tactic(tactic_loc: Meta, body: Proof,
+                                 residual: CheckedFormula,
+                                 tactic: str, env: Env) -> bool:
+  # When a tactic-style goal (`replace` / `expand` / `simplify`) has a
+  # `PHole` body and the residual reduces to `true`, the user is one
+  # period away from a valid proof. The generic `PHole` diagnostic
+  # reports `Goal: true` with the equally generic advice "prove `true`
+  # with a period," which is correct but doesn't point at the tactic
+  # that produced the tautology -- in an `equations` chain especially,
+  # the body location reads as the next step's boundary and the user
+  # has to figure out which step is missing the period. Emit a
+  # targeted hint anchored at the tactic itself and return `True` so
+  # the caller skips the generic path.
+  if not isinstance(body, PHole):
+    return False
+  reduced = remove_mark(residual).reduce(env)
+  if not (isinstance(reduced, Bool) and reduced.value is True):
+    return False
+  add_incomplete(tactic_loc,
+    style.bold_red('incomplete proof') + '\n'
+    + 'the `' + tactic + '` already reduced the goal to `true`.\n'
+    + style.dark_green('Advice:') + '\n'
+    + '\tAdd a trailing `.` after `' + tactic
+    + '` (e.g. `by ' + tactic + ' ... .`) to close this step.\n'
+    + givens_str(env),
+    formula=reduced, env=env)
+  return True
+
 def _check_proof_of_rewrite_goal(proof: RewriteGoal, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   equations = [check_proof(proof, env) for proof in proof.equations]
@@ -1435,6 +1463,8 @@ def _check_proof_of_rewrite_goal(proof: RewriteGoal, formula: CheckedFormula, en
   new_formula = formula.reduce(env)
   new_formula = apply_rewrites(loc, new_formula, eqns, env,
                                display_formula=formula)
+  if _missing_period_after_tactic(loc, proof.body, new_formula, 'replace', env):
+    return
   _try_check_proof_of(proof.body, new_formula, env)
 
 def _check_proof_of_simplify_goal(proof: SimplifyGoal, formula: CheckedFormula, env: Env) -> None:
@@ -1444,12 +1474,16 @@ def _check_proof_of_simplify_goal(proof: SimplifyGoal, formula: CheckedFormula, 
   eqns = [equation.reduce(env) for equation in equations]
   new_formula = apply_rewrites(loc, formula, eqns, env)
   new_formula = new_formula.reduce(env)
+  if _missing_period_after_tactic(loc, proof.body, new_formula, 'simplify', env):
+    return
   _try_check_proof_of(proof.body, new_formula, env)
 
 def _check_proof_of_apply_defs_goal(proof: ApplyDefsGoal, formula: CheckedFormula, env: Env) -> None:
   loc = proof.location
   new_formula = expand_definitions(loc, formula, proof.definitions, env)
   red_formula = new_formula.reduce(env)
+  if _missing_period_after_tactic(loc, proof.body, red_formula, 'expand', env):
+    return
   sink = get_active_sink()
   before_len = len(sink.errors) if sink is not None else 0
   try:

--- a/test/should-error/equations_replace_no_period_905.pf
+++ b/test/should-error/equations_replace_no_period_905.pf
@@ -1,0 +1,22 @@
+import UInt
+import List
+
+// Regression test for #905. A tactic-style `by REASON` in an `equations`
+// step needs a trailing `.` to close the residual that the rewrite/
+// expansion leaves behind. When the period is missing and the residual
+// happens to reduce to `true`, the user used to see the generic
+// "incomplete proof; Goal: true" diagnostic, anchored at the *next*
+// equation step. The new diagnostic names the tactic (`replace` here),
+// anchors at the tactic itself, and tells the user exactly what to add.
+theorem bug_905: all xs:List<UInt>, ys:List<UInt>, zs:List<UInt>, x:UInt, y:UInt.
+  if length(node(x,xs)) = length(ys) then if ys = node(y,zs) then 1 + length(xs) = 1 + length(zs)
+proof
+  arbitrary xs:List<UInt>, ys:List<UInt>, zs:List<UInt>, x:UInt, y:UInt
+  suppose len_eq: length(node(x,xs)) = length(ys)
+  suppose ys_def: ys = node(y,zs)
+  equations
+    1 + length(xs) =# length(node(x, xs)) #  by expand length.
+               ... = length(ys)              by len_eq
+               ... = length(node(y, zs))     by replace ys_def
+               ... = 1 + length(zs)          by expand length.
+end

--- a/test/should-error/equations_replace_no_period_905.pf.err
+++ b/test/should-error/equations_replace_no_period_905.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/equations_replace_no_period_905.pf:20.49-20.63: incomplete proof
+the `replace` already reduced the goal to `true`.
+Advice:
+	Add a trailing `.` after `replace` (e.g. `by replace ... .`) to close this step.
+
+Givens:
+	ys_def: ys = node(y, zs),
+	len_eq: length(node(x, xs)) = length(ys)

--- a/test/should-error/simplify1.pf.err
+++ b/test/should-error/simplify1.pf.err
@@ -1,5 +1,5 @@
-./test/should-error/simplify1.pf:4.3-4.4: incomplete proof
-Goal:
-	true
+./test/should-error/simplify1.pf:3.3-3.11: incomplete proof
+the `simplify` already reduced the goal to `true`.
 Advice:
-	You can prove "true" with a period.
+	Add a trailing `.` after `simplify` (e.g. `by simplify ... .`) to close this step.
+


### PR DESCRIPTION
## Summary

Fixes #905. In an `equations` chain, a step like `... = b by replace foo` (no trailing `.`) used to fail with the generic `incomplete proof; Goal: true` — anchored at the *next* equation step's `=`, with the equally generic advice "you can prove `true` with a period." The advice was technically correct but it didn't point at the tactic that produced the tautology, so the user had to walk back through the chain and guess which step was missing the period. And whether the failure fired at all was sensitive to whether the *previous* step happened to use `replace`, because equivalent rewrites can produce different ASTs.

This PR keeps the period requirement (so writing tactics the same way in and out of `equations` continues to work the same way) and replaces the diagnostic with a targeted one when the body is `PHole` and the tactic's residual reduces to `true`:

```
…/file.pf:23.49-23.63: incomplete proof
the `replace` already reduced the goal to `true`.
Advice:
	Add a trailing `.` after `replace` (e.g. `by replace ... .`) to close this step.

Givens:
	ys_def: ys = node(y, zs),
	len_eq: length(node(x, xs)) = length(ys)
```

The new diagnostic is anchored at the tactic itself, names which tactic produced the tautology, and tells the user the exact one-character fix. Applied uniformly to `replace`, `expand`, and `simplify`, in or out of an `equations` chain.

Note on alternative I rejected: an earlier draft auto-closed a missing-period `PHole` to `PTrue` so `by replace foo` (no period) would succeed when the residual is `true`. That fix worked but only inside `equations`, which introduced a new inconsistency — `replace foo` would silently succeed there but error elsewhere. The user surfaced that concern in review; this revision drops the auto-close.

## Test plan
- [x] `test/should-error/equations_replace_no_period_905.pf` — captures the issue's `bug` reproducer and the new diagnostic shape (location, wording, advice, givens).
- [x] `test/should-error/simplify1.pf.err` updated to the new wording.
- [x] Full `python test-deduce.py` (lib + passable + errors + equiv + prelude + parser, both parsers) and `pytest test/unit` pass locally.
- [x] `make static` clean.
- [x] Manual smoke: the original `ok` baseline still validates; the `bug` repro now errors with the targeted message; a top-level `expand length` (no period) gets the same targeted message.

[Claude session](claude://resume?session=26d42874-8779-4d08-b89e-6bd26ab8b7d4) — fallback UUID: `26d42874-8779-4d08-b89e-6bd26ab8b7d4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
