### PR TITLE
Predicate pretty-printer: keep `operator` prefix for operator-named relations (Refs #931)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -331,7 +331,7 @@ class Predicate(Declaration):
     if get_verbose():
       shown_name = self.name
     else:
-      shown_name = base_name(self.name)
+      shown_name = complete_name(self.name)
     header = self.visibility_prefix() + self.original_keyword + ' ' + shown_name
     if self.type_params:
       header += '<' + ','.join([base_name(t) for t in self.type_params]) + '>'

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -260,6 +260,7 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/mark3.pf",             # `equations` + `#`-marks
     "./test/should-validate/ListTests.pf",         # operator-call rator: `(f ∘ g)(x)`
     "./test/should-validate/function_type_paren.pf",  # multi-arg `fn` types
+    "./test/should-validate/relation_operator_name.pf",  # `relation operator <op>`
 )
 
 


### PR DESCRIPTION
## Summary

- `Predicate.__str__` rendered `relation operator ≤ : ...` as `relation ≤ : ...` because it emitted the name via `base_name(self.name)`, dropping the `operator ` keyword the parser needs for operator-symbol predicate names. The existing `complete_name(...)` helper (already used by `RecFun` and `Define`) handles this exact case, so this swap is a one-line fix.
- Adds `test/should-validate/relation_operator_name.pf` to `PARSER_ROUND_TRIP_FILES` so the round-trip pretty-print → reparse coverage exercises operator-named relations going forward.
- Refs #931 (one more sub-bug from the remaining parse-fail set; remaining files: `array4.pf`, `array5.pf`, `int_pow.pf`, `suffices_implies_omitted.pf`, `ImportTests.pf`).

## Test plan

- [x] `python3.13 test-deduce.py --equiv` — passes (parser equivalence + pretty-print round trip, including the newly-added file).
- [x] `make static` — ruff + mypy clean.
- [x] Manual repro: `python3.13 tmp/check_roundtrip.py test/should-validate/relation_operator_name.pf` — all four `{RD,LALR} src × {RD,LALR} reparse` combinations OK after the fix (all four were `PARSE-FAIL` before).
- [ ] Full `python3.13 test-deduce.py` in CI.

[Claude session](claude://resume?session=2d71dfe3-bc08-4d53-b3de-aeab44265af9) — fallback UUID: `2d71dfe3-bc08-4d53-b3de-aeab44265af9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
