### PR TITLE
Pretty-printer: emit private/opaque prefix on Theorem/Postulate (Refs #931)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -97,7 +97,8 @@ class Postulate(Declaration):
       print(base_name(self.name) + ': ' + str(self.what) + '\n', file=f)
   
   def __str__(self) -> str:
-    return 'postulate ' + self.name + ': ' + str(self.what) + '\n\n'
+    return self.visibility_prefix() + 'postulate ' + self.name \
+      + ': ' + str(self.what) + '\n\n'
 
   def uniquify(self, env: object, ctx: object) -> Postulate:
     env_map = cast(UniquifyEnv, env)
@@ -127,7 +128,8 @@ class Theorem(Declaration):
       print(base_name(self.name) + ': ' + str(self.what) + '\n', file=f)
   
   def __str__(self) -> str:
-    return ('lemma ' if self.isLemma else 'theorem ') \
+    return self.visibility_prefix() \
+      + ('lemma ' if self.isLemma else 'theorem ') \
       + self.name + ': ' + str(self.what) \
       + '\nproof\n' + self.proof.pretty_print(2) + '\nend\n'
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -243,6 +243,9 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/induction-tlet.pf",    # `induction T case A { . }`
     "./test/should-validate/induction_auto_assume.pf",  # induction + suffices body
     "./test/should-validate/private_roundtrip.pf", # `private type` + `private fun`
+    # `private theorem` / `private lemma` / `private postulate` visibility
+    # round-trip (Theorem.__str__ / Postulate.__str__ visibility prefix).
+    "./test/should-validate/private_theorem.pf",
 )
 
 

--- a/test/should-validate/private_theorem.pf
+++ b/test/should-validate/private_theorem.pf
@@ -12,6 +12,8 @@ proof
   reflexive
 end
 
+private postulate private_postulate_refl: all x:Nat. x = x
+
 theorem private_theorem_user: all x:Nat. x = x
 proof
   arbitrary x:Nat


### PR DESCRIPTION
## Summary

- `Theorem.__str__` and `Postulate.__str__` produced `theorem foo: ...` / `postulate foo: ...` even when the source had a leading `private` (or `opaque`).
- After #941 threaded `visibility` into the RD-parsed AST, `test/should-validate/private_theorem.pf` round-tripped to a Theorem with `visibility='default'`, failing the AST-equivalence half of `test-deduce.py --equiv` if the file were added to `PARSER_ROUND_TRIP_FILES`.
- Prefix both stringifiers with `self.visibility_prefix()`, the same helper used by every other `Declaration` subclass (`Union`, `Predicate`, `RecFun`, `Define`, ...). Extend the existing `private_theorem.pf` fixture with a `private postulate` line so the Postulate fix has direct coverage too, and promote the file into `PARSER_ROUND_TRIP_FILES`.

This is one of the categories listed in the [#931 follow-up comment](https://github.com/jsiek/deduce/issues/931#issuecomment-4679029961) (the `private` visibility category, sub-bug 2). It was previously fixed for every other declaration kind by #935 / #937 / #942 — Theorem and Postulate were the last hold-outs.

## Test plan

- [x] `make static` — ruff + mypy (both passes) clean
- [x] `python test-deduce.py --equiv` — parser equivalence + round-trip pass (`private_theorem.pf` now round-trips cleanly)
- [x] `python deduce.py test/should-validate/private_theorem.pf` — file still valid after the `private postulate` addition
- [ ] CI: full `test-deduce.py` (lib + should-validate + should-error + should-warn + prelude + equiv) via GitHub Actions

[Claude session](claude://resume?session=b1df0723-26ba-4241-a53f-08ceb48bd0c5) — fallback UUID: `b1df0723-26ba-4241-a53f-08ceb48bd0c5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
