### PR TITLE
test-deduce.py: add private_roundtrip.pf to round-trip set (Refs #931)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -242,6 +242,7 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/cases-tlet.pf",        # `cases prem` with `case <l>: <t>`
     "./test/should-validate/induction-tlet.pf",    # `induction T case A { . }`
     "./test/should-validate/induction_auto_assume.pf",  # induction + suffices body
+    "./test/should-validate/private_roundtrip.pf", # `private type` + `private fun`
 )
 
 

--- a/test/should-validate/private_roundtrip.pf
+++ b/test/should-validate/private_roundtrip.pf
@@ -1,0 +1,31 @@
+private union Color {
+    Red
+    Green
+    Blue
+}
+
+private type Hue = Color
+
+private union Tree {
+    leaf
+    node(Tree, Tree)
+}
+
+private recursive left_spine(Tree) -> Tree {
+    left_spine(leaf) = leaf
+    left_spine(node(l, r)) = left_spine(l)
+}
+
+private fun flip(c : Color) {
+    switch c {
+        case Red { Green }
+        case Green { Red }
+        case Blue { Blue }
+    }
+}
+
+assert flip(Red) = Green
+assert flip(Green) = Red
+assert flip(Blue) = Blue
+assert left_spine(leaf) = leaf
+assert left_spine(node(leaf, leaf)) = leaf


### PR DESCRIPTION
## Summary

After [#935](https://github.com/jsiek/deduce/pull/935) and
[#937](https://github.com/jsiek/deduce/pull/937) landed, the
pretty-printer already re-emits `private` (and `opaque`) on every
declaration kind, and the three `private_*.pf` fixtures are in
`PARSER_ROUND_TRIP_FILES`. The branch I had open for bug category 2 of
[#931](https://github.com/jsiek/deduce/issues/931) was duplicate work
after rebasing on `main`.

What remains here is one extra synthetic fixture,
[test/should-validate/private_roundtrip.pf](test/should-validate/private_roundtrip.pf),
that covers two surface forms the existing `private_*.pf` files don't
exercise:

- `private type Hue = Color` — `TypeAlias` with private visibility.
- `private fun flip(c : Color) { ... }` — `Define` with an explicit
  `fun` head (distinct from `private define ... = fun ...`, which
  `private_define.pf` already covers).

It is also wired into `PARSER_ROUND_TRIP_FILES` so a future regression
on either form is caught for all four RD/LALR source × roundtrip
combinations.

Refs #931 (extra coverage; bug category 2 itself already fixed by #935 / #937).

## Test plan

- [x] `python test-deduce.py --equiv` passes (parser equivalence +
      round-trip).
- [ ] Full CI green.

[Claude session](claude://resume?session=b451abc6-a51f-4462-9dc3-dd58264c4488) — fallback UUID: `b451abc6-a51f-4462-9dc3-dd58264c4488`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
