### PR TITLE
lib/BigO.pf: add bigo_summation_pow (refs #725)

### DIFF
--- a/lib/BigO.pf
+++ b/lib/BigO.pf
@@ -1939,3 +1939,148 @@ proof
 
   upper, lower
 end
+
+// `Σ_{i<n} a^i ≈ (fun n. a^n)` for `2 ≤ a`: the generic geometric-series
+// bound, generalising `bigo_summation_pow2`. From the closed form
+// `1 + (a − 1) · Σ = a^n` (`uint_summation_pow_succ`), the upper bound
+// `Σ ≤ a^n` follows at `(n0, c) = (0, 1)` via `Σ ≤ (a − 1) · Σ ≤ 1 + (a − 1) · Σ`,
+// and the lower bound `a^n ≤ a · Σ` at `(n0, c) = (1, a)` via
+// `Σ ≥ 1` for `n ≥ 1` (since `a^n ≥ a ≥ 2`, so `(a − 1) · Σ ≥ 1`, and
+// `a − 1 ≥ 1` forces `Σ ≥ 1`), then `a · Σ = (a − 1) · Σ + Σ ≥ (a − 1) · Σ + 1 = a^n`.
+// Fourth slice of Section H of the BigO catalogue (#725).
+theorem bigo_summation_pow: all a:UInt. if 2 ≤ a then
+  (fun x:UInt { uint_summation(x, 0, fun i:UInt { a ^ i }) })
+  ≈ (fun x:UInt { a ^ x })
+proof
+  arbitrary a:UInt
+  assume two_le_a: 2 ≤ a
+
+  have one_le_a: 1 ≤ a by {
+    have h: (1:UInt) ≤ 2 by .
+    apply uint_less_equal_trans to h, two_le_a
+  }
+  have one_le_am1: 1 ≤ a ∸ 1 by {
+    have ident: 1 + (a ∸ 1) = a by apply uint_monus_add_identity[a, 1] to one_le_a
+    have step: 1 + 1 ≤ 1 + (a ∸ 1) by {
+      replace ident
+      two_le_a
+    }
+    apply uint_add_both_sides_of_less_equal[1, 1, a ∸ 1] to step
+  }
+
+  have closed: all n:UInt.
+    1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) = a ^ n
+    by apply uint_summation_pow_succ to one_le_a
+
+  expand operator≈
+
+  // Upper: Σ ≤ (a − 1) · Σ ≤ 1 + (a − 1) · Σ = a^n.
+  have upper: (fun x:UInt { uint_summation(x, 0, fun i:UInt { a ^ i }) })
+              ≲ (fun x:UInt { a ^ x }) by {
+    expand operator≲
+    choose 0, 1
+    arbitrary n:UInt
+    assume _
+    show uint_summation(n, 0, fun i:UInt { a ^ i }) ≤ 1 * (fun x:UInt { a ^ x })(n)
+    have an_eq: 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) = a ^ n
+      by closed[n]
+    have S_le_am1S: uint_summation(n, 0, fun i:UInt { a ^ i })
+                  ≤ (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) by {
+      have h: 1 * uint_summation(n, 0, fun i:UInt { a ^ i })
+            ≤ (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+        by apply uint_mult_mono_le2[1, uint_summation(n, 0, fun i:UInt { a ^ i }),
+              a ∸ 1, uint_summation(n, 0, fun i:UInt { a ^ i })]
+           to one_le_am1, uint_less_equal_refl
+      h
+    }
+    have am1S_le_oneplus: (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+                        ≤ 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+      by uint_less_equal_add_left
+    have S_le_oneplus: uint_summation(n, 0, fun i:UInt { a ^ i })
+                     ≤ 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+      by apply uint_less_equal_trans to S_le_am1S, am1S_le_oneplus
+    replace symmetric an_eq
+    S_le_oneplus
+  }
+
+  // Lower: a^n = 1 + (a − 1) · Σ ≤ Σ + (a − 1) · Σ = a · Σ, using Σ ≥ 1
+  // when n ≥ 1.
+  have lower: (fun x:UInt { a ^ x })
+              ≲ (fun x:UInt { uint_summation(x, 0, fun i:UInt { a ^ i }) }) by {
+    expand operator≲
+    choose 1, a
+    arbitrary n:UInt
+    assume one_le_n: 1 ≤ n
+    show (fun x:UInt { a ^ x })(n)
+       ≤ a * uint_summation(n, 0, fun i:UInt { a ^ i })
+
+    have an_eq: 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) = a ^ n
+      by closed[n]
+
+    // Σ ≥ 1 when n ≥ 1: from a^n ≥ a ≥ 2, hence 1 + (a − 1) · Σ ≥ 2,
+    // hence (a − 1) · Σ ≥ 1, hence Σ ≥ 1 (since a − 1 ≥ 1, a Σ of 0
+    // would give (a − 1) · 0 = 0, contradicting (a − 1) · Σ ≥ 1).
+    have an_ge_2: 2 ≤ a ^ n by {
+      have a_le_an: a ≤ a ^ n
+        by apply (apply uint_pow_le_mono_r[n, a, 1] to one_le_a) to one_le_n
+      apply uint_less_equal_trans to two_le_a, a_le_an
+    }
+    have step_2: 2 ≤ 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) by {
+      replace an_eq
+      an_ge_2
+    }
+    have am1S_ge_1: 1 ≤ (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) by {
+      have h: 1 + 1 ≤ 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+        by step_2
+      apply uint_add_both_sides_of_less_equal[1, 1,
+            (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })] to h
+    }
+    have S_ge_1: 1 ≤ uint_summation(n, 0, fun i:UInt { a ^ i }) by {
+      have dichot: 1 ≤ uint_summation(n, 0, fun i:UInt { a ^ i })
+                or uint_summation(n, 0, fun i:UInt { a ^ i }) < 1
+        by uint_dichotomy[1, uint_summation(n, 0, fun i:UInt { a ^ i })]
+      cases dichot
+      case yes { yes }
+      case S_lt_1: uint_summation(n, 0, fun i:UInt { a ^ i }) < 1 {
+        have S_le_0: uint_summation(n, 0, fun i:UInt { a ^ i }) ≤ 0
+          by apply uint_less_add_one_implies_less_equal[uint_summation(n, 0, fun i:UInt { a ^ i }), 0] to S_lt_1
+        have S_eq_0: uint_summation(n, 0, fun i:UInt { a ^ i }) = 0
+          by apply uint_less_equal_zero to S_le_0
+        have prod_zero: (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) = 0
+          by replace S_eq_0.
+        have absurd: (1:UInt) ≤ 0 by replace prod_zero in am1S_ge_1
+        conclude false by evaluate in absurd
+      }
+    }
+
+    // a · Σ = (1 + (a − 1)) · Σ = Σ + (a − 1) · Σ.
+    have ident: 1 + (a ∸ 1) = a by apply uint_monus_add_identity[a, 1] to one_le_a
+    have a_split: a * uint_summation(n, 0, fun i:UInt { a ^ i })
+                = uint_summation(n, 0, fun i:UInt { a ^ i })
+                + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) by {
+      have h: (1 + (a ∸ 1)) * uint_summation(n, 0, fun i:UInt { a ^ i })
+            = 1 * uint_summation(n, 0, fun i:UInt { a ^ i })
+             + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+        by uint_dist_mult_add_right[1, a ∸ 1, uint_summation(n, 0, fun i:UInt { a ^ i })]
+      replace ident in h
+    }
+
+    // Σ + (a − 1) · Σ ≥ 1 + (a − 1) · Σ = a^n.
+    have one_plus_le: 1 + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+                    ≤ uint_summation(n, 0, fun i:UInt { a ^ i })
+                    + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })
+      by apply uint_add_mono_less_equal[1,
+            (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }),
+            uint_summation(n, 0, fun i:UInt { a ^ i }),
+            (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i })]
+         to S_ge_1, uint_less_equal_refl
+
+    have an_le: a ^ n ≤ a * uint_summation(n, 0, fun i:UInt { a ^ i }) by {
+      replace a_split | symmetric an_eq
+      one_plus_le
+    }
+    an_le
+  }
+
+  upper, lower
+end

