### PR TITLE
Pretty-printer: emit body for opaque define (Refs #931)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -888,20 +888,6 @@ class Define(Declaration):
       return True
     return False
 
-  def str_header(self) -> str:
-    prefix = self.visibility_prefix()
-    if self._can_use_fun_form() and isinstance(self.body, Lambda):
-        params = [(base_name(x), t) for (x,t) in self.body.vars]
-        return prefix + pretty_print_function_header(self.name,[],params)
-    elif self._can_use_fun_form() and isinstance(self.body, Generic):
-        assert isinstance(self.body.body, Lambda)
-        typarams = self.body.type_params
-        params = [(base_name(x), t) for (x,t) in self.body.body.vars]
-        return prefix + pretty_print_function_header(self.name, typarams, params)
-    else:
-        return prefix + 'define ' + complete_name(self.name) \
-            + (' : ' + str(self.typ) if self.typ else '') + '\n'
-
   def __str__(self) -> str:
     prefix = self.visibility_prefix()
     if self._can_use_fun_form() and isinstance(self.body, Lambda):
@@ -918,12 +904,6 @@ class Define(Declaration):
             + (' : ' + str(self.typ) if self.typ else '') \
             + ' = ' + self.body.pretty_print(4, False) + '\n'
 
-  def pretty_print(self, indent: int) -> str:
-      if self.visibility == 'opaque':
-          return self.str_header()
-      else:
-          return str(self)
-    
   def uniquify(self, env: object, ctx: object) -> Define:
     env = cast(UniquifyEnv, env)
     ctx = cast(UniquifyContext, ctx)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -270,6 +270,11 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/array4.pf",            # `array(...)` + `[i]`
     "./test/should-validate/array5.pf",            # nested `(array(...))[i]`
     "./test/should-validate/postfix_chain_roundtrip.pf",  # synthetic chain
+    # `opaque define name : T = body` — `Define.pretty_print` used to
+    # short-circuit to header-only when `visibility == 'opaque'`, dropping
+    # the `= body`. Covers both an annotated `opaque define : T = fun ...`
+    # and the visibility coexisting with the broader Define pretty-print.
+    "./test/should-validate/ImportTests.pf",
 )
 
 


### PR DESCRIPTION
## Summary

- `Define.pretty_print` short-circuited to `self.str_header()` whenever `self.visibility == 'opaque'`, emitting only the head (`opaque define name : type`) and dropping the required `= body`. The parser requires every `define` to be followed by `=` and a body, so the freshly-pretty-printed source for `opaque define id_one_two : fn OneTwo -> OneTwo = fun b { b }` reparsed with a `ParseError: expected "=" after name in "define"` on the next top-level token.
- The opaque-elides-body branch was a leftover from when `pretty_print` was also used by `.thm` printing to hide opaque bodies. [#935](https://github.com/jsiek/deduce/pull/935) already removed the same branch from `Union` / `RecFun` / `GenRecFun` (`Import` semantics are unaffected because opacity is enforced by the checker, not by the surface form). `Define` was missed in that pass — fixed now.
- `Define.str_header()` was only used by the dropped opaque branch, and the now-trivial `pretty_print` (`return str(self)`) just shadowed the base `Statement.pretty_print`, so both are deleted.
- `PARSER_ROUND_TRIP_FILES` gains [`test/should-validate/ImportTests.pf`](test/should-validate/ImportTests.pf), the existing fixture that exercises the `opaque define name : T = fun ...` shape (alongside `private union`, `private recursive`, and a downstream `expand id_one_two` proof). After this patch all four `RD/LALR × RD/LALR` round-trip combinations pass for that file.

Refs [#931](https://github.com/jsiek/deduce/issues/931). Five of the original 8 bug categories plus the recent follow-ups already landed; this is one of the remaining parse-fail items called out in the [most recent triage comment](https://github.com/jsiek/deduce/issues/931#issuecomment-4693699168).

## Test plan

- [x] `python3.13 test-deduce.py --equiv` (parser equivalence + round-trip sweep, including the new `ImportTests.pf` entry)
- [x] `python3.13 test-deduce.py --passable` (every `test/should-validate/*.pf` still checks under both parsers)
- [x] `make static` (ruff + mypy)
- [ ] CI green

[Claude session](claude://resume?session=41852f93-8a03-47e4-9c79-35651aa28d9a) — fallback UUID: `41852f93-8a03-47e4-9c79-35651aa28d9a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
