### PR TITLE
lib/BigO.pf: add bigo_summation_pow2 (refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -1862,3 +1862,80 @@ proof
 
   upper, lower
 end
+
+// `Σ_{i<n} 2^i ≈ O_2pow_n`: the geometric-series bound. From the closed
+// form `1 + Σ = 2^n` (`uint_summation_pow2_succ`), the upper bound
+// `Σ ≤ 2^n` follows at `(n0, c) = (0, 1)` and the lower bound `2^n ≤ 2·Σ`
+// at `(n0, c) = (1, 2)`: when `n ≥ 1`, `2^n ≥ 2`, so `Σ = 2^n − 1 ≥ 1`,
+// giving `2·Σ = Σ + Σ ≥ 1 + Σ = 2^n`. Third slice of Section H of the
+// BigO catalogue (#725).
+theorem bigo_summation_pow2:
+  (fun x:UInt { uint_summation(x, 0, fun i:UInt { 2 ^ i }) }) ≈ O_2pow_n
+proof
+  expand operator≈
+  have closed: all m:UInt.
+    1 + uint_summation(m, 0, fun i:UInt { 2 ^ i }) = 2 ^ m
+    by uint_summation_pow2_succ
+
+  // Upper: Σ ≤ 1 + Σ = 2^n.
+  have upper: (fun x:UInt { uint_summation(x, 0, fun i:UInt { 2 ^ i }) })
+              ≲ O_2pow_n by {
+    expand operator≲
+    choose 0, 1
+    arbitrary n:UInt
+    assume _
+    show uint_summation(n, 0, fun i:UInt { 2 ^ i }) ≤ 1 * O_2pow_n(n)
+    expand O_2pow_n
+    have one_S_eq: 1 + uint_summation(n, 0, fun i:UInt { 2 ^ i }) = 2 ^ n
+      by closed[n]
+    have S_le_oneS: uint_summation(n, 0, fun i:UInt { 2 ^ i })
+                    ≤ 1 + uint_summation(n, 0, fun i:UInt { 2 ^ i })
+      by uint_less_equal_add_left
+    replace symmetric one_S_eq
+    S_le_oneS
+  }
+
+  // Lower: 2·Σ = Σ + Σ ≥ 1 + Σ = 2^n, since Σ ≥ 1 when n ≥ 1.
+  have lower: O_2pow_n
+              ≲ (fun x:UInt { uint_summation(x, 0, fun i:UInt { 2 ^ i }) }) by {
+    expand operator≲
+    choose 1, 2
+    arbitrary n:UInt
+    assume one_le_n: 1 ≤ n
+    show O_2pow_n(n) ≤ 2 * uint_summation(n, 0, fun i:UInt { 2 ^ i })
+    expand O_2pow_n
+    have one_S_eq: 1 + uint_summation(n, 0, fun i:UInt { 2 ^ i }) = 2 ^ n
+      by closed[n]
+
+    // `2^n ≥ 2^1 = 2`, hence `1 + Σ = 2^n ≥ 2`, hence `Σ ≥ 1`.
+    have two_le_pow: (2:UInt) ≤ 2 ^ n
+      by apply (apply uint_pow_le_mono_r[n, 2, 1]
+                to (conclude (1:UInt) ≤ 2 by .)) to one_le_n
+    have one_le_S: 1 ≤ uint_summation(n, 0, fun i:UInt { 2 ^ i }) by {
+      have step: 1 + 1 ≤ 1 + uint_summation(n, 0, fun i:UInt { 2 ^ i }) by {
+        replace one_S_eq
+        two_le_pow
+      }
+      apply uint_add_both_sides_of_less_equal[1, 1,
+            uint_summation(n, 0, fun i:UInt { 2 ^ i })] to step
+    }
+
+    // `2 · Σ = Σ + Σ ≥ 1 + Σ = 2^n`.
+    have twoS_eq: 2 * uint_summation(n, 0, fun i:UInt { 2 ^ i })
+                = uint_summation(n, 0, fun i:UInt { 2 ^ i })
+                + uint_summation(n, 0, fun i:UInt { 2 ^ i })
+      by uint_two_mult
+    have oneS_le_twoS: 1 + uint_summation(n, 0, fun i:UInt { 2 ^ i })
+                     ≤ 2 * uint_summation(n, 0, fun i:UInt { 2 ^ i }) by {
+      replace twoS_eq
+      apply uint_add_mono_less_equal[1, uint_summation(n, 0, fun i:UInt { 2 ^ i }),
+            uint_summation(n, 0, fun i:UInt { 2 ^ i }),
+            uint_summation(n, 0, fun i:UInt { 2 ^ i })]
+        to one_le_S, uint_less_equal_refl
+    }
+    replace symmetric one_S_eq
+    oneS_le_twoS
+  }
+
+  upper, lower
+end

--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -311,6 +311,38 @@ proof
     }
 end
 