--- a/lib/Nat.pf
+++ b/lib/Nat.pf
@@ -343,6 +343,62 @@ proof
   }
 end
 
+// Generic geometric sum closed form: `1 + (a − 1) · Σ_{i<n} a^i = a^n`,
+// written additively so the closed form stays in Nat (no monus on the
+// RHS). The premise `1 ≤ a` lets `monus_add_identity` recover
+// `(a ∸ 1) + 1 = a` inside the inductive step. The pow2 specialization
+// (`a = 2`, so `a ∸ 1 = 1`) recovers `summation_pow2_succ`.
+theorem summation_pow_succ: all a:Nat. if ℕ1 ≤ a then
+  all n:Nat.
+  ℕ1 + (a ∸ ℕ1) * summation(n, ℕ0, λ i:Nat { a ^ i }) = a ^ n
+proof
+  arbitrary a:Nat
+  assume one_le_a: ℕ1 ≤ a
+  have a_eq: ℕ1 + (a ∸ ℕ1) = a by apply monus_add_identity to one_le_a
+  induction Nat
+  case zero {
+    expand summation
+    evaluate
+  }
+  case suc(n') suppose IH {
+    show ℕ1 + (a ∸ ℕ1) * summation(suc(n'), ℕ0, λ i:Nat { a ^ i }) = a ^ suc(n')
+    have e_suc: suc(zero) + n' = suc(n') by expand operator+.
+    have step:
+      summation(suc(n'), ℕ0, λ i:Nat { a ^ i })
+      = summation(n', ℕ0, λ i:Nat { a ^ i }) + a ^ n'
+    by {
+      have h1: summation(suc(zero) + n', ℕ0, λ i:Nat { a ^ i })
+             = summation(n', ℕ0, λ i:Nat { a ^ i }) + (λ i:Nat { a ^ i })(ℕ0 + n')
+        by summation_suc_add[n', ℕ0, λ i:Nat { a ^ i }]
+      replace e_suc in h1
+    }
+    replace step
+    show ℕ1 + (a ∸ ℕ1) * (summation(n', ℕ0, λ i:Nat { a ^ i }) + a ^ n') = a ^ suc(n')
+
+    have pow_step: a ^ suc(n') = a * a ^ n' by expand operator^ | expt.
+
+    // `((a ∸ 1) + 1) · a^n' = a · a^n' = a^(suc n')`.
+    have a_eq': (a ∸ ℕ1) + ℕ1 = a by replace add_commute in a_eq
+    have d: ((a ∸ ℕ1) + ℕ1) * a ^ n' = (a ∸ ℕ1) * a ^ n' + ℕ1 * a ^ n'
+      by dist_mult_add_right[a ∸ ℕ1, ℕ1, a ^ n']
+    have e: a * a ^ n' = (a ∸ ℕ1) * a ^ n' + a ^ n' by replace a_eq' in d
+    have collapse: (a ∸ ℕ1) * a ^ n' + a ^ n' = a ^ suc(n')
+      by transitive (symmetric e) (symmetric pow_step)
+
+    equations
+          ℕ1 + (a ∸ ℕ1) * (summation(n', ℕ0, λ i:Nat { a ^ i }) + a ^ n')
+        = ℕ1 + ((a ∸ ℕ1) * summation(n', ℕ0, λ i:Nat { a ^ i })
+                + (a ∸ ℕ1) * a ^ n')
+            by replace dist_mult_add.
+    ... = (ℕ1 + (a ∸ ℕ1) * summation(n', ℕ0, λ i:Nat { a ^ i }))
+            + (a ∸ ℕ1) * a ^ n'
+            by symmetric add_assoc[ℕ1, (a ∸ ℕ1) * summation(n', ℕ0, λ i:Nat { a ^ i }), (a ∸ ℕ1) * a ^ n']
+    ... = a ^ n' + (a ∸ ℕ1) * a ^ n'    by replace IH.
+    ... = (a ∸ ℕ1) * a ^ n' + a ^ n'    by add_commute
+    ... = a ^ suc(n')                    by collapse
+  }
+end
+
 // Closed form: twice the sum 0+1+...+n equals n*(n+1).
 theorem sum_n' : all n : Nat.
     ℕ2 * summation(suc(n), ℕ0, λ x {x}) = n * (n + ℕ1)

--- a/lib/UIntSum.pf
+++ b/lib/UIntSum.pf
@@ -213,6 +213,49 @@ proof
   summation_pow2_succ[toNat(n)]
 end
 
+// UInt analogue of `summation_pow_succ` (lib/Nat.pf): the generic
+// geometric sum closed form `1 + (a − 1) · Σ_{i<n} a^i = a^n` for
+// `1 ≤ a`. Transported through `toNat`/`fromNat` to the Nat lemma.
+// The additive form keeps the closed form in UInt (no rationals).
+theorem uint_summation_pow_succ: all a:UInt. if 1 ≤ a then
+  all n:UInt.
+  (1:UInt) + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }) = a ^ n
+proof
+  arbitrary a:UInt
+  assume one_le_a: 1 ≤ a
+  arbitrary n:UInt
+  suffices toNat((1:UInt) + (a ∸ 1) * uint_summation(n, 0, fun i:UInt { a ^ i }))
+           = toNat(a ^ n) by uint_toNat_injective
+  replace toNat_add | toNat_mult | toNat_uint_summation | toNat_monus
+  have body_eq:
+    summation(toNat(n), toNat(0:UInt),
+              λ j { toNat((fun u:UInt { a ^ u })(fromNat(j))) })
+    = summation(toNat(n), ℕ0, λ j:Nat { toNat(a) ^ j }) by {
+    apply summation_cong[toNat(n),
+        λ j { toNat((fun u:UInt { a ^ u })(fromNat(j))) },
+        λ j:Nat { toNat(a) ^ j },
+        toNat(0:UInt), ℕ0]
+    to arbitrary i:Nat
+       assume _
+       have tonat_zero: toNat(0:UInt) = ℕ0
+         by replace symmetric from_zero in uint_toNat_fromNat[ℕ0]
+       replace tonat_zero
+       show toNat(a ^ fromNat(ℕ0 + i)) = toNat(a) ^ (ℕ0 + i)
+       replace toNat_expt | uint_toNat_fromNat.
+  }
+  replace body_eq
+  have tonat_one: toNat(1:UInt) = ℕ1 by {
+    have h: toNat(fromNat(ℕ1)) = ℕ1 by uint_toNat_fromNat
+    h
+  }
+  replace toNat_expt | tonat_one
+  have one_le_toNat_a: ℕ1 ≤ toNat(a) by {
+    have h: toNat(1:UInt) ≤ toNat(a) by apply toNat_less_equal to one_le_a
+    replace tonat_one in h
+  }
+  apply summation_pow_succ[toNat(a)] to one_le_toNat_a
+end
+
 // UInt analogue of `sum_n` (lib/Nat.pf): twice the sum 0+1+...+(n-1)
 // equals n*(n ∸ 1). Transported through `toNat`/`fromNat` to the Nat
 // lemma. The doubled form keeps the closed form in UInt (no rationals).


### PR DESCRIPTION
## Summary

Generic geometric-series BigO bound for any base `2 ≤ a`:

```
(fun n. uint_summation(n, 0, fun i. a^i)) ≈ (fun n. a^n)
```

Generalises [`bigo_summation_pow2`](https://github.com/jsiek/deduce/pull/914) (which is the `a = 2` specialisation).

Supporting closed-form lemmas land alongside the existing pow2 ones:

- `summation_pow_succ` (lib/Nat.pf): `1 + (a ∸ 1) · Σ_{i<n} a^i = a^n` for `1 ≤ a`. Proved by induction on `n`; the inductive step peels off the final term via `summation_suc_add`, folds `a^suc(n')` through `a · a^n'`, and uses `monus_add_identity` to recover `(a ∸ 1) + 1 = a`.
- `uint_summation_pow_succ` (lib/UIntSum.pf): UInt analogue, transported via `toNat` / `fromNat`.
- `bigo_summation_pow` (lib/BigO.pf): Upper bound at `(n0, c) = (0, 1)`: `Σ ≤ (a − 1) · Σ ≤ 1 + (a − 1) · Σ = a^n`. Lower bound at `(n0, c) = (1, a)`: for `n ≥ 1`, `a^n ≥ a ≥ 2`, so `(a − 1) · Σ ≥ 1`, and `a − 1 ≥ 1` forces `Σ ≥ 1` (a `Σ = 0` would give `(a − 1) · 0 = 0`, contradicting the lower bound). Then `a · Σ = (a − 1) · Σ + Σ ≥ (a − 1) · Σ + 1 = a^n`.

The additive form keeps the closed form in Nat/UInt (no rationals or truncating subtraction in the RHS).

Refs #725 — fourth slice of Section H. Remaining Section H slices (`Σ i^k`, harmonic) need their own follow-ups.

## Test plan

- [x] `python3.13 deduce.py lib/Nat.pf`
- [x] `python3.13 deduce.py lib/UIntSum.pf`
- [x] `python3.13 deduce.py lib/BigO.pf`
- [x] `python3.13 test-deduce.py` (full lib + should-validate + should-error + prelude + parser equivalence) — 126.9s, all tests passed
- [x] `make static` (ruff + mypy) — all checks pass

[Claude session](claude://resume?session=b53a4948-c4a3-49db-9c86-6b08c78ecfd7) — fallback UUID: `b53a4948-c4a3-49db-9c86-6b08c78ecfd7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
