### PR TITLE
Add `warns` matrix entry to CI workflow (Refs #922)

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -68,6 +68,9 @@ jobs:
           - name: errors
             args: --errors
             requirements: core
+          - name: warns
+            args: --warns
+            requirements: core
           - name: equiv
             args: --equiv
             requirements: core


### PR DESCRIPTION
## Summary

Follow-up to [#925](https://github.com/jsiek/deduce/pull/925) (closes the loose end called out in that PR's description). #925 added the `test/should-warn/` category and wired `--warns` into the default sweep, but the CI matrix in `.github/workflows/test_deduce.yml` only fans out the categories it explicitly lists. Without a dedicated `warns` job, CI never exercises `--warns` independently and a regression in the new fixture diffing would slip through.

This commit was originally part of the #925 branch but couldn't be pushed at the time because the bot OAuth token lacked `workflow` scope.

## Test plan

- [x] `python test-deduce.py --warns` passes locally (already in #925).
- [ ] CI: the new matrix entry should produce a `regression (warns)` job that goes green.

Refs [#922](https://github.com/jsiek/deduce/issues/922).

[Claude session](claude://resume?session=05c89185-d189-43b9-801a-8d73d16d2f95) — fallback UUID: `05c89185-d189-43b9-801a-8d73d16d2f95`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
