### PR TITLE
lib/BigO.pf: add bigo_add_dominated and bigo_pow_add_dominated (refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -656,6 +656,20 @@ proof
   A, B
 end
 
+// Sibling of `bigo_add_dominated_absorb_equiv` with the summands in the
+// opposite order: if `f ≲ g` then `f + g ≈ g`. Lets callers write the
+// dominant function on the right of `+` without first invoking
+// commutativity.
+theorem bigo_add_dominated: all f:fn UInt->UInt, g:fn UInt->UInt.
+  if f ≲ g then f + g ≈ g
+proof
+  arbitrary f:fn UInt->UInt, g:fn UInt->UInt
+  assume f_g: f ≲ g
+  have gf_g: g + f ≈ g by apply bigo_add_dominated_absorb_equiv[g, f] to f_g
+  have fg_gf: f + g ≈ g + f by bigo_add_commute
+  apply bigo_equiv_trans to fg_gf, gf_g
+end
+
 // A positive constant factor drops out of ≈.
 theorem bigo_const_mult_equiv: all f:fn UInt->UInt, k:UInt.
   if 0 < k then k * f ≈ f
@@ -1342,6 +1356,21 @@ proof
   replace pow_factor
   replace uint_mult_commute[c, n^a]
   mult_step
+end
+
+// Monomial-sum dominance: when `a ≤ b`, adding a lower-degree monomial
+// `n^a` to the higher-degree monomial `n^b` does not change the
+// asymptotic equivalence class — the lower-degree term is absorbed.
+// Specializes `bigo_add_dominated` along `bigo_pow_mono`.
+theorem bigo_pow_add_dominated: all a:UInt, b:UInt.
+  if a ≤ b
+  then (fun n:UInt { n^a }) + (fun n:UInt { n^b }) ≈ (fun n:UInt { n^b })
+proof
+  arbitrary a:UInt, b:UInt
+  assume a_le_b: a ≤ b
+  have na_le_nb: (fun n:UInt { n^a }) ≲ (fun n:UInt { n^b })
+    by apply bigo_pow_mono to a_le_b
+  apply bigo_add_dominated[fun n:UInt { n^a }, fun n:UInt { n^b }] to na_le_nb
 end
 
 // Polynomial closure, degree 1: a degree-1 polynomial with positive leading


### PR DESCRIPTION
## Summary

Addresses [#725](https://github.com/jsiek/deduce/issues/725) (Section F monomial-sum slice). Two small `lib/BigO.pf` additions:

- `bigo_add_dominated`: `if f ≲ g then f + g ≈ g` — a sibling of the existing
  `bigo_add_dominated_absorb_equiv` with the operands flipped. Lets callers
  put the dominant function on the right of `+` without invoking
  `bigo_add_commute` by hand.
- `bigo_pow_add_dominated`: `if a ≤ b then (fun n. n^a) + (fun n. n^b) ≈ (fun n. n^b)` —
  the monomial-level "sum of polynomials" claim from Section F of #725,
  derived from `bigo_pow_mono` via `bigo_add_dominated`.

## Catalogue status (sub-tasks of #725)

This PR completes (one bullet from Section F):

- [x] Section F: "Sum of polynomials: `O(p(n)) + O(q(n)) ≈ O(max-degree)`" — at the monomial level. The full polynomial version remains.

Remaining in #725 after this PR:

- Section E: `O_sqrt_n` (needs a `UInt sqrt`).
- Section F: full `poly_eval(p1, n) + poly_eval(p2, n) ≈ poly_eval of max-degree` generalization (beyond the monomial-level slice).
- Section G: change-of-base for `log_b` for general bases (or document the current `log = log_2` convention).
- Section G strict variant: `log(log(n)) ≪ log(n)`.
- Section H: standard asymptotic summation formulas (depends on the Int summation work in #719/#910).
- Section I: recurrences / Master Theorem (separate research project).
- Section J: ongoing per-theorem doc comments (the file already has these for current theorems; this PR's additions include them).

## Test plan

- [x] `mcp__deduce__check_file` on `lib/BigO.pf` with `parser=both` → no diagnostics
- [x] `make static` (ruff + mypy, both runs) clean
- [x] `python test-deduce.py --lib` passes (both parsers, lib + parser-equivalence corpus)
- [x] `python test-deduce.py --equiv` passes
- [ ] Full CI run on PR

[Claude session](claude://resume?session=9a46b365-443d-4fce-8e99-9542b013ec88) — fallback UUID: `9a46b365-443d-4fce-8e99-9542b013ec88`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
