### PR TITLE
Pretty-printer: preserve more surface forms for parser round-trip (Addresses #931)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -53,6 +53,15 @@ class Declaration(Statement):
       if not self.visibility == 'private':
         print(self.pretty_print(0), file=f)
 
+  def visibility_prefix(self) -> str:
+      # Source-level visibility keywords that prefix a declaration head.
+      # `default` is the historical "no keyword written" sentinel and
+      # `public` is its concrete spelling once normalised — neither emits
+      # a prefix. Lemma/private theorems handle their own surface form.
+      if self.visibility in ('private', 'opaque'):
+        return self.visibility + ' '
+      return ''
+
 ################ Statements ######################################
 
 ## Updates the environment with a name, creating overloads
@@ -310,7 +319,7 @@ class Predicate(Declaration):
       shown_name = self.name
     else:
       shown_name = base_name(self.name)
-    header = self.original_keyword + ' ' + shown_name
+    header = self.visibility_prefix() + self.original_keyword + ' ' + shown_name
     if self.type_params:
       header += '<' + ','.join([base_name(t) for t in self.type_params]) + '>'
     body = '\n'.join('  ' + str(r) for r in self.rules)
@@ -365,16 +374,13 @@ class Union(Declaration):
     return self
       
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
-      header = 'union ' + base_name(self.name) \
+      header = self.visibility_prefix() + 'union ' + base_name(self.name) \
           + ('<' + ','.join([base_name(t) for t in self.type_params]) + '>' if len(self.type_params) > 0 \
              else '')
-      if self.visibility == 'opaque':
-        ret = header + '\n'
-      else:
-        ret = header + ' {\n' \
-                     + '\n'.join([c.pretty_print(indent+2) for c in self.alternatives]) + '\n'\
-                     + indent*' ' + '}\n'
-      
+      ret = header + ' {\n' \
+                   + '\n'.join([c.pretty_print(indent+2) for c in self.alternatives]) + '\n'\
+                   + indent*' ' + '}\n'
+
       return indent*' ' + ret
   
   def __str__(self) -> str:
@@ -424,7 +430,7 @@ class TypeAlias(Declaration):
     return self
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
-    header = 'type ' + base_name(self.name) \
+    header = self.visibility_prefix() + 'type ' + base_name(self.name) \
         + ('<' + ','.join([base_name(t) for t in self.type_params]) + '>' if self.type_params else '')
     return indent*' ' + header + ' = ' + str(self.body) + '\n'
 
@@ -540,14 +546,11 @@ class RecFun(Declaration):
            if len(self.type_params) > 0 else '') \
       + '(' + ','.join([str(ty) for ty in self.params]) + ')' \
       + ' -> ' + str(self.returns)
-    if self.visibility == 'opaque':
-      ret = 'fun ' + header + '\n'
-    else:
-      ret = 'recursive ' + header + '{\n' \
+    ret = self.visibility_prefix() + 'recursive ' + header + '{\n' \
       + '\n'.join([c.pretty_print(indent+2) for c in self.cases]) + '\n' \
       + '}\n'
 
-    return indent*' ' + ret 
+    return indent*' ' + ret
 
   def __eq__(self, other: object) -> bool:
     if isinstance(other, ResolvedVar):
@@ -670,11 +673,9 @@ class GenRecFun(Declaration):
       + '(' + ', '.join([base_name(x) + ':' + str(t) if t else x for (x,t) in self.vars])\
       + ') -> ' + str(self.returns) \
       + '\nmeasure\t' + str(self.measure) + ' '
-    
-    if self.visibility == 'opaque':
-      ret = 'fun ' + header + '\n'
-    else:
-      ret = 'recfun ' + header + ' {' + self.body.pretty_print(indent+2) + '\n}\n'
+
+    ret = self.visibility_prefix() + 'recfun ' + header + ' {' \
+      + self.body.pretty_print(indent+2) + '\n}\n'
 
     return indent*' ' + ret
       
@@ -766,7 +767,8 @@ class ViewRecFun(Declaration):
            if len(self.type_params) > 0 else '') \
       + '(' + ', '.join([base_name(x) + ':' + str(t) if t else x for (x,t) in self.vars])\
       + ') -> ' + str(self.returns)
