### PR TITLE
Reference.md: migrate Bool and Function Type grammar to checked blocks (Refs #473)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -490,7 +490,7 @@ The biconditional formula `P ⇔ Q` is syntactic sugar for
 
 ## Bool (Type)
 
-```
+```deduce-grammar
 type ::= "bool"
 ```
 
@@ -1118,7 +1118,7 @@ assert interchange(pair(1,2)) = pair(2,1)
 
 ## Function Type
 
-```
+```deduce-grammar
 type ::= "fn" type_params_opt type_list "->" type
 type ::= "fn" type_params_opt "(" type "," type_list ")" "->" type
 ```

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -47,6 +47,7 @@ SUBSET_RULES = {
     "multiplicative_term",
     "proof_stmt",
     "statement",
+    "type",
     "visibility",
 }
 


### PR DESCRIPTION
## Summary

Migrate two unmarked grammar code blocks in `gh_pages/doc/Reference.md` to checked `deduce-grammar` blocks for the **Bool** and **Function Type** sections. Both fragments document single alternatives of the `type` rule (`type ::= "bool"` and the two `type ::= "fn" ...` forms), so this also adds `type` to `SUBSET_RULES` in `gh_pages/scripts/reference_grammar.py` — matching the existing pattern for `atomic_term`, `atomic_proof`, `conclusion`, `proof_stmt`, `statement`, `visibility`, and the precedence-level term rules.

The full `type` block at line 2856 (eight alternatives, already a checked `deduce-grammar` block) keeps validating unchanged — subset = full equality is trivially a match. Checker count goes from 132 to 134.

Refs #473.

## Test plan

- [x] `python3.13 gh_pages/scripts/reference_grammar.py` reports `Checked 134 Reference.md grammar rule(s) against Deduce.lark.`
- [x] `make static` — ruff + mypy clean
- [x] `make tests-tokens` — keyword + grammar checks pass
- [ ] CI: `make` / `test-deduce.py` full pass (running)

[Claude session](claude://resume?session=a118e8e7-93fb-47ab-b79a-1feb881c18a5) — fallback UUID: `a118e8e7-93fb-47ab-b79a-1feb881c18a5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
