### PR TITLE
Reference.md: migrate If Then / If Then Else grammar to checked blocks (Refs #473)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -1335,6 +1335,10 @@ See the entry for [Biconditional](#biconditional-if-and-only-if).
 
 ## If Then (Conditional Formula)
 
+```deduce-grammar
+atomic_term ::= "if" term "then" term
+```
+
 A formula `if P then Q` is true when both `P` and `Q` are true and it
 is true when `P` is false.
 
@@ -1344,6 +1348,10 @@ To use a given that is a conditional formula, use `apply`-`to`.
 (See the entry for [Apply-To](#apply-to-proof-modus-ponens).)
 
 ## If Then Else (Term)
+
+```deduce-grammar
+atomic_term ::= "if" term "then" term "else" term
+```
 
 A term of the form
 


### PR DESCRIPTION
## Summary

Migrate two unmarked grammar code blocks in `gh_pages/doc/Reference.md` to checked `deduce-grammar` blocks for the **If Then (Conditional Formula)** and **If Then Else (Term)** sections.

Before this PR, neither section had any grammar block at all — only prose. Both forms are real `atomic_term` productions in `Deduce.lark`:

```
| "if" term "then" term "else" term            -> conditional
| "if" term "then" term                        -> if_then_formula
```

Adding `deduce-grammar` fences makes those rules participate in the strict Reference.md ↔ Deduce.lark check from PR #554 / PR #916.

Both rules are subsets of `atomic_term`, which is already in `SUBSET_RULES` in `gh_pages/scripts/reference_grammar.py`, so no checker change is needed. Checked rule count goes 139 → 141.

Refs #473.

## Test plan

- [x] `python3.13 gh_pages/scripts/reference_grammar.py` reports `Checked 141 Reference.md grammar rule(s) against Deduce.lark.`
- [x] `make static` — ruff + mypy clean
- [x] `make tests-tokens` — keyword + grammar checks pass
- [ ] CI: `make` / `test-deduce.py` full pass

[Claude session](claude://resume?session=3bde721b-fe4f-497d-8bbb-7f67bd67ce26) — fallback UUID: `3bde721b-fe4f-497d-8bbb-7f67bd67ce26`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
