### PR TITLE
Pretty-printer: parenthesize operator-call rator (closes #947)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1141,7 +1141,15 @@ class Call(Term):
     elif isEmptySet(self) and not get_verbose():
       return '∅'
     else:
-      return str(self.rator) + "(" \
+      rator_str = str(self.rator)
+      # The parser parses a Call's rator at the `parse_array_get` level,
+      # which only accepts atoms, array accesses, and chained calls. An
+      # operator-call rator (e.g. `f ∘ g`) must be parenthesized so the
+      # printed form reparses as `Call(Call(∘, f, g), [args])` instead of
+      # `Call(∘, f, Call(g, [args]))`.
+      if precedence(self.rator) is not None:
+        rator_str = "(" + rator_str + ")"
+      return rator_str + "(" \
         + ", ".join([str(arg) for arg in self.args])\
         + ")"
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -258,6 +258,7 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/induction1.pf",        # `equations` under induction
     "./test/should-validate/postulate1.pf",        # `equations` + `postulate`
     "./test/should-validate/mark3.pf",             # `equations` + `#`-marks
+    "./test/should-validate/ListTests.pf",         # operator-call rator: `(f ∘ g)(x)`
 )
 
 


### PR DESCRIPTION
## Summary

Closes #947.

The fallback branch of `Call.__str__` printed `str(rator) + "(args)"`
without parens around the rator, so a rator that was itself an
infix/prefix operator call (e.g. `f ∘ g`) round-tripped as
`Call(∘, f, Call(g, [args]))` instead of the original
`Call(Call(∘, f, g), [args])`.

Fix: wrap the rator in parens when `precedence(rator)` is non-None — the
existing helper already returns the right precedence for operator-call
rators (infix when len(args) ≥ 2, prefix when len(args) == 1).

This was the last `equations`-fixture failure for
`test/should-validate/ListTests.pf` in the `--equiv` round-trip sweep,
so this PR also adds `ListTests.pf` to `PARSER_ROUND_TRIP_FILES`.

Sweep over `lib/` + `test/should-validate/`: 28 round-trip failures → 27
(no regressions; one removed: ListTests.pf).

## Test plan

- [x] `python3.13 test-deduce.py --equiv` — passes (round-trip set + parser equivalence)
- [x] `python3.13 test-deduce.py --passable` — passes (should-validate suite, both parsers)
- [x] `make static` — ruff + mypy clean
- [x] Minimal repro from the issue prints `Equal: True`
- [x] Repro on the trimmed `assert (id_nat ∘ id_nat)(0) = 0`: pretty-printer emits `(id_nat ∘ id_nat)(0)` with parens

[Claude session](claude://resume?session=2a9b7988-8f58-4f30-a40f-c2d63756d982) — fallback UUID: `2a9b7988-8f58-4f30-a40f-c2d63756d982`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
