### PR TITLE
RD parser: thread visibility into Theorem/Postulate (closes #940)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1422,11 +1422,11 @@ def parse_theorem(visibility: str) -> Statement:
 
     if is_postulate:
         return Postulate(meta_from_tokens(start_token, previous_token()),
-                         name, what)
+                         name, what, visibility=visibility)
 
     proof = parse_reason()
     return Theorem(meta_from_tokens(start_token, previous_token()),
-                   name, what, proof, is_lemma)
+                   name, what, proof, is_lemma, visibility=visibility)
   except ParseError as e:
     raise e.extend(meta_from_tokens(start_token, previous_token()),
                    while_parsing)

--- a/test/should-validate/private_theorem.pf
+++ b/test/should-validate/private_theorem.pf
@@ -1,0 +1,19 @@
+import Nat
+
+private theorem private_theorem_refl: all x:Nat. x = x
+proof
+  arbitrary x:Nat
+  reflexive
+end
+
+private lemma private_lemma_refl: all x:Nat. x = x
+proof
+  arbitrary x:Nat
+  reflexive
+end
+
+theorem private_theorem_user: all x:Nat. x = x
+proof
+  arbitrary x:Nat
+  private_theorem_refl[x]
+end


### PR DESCRIPTION
## Summary

The recursive-descent parser was silently dropping the `private`/`opaque` visibility modifier on top-level `theorem`/`lemma`/`postulate`: `parse_theorem` accepted the `visibility` argument but never threaded it into the resulting `Theorem`/`Postulate` AST node, so `private theorem foo: …` parsed to `Theorem(visibility='public')` under RD while LALR correctly produced `Theorem(visibility='private')`. This was a parser-equivalence drift — both parsers accepted the syntax, but they disagreed on what it meant, and it changed the cross-module export behavior of any file relying on `private theorem`.

## Fix

- [rec_desc_parser.py:1424-1429](rec_desc_parser.py#L1424-L1429): pass `visibility=visibility` into both `Postulate(...)` and `Theorem(...)`, mirroring the LALR parser's `set_visibility` plumbing.
- [test/should-validate/private_theorem.pf](test/should-validate/private_theorem.pf): new fixture exercising `private theorem`, `private lemma`, and same-module use — picked up by the `--equiv` sweep and the regular validate suite.

Closes #940.

## Test plan

- [x] `python3.13 deduce.py test/should-validate/private_theorem.pf` (RD, default)
- [x] `python3.13 deduce.py --lalr test/should-validate/private_theorem.pf`
- [x] `python3.13 test-deduce.py --equiv` — parser equivalence over lib + should-validate + should-error (+ pretty-print round trip): all green.
- [x] `make static` — ruff + mypy clean.
- [x] Repro driver from #940: RD and LALR canonical ASTs now match for `private theorem`, `private lemma`, and `private postulate`.

[Claude session](claude://resume?session=f0ae3e43-53c2-4e89-ace6-60c57c3358d8) — fallback UUID: `f0ae3e43-53c2-4e89-ace6-60c57c3358d8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