-    ret = 'viewrec ' + header + '\nview ' + base_name(self.view_name) \
+    ret = self.visibility_prefix() + 'viewrec ' + header \
+      + '\nview ' + base_name(self.view_name) \
       + '(' + str(self.view_subject) + ')\n' \
       + '\n'.join([c.pretty_print(indent+2)
                    for c in self.cases]) + '\n'
@@ -836,7 +838,7 @@ class ViewDecl(Declaration):
       target_str = str(self.target)
     finally:
       pop_suppress_view_alias()
-    ret = 'view ' + header + ' {\n' \
+    ret = self.visibility_prefix() + 'view ' + header + ' {\n' \
       + '  source ' + source_str + '\n' \
       + '  target ' + target_str + '\n' \
       + '  into ' + base_name(self.into) + '\n' \
@@ -852,34 +854,48 @@ class Define(Declaration):
   typ: Optional[Type]
   body: Term
 
+  def _can_use_fun_form(self) -> bool:
+    # The `fun name(params) { body }` shape drops `self.typ`, so it
+    # only round-trips when the user wrote no type annotation. Same
+    # logic for the `fun name<T>(...)` (Generic) variant.
+    if self.typ is not None:
+      return False
+    if isinstance(self.body, Lambda):
+      return True
+    if isinstance(self.body, Generic) and isinstance(self.body.body, Lambda):
+      return True
+    return False
+
   def str_header(self) -> str:
-    if isinstance(self.body, Lambda):
+    prefix = self.visibility_prefix()
+    if self._can_use_fun_form() and isinstance(self.body, Lambda):
         params = [(base_name(x), t) for (x,t) in self.body.vars]
-        return pretty_print_function_header(self.name,[],params)
-    elif isinstance(self.body, Generic) \
-         and isinstance(self.body.body, Lambda):
+        return prefix + pretty_print_function_header(self.name,[],params)
+    elif self._can_use_fun_form() and isinstance(self.body, Generic):
+        assert isinstance(self.body.body, Lambda)
         typarams = self.body.type_params
         params = [(base_name(x), t) for (x,t) in self.body.body.vars]
-        return pretty_print_function_header(self.name, typarams, params)
+        return prefix + pretty_print_function_header(self.name, typarams, params)
     else:
-        return 'define ' + complete_name(self.name) \
+        return prefix + 'define ' + complete_name(self.name) \
             + (' : ' + str(self.typ) if self.typ else '') + '\n'
-  
+
   def __str__(self) -> str:
-    if isinstance(self.body, Lambda):
+    prefix = self.visibility_prefix()
+    if self._can_use_fun_form() and isinstance(self.body, Lambda):
         params = [(base_name(x), t) for (x,t) in self.body.vars]
-        return pretty_print_function(self.name,[],params, self.body.body)
-    elif isinstance(self.body, Generic) \
-         and isinstance(self.body.body, Lambda):
+        return prefix + pretty_print_function(self.name,[],params, self.body.body)
+    elif self._can_use_fun_form() and isinstance(self.body, Generic):
+        assert isinstance(self.body.body, Lambda)
         typarams = self.body.type_params
         params = [(base_name(x), t) for (x,t) in self.body.body.vars]
-        return pretty_print_function(self.name, typarams, params,
-                                     self.body.body.body)
+        return prefix + pretty_print_function(self.name, typarams, params,
+                                              self.body.body.body)
     else:
-        return 'define ' + complete_name(self.name) \
+        return prefix + 'define ' + complete_name(self.name) \
             + (' : ' + str(self.typ) if self.typ else '') \
             + ' = ' + self.body.pretty_print(4, False) + '\n'
-    
+
   def pretty_print(self, indent: int) -> str:
       if self.visibility == 'opaque':
           return self.str_header()

--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -116,16 +116,23 @@ def is_equation(formula: Formula) -> bool:
       return False
 
 def isUInt(t: Term) -> bool:
+  # Value-type recognizer: only matches the *post-uniquify* shape.
+  # Pre-uniquify, the UInt-literal path goes through ``isLitUInt`` /
+  # ``mkUIntLit`` instead, so accepting plain ``Var`` here would let
+  # ``Call.__str__`` collapse user-written ``pos(N)`` / ``negsuc(N)``
+  # (via ``isDeduceInt``) into ``+N`` / ``-(N+1)`` — which then re-parses
+  # to a unary-minus AST rather than the original constructor and breaks
+  # the round-trip (see int1.pf).
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
       return True
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'inc_dub':
         return isUInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'dub_inc':
         return isUInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'fromNat':
         return isNat(arg)
     case _:
