### PR TITLE
Expand parser round-trip corpus with 11 more should-validate files (Refs #473)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -204,6 +204,17 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/relation_basic.pf",    # `relation` declaration
     "./test/should-validate/opaque_define.pf",     # `opaque` visibility
     "./test/should-validate/import_using.pf",      # `import ... using ...`
+    "./test/should-validate/auto_conditional.pf",  # `auto` + `postulate` decl
+    "./test/should-validate/recall1.pf",           # `recall` proof
+    "./test/should-validate/simplify1.pf",         # `simplify` proof
+    "./test/should-validate/trace_recursive.pf",   # `trace` decl + `print`
+    "./test/should-validate/union_positive_nested.pf",  # nested generic union
+    "./test/should-validate/mark2.pf",             # `#`-mark term + `expand a | b`
+    "./test/should-validate/nat_literals.pf",      # `ℕn` Nat literals + `lit`
+    "./test/should-validate/fun_zero_param.pf",    # zero-parameter `fun`
+    "./test/should-validate/some-intro-tlet.pf",   # `define ... ; ...` term-let
+    "./test/should-validate/int1.pf",              # Int negation / literals
+    "./test/should-validate/theorem_let.pf",       # inline `apply ... to ...`
 )
 
 


### PR DESCRIPTION
## Summary

- Expand `PARSER_ROUND_TRIP_FILES` in `test-deduce.py` by 11 more entries.
- Each addition is a small `test/should-validate` file that exercises a
  distinct surface construct not represented in the previous curated set,
  and already round-trips cleanly under today's pretty-printer.
- No pretty-printer changes — broader regression coverage only.
- Continuation of the curated-corpus expansion started in #909.

## Constructs newly exercised by round-trip

| File | Construct |
|---|---|
| `auto_conditional.pf` | `auto` + `postulate` declarations |
| `recall1.pf` | `recall` proof |
| `simplify1.pf` | `simplify` proof |
| `trace_recursive.pf` | `trace` declaration + `print` |
| `union_positive_nested.pf` | nested generic union (`List<Tree>`) |
| `mark2.pf` | `#`-mark term + `expand a \| b` |
| `nat_literals.pf` | `ℕn` Nat literals + `lit` |
| `fun_zero_param.pf` | zero-parameter `fun` |
| `some-intro-tlet.pf` | `define ... ; ...` term-let |
| `int1.pf` | `Int` negation / literals |
| `theorem_let.pf` | inline `apply ... to ...` |

## How candidates were chosen

A standalone script ran the same RD/LALR × RD/LALR round-trip the test
harness performs against every non-`doc_` `test/should-validate/*.pf`
that isn't already in the corpus, and filtered to files that:

- parse cleanly with both parsers,
- pretty-print without raising, and
- canonical-AST-match after reparsing the pretty output with either
  parser, from either source-parser.

That sweep produced 51 candidates; I curated the list above to one
file per distinct surface construct so each entry pulls its weight as
regression coverage.

## Validation

- `python3.13 test-deduce.py --equiv --workers 1` — passes
  (`lib + should-validate + should-error` parser equivalence in ~122 s,
  expanded pretty-print round trip in ~21 s).
- `make static` — ruff + mypy clean.

## Issue

Refs #473 — parser equivalence umbrella.

Sub-task status (per the "Status after #893" checklist in the issue):

- [ ] Continue migrating remaining `Reference.md` grammar fragments —
      **not addressed here**; the only unmarked `::=` block remaining is
      the conceptual `formula ::= term` at line 1066, which intentionally
      stays unchecked because `formula` is not a `Deduce.lark` nonterminal.
- [ ] Decide whether and how much of `test/should-error/` should
      participate in parser equivalence checks — **already done in #918**.
- [ ] Expand round-trip coverage after improving the pretty-printer for
      currently non-parse-preserving proof/declaration forms —
      **partially addressed**: this PR picks up another batch of files
      that already round-trip under today's pretty-printer, with no
      pretty-printer changes. Further expansion still needs
      pretty-printer work for the non-parse-preserving forms.

The umbrella issue stays open.

## Test plan

- [ ] `make tests` green in CI.
- [ ] `test-deduce.py --site` green in CI (site mode).

[Claude session](claude://resume?session=1ae311ec-4850-400f-85f1-2fa2644ea3d9) — fallback UUID: `1ae311ec-4850-400f-85f1-2fa2644ea3d9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
