### PR TITLE
RD parser: accept `__` as identifier (Refs #919)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -170,6 +170,9 @@ def parse_identifier() -> str:
   if token.type == 'IDENT':
     advance()
     return cast(str, token.value)
+  elif token.value == '__':
+    advance()
+    return '__'
   elif current_token().value == 'operator':
     advance()
     rator = cast(str, current_token().value)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -165,7 +165,6 @@ SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/paren_term.pf",
     "./test/should-error/private_opaque.pf",
     "./test/should-error/suffices_misspell.pf",
-    "./test/should-error/suffices_omitted.pf",
     "./test/should-error/switch_case_close.pf",
     "./test/should-error/switch_case_empty.pf",
     "./test/should-error/switch_case_open.pf",

--- a/test/should-error/suffices_omitted.pf.err
+++ b/test/should-error/suffices_omitted.pf.err
@@ -1,8 +1,1 @@
-./test/should-error/suffices_omitted.pf:4.1-4.8: while parsing
-	proof_stmt ::= "theorem" identifier ":" formula "proof" proof "end"
-
-theorem __: all x:UInt. length([x]) = 1
-        ^^
-
-./test/should-error/suffices_omitted.pf:4.9-4.11: expected name of theorem, not:
-	__
+./test/should-error/suffices_omitted.pf:6.15-6.18: undefined variable: Nat


### PR DESCRIPTION
## Summary

Closes the `suffices_omitted.pf` / double-underscore identifier sub-task in #919, per [the maintainer comment](https://github.com/jsiek/deduce/issues/919#issuecomment-4662821364):

> "in the past that was a keyword but I think that is no longer the case (double check this). So we should allow double underscore as an identifier."

The LALR parser already accepts `theorem __:` (its contextual lexer matches the `IDENT` regex in identifier-position, since `_` is a word character). The recursive-descent parser kept an explicit reject in `parse_identifier` that rejected `__` as a theorem name (and as any other identifier).

This PR drops that reject:

- `rec_desc_parser.py:parse_identifier` — add one branch that accepts the `__` token and returns it as the identifier string.
- `test/should-error/suffices_omitted.pf.err` — regenerated; the file now reaches the downstream `arbitrary x:Nat` vs `UInt` mismatch instead of failing at parse time (the test file imports `UInt`/`List` but not `Nat`, so the error surfaces as `undefined variable: Nat` under the test harness's `prewarm_modules` semantics).
- `test-deduce.py` — drop `./test/should-error/suffices_omitted.pf` from `SHOULD_ERROR_PARSER_EQUIV_SKIP`; both parsers now agree on this file's shape, so the equivalence harness covers it and the staleness check added in #918 enforces that going forward.

Note: `─` (horizontal line) is intentionally **not** added to `parse_identifier` — LALR rejects it as a theorem name too (only `__` round-trips through both parsers as an identifier).

## Remaining sub-tasks in #919

- [ ] Hole-tolerant proof grammar (5 files: `conclude.pf`, `missing-conclusion1.pf`, `givens_cases_not_or.pf`, `givens_induction_not_all.pf`, `induction_case.pf`) — RD silently fills a `?` where LALR demands an explicit body. Likely a single LALR-grammar PR.

## Test plan

- [x] `make static` — clean (ruff + mypy, including `--no-site-packages`)
- [x] `python test-deduce.py --errors` — all pass
- [x] `python test-deduce.py --equiv` — all pass (RD/LALR ASTs match across `lib + should-validate + should-error`)
- [x] `python deduce.py test/should-error/suffices_omitted.pf` (RD) and `--lalr` both produce the same error
- [ ] Full `python test-deduce.py` (running)

[Claude session](claude://resume?session=39201fce-814d-4d9b-8f23-b5f09dd9acc5) — fallback UUID: `39201fce-814d-4d9b-8f23-b5f09dd9acc5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
