### PR TITLE
Pretty-printer: emit `__` for Omitted term (Refs #931)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1660,7 +1660,7 @@ class Hole(Term):
 class Omitted(Term):
 
   def __str__(self) -> str:
-      return '--'
+      return '__'
 
 @dataclass
 class Mark(Term):

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -261,6 +261,9 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/ListTests.pf",         # operator-call rator: `(f ∘ g)(x)`
     "./test/should-validate/function_type_paren.pf",  # multi-arg `fn` types
     "./test/should-validate/relation_operator_name.pf",  # `relation operator <op>`
+    # `Omitted.__str__` previously returned `--`, which neither parser
+    # accepts; the surface form is `__` (or `─`). Covers `suffices __ by …`.
+    "./test/should-validate/suffices_implies_omitted.pf",
 )
 
 


### PR DESCRIPTION
## Summary

Picks up another sub-bug from the parse-fail set in #931 — `suffices_implies_omitted.pf`.

`Omitted.__str__` returned `'--'` (two ASCII hyphens), but neither parser accepts that surface form — both the recursive-descent and LALR parsers recognize only `__` (two underscores) or `─` (em dash) as the Omitted term. So a source like

```
suffices __ by pq
```

round-tripped through the pretty-printer to

```
suffices --  by { pq }
```

which the RD parser rejected with `expected a term, not "by"` (the leading `--` was consumed as a prefix-minus chain looking for an operand on the right).

The fix is a one-line change: have `Omitted.__str__` return `'__'`, matching what the surface syntax expects and what the lone test file using this form actually writes.

Also adds `suffices_implies_omitted.pf` to `PARSER_ROUND_TRIP_FILES` so a regression here would fail CI.

## Test plan

- [x] `make static` (ruff + mypy) passes locally.
- [x] `python3.13 test-deduce.py --equiv` passes locally — covers both parser equivalence and the round-trip set (including the new file).
- [x] Spot-checked the round-trip on `suffices_implies_omitted.pf` directly: RD and LALR both re-parse the pretty-printed output and produce the same canonical AST.

[Claude session](claude://resume?session=b377b941-a3b6-428e-8a1c-40b8b3b0d9db) — fallback UUID: `b377b941-a3b6-428e-8a1c-40b8b3b0d9db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