+// Geometric sum closed form: Σ_{i<n} 2^i = 2^n − 1, stated additively
+// as `1 + Σ = 2^n` to stay in Nat (no monus). Proved by induction on n,
+// peeling off the final term via `summation_suc_add` and reducing
+// `2^(suc n') = 2 * 2^n'` to `2^n' + 2^n'`.
+theorem summation_pow2_succ: all n:Nat.
+  ℕ1 + summation(n, ℕ0, λ i:Nat { ℕ2 ^ i }) = ℕ2 ^ n
+proof
+  induction Nat
+  case zero {
+    expand summation
+    evaluate
+  }
+  case suc(n') suppose IH {
+    show ℕ1 + summation(suc(n'), ℕ0, λ i:Nat { ℕ2 ^ i }) = ℕ2 ^ suc(n')
+    have e_suc: suc(zero) + n' = suc(n') by expand operator+.
+    have step:
+      summation(suc(n'), ℕ0, λ i:Nat { ℕ2 ^ i })
+      = summation(n', ℕ0, λ i:Nat { ℕ2 ^ i }) + ℕ2 ^ n'
+    by {
+      have h1: summation(suc(zero) + n', ℕ0, λ i:Nat { ℕ2 ^ i })
+             = summation(n', ℕ0, λ i:Nat { ℕ2 ^ i }) + (λ i:Nat { ℕ2 ^ i })(ℕ0 + n')
+        by summation_suc_add[n', ℕ0, λ i:Nat { ℕ2 ^ i }]
+      replace e_suc in h1
+    }
+    replace step | IH
+    show ℕ2 ^ n' + ℕ2 ^ n' = ℕ2 ^ suc(n')
+    have pow_step: ℕ2 ^ suc(n') = ℕ2 * ℕ2 ^ n' by expand operator^ | expt.
+    replace pow_step
+    symmetric lit_two_mult[ℕ2 ^ n']
+  }
+end
+
 // Closed form: twice the sum 0+1+...+n equals n*(n+1).
 theorem sum_n' : all n : Nat.
     ℕ2 * summation(suc(n), ℕ0, λ x {x}) = n * (n + ℕ1)

--- a/lib/UIntSum.pf
+++ b/lib/UIntSum.pf
@@ -8,6 +8,7 @@ import UIntLess
 import UIntAdd
 import UIntMult
 import UIntMonus
+import UIntPowLog
 
 /*
   Finite summation over UInt ranges.
@@ -170,6 +171,46 @@ proof
   }
   replace body_eq
   summation_const_one[toNat(n), toNat(s)]
+end
+
+// UInt analogue of `summation_pow2_succ` (lib/Nat.pf): the geometric
+// sum closed form `1 + Σ_{i<n} 2^i = 2^n`. Transported through
+// `toNat`/`fromNat` to the Nat lemma. The additive form keeps the
+// closed form in UInt (no monus).
+theorem uint_summation_pow2_succ: all n:UInt.
+  (1:UInt) + uint_summation(n, 0, fun i:UInt { 2 ^ i }) = 2 ^ n
+proof
+  arbitrary n:UInt
+  suffices toNat((1:UInt) + uint_summation(n, 0, fun i:UInt { 2 ^ i }))
+           = toNat(2 ^ n) by uint_toNat_injective
+  replace toNat_add | toNat_uint_summation
+  have body_eq:
+    summation(toNat(n), toNat(0:UInt),
+              λ j { toNat((fun u:UInt { 2 ^ u })(fromNat(j))) })
+    = summation(toNat(n), ℕ0, λ j:Nat { ℕ2 ^ j }) by {
+    apply summation_cong[toNat(n),
+        λ j { toNat((fun u:UInt { 2 ^ u })(fromNat(j))) },
+        λ j:Nat { ℕ2 ^ j },
+        toNat(0:UInt), ℕ0]
+    to arbitrary i:Nat
+       assume _
+       have tonat_zero: toNat(0:UInt) = ℕ0
+         by replace symmetric from_zero in uint_toNat_fromNat[ℕ0]
+       replace tonat_zero
+       show toNat((2:UInt) ^ fromNat(ℕ0 + i)) = ℕ2 ^ (ℕ0 + i)
+       replace toNat_expt | uint_toNat_fromNat.
+  }
+  replace body_eq
+  have tonat_one: toNat(1:UInt) = ℕ1 by {
+    have h: toNat(fromNat(ℕ1)) = ℕ1 by uint_toNat_fromNat
+    h
+  }
+  have tonat_two: toNat(2:UInt) = ℕ2 by {
+    have h: toNat(fromNat(ℕ2)) = ℕ2 by uint_toNat_fromNat
+    h
+  }
+  replace toNat_expt | tonat_one | tonat_two
+  summation_pow2_succ[toNat(n)]
 end
 
 // UInt analogue of `sum_n` (lib/Nat.pf): twice the sum 0+1+...+(n-1)


### PR DESCRIPTION
## Summary

Section H next slice of [#725](https://github.com/jsiek/deduce/issues/725) — geometric-sum bound `Σ_{i<n} 2^i ≈ O_2pow_n`. Follows [#912](https://github.com/jsiek/deduce/pull/912) (`Σ 1 ≈ O_n`) and [#913](https://github.com/jsiek/deduce/pull/913) (`Σ i ≈ O_n2`).

This PR completes one slice of #725; the issue's other Section H entries (Σ i^k, harmonic) and remaining sections (E rest, G rest, I, J rest) stay open. See the "Sub-task status" section below.

## Changes

- `summation_pow2_succ` (lib/Nat.pf): closed form `1 + summation(n, 0, λ i { 2 ^ i }) = 2 ^ n` over Nat, by induction on n. Stated additively to avoid Nat monus.
- `uint_summation_pow2_succ` (lib/UIntSum.pf): UInt analogue, via `toNat`/`fromNat`.
- `bigo_summation_pow2` (lib/BigO.pf): the BigO theorem. Upper bound at (n0, c) = (0, 1) via `Σ ≤ 1 + Σ = 2^n`; lower bound at (1, 2) uses `2^n ≥ 2` (from `uint_pow_le_mono_r`) to derive `Σ ≥ 1`, then `2·Σ = Σ + Σ ≥ 1 + Σ = 2^n`.

Also adds `import UIntPowLog` to `lib/UIntSum.pf` so the UInt analogue can reach `toNat_expt` (no cycle — `UIntPowLog` does not import `UIntSum`).

## Sub-task status for #725

Completed by this PR:
- [x] Section H — `Σ_{i<n} 2^i ≈ O_2pow_n` (geometric series)

Already done before this PR (see #912, #913):
- [x] Section H — `Σ 1 ≈ O_n`
- [x] Section H — `Σ i ≈ O_n2`

Remaining:
- [ ] Section E (rest) — general `n^k ≲ 2^n` family
- [ ] Section G (rest) — change of base for `log_b`
- [ ] Section H (rest) — `Σ i^k`, more general geometric `Σ a^i` for `a > 1`, harmonic
- [ ] Section I — recurrences
- [ ] Section J (rest) — per-theorem docstrings for other stdlib files still missing them, tracked alongside #99

## Test plan
- [x] `python deduce.py -r lib --no-stdlib --dir lib` (recursive-descent)
- [x] `python deduce.py --lalr -r lib --no-stdlib --dir lib` (LALR)
- [x] `python test-deduce.py --lib` — all 38 lib modules pass under both parsers
- [x] `make static` — ruff + mypy clean
- [ ] CI green

[Claude session](claude://resume?session=aab7c598-a0b9-4a70-a5d7-4645b055b12d) — fallback UUID: `aab7c598-a0b9-4a70-a5d7-4645b055b12d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
