### PR TITLE
CLAUDE.md: file GitHub issues for bugs noticed in passing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,29 @@ Smaller code is better. Prefer the change that removes lines over the one that a
 
 This applies to refactors especially: when a global goes away, the module-level alias for it goes away too. When a function's signature changes, every caller updates in the same PR — no overload that accepts both shapes.
 
+## Filing bugs you notice in passing
+
+When you spot a bug — or a strong-suspicion bug — while doing something else, **file it as a GitHub issue before declaring your current task done**. Do not just mention it in your reply summary; the reply gets thrown away, the issue persists. **If you noticed a bug, the task is not done until the issue exists.**
+
+Trigger this when any of the following hold:
+
+- A test, sweep, or experiment surfaced concrete evidence of a defect (failing fixture, divergent output, crash, wrong AST, broken round-trip).
+- Reading the code, you saw a clear logic error a fix-this-now ticket would describe.
+- A documented invariant is violated in code you read.
+
+Do **not** file for: vague code smells, "could be cleaner," missing features, or hunches without a concrete repro.
+
+Each issue must include:
+
+- One sentence stating the bug.
+- A minimal repro (source file or shell command — prefer pulling an existing in-tree file over fabricating one).
+- Observed vs. expected behavior.
+- A link back to where you found it (PR, sweep script, file path).
+
+Group related defects into one issue with categorized sub-bugs (see #931 for the shape) rather than spamming N tiny issues. Cross-reference any umbrella issue the bug sits under with `Refs #N`.
+
+Default to filing without asking first. The exception is when the "bug" might be intentional design — in that case, file anyway but lead the body with "Is this intentional? If so, close." Better to over-file with a quick close than to silently drop a real bug.
+
 ## Running and testing
 
 ```sh


### PR DESCRIPTION
## Summary

Adds a new "Filing bugs you notice in passing" section to `CLAUDE.md`,
between "Code style" and "Running and testing".

## Why

While prepping #930 I ran a sweep that surfaced 110 round-trip failures
in `should-validate`. I almost let those drop on the floor — they
weren't part of the task list, and the obvious move was to mention
them in the reply summary and move on. The reply gets thrown away;
the issue (now #931) persists.

This change codifies the rule so the next agent doesn't repeat the
near-miss: **if you noticed a bug, the task is not done until the
issue exists**. The section includes a quality bar (concrete repro,
observed vs. expected, link back to where the bug surfaced) so the
policy doesn't turn into noise.

A parallel addition has already been made to the
`deduce-issues` scheduled-task `SKILL.md` in the user's local config
so unattended routine runs follow the same rule — the routine is the
worst case, since there is no user in the loop to nudge the agent.

## Example

#931 is the worked example referenced in the new section.

## Test plan

- [ ] N/A — documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
