### PR TITLE
FunctionType pretty-print: wrap multi-arg params in parens (Refs #931)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -142,7 +142,10 @@ class FunctionType(Type):
       typarams = '<' + ','.join([(x if get_verbose() else base_name(x)) for x in self.type_params]) + '> '
     else:
       typarams = ''
-    return '(' + 'fn ' + typarams + ', '.join([str(ty) for ty in self.param_types]) \
+    params_str = ', '.join([str(ty) for ty in self.param_types])
+    if len(self.param_types) >= 2:
+      params_str = '(' + params_str + ')'
+    return '(' + 'fn ' + typarams + params_str \
       + ' -> ' + str(self.return_type) + ')'
 
   def __eq__(self, other: object) -> bool:

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -259,6 +259,7 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/postulate1.pf",        # `equations` + `postulate`
     "./test/should-validate/mark3.pf",             # `equations` + `#`-marks
     "./test/should-validate/ListTests.pf",         # operator-call rator: `(f ∘ g)(x)`
+    "./test/should-validate/function_type_paren.pf",  # multi-arg `fn` types
 )
 
 

--- a/test/should-error/nat_literal_hint_overload.pf.err
+++ b/test/should-error/nat_literal_hint_overload.pf.err
@@ -2,6 +2,6 @@
 	2 * n
 argument types: UInt, Nat
 overloads:
-	(fn Nat, Nat -> Nat)
-	(fn UInt, UInt -> UInt)
+	(fn (Nat, Nat) -> Nat)
+	(fn (UInt, UInt) -> UInt)
 	numeric literals default to `UInt`; for a `Nat` literal write `ℕ2`.

--- a/test/should-error/nested_child_recursive_call.pf.err
+++ b/test/should-error/nested_child_recursive_call.pf.err
@@ -2,5 +2,5 @@
 expected first argument to be n or h or kids, not x
 
 	in context of call all_elements(kids, fun x:BinTree { is_valid(x) })
-	function type: (fn <T> List<T>, (fn T -> bool) -> bool)
+	function type: (fn <T> (List<T>, (fn T -> bool)) -> bool)
 	inferred type arguments: T := BinTree

--- a/test/should-error/overload_return_type.pf.err
+++ b/test/should-error/overload_return_type.pf.err
@@ -3,6 +3,6 @@
 argument types: UInt, UInt
 expected return type: Nat
 overloads:
-	(fn Nat, Nat -> Nat)   <-- result type matches, but argument types don't
-	(fn UInt, UInt -> UInt)   <-- argument types match, but result type UInt doesn't match expected Nat
+	(fn (Nat, Nat) -> Nat)   <-- result type matches, but argument types don't
+	(fn (UInt, UInt) -> UInt)   <-- argument types match, but result type UInt doesn't match expected Nat
 	numeric literals default to `UInt`; for a `Nat` literal write `ℕ1`.


### PR DESCRIPTION
## Summary

Picks up another sub-bug from the umbrella round-trip issue #931. The
pretty-printer emitted multi-arg `fn` types in the comma-form
`fn T1, T2 -> R`. When `T1` itself started with `(` — e.g. a nested
parenthesized `FunctionType` like `(fn UInt, UInt -> UInt)` — the
parser interpreted the leading `(` as the explicit paren-form
`fn (T, T_list) -> R`, consumed the inner type up through its `->`
and return type, and then failed on the trailing `, T2 -> R`.

Fix: always wrap multi-arg parameter lists in parens
`fn (T1, T2, ..., Tn) -> R`. The parser unconditionally takes the
paren-form branch and reads the comma-separated list inside, so
there's no ambiguity regardless of what `T1` looks like. Single-arg
`fn T -> R` keeps the bare form since there's no parse-ambiguity
there.

Three `should-error` fixtures had expected stderr embedding a
`FunctionType` string and were regenerated (`nat_literal_hint_overload`,
`nested_child_recursive_call`, `overload_return_type`).
`function_type_paren.pf` — the in-tree repro for this bug — joins
`PARSER_ROUND_TRIP_FILES`.

After this change the remaining parse-fail set for
`should-validate/*.pf` round-trip is down to 6 files
(`array4.pf`, `array5.pf`, `int_pow.pf`, `suffices_implies_omitted.pf`,
`ImportTests.pf`, `relation_operator_name.pf`). Each is a separate
pretty-printer category and will land as its own PR.

## Test plan

- [x] `python3.13 test-deduce.py` (lib + should-validate + should-error
  + should-warn + parser equivalence + round-trip) — all pass
- [x] `make static` (ruff + mypy) — clean
- [x] `python3.13 -m pytest test/lsp test/unit` — passes (1035 collected)
- [x] Local probe over all 51 existing `PARSER_ROUND_TRIP_FILES` confirms
  no regression in the 4 (RD→RD, RD→LALR, LALR→RD, LALR→LALR) round-trip
  combinations.
- [x] `function_type_paren.pf` round-trips cleanly under both parsers
  with my fix.

Refs #931

[Claude session](claude://resume?session=f30dca44-eee6-4c39-913b-e31a3dbcf526) — fallback UUID: `f30dca44-eee6-4c39-913b-e31a3dbcf526`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
