### PR TITLE
Pretty-printer: emit `of <measure_ty>` and `terminates` on recfun (Refs #931)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -680,18 +680,27 @@ class GenRecFun(Declaration):
         + 'terminates {\n' + str(self.terminates) + '\n}\n'
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
+    pad = indent * ' '
     header = complete_name(self.name) \
         + ('<' + ','.join([name2str(t) for t in self.type_params]) + '>' \
            if len(self.type_params) > 0 else '') \
       + '(' + ', '.join([base_name(x) + ':' + str(t) if t else x for (x,t) in self.vars])\
       + ') -> ' + str(self.returns) \
-      + '\nmeasure\t' + str(self.measure) + ' '
+      + '\n' + pad + '  measure ' + str(self.measure) \
+      + ' of ' + str(self.measure_ty)
 
-    ret = self.visibility_prefix() + 'recfun ' + header + ' {' \
-      + self.body.pretty_print(indent+2) + '\n}\n'
+    terminates_str = self.terminates.pretty_print(indent + 2)
+    if not terminates_str.startswith('\n'):
+      terminates_str = '\n' + terminates_str
+    if not terminates_str.endswith('\n'):
+      terminates_str = terminates_str + '\n'
 
-    return indent*' ' + ret
-      
+    ret = self.visibility_prefix() + 'recfun ' + header + '\n' \
+      + pad + '{' + self.body.pretty_print(indent + 2) + '\n' + pad + '}\n' \
+      + pad + 'terminates {' + terminates_str + pad + '}\n'
+
+    return pad + ret
+
 
   def __eq__(self, other: object) -> bool:
     if isinstance(other, ResolvedVar):

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -246,6 +246,10 @@ PARSER_ROUND_TRIP_FILES = (
     # `private theorem` / `private lemma` / `private postulate` visibility
     # round-trip (Theorem.__str__ / Postulate.__str__ visibility prefix).
     "./test/should-validate/private_theorem.pf",
+    # `recfun ... measure n of T { body } terminates { proof }` — both
+    # the `of <measure_ty>` clause and the `terminates` proof block were
+    # silently dropped by `GenRecFun.pretty_print`; covers both shapes.
+    "./test/should-validate/recfun_roundtrip.pf",
 )
 
 

--- a/test/should-validate/recfun_roundtrip.pf
+++ b/test/should-validate/recfun_roundtrip.pf
@@ -1,0 +1,32 @@
+// Round-trip fixture for the `recfun` (GenRecFun) declaration form.
+// Covers the `measure ... of <type>` clause and the `terminates { ... }`
+// proof block, both of which the pretty-printer used to drop entirely.
+
+import UInt
+import List
+
+recfun count_down(n : UInt) -> UInt
+  measure n of UInt
+{
+  if n = 0 then 0
+  else count_down(n ∸ 1)
+}
+terminates {
+  arbitrary n:UInt
+  uint_monus_one_less[n]
+}
+
+recfun replicate<T>(n : UInt, x : T) -> List<T>
+  measure n of UInt
+{
+  if n = 0 then empty
+  else node(x, replicate(n ∸ 1, x))
+}
+terminates {
+  arbitrary n:UInt, x:T
+  uint_monus_one_less[n]
+}
+
+assert count_down(3) = 0
+assert count_down(0) = 0
+assert replicate(2, true) = node(true, node(true, empty))


### PR DESCRIPTION
## Summary

- `GenRecFun.pretty_print` was silently dropping the `of <measure_ty>` half of the `measure n of T` clause and the entire `terminates { ... }` proof block, so every accepted `recfun` declaration round-tripped through the pretty-printer into a structurally different program. The four `recfun`-using `should-validate` fixtures the #931 sweep flagged (`fib.pf`, `fib_switch.pf`, `trace_genrecfun.pf`, `uint_replicate.pf`) all failed to reparse because `measure n  {` is not a valid `recfun` head.
- Restore both: emit `measure <measure> of <measure_ty>` on its own indented line, then `{ body }`, then `terminates { proof }` on its own line. Re-uses the existing `Proof.pretty_print(indent+2)` for the termination proof.
- Add `test/should-validate/recfun_roundtrip.pf` to `PARSER_ROUND_TRIP_FILES` — a synthetic fixture covering plain `recfun` (`count_down`) and type-parameterized `recfun<T>` (`replicate`) so a regression in this emission is caught by the parser-roundtrip sweep.

After the fix, the local round-trip sweep over `test/should-validate/` drops from 12 parse failures to 8: the four `recfun` fixtures now reparse. The remaining four parse failures (`array4.pf`, `array5.pf`, `function_type_paren.pf`, `int_pow.pf`, `relation_operator_name.pf`, `suffices_implies_omitted.pf`, plus `ImportTests.pf` and `uint_arith.pf`) belong to other unrelated pretty-printer categories called out in the #931 follow-up — left for separate PRs.

## Test plan

- [x] `python3.13 deduce.py test/should-validate/recfun_roundtrip.pf` → "is valid"
- [x] `python3.13 test-deduce.py --equiv` → All tests passed (123.29s equivalence + 42.80s round-trip, total 166.09s)
- [x] `make static` (ruff + mypy + mypy --no-site-packages) → all clean

[Claude session](claude://resume?session=aa96812a-aabb-41e5-a803-3e8e33423d73) — fallback UUID: `aa96812a-aabb-41e5-a803-3e8e33423d73`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
