### PR TITLE
RD/LALR parsers: emit `Var('=')` for equations-block `=` (closes #945)

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -52,7 +52,26 @@ class AutoRewriteRule:
   rhs: Term
   
 def mkEqual(loc: Meta, arg1: Term, arg2: Term) -> Formula:
+  # Post-uniquify/post-typecheck constructor.  Callers in the proof
+  # checker (e.g. transitivity, symmetry, extensionality) build new
+  # goal formulas with this helper, and those goals are then compared
+  # against already-uniquified terms without a fresh type-check pass,
+  # so the rator must already be a ``ResolvedVar`` to match.
+  #
+  # The *parser* paths that build an ``equations``-block claim do NOT
+  # use this helper -- they construct ``Call(Var('='), ...)`` directly
+  # so the AST matches the ordinary infix-`=` parsing path and the
+  # pretty-print/parse round-trip succeeds (issue #945).
   ret = Call(loc, None, ResolvedVar(loc, None, '='), [arg1, arg2])
+  return cast(Formula, ret)
+
+def mkEqualVar(loc: Meta, arg1: Term, arg2: Term) -> Formula:
+  # Pre-uniquify constructor for parser use.  Matches the AST shape
+  # the ordinary infix-`=` path produces (``Call(Var('='), ...)``) so
+  # the two surface forms for ``a = b`` converge at parse time (see
+  # issue #945).  Downstream phases narrow this to ``OverloadedVar``
+  # / ``ResolvedVar`` the same way they do for every other operator.
+  ret = Call(loc, None, Var(loc, None, '='), [arg1, arg2])
   return cast(Formula, ret)
 
 def split_equation(loc: Meta, equation: Term, env: Env) -> tuple[Term, Term]:

--- a/parser.py
+++ b/parser.py
@@ -15,7 +15,7 @@ from abstract_syntax import (
     SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, Term, TermInst,
     Theorem, Trace, Proof, TypeAlias, TypeInst, TypeType, Union, Var,
     ViewDecl, count_marks, extract_and, extract_or, extract_tuple,
-    get_default_mark_LHS, intToNat, listToNodeList, mkEqual, mkIntLit,
+    get_default_mark_LHS, intToNat, listToNodeList, mkEqualVar, mkIntLit,
     mkUIntLit, remove_mark,
 )
 import re
@@ -214,7 +214,7 @@ def build_equations_proof(loc: Meta, eqs: list[tuple[Term, Term, Proof]]) -> Pro
         else:
             new_lhs = lhs
 
-        eq_proof = PAnnot(loc, mkEqual(loc, new_lhs, rhs), reason)
+        eq_proof = PAnnot(loc, mkEqualVar(loc, new_lhs, rhs), reason)
         if result == None:
             result = eq_proof
         else:

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -20,7 +20,7 @@ from abstract_syntax import (
     SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, Term, TermInst,
     Theorem, Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, ViewDecl,
     count_marks, extract_and, extract_or, extract_tuple, get_default_mark_LHS,
-    intToNat, listToNodeList, mkEqual, mkIntLit, mkUIntLit, remove_mark,
+    intToNat, listToNodeList, mkEqualVar, mkIntLit, mkUIntLit, remove_mark,
 )
 from lark import Lark, Token, exceptions
 from lark.tree import Meta
@@ -788,7 +788,7 @@ def parse_proof_hi() -> Proof:
         else:
             new_lhs = lhs
 
-        eq_proof = PAnnot(meta, mkEqual(meta, new_lhs, rhs), reason)
+        eq_proof = PAnnot(meta, mkEqualVar(meta, new_lhs, rhs), reason)
         if result == None:
             result = eq_proof
         else:

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -250,6 +250,14 @@ PARSER_ROUND_TRIP_FILES = (
     # the `of <measure_ty>` clause and the `terminates` proof block were
     # silently dropped by `GenRecFun.pretty_print`; covers both shapes.
     "./test/should-validate/recfun_roundtrip.pf",
+    # Coverage added with the issue #945 fix for `mkEqual` emitting
+    # `Var('=')` from the parser (so `equations`-block `=` matches the
+    # ordinary infix-`=` parsing shape):
+    "./test/should-validate/assoc1.pf",            # `equations` + `replace`
+    "./test/should-validate/assoc2.pf",            # `equations` chain
+    "./test/should-validate/induction1.pf",        # `equations` under induction
+    "./test/should-validate/postulate1.pf",        # `equations` + `postulate`
+    "./test/should-validate/mark3.pf",             # `equations` + `#`-marks
 )
 
 


### PR DESCRIPTION
## Summary

Closes #945.

The `equations` step in both parsers built its claim via `mkEqual`, which constructed the rator as `ResolvedVar('=')` — a post-uniquify shape. The ordinary infix-`=` path (`parse_term_compare`) builds `Var('=')` instead, so the same surface form `a = b` produced two different ASTs depending on whether it sat inside `equations` or a plain comparison.

Pretty-printing then re-parsed back to `Var('=')` on both sides, breaking the AST round-trip for five accepted programs.

## Fix

Split `mkEqual` into two helpers (`abstract_syntax/literals.py`):

- `mkEqual` keeps emitting `ResolvedVar('=')`. Used by post-uniquify proof-checker call sites (transitivity, symmetry, extensionality, case-split, …) where the constructed formula is compared against already-uniquified terms without a fresh type-check pass and so must already be in resolved shape.
- `mkEqualVar` emits `Var('=')`. Used by the two parser call sites that build an `equations`-block claim (`parser.py` / `rec_desc_parser.py`). Downstream phases narrow it to `OverloadedVar` / `ResolvedVar` the same way they do for every other operator.

After this, five round-trip fixtures from the #931 sweep stop failing and are added to `PARSER_ROUND_TRIP_FILES`:

- `assoc1.pf` — `equations` + `replace`
- `assoc2.pf` — `equations` chain
- `induction1.pf` — `equations` under induction
- `postulate1.pf` — `equations` + `postulate`
- `mark3.pf` — `equations` + `#`-marks

`ListTests.pf` (the sixth fixture mentioned in #945) has a separate, unrelated pretty-printer bug around `(f ∘ g)(x)` losing its parens — filed as #947, not addressed here.

## Test plan

- [x] `make static` — ruff + mypy clean.
- [x] `python3.13 test-deduce.py` — full suite passes (245s) including:
  - lib + should-validate + should-error round-trip equivalence (~133s)
  - pretty-print round-trip (~48s) — now exercises the five new fixtures
  - should-validate × 2 parsers, should-error, should-warn
- [x] `python3.13 -m pytest test/unit` — 539 / 539 passed.
- [x] Spot check: `python3.13 deduce.py test/should-validate/assoc1.pf` valid.

[Claude session](claude://resume?session=b0b4395a-6f0b-4c70-9a5a-0c898294b41f) — fallback UUID: `b0b4395a-6f0b-4c70-9a5a-0c898294b41f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
