### PR TITLE
Lift TermInst result-type dispatch to _instantiation_result_type (Refs #813)

### DIFF
--- a/checker_types.py
+++ b/checker_types.py
@@ -820,6 +820,19 @@ def type_first_letter(typ: TypeExpr) -> str:
       print('error in type_first_letter: unhandled type ' + repr(typ))
       exit(-1)
 
+def _instantiation_result_type(
+    loc: Meta, ty: Type, tyargs: list[Type], not_instantiable_msg: str,
+) -> Type:
+  if isinstance(ty, VarRef):
+    return TypeInst(loc, ty, tyargs)
+  match ty:
+    case FunctionType() as fty:
+      return fty.instantiate(tyargs)
+    case GenericUnknownInst(loc2, union_type):
+      return TypeInst(loc2, union_type, tyargs)
+    case _:
+      user_error(loc, not_instantiable_msg + str(ty))
+
 def type_check_term_inst(
     loc: Meta,
     subject: Term,
@@ -831,17 +844,8 @@ def type_check_term_inst(
 ) -> TermInst:
   tyargs = [check_type(ty, env) for ty in tyargs]
   new_subject = type_synth_term(subject, env, recfun, subterms)
-  ty = new_subject.typeof
-  if isinstance(ty, VarRef):
-    retty = TypeInst(loc, ty, tyargs)
-  else:
-    match ty:
-      case FunctionType() as fty:
-        retty = fty.instantiate(tyargs)
-      case GenericUnknownInst(loc2, union_type):
-        retty = TypeInst(loc2, union_type, tyargs)
-      case _:
-        user_error(loc, 'expected a type name, not ' + str(ty))
+  retty = _instantiation_result_type(
+      loc, new_subject.typeof, tyargs, 'expected a type name, not ')
   return TermInst(loc, retty, new_subject, tyargs, inferred)
 
 def type_check_term_inst_var(
@@ -849,17 +853,9 @@ def type_check_term_inst_var(
 ) -> TermInst:
   if isinstance(subject_var, VarRef):
       tyargs = [check_type(ty, env) for ty in tyargs]
-      ty = env.get_type_of_term_var(subject_var)
-      if isinstance(ty, VarRef):
-        retty = TypeInst(loc, ty, tyargs)
-      else:
-        match ty:
-          case FunctionType() as fty:
-            retty = fty.instantiate(tyargs)
-          case GenericUnknownInst(loc3, union_type):
-            retty = TypeInst(loc3, union_type, tyargs)
-          case _:
-            user_error(loc, 'cannot instantiate a term of type ' + str(ty))
+      retty = _instantiation_result_type(
+          loc, env.get_type_of_term_var(subject_var), tyargs,
+          'cannot instantiate a term of type ')
       # Subject is now resolved (we've narrowed to its single typed name).
       return TermInst(loc, retty,
                       ResolvedVar(subject_var.location, subject_var.typeof,


### PR DESCRIPTION
## Summary

Picks up another focused slice on the umbrella code-duplication issue #813.

`type_check_term_inst` and `type_check_term_inst_var` in `checker_types.py`
each open a TermInst (`subject<tyargs>`) and need to compute the *result*
type from the subject's type. Both contained the same isinstance/match
block:

```python
if isinstance(ty, VarRef):
    retty = TypeInst(loc, ty, tyargs)
else:
    match ty:
        case FunctionType() as fty:
            retty = fty.instantiate(tyargs)
        case GenericUnknownInst(loc2, union_type):
            retty = TypeInst(loc2, union_type, tyargs)
        case _:
            user_error(loc, '... ' + str(ty))
```

The only differences between the two copies were:

- where the type came from (`new_subject.typeof` vs.
  `env.get_type_of_term_var(subject_var)`), and
- the `user_error` prefix used when the type is not instantiable
  (`'expected a type name, not '` vs.
  `'cannot instantiate a term of type '`).

This PR lifts the shared dispatch into a small private helper
`_instantiation_result_type(loc, ty, tyargs, not_instantiable_msg)` that
returns the result type or calls `user_error` with the supplied prefix.
Each call site shrinks from a 10-line `if/match` chain to a single call.

Same pattern as #938 (`Constructor.instantiate_parameters`) and #943
(`FunctionType.instantiate`) — collapse a near-identical block that was
duplicated across the type checker.

`checker_types.py | 40 ++++++++++++++++++----------------------`
`1 file changed, 18 insertions(+), 22 deletions(-)`

## Test plan

- [x] `make static` (ruff + mypy, including `--no-site-packages` pass) —
  clean
- [x] `python3.13 test-deduce.py` (lib + should-validate + should-error +
  should-warn + parser equivalence + round-trip) — all pass
- [x] `python3.13 -m pytest test/lsp test/unit` — exits 0

Refs #813

[Claude session](claude://resume?session=78d51d9b-237e-4384-901f-6e01056f6a3f) — fallback UUID: `78d51d9b-237e-4384-901f-6e01056f6a3f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
