### PR TITLE
Expand parser round-trip corpus with 11 should-validate files (Refs #473)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -144,6 +144,21 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/bintree.pf",
     "./test/should-validate/uint_viewrec.pf",
     "./lib/Option.pf",
+    # Broaden coverage to additional small files that already
+    # round-trip cleanly under today's pretty-printer. Each one
+    # exercises a distinct surface construct so a regression in
+    # any of these forms is caught here too.
+    "./test/should-validate/empty_file.pf",        # empty input
+    "./test/should-validate/bicond1.pf",           # biconditional <=>
+    "./test/should-validate/conditional1.pf",      # if-then-else term
+    "./test/should-validate/array1.pf",            # array literal + indexing
+    "./test/should-validate/some1.pf",             # existential + `choose`
+    "./test/should-validate/inst1.pf",             # all-elim by application
+    "./test/should-validate/switch_term.pf",       # switch in a term position
+    "./test/should-validate/predicate_basic.pf",   # `predicate` declaration
+    "./test/should-validate/relation_basic.pf",    # `relation` declaration
+    "./test/should-validate/opaque_define.pf",     # `opaque` visibility
+    "./test/should-validate/import_using.pf",      # `import ... using ...`
 )
 
 


### PR DESCRIPTION
## Summary

- Expand `PARSER_ROUND_TRIP_FILES` in `test-deduce.py` from 6 to 17 entries.
- Each addition is a small `test/should-validate` file that exercises a
  distinct surface construct not represented in the previous curated set,
  and already round-trips cleanly under today's pretty-printer.
- No pretty-printer changes — broader regression coverage only.

## Constructs newly exercised by round-trip

| File | Construct |
|---|---|
| `empty_file.pf` | empty input |
| `bicond1.pf` | biconditional `<=>` |
| `conditional1.pf` | `if … then … else` term |
| `array1.pf` | array literal and indexing |
| `some1.pf` | existential + `choose` |
| `inst1.pf` | all-elimination by application |
| `switch_term.pf` | `switch` in a term position |
| `predicate_basic.pf` | `predicate` declaration |
| `relation_basic.pf` | `relation` declaration |
| `opaque_define.pf` | `opaque` visibility |
| `import_using.pf` | `import … using …` |

## Validation

- `python3 test-deduce.py --equiv --workers 1` — passes (`lib + should-validate`
  parser equivalence in ~54 s, expanded pretty-print round-trip in ~12 s).
- `make static` — ruff + mypy clean.

## Issue

Refs #473 — parser equivalence umbrella.

Sub-task status (per the "Status after #893" checklist in the issue):

- [ ] Continue migrating remaining `Reference.md` grammar fragments — **not
      addressed here**; covered by #893 and #904, with one block
      (`formula ::= term`) intentionally left unmarked.
- [ ] Decide whether and how much of `test/should-error/` should participate
      in parser equivalence checks — **not addressed here**.
- [ ] Expand round-trip coverage after improving the pretty-printer for
      currently non-parse-preserving proof/declaration forms — **partially
      addressed**: this PR picks up the files that already round-trip
      under today's pretty-printer without any pretty-printer changes.
      Further expansion still needs pretty-printer work for the
      non-parse-preserving forms.

The umbrella issue stays open.

## Test plan

- [ ] `make tests` green in CI.
- [ ] `test-deduce.py --site` green in CI (site mode).

[Claude session](claude://resume?session=08d41d66-2275-4b6f-805b-2d18ade114ea) — fallback UUID: `08d41d66-2275-4b6f-805b-2d18ade114ea`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
