### PR TITLE
LALR parser: raise structured ParseError so LSP/MCP reports parse errors cleanly (closes #933)

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -983,16 +983,21 @@ def parse(program_text: str,
       # actively misleading for backslash: "Expected one of: DOT, ..."
       # reads as "you forgot a period"). Route through the shared
       # helper so `\` gets a Deduce-flavored hint and other stray
-      # characters at least get a clean header.
-      raise Exception(str(lark_unexpected_chars_to_parse_error(e, get_filename())))
+      # characters at least get a clean header. Raise the ParseError
+      # directly (matching rec_desc_parser) so library/LSP callers can
+      # read `.location` / `.message_body` instead of dropping into
+      # the unstructured-exception traceback path.
+      raise lark_unexpected_chars_to_parse_error(e, get_filename())
   except exceptions.UnexpectedToken as t:
       if error_expected:
           raise Exception()
       else:
-          # Raise instead of print+exit so library/LSP callers can
-          # surface the message without their process being killed.
-          # The CLI in deduce.py catches this and prints str(e), which
-          # produces the same stdout the print() did before.
+          # Route through ParseError so library/LSP callers see a
+          # structured diagnostic with `.location` / `.message_body`,
+          # matching the recursive-descent parser. Without this, the
+          # LSP/MCP `check_file` path falls into
+          # `_format_unstructured_exception` and prints a Python
+          # traceback for an ordinary syntax error (issue #933).
           hint = ''
           if t.token.type == 'LESSTHAN':
               preceding = program_text[:t.token.start_pos]
@@ -1006,9 +1011,18 @@ def parse(program_text: str,
                           'or use `fun`/`recursive`:\n'
                           '\tfun ' + name + '<T>(...) { ... }\n'
                           '\trecursive ' + name + '<T>(...) -> ... { ... }')
-          msg = (get_filename() + ":" + str(t.token.line) + "." + str(t.token.column)
-                 + "-" + str(t.token.end_line) + "." + str(t.token.end_column) + ": "
-                 + "error in parsing, unexpected token: " + token_str(t.token, program_text) + '\n'
-                 + "(The error may be immediately before this token.)" + hint)
-          raise Exception(msg)
+          meta = Meta()  # type: ignore[no-untyped-call,unused-ignore]
+          meta.empty = False
+          setattr(meta, 'filename', get_filename())
+          meta.line = t.token.line
+          meta.column = t.token.column
+          meta.start_pos = t.token.start_pos
+          meta.end_line = t.token.end_line
+          meta.end_column = t.token.end_column
+          meta.end_pos = t.token.end_pos
+          msg = ("error in parsing, unexpected token: "
+                 + token_str(t.token, program_text) + '\n'
+                 + "(The error may be immediately before this token.)"
+                 + hint)
+          raise ParseError(meta, msg)
         

--- a/test/lsp/test_library.py
+++ b/test/lsp/test_library.py
@@ -171,6 +171,38 @@ def test_parser_argument_rejects_unknown_value() -> None:
         check_file(str(path), prelude=(), parser="bogus")
 
 
+@pytest.mark.parametrize("parser", ["recursive-descent", "lalr"])
+def test_parse_error_is_structured(tmp_path: Path, parser: str) -> None:
+    """Regression test for issue #933: a syntax error reported via
+    ``check_file`` must carry a structured location and a clean
+    diagnostic body. The LALR path used to raise a bare ``Exception``
+    here, which the LSP/MCP layer formatted as ``internal error in
+    Deduce: ... <Python traceback>`` -- useless for an editor."""
+    path = tmp_path / "syntax_error.pf"
+    path.write_text(
+        "theorem foo: all T:type. all xs:List<T>. xs = xs\n"
+        "proof\n"
+        "  arbitrary T:type\n"
+        "  arbitrary xs:List<T>\n"
+        "  expand reverse | foo<T>[xs]\n"
+        "end\n",
+        encoding="utf-8",
+    )
+
+    result = check_file(str(path), prelude=(), parser=parser)
+
+    assert not result.ok
+    assert result.exception is not None
+    location = getattr(result.exception, "location", None)
+    assert location is not None and not getattr(location, "empty", True), (
+        f"{parser}: parse error should carry a non-empty location, got {location!r}"
+    )
+    body = getattr(result.exception, "message_body", None)
+    assert body is not None, f"{parser}: parse error should carry message_body"
+    assert "Traceback" not in body
+    assert "internal error in Deduce" not in body
+
+
 def test_collect_errors_includes_expand_residual_hint() -> None:
     """Regression test for issue #745: the ``expand_residual_hint``
     appended by ``_check_proof_of_apply_defs_goal`` must reach the


### PR DESCRIPTION
## Summary

Fixes #933: a syntax error in a `.pf` file checked through the LSP / MCP `check_file` path with the LALR parser used to be reported as `internal error in Deduce` plus a Python traceback. The recursive-descent parser already produced a clean diagnostic, and so did the LALR CLI; the bug was the LSP/MCP + LALR combination.

Root cause: the `UnexpectedToken` branch in `parser.py` raised a bare `Exception(msg)` (and the `UnexpectedCharacters` branch wrapped the structured `ParseError` in `Exception(str(...))`). Neither exception carried `.location` / `.message_body`, so `lsp/query._diagnostic_from_exception` fell into `_format_unstructured_exception` and attached the traceback.

Fix: route both lark error branches through `ParseError`, matching `rec_desc_parser`:

- `UnexpectedToken` now builds a `Meta` from the token's `line` / `column` / `start_pos` / `end_pos` and raises `ParseError(meta, body)`. The new diagnostic message body is the same `error in parsing, unexpected token: <tok>\n(The error may be immediately before this token.)` text as before (plus the existing `define`-with-type-parameters hint), but without the file:line.col header prefix — `ParseError.__str__` now reformats it.
- `UnexpectedCharacters` drops the `Exception(str(...))` wrap and raises the `ParseError` from `lark_unexpected_chars_to_parse_error` directly (matching what `rec_desc_parser.py` already does).

User-visible side effect: the LALR CLI now prints the same `<source-line>\n   ^^^\n<header>: <msg>` format that the RD parser and `UnexpectedCharacters` already use, instead of just the header line. The LSP/MCP path renders only the structured `message_body`, no traceback.

## Test plan

- [x] `make static` (ruff + mypy)
- [x] `python test-deduce.py --passable` (should-validate × both parsers)
- [x] `python test-deduce.py --errors` (should-error fixtures)
- [x] `python test-deduce.py --parser` (test/parse fixtures — RD-only)
- [x] `python test-deduce.py --lib --equiv` (lib + parser equivalence + pretty-print round-trip)
- [x] `pytest test/lsp test/unit`
- [x] New regression test `test/lsp/test_library.py::test_parse_error_is_structured`, parametrized over both parsers, asserts the parse exception carries a non-empty `.location`, a non-`None` `.message_body`, and that the body contains neither `Traceback` nor `internal error in Deduce`.
- [x] Manual: `mcp__deduce__check_file` on the issue's repro now returns one clean diagnostic per parser instead of the previous LALR traceback dump.

[Claude session](claude://resume?session=f5a387e4-ad7c-4fe5-8180-c1d7aab03749) — fallback UUID: `f5a387e4-ad7c-4fe5-8180-c1d7aab03749`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
