### PR TITLE
Pretty-printer: close suffices brace, fix cases/IndCase emission (Refs #931)

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -160,6 +160,7 @@ class Suffices(Proof):
   def pretty_print(self, indent: int) -> str:
       return indent*' ' + 'suffices ' + str(self.claim) + '  by {\n' \
           + self.reason.pretty_print(indent+2) + '\n' \
+          + indent*' ' + '}\n' \
           + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
@@ -170,13 +171,21 @@ class Cases(Proof):
   subject: Proof
   cases: List[Tuple[str,Optional[Formula],Proof]]
 
+  def _case_header(self, label: str, frm: Optional[Formula]) -> str:
+    label_str = base_name(label)
+    if frm is None:
+      return 'case ' + label_str
+    return 'case ' + label_str + ': ' + str(frm)
+
   def pretty_print(self, indent: int) -> str:
-      cases_str = ''
+      lines = [indent*' ' + 'cases ' + self.subject.pretty_print(indent).strip()]
       for (label, frm, body) in self.cases:
-          cases_str += indent*' ' + 'case ' + base_name(label) + ' : ' + str(frm) + '{\n' \
-              + body.pretty_print(indent+2) + '\n' \
-              + indent*' ' + '}'
-      return '\n'.join(cases_str) + '\n'
+          lines.append(
+            indent*' ' + self._case_header(label, frm) + ' {\n'
+            + body.pretty_print(indent+2) + '\n'
+            + indent*' ' + '}'
+          )
+      return '\n'.join(lines) + '\n'
       
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Cases:
     new_subject = self.subject.uniquify(env, ctx)
@@ -491,17 +500,25 @@ class IndCase(AST):
   induction_hypotheses: list[Tuple[str,Formula]]
   body: Proof
 
+  def _hyp_clause(self) -> str:
+    if not self.induction_hypotheses:
+      return ''
+    return ' assume ' + ', '.join(
+      x + ': ' + str(f) if f is not None else x
+      for (x, f) in self.induction_hypotheses
+    )
+
   def pretty_print(self, indent: int) -> str:
     return indent*' ' + 'case ' + str(self.pattern) \
-      + ' assume ' + ', '.join([x + ': ' + str(f) for (x,f) in self.induction_hypotheses]) \
-      + '{\n' \
+      + self._hyp_clause() \
+      + ' {\n' \
       + self.body.pretty_print(indent+2) \
       + indent*' ' + '}\n'
-      
+
   def __str__(self) -> str:
     return 'case ' + str(self.pattern) \
-      + ' assume ' + ', '.join([x + ': ' + str(f) for (x,f) in self.induction_hypotheses]) \
-      + '{' + str(self.body) + '}'
+      + self._hyp_clause() \
+      + ' {' + str(self.body) + '}'
 
   def uniquify(self, env: object, ctx: object) -> IndCase:
     env_map = cast(UniquifyEnv, env)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -232,6 +232,16 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/rewrite_with_all.pf",  # `replace x.` finishing form
     "./test/should-validate/type_alias.pf",        # `type Foo = Bar` round-trip
     "./test/should-validate/predicate_opaque.pf",  # `opaque predicate`
+    # Coverage added with the follow-up pretty-printer round (#931 again):
+    # `suffices ... by { ... }` block, `cases <subject> case ... { ... }`,
+    # and `induction T case <pat> { ... }` (no induction-hypothesis clause).
+    "./test/should-validate/suffices1.pf",         # `suffices ... by ...`
+    "./test/should-validate/suffices_def.pf",      # `suffices` with `define`
+    "./test/should-validate/suffices_omitted.pf",  # `suffices ... by` then proof
+    "./test/should-validate/suffices_rewrite.pf",  # `suffices ... by replace ...`
+    "./test/should-validate/cases-tlet.pf",        # `cases prem` with `case <l>: <t>`
+    "./test/should-validate/induction-tlet.pf",    # `induction T case A { . }`
+    "./test/should-validate/induction_auto_assume.pf",  # induction + suffices body
 )
 
 


### PR DESCRIPTION
## Summary

Three more pretty-printer bugs from the follow-up list on #931 (a-c
below). Each one was reshaping accepted source into a form one or both
parsers reject, blocking those files from joining the round-trip
corpus.

