### PR TITLE
Pretty-printer: paren TAnnote args of operator Calls (Refs #931)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -968,6 +968,12 @@ def op_arg_str(trm: Term, arg: Term) -> str:
       return "(" + str(arg) + ")"
     elif arg_precedence == trm_precedence: # and left_child(trm, arg):
       return "(" + str(arg) + ")"
+  # TAnnote's `:` binds looser than every operator (the parsers consume
+  # `:` only after the full operator chain), so a TAnnote arg of an
+  # operator Call must always be parenthesized -- otherwise the printed
+  # form `subject:type ^ ...` reparses as `subject : (type ^ ...)`.
+  if trm_precedence is not None and isinstance(arg, TAnnote):
+    return "(" + str(arg) + ")"
   return str(arg)
 
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -275,6 +275,11 @@ PARSER_ROUND_TRIP_FILES = (
     # the `= body`. Covers both an annotated `opaque define : T = fun ...`
     # and the visibility coexisting with the broader Define pretty-print.
     "./test/should-validate/ImportTests.pf",
+    # `op_arg_str` now parenthesizes `TAnnote` args of operator Calls --
+    # `:` binds looser than every operator, so the printed
+    # `subject:type ^ ...` previously reparsed as `subject : (type ^ ...)`
+    # and the leftover operator tripped the next statement.
+    "./test/should-validate/int_pow.pf",
 )
 
 


### PR DESCRIPTION
## Summary

Pretty-printer fix for one more sub-bug of #931: a `TAnnote` (`subject:type`)
inside an operator `Call` was emitted without parens, but `:` binds looser
than every operator -- the RD/LALR parsers each consume `COLON` only *after*
their operator chains return (see `parse_term_logic` / `parse_term_iff` /
`parse_term` in `rec_desc_parser.py`). So a source like

```
assert (+2:Int) ^ (3:UInt) = +8
```

round-tripped to

```
assert pos(2):Int ^ 3:UInt = pos(8)
```

which the RD parser reads as `assert (pos(2)):(Int)` -- the `:Int` annotation
greedily consumes through `^`, and the leftover `^ 3:UInt = pos(8)` then
trips an `expected a statement, not ^` at the next top-level position.

Fix is in `op_arg_str`: when a `TAnnote` appears as an arg of an operator
`Call`, wrap it in parens. `TAnnote` has effectively lower precedence than
any operator (none of the operator levels handle `:`), so this is the
correct parenthesization regardless of the parent operator's precedence.

After the fix, every `assert` in `int_pow.pf` (e.g. `(+2:Int) ^ (3:UInt)
= +8`) plus the parenthesized `^` lines in `Tneg_even` / `Tneg_one_even` /
`Tneg_one_odd` reparse cleanly under both parsers and produce structurally
identical ASTs. Adds `int_pow.pf` to `PARSER_ROUND_TRIP_FILES`.

This is the same shape of fix as #952 (`Predicate.__str__` keep `operator`
keyword) and #950 (`FunctionType.__str__` always paren multi-arg): a small
pretty-printer/op_arg_str adjustment plus a single new entry in
`PARSER_ROUND_TRIP_FILES`.

## Relation to #931 sub-bug list

The original 8 bug categories all have at least one fix in place (see the
`944` status comment on #931). This PR is part of the follow-up wave on
the remaining parse-fail / AST-drift files.

**Completed by this PR:**

- `int_pow.pf` (last of the parse-fail set that needed the operator-arg
  TAnnote parenthesization).

**Remaining (umbrella stays open):**

- Parse-fail set: `array4.pf`, `array5.pf`, `suffices_implies_omitted.pf`,
  `ImportTests.pf` — each has its own open PR (#953 / #954 / #956) or a
  dedicated `in progress` comment on #931.
- AST-drift set: `Var` vs `ResolvedVar` rator drift inside
  `PTransitive` / `PAnnot` (`assoc1.pf`-shaped families) — a separate
  follow-up; not in the parse-fail set.

## Test plan

- [x] `python3.13 test-deduce.py --equiv` -- parser equivalence + round-trip
      suite passes (RD source × RD/LALR reparse, LALR source × RD/LALR reparse).
- [x] `make static` -- ruff + mypy pass.
- [x] `python3.13 deduce.py --quiet test/should-validate/int_pow.pf` -- still
      validates.
- [ ] CI matrix on push.

[Claude session](claude://resume?session=fcde231b-9a7b-435d-90c9-b3c80dfc56b4) — fallback UUID: `fcde231b-9a7b-435d-90c9-b3c80dfc56b4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