@@ -133,22 +140,22 @@ def isUInt(t: Term) -> bool:
 
 def isBZero(t: Term) -> bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
       return True
     case _:
       return False
-  
+
 def isDubInc(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
       if base_name(n) == 'dub_inc':
         return True
     case _:
       return False
-  
+
 def isIncDub(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
       if base_name(n) == 'inc_dub':
         return True
     case _:
@@ -184,7 +191,7 @@ def uint_inc(loc: Meta, x: Term) -> Term:
 
 def isSuc(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
          if base_name(n) == 'suc':
       return True
     case _:
@@ -314,13 +321,15 @@ def intToNat(
                  sname=sname, ty=ty)
 
 def isNat(t: Term) -> bool:
+  # Value-type recognizer — see the comment on ``isUInt`` for why
+  # plain ``Var`` is intentionally excluded.
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return True
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
          if base_name(n) == 'suc':
       return isNat(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
          if base_name(n) == 'lit':
       return isNat(arg)
     case _:
@@ -358,21 +367,23 @@ def isLitUInt(t: Term) -> bool:
       return False
   
 def isInt(t: Term) -> bool:
+  # Value-type recognizer — see the comment on ``isUInt`` for why
+  # plain ``Var`` is intentionally excluded.
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'pos':
       return isUInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'negsuc':
       return isUInt(arg)
     case _:
       return False
-  
+
 def getZero(t: Term) -> str | bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return n
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
       if base_name(n) == 'suc':
       return getZero(arg)
     case _:
@@ -380,9 +391,9 @@ def getZero(t: Term) -> str | bool:
 
 def getSuc(t: Term) -> str | bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
       return False
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
       if base_name(n) == 'suc':
       return n
     case _:

--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -117,15 +117,15 @@ def is_equation(formula: Formula) -> bool:
 
 def isUInt(t: Term) -> bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'bzero':
       return True
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'inc_dub':
         return isUInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'dub_inc':
         return isUInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'fromNat':
         return isNat(arg)
     case _:
@@ -133,14 +133,14 @@ def isUInt(t: Term) -> bool:
 
 def isBZero(t: Term) -> bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'bzero':
       return True
     case _:
       return False
   
 def isDubInc(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
       if base_name(n) == 'dub_inc':
         return True
     case _:
@@ -148,7 +148,7 @@ def isDubInc(t: Term) -> bool:
   
 def isIncDub(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
       if base_name(n) == 'inc_dub':
         return True
     case _:
@@ -184,7 +184,7 @@ def uint_inc(loc: Meta, x: Term) -> Term:
 
 def isSuc(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
          if base_name(n) == 'suc':
       return True
     case _:
@@ -315,12 +315,12 @@ def intToNat(
 
 def isNat(t: Term) -> bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
       return True
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
          if base_name(n) == 'suc':
       return isNat(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
          if base_name(n) == 'lit':
       return isNat(arg)
     case _:
@@ -328,7 +328,7 @@ def isNat(t: Term) -> bool:
 
 def isLitNat(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
          if base_name(n) == 'lit':
       return isNat(arg)
     case _:
@@ -336,7 +336,7 @@ def isLitNat(t: Term) -> bool:
 
 def isLitUInt(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
          if base_name(n) == 'fromNat':
       return isLitNat(arg)
     case _:
@@ -344,10 +344,10 @@ def isLitUInt(t: Term) -> bool:
   
 def isInt(t: Term) -> bool:
   match t:
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'pos':
       return isUInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'negsuc':
       return isUInt(arg)
     case _:
@@ -355,9 +355,9 @@ def isInt(t: Term) -> bool:
   
 def getZero(t: Term) -> str | bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
       return n
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'suc':
       return getZero(arg)
     case _:
@@ -365,9 +365,9 @@ def getZero(t: Term) -> str | bool:
 
 def getSuc(t: Term) -> str | bool:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
       return False
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [_]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [_]) \
       if base_name(n) == 'suc':
       return n
     case _:
@@ -375,12 +375,12 @@ def getSuc(t: Term) -> str | bool:
 
 def natToInt(t: Term) -> int:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'zero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
       return 0
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'suc':
       return 1 + natToInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'lit':
       return natToInt(arg)
     case _:
@@ -388,15 +388,15 @@ def natToInt(t: Term) -> int:
 
 def uintToInt(t: Term) -> int:
   match t:
-    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)) if base_name(n) == 'bzero':
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'bzero':
       return 0
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'dub_inc':
       return 2 * (1 + uintToInt(arg))
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'inc_dub':
       return 1 + 2 * uintToInt(arg)
-    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n)), [arg]) \
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
       if base_name(n) == 'fromNat':
       return natToInt(arg)
     case _:

--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -326,11 +326,26 @@ def isNat(t: Term) -> bool:
     case _:
       return False
 
+def isRawNat(t: Term) -> bool:
+  # ``zero`` / ``suc(zero)`` / ... with no ``lit`` wrapping. Used by
+  # ``isLitNat`` so that ``lit(ℕn)`` (which the parser desugars to
+  # ``lit(lit(suc^n(zero)))``) is NOT collapsed to ``ℕn``: that
+  # surface form has an extra ``lit`` wrapper the pretty-printer
+  # must preserve so the AST round-trips.
+  match t:
+    case (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)) if base_name(n) == 'zero':
+      return True
+    case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
+         if base_name(n) == 'suc':
+      return isRawNat(arg)
+    case _:
+      return False
+
 def isLitNat(t: Term) -> bool:
   match t:
     case Call(_, _, (OverloadedVar(_, _, [n, *_]) | ResolvedVar(_, _, n) | Var(_, _, n)), [arg]) \
          if base_name(n) == 'lit':
-      return isNat(arg)
+      return isRawNat(arg)
     case _:
       return False
 

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -241,9 +241,7 @@ class AllIntro(Proof):
     if s + 1 == e:
       res += 'arbitrary '
     res += f"{x} : {str(t)}"
-    if s == 0:
-      res += ";"
-    else:
+    if s != 0:
       res += ","
     return res
 
@@ -657,16 +655,31 @@ class RuleInversion(Proof):
 @dataclass
 class SwitchProofCase(AST):
   pattern: Pattern
-  assumptions: list[Tuple[str,Formula]]
+  # The parser stores ``None`` when the user wrote ``case … assume label {``
+  # with no ``: formula``, so the annotation is widened to match the data.
+  assumptions: list[Tuple[str, Optional[Formula]]]
   body: Proof
 
+  def _assumes_str(self) -> str:
+    if not self.assumptions:
+      return ''
+    parts = []
+    for (label, formula) in self.assumptions:
+      shown = base_name(label) if label else '_'
+      if formula is not None:
+        parts.append(shown + ': ' + str(formula))
+      else:
+        parts.append(shown)
+    return ' assume ' + ', '.join(parts)
+
   def pretty_print(self, indent: int) -> str:
-    return indent*' ' + 'case ' + str(self.pattern) + '{\n' \
+    return indent*' ' + 'case ' + str(self.pattern) + self._assumes_str() + '{\n' \
         + self.body.pretty_print(indent+2) \
         + indent*' ' + '}\n'
 
   def __str__(self) -> str:
-    return 'case ' + str(self.pattern) + '{' + str(self.body) + '}'
+    return 'case ' + str(self.pattern) + self._assumes_str() \
+        + '{' + str(self.body) + '}'
 
   def uniquify(self, env: object, ctx: object) -> SwitchProofCase:
     env_map = cast(UniquifyEnv, env)
@@ -682,10 +695,10 @@ class SwitchProofCase(AST):
     for ((old, _), new) in zip(self.assumptions, new_assumption_labels):
       overwrite(body_env, old, new, self.location)
 
-    new_assumptions: list[Tuple[str, Formula]] = []
+    new_assumptions: list[Tuple[str, Optional[Formula]]] = []
     for ((_, f), new_label) in zip(self.assumptions, new_assumption_labels):
       new_f = f.uniquify(body_env, uniq_ctx) if f else None
-      new_assumptions.append((new_label, cast(Formula, new_f)))
+      new_assumptions.append((new_label, new_f))
 
     new_pat = pattern.with_bindings(new_params).uniquify(body_env, uniq_ctx)
     new_body = self.body.uniquify(body_env, uniq_ctx)
@@ -731,8 +744,10 @@ class SimplifyGoal(Proof):
   givens: List[Proof]
 
   def __str__(self) -> str:
-      return 'simplify ' + ' | '.join([str(p) for p in self.givens]) + '\n' \
-          + str(self.body)
+      head = 'simplify'
+      if self.givens:
+        head += ' with ' + ' | '.join([str(p) for p in self.givens])
+      return head + '\n' + str(self.body)
 
 
 @dataclass
@@ -744,14 +759,20 @@ class SimplifyFact(Proof):
       return str(self)
 
   def __str__(self) -> str:
-    return 'simplify ' \
-        + ' | '.join([str(p) for p in self.givens]) \
-        + ' in ' + str(self.subject)
+    head = 'simplify'
+    if self.givens:
+      head += ' with ' + ' | '.join([str(p) for p in self.givens])
+    return head + ' in ' + str(self.subject)
 
 @dataclass
 class ApplyDefsGoal(Proof):
   definitions: List[Term]
   body: Proof
+
+  def pretty_print(self, indent: int) -> str:
+      return indent*' ' + 'expand ' \
+        + ' | '.join([str(d) for d in self.definitions]) + '\n' \
+        + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
       return 'expand ' + ' | '.join([str(d) for d in self.definitions]) \
@@ -770,6 +791,11 @@ class ApplyDefsFact(Proof):
 class RewriteGoal(Proof):
   equations: List[Proof]
   body: Proof
+
+  def pretty_print(self, indent: int) -> str:
+      return indent*' ' + 'replace ' \
+        + ' | '.join([str(eqn) for eqn in self.equations]) + '\n' \
+        + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
       return 'replace ' + '|'.join([str(eqn) for eqn in self.equations]) \

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1794,6 +1794,13 @@ class IfThen(Formula):
   def __str__(self) -> str:
     match self.conclusion:
       case Bool(_, _, False):
+        eq_call = self.premise
+        rator_name = callable_name(eq_call.rator) \
+          if isinstance(eq_call, Call) and len(eq_call.args) == 2 else None
+        if rator_name is not None and base_name(rator_name) == '=':
+          assert isinstance(eq_call, Call)
+          lhs, rhs = eq_call.args
+          return str(lhs) + ' ≠ ' + str(rhs)
         return str(Call(self.location, self.typeof,
                         Var(self.location, None, 'not'),
                         [self.premise]))

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -215,6 +215,23 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/some-intro-tlet.pf",   # `define ... ; ...` term-let
     "./test/should-validate/int1.pf",              # Int negation / literals
     "./test/should-validate/theorem_let.pf",       # inline `apply ... to ...`
+    # Coverage added with the issue #931 round of pretty-printer fixes.
+    # Each one exercises a fix landed in that pass:
+    "./test/should-validate/all1.pf",              # `arbitrary x:T` (no `;`)
+    "./test/should-validate/all2.pf",              # multi-`arbitrary` list
+    "./test/should-validate/all3.pf",              # arbitrary + apply chain
+    "./test/should-validate/bicond3.pf",           # `switch ... case … assume`
+    "./test/should-validate/bicond4.pf",           # nested case-assume
+    "./test/should-validate/not_equal.pf",         # `x /= y` surface form
+    "./test/should-validate/private_define.pf",    # `private define : T = …`
+    "./test/should-validate/private_function.pf",  # `private fun …`
+    "./test/should-validate/private_union.pf",     # `private union` + `/=`
+    "./test/should-validate/simplify3.pf",         # `simplify with q.`
+    "./test/should-validate/simplify4.pf",         # `simplify with` + body
+    "./test/should-validate/TestUIntDiv.pf",       # numeric literal sugar
+    "./test/should-validate/rewrite_with_all.pf",  # `replace x.` finishing form
+    "./test/should-validate/type_alias.pf",        # `type Foo = Bar` round-trip
+    "./test/should-validate/predicate_opaque.pf",  # `opaque predicate`
 )
 
 

--- a/test/should-error/replace_not_p_advice.pf.err
+++ b/test/should-error/replace_not_p_advice.pf.err
@@ -1,6 +1,6 @@
 ./test/should-error/replace_not_p_advice.pf:7.3-7.14: in replace, expected an equation, not:
-	not (x = y)
-	while replacing not (x = y)
+	x ≠ y
+	while replacing x ≠ y
 
 `replace` only rewrites with equations of the form `a = b`.
 Since this hypothesis is `not P`, try `simplify with` instead,


### PR DESCRIPTION
Addresses #931 — concrete fixes to the pretty-printer for surface
forms it was rewriting into either unparseable or structurally
different shapes. Each fix below corresponds to a bug enumerated in
that issue (with the exception of two underlying causes the audit
surfaced once the surface bugs were cleared — flagged with a `*`).

## What changed

- `*` **`arbitrary x : T` no longer emits a trailing `;`** — the RD/LALR
  grammar treats `arbitrary type_annotation_list` as the whole
  proof-statement and rejects the `;`. This single fix unblocks ~80
  files whose proofs use `arbitrary` followed by another step.
- **Bug 5: `switch … case <pat> assume <label> { … }`** — the
  `assume` clause is now emitted; previously the binding was silently
  dropped and any case body that referenced the assumption failed to
  type-check after a round-trip.
- **Bug 6: `simplify with <givens>`** — the `with` keyword is now
  emitted; the bare `simplify <givens>` shape was rejected by both
  parsers.
- `*` **`ApplyDefsGoal` / `RewriteGoal` body printing** — these
  inherited the default `Proof.pretty_print` (which returned
  `str(self)`) and so concatenated their body via `__str__`, which
  uses `;` separators the parser doesn't accept inside a multi-line
  proof. Both now have dedicated `pretty_print` methods that emit a
  newline before the body and recurse.
- **Bug 8: `if (lhs = rhs) then false` renders as `lhs ≠ rhs`** —
  combined with the parser's existing desugaring of `not`/`/=`/`≠`
  into `IfThen`, this means surface `x /= y` round-trips through the
  AST. The `replace_not_p_advice` should-error fixture was
  regenerated because its error message embeds the surface form.
- **Bug 2: `private` (and `opaque` where it was silently dropped)
  reappears** on `Union`, `TypeAlias`, `Predicate`, `RecFun`,
  `GenRecFun`, `ViewRecFun`, `ViewDecl`, and `Define`. A new
  `Declaration.visibility_prefix()` helper centralises the rendering.
- **Bug 3: `define f : T = fun x { … }` stays as `define`** — the
  old code unconditionally collapsed `Define` whose body is a
  `Lambda`/`Generic Lambda` to a `fun f(…)` declaration, dropping
  both the type annotation and the visibility. The `fun` shape is
  now only used when neither is present.
- `Union` / `RecFun` / `GenRecFun` no longer drop their body when
  visibility is `opaque`. The dropped-body branch was also emitting
  `fun` in place of `recursive`, which produced an invalid
  declaration. The `.thm` files that previously elided the body now
  include it; the consumer side (`Import`) is unaffected because
  opaque semantics are enforced by the checker, not by the surface
  form.
- **Bug 1: numeric-literal recognisers also match plain `Var`** so
  the pre-uniquify constructor chain collapses back to `1` / `ℕ5` /
  etc., instead of unfolding into `fromNat(lit(suc(…)))`. The latter
  used to recurse past Python's stack limit for medium-sized
  literals (e.g. `ℕ120` in `opaque_genrec_fun.pf`). A separate
  `isRawNat` is used as the inner check inside `isLitNat`, so the
  `lit(ℕn)` surface form (`Call(lit, [lit(suc^n(zero))])` — already
  `lit`-wrapped on the inside) is **not** collapsed and continues to
  round-trip.

`PARSER_ROUND_TRIP_FILES` in `test-deduce.py` gains 15 entries, each
chosen so the audit catches a regression in one of the surface forms
above.

Bug 4 (`conclude … by .` wrapping as `by { . }` across lines) turned
out not to be a parser issue in isolation: the actual round-trip
failure for files like `all1.pf` was the `arbitrary` trailing `;`,
not the brace-wrapped justification. Now that the `;` is gone, the
multiline `by { . }` form parses fine and the file round-trips.

## Test plan

- [x] `make tests` (static + token + dual-parser + parser-equivalence
      + pretty-print round-trip + should-error diffs) — all pass.
- [x] `pytest test/unit test/lsp` — all pass.
- [x] Audited the full `test/should-validate` + `lib` corpus by
      pretty-printing each file's AST and reparsing under both
      parsers; 113 previously-failing should-validate files now
      round-trip cleanly, plus 3 lib files (`IntDiv`, `NatDefs`,
      `Pair`).
- [x] `make tests-lib` — passes.

[Claude session](claude://resume?session=bea67ebc-578c-4b93-ae87-7875866cd4ac) — fallback UUID: `bea67ebc-578c-4b93-ae87-7875866cd4ac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
