### PR TITLE
Lift FunctionType type-argument instantiation to FunctionType.instantiate (Refs #813)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -165,6 +165,20 @@ class FunctionType(Type):
     return FunctionType(self.location, new_type_params,
                         new_param_types, new_return_type)
 
+  def instantiate(self, tyargs: List[Type]) -> FunctionType:
+    """Replace this function type's `type_params` with `tyargs`, returning a
+    flat (non-generic) function type. With no type parameters, returns a
+    structurally equivalent copy."""
+    if not self.type_params:
+      return FunctionType(self.location, [], list(self.param_types),
+                          self.return_type)
+    sub: dict[str, Type] = {x: t for (x, t) in zip(self.type_params, tyargs)}
+    return FunctionType(
+        self.location, [],
+        [t.substitute(sub) for t in self.param_types],
+        self.return_type.substitute(sub),
+    )
+
 @dataclass
 class ArrayType(Type):
   elt_type: Type

--- a/checker_types.py
+++ b/checker_types.py
@@ -836,11 +836,8 @@ def type_check_term_inst(
     retty = TypeInst(loc, ty, tyargs)
   else:
     match ty:
-      case FunctionType(loc2, typarams, param_types, return_type):
-        sub = {x: t for (x,t) in zip(typarams, tyargs)}
-        inst_param_types = [t.substitute(sub) for t in param_types]
-        inst_return_type = return_type.substitute(sub)
-        retty = FunctionType(loc2, [], inst_param_types, inst_return_type)
+      case FunctionType() as fty:
+        retty = fty.instantiate(tyargs)
       case GenericUnknownInst(loc2, union_type):
         retty = TypeInst(loc2, union_type, tyargs)
       case _:
@@ -857,11 +854,8 @@ def type_check_term_inst_var(
         retty = TypeInst(loc, ty, tyargs)
       else:
         match ty:
-          case FunctionType(loc3, typarams, param_types, return_type):
-            sub = {x: t for (x,t) in zip(typarams, tyargs)}
-            inst_param_types = [t.substitute(sub) for t in param_types]
-            inst_return_type = return_type.substitute(sub)
-            retty = FunctionType(loc3, [], inst_param_types, inst_return_type)
+          case FunctionType() as fty:
+            retty = fty.instantiate(tyargs)
           case GenericUnknownInst(loc3, union_type):
             retty = TypeInst(loc3, union_type, tyargs)
           case _:


### PR DESCRIPTION
## Summary

Two sites in `checker_types` &mdash; `type_check_term_inst` and
`type_check_term_inst_var` &mdash; were repeating the same five-line pattern
for explicit `@subject<tyargs>` instantiation against a generic function
type: build a `typarams → tyargs` substitution dict, apply it to
`param_types` and `return_type`, and construct a flat `FunctionType`
with empty `type_params`.

Centralize the substitution as an `instantiate` method on `FunctionType`
in `abstract_syntax/terms.py` so both call sites share one implementation.
Mirrors the `Constructor.instantiate_parameters` helper added in #938 for
the same umbrella issue.

## Relation to #813

This is one focused slice of the umbrella "reduce code duplication" issue.
Addresses the duplicated `FunctionType` type-argument instantiation
pattern only. The umbrella remains open: many other duplications across
the codebase have not been touched here (e.g. `type_check_call_funty`
still builds an instantiated `FunctionType` inline using a `matching`
dict rather than the new helper, and several substitution-dict patterns
in `checker_pipeline` are unrelated to this slice). Refs #813.

## Test plan

- [x] `make static` (ruff + mypy, both passes)
- [x] `python test-deduce.py` (full suite: lib + should-validate + should-error + should-warn + equiv + round-trip)
- [x] `python -m pytest test/unit` (539 passed)
- [x] `python -m pytest test/lsp` (passed)
- [x] CI: all 9 jobs green

[Claude session](claude://resume?session=c39b5a42-4f25-4bff-a3ed-43321af97cfe) &mdash; fallback UUID: `c39b5a42-4f25-4bff-a3ed-43321af97cfe`

&#x1F916; Generated with [Claude Code](https://claude.com/claude-code)