- **`Suffices`** — `pretty_print` opened `by {` but never emitted the
  closing `}`, so the unclosed brace ate every subsequent proof step.
  Add the matching `}` line, mirroring `PLet`.
- **`Cases`** — `pretty_print` ran `'\n'.join(cases_str)` over a
  *string* (joining char-by-char) and never emitted the leading
  `cases <subject>` header. Rebuilt around a list of segments + a
  proper header, with a `_case_header()` helper that drops the
  `: None` for unannotated case labels.
- **`IndCase`** — `pretty_print` always emitted `assume` and printed
  `IH: None` when there was no hypothesis formula, so `case <pat> { ... }`
  (no IH) was rewritten to a form the `assume_list` grammar rule
  rejects. Pulled the clause out into `_hyp_clause()` and made it
  return `''` when the IH list is empty.

`PARSER_ROUND_TRIP_FILES` gains seven entries, each exercising one of
the fixed shapes:

- `suffices1.pf`, `suffices_def.pf`, `suffices_omitted.pf`,
  `suffices_rewrite.pf` — the four `suffices ... by ...` variants
  (with `define`, with omitted body, with `replace` reason).
- `cases-tlet.pf` — `cases <subject>` with `case <label>: <term>`.
- `induction-tlet.pf` — `induction T case A { . } case B { . }` (no IH).
- `induction_auto_assume.pf` — induction over a recursive type, body
  uses the new `suffices` form.

Broader local audit after the fix: 145 of 177 non-`doc_*`
should-validate files now round-trip through both RD and LALR
(was 115 after #935).

## Relation to #931

This is a partial — Refs #931, not Closes — picked from the open
follow-up checklist in
[`#931 (comment)`](https://github.com/jsiek/deduce/issues/931#issuecomment-4674096246).

**Addressed in this PR:**
- `suffices … by …` / `suffices implies` shape
  (`suffices1.pf`, `suffices_def.pf`, `suffices_omitted.pf`,
  `suffices_rewrite.pf`). `suffices_implies_omitted.pf` still drifts
  — the `__` wildcard term pretty-prints as `--`, a separate
  term-printer bug.
- `cases-tlet.pf` / `define_cases.pf` — `cases` proof printing.
  `cases-tlet.pf` round-trips; `define_cases.pf` parses cleanly but
  its AST still differs due to an unrelated `TLet` scope-extent bug
  in the formula pretty-printer.
- `induction` / `case <pat> { … }` body emission for IH-less cases
  (`induction-tlet.pf`, `induction_auto_assume.pf`, and several
  others picked up incidentally).

**Still open from that checklist (NOT touched here):**
- Full `induction1.pf` / `induction_uint_view_inverse.pf` /
  `custom_induction.pf` — equations → transitive surface drift.
- `switch_case_alpha.pf`, `switch_auto_assume_bool.pf` — additional
  switch-printing edge cases.
- `generic1.pf` / `generic2.pf` — `choose` body printing (now mostly
  fine after the suffices fix, but worth a direct check).
- `function_type_paren.pf`, `array4.pf`, `array5.pf`, `int_pow.pf`,
  `relation_operator_name.pf`, `list2.pf`, `replace_inst_assoc.pf`,
  `trace_genrecfun.pf`, `fib*.pf`, `uint_*.pf`, `expand-repeat.pf`,
  `bicond2.pf`, `replace_in_assoc_753.pf`, `comp_switchcase.pf`,
  `ImportTests.pf`, `mark3.pf`, `postulate1.pf`, `theorem_false2.pf`,
  `assoc1.pf`/`assoc2.pf`, `equation-logic-connectives.pf`,
  `contradict-tlet.pf`, `extensionality-tlet.pf`, `int_arith.pf`,
  `nat_arith.pf`, `ListTests.pf`, and most `lib/` files.

## Test plan

- [x] `make static` — ruff + mypy clean
- [x] `python test-deduce.py --equiv` — RD/LALR parser equivalence +
      the expanded `PARSER_ROUND_TRIP_FILES` set both pass
- [x] `python test-deduce.py` — full suite (lib + should-validate +
      should-error + parser equivalence + round trip) passes

[Claude session](claude://resume?session=a02d1e4b-1d76-4eea-87d7-1fc7ddda3a33) — fallback UUID: `a02d1e4b-1d76-4eea-87d7-1fc7ddda3a33`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
