### PR TITLE
lib/BigO.pf: add bigo_summation_const_one (refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -1730,3 +1730,21 @@ proof
   }
   upper, lower
 end
+
+// `Σ_{i<n} 1 ≈ O_n`: summing the constant 1 over a range of length `n`
+// is asymptotically linear. The simplest of the standard asymptotic
+// summation formulas (CLRS / Knuth) and the first slice of Section H
+// of the BigO catalogue (#725).
+theorem bigo_summation_const_one:
+  (fun x:UInt { uint_summation(x, 0, fun i:UInt { 1 }) }) ≈ O_n
+proof
+  have pointwise: all m:UInt.
+      (fun x:UInt { uint_summation(x, 0, fun i:UInt { 1 }) })(m) = O_n(m) by {
+    arbitrary m:UInt
+    expand O_n
+    show uint_summation(m, 0, fun i:UInt { 1 }) = m
+    uint_summation_const_one[m, 0]
+  }
+  apply bigo_pointwise_eq[fun x:UInt { uint_summation(x, 0, fun i:UInt { 1 }) }, O_n]
+    to pointwise
+end

--- a/lib/NatSum.pf
+++ b/lib/NatSum.pf
@@ -199,6 +199,26 @@ proof
   }
 end
 
+// Summing the constant function `1` over a range of length `n` equals
+// `n`. The simplest of the standard asymptotic-summation building blocks.
+theorem summation_const_one: all n:Nat. all s:Nat.
+  summation(n, s, fun i:Nat { suc(zero) }) = n
+proof
+  induction Nat
+  case zero {
+    arbitrary s:Nat
+    expand summation.
+  }
+  case suc(n') assume IH {
+    arbitrary s:Nat
+    suffices suc(zero) + summation(n', suc(s), fun i:Nat { suc(zero) }) = suc(n')
+      by expand summation.
+    replace IH[suc(s)]
+    show suc(zero) + n' = suc(n')
+    expand operator+.
+  }
+end
+
 // Append a final term to a summation: `Σ_{i<n+1} f(s+i) = Σ_{i<n} + f(s+n)`.
 lemma summation_suc_add: all n:Nat, s:Nat, f:fn Nat->Nat.
   summation(suc(zero) + n, s, f) = summation(n, s, f) + f(s + n)

--- a/lib/UIntSum.pf
+++ b/lib/UIntSum.pf
@@ -142,3 +142,30 @@ proof
       λ i { toNat(g(fromNat(i))) },
       λ i { toNat(h(fromNat(i))) }] to p1, p2).
 end
+
+// UInt analogue of `summation_const_one`: summing the constant `1`
+// over a UInt range of length `n` equals `n`. Transported through
+// `toNat`/`fromNat` to the Nat lemma.
+theorem uint_summation_const_one: all n:UInt. all s:UInt.
+  uint_summation(n, s, fun i:UInt { 1 }) = n
+proof
+  arbitrary n:UInt
+  arbitrary s:UInt
+  suffices toNat(uint_summation(n, s, fun i:UInt { 1 })) = toNat(n)
+    by uint_toNat_injective
+  replace toNat_uint_summation
+  have body_eq:
+    summation(toNat(n), toNat(s),
+              λ j { toNat((fun u:UInt { 1 })(fromNat(j))) })
+    = summation(toNat(n), toNat(s), fun j:Nat { suc(zero) }) by {
+    apply summation_cong[toNat(n),
+        λ j { toNat((fun u:UInt { 1 })(fromNat(j))) },
+        fun j:Nat { suc(zero) },
+        toNat(s), toNat(s)]
+    to arbitrary i:Nat
+       assume _
+       evaluate
+  }
+  replace body_eq
+  summation_const_one[toNat(n), toNat(s)]
+end


### PR DESCRIPTION
## Summary

Addresses [#725](https://github.com/jsiek/deduce/issues/725) (Section H — first
slice). With `lib/IntSum.pf` now landed (#910), the standard asymptotic-summation
formulas from CLRS/Knuth are unblocked. This PR adds the simplest of them and
the supporting closed-form lemmas:

- `summation_const_one` (lib/NatSum.pf): `Σ_{i<n} 1 = n` over Nat, by
  induction on `n`. Base case is `summation(zero, …) = zero`; step uses
  `summation(suc(n'), …) = 1 + summation(n', …)`.
- `uint_summation_const_one` (lib/UIntSum.pf): the UInt analogue
  `uint_summation(n, s, fun i { 1 }) = n`, transported through
  `toNat`/`fromNat` to the Nat lemma via `summation_cong`.
- `bigo_summation_const_one` (lib/BigO.pf): the asymptotic statement
  `(fun n. uint_summation(n, 0, fun i { 1 })) ≈ O_n`, by
  `bigo_pointwise_eq` applied to the UInt lemma.

## Catalogue status (sub-tasks of #725)

Completes one bullet from Section H:

- [x] `sum_{i=0}^{n} 1 ≈ O_n`.

Remaining in Section H (each needs more infrastructure than this slice):

- `sum_{i=0}^{n} i ≈ O_n2` — needs a Gauss-style closed form or a direct
  bounding lemma over UInt.
- `sum_{i=0}^{n} i^k ≈ (fun n. n^(k+1))`.
- `sum_{i=0}^{n} 2^i ≈ O_2pow_n` (geometric series).
- `sum_{i=0}^{n} a^i ≈ (fun n. a^n)` for `a > 1`.
- Harmonic — needs rationals or a rational-free reformulation.

## Test plan

- [x] `python deduce.py --quiet lib/NatSum.pf` — valid
- [x] `python deduce.py --quiet lib/UIntSum.pf` — valid
- [x] `python deduce.py --quiet lib/BigO.pf` — valid
- [x] `python test-deduce.py --lib` — pass (both parsers)
- [x] `python test-deduce.py --equiv` — pass (parser equivalence + round-trip)
- [x] `python test-deduce.py --passable` — pass (both parsers)
- [x] `make static` — ruff + mypy clean
- [ ] Full CI run on PR

[Claude session](claude://resume?session=78c88e12-a713-4283-8f94-eb9b08262a24) — fallback UUID: `78c88e12-a713-4283-8f94-eb9b08262a24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
