### PR TITLE
LALR parser: pass loop index into AllElimTypes.pos (Refs #931)

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -556,7 +556,7 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
         type_args = parse_tree_to_list(e.children[1], e)
         result = univ
         for i, ty in enumerate(type_args):
-            result = AllElimTypes(e.meta, result, ty, (e ,len(type_args)))
+            result = AllElimTypes(e.meta, result, ty, (i, len(type_args)))
         return result
     elif e.data == 'some_intro':
         witnesses = parse_tree_to_list(e.children[0], e)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -128,16 +128,7 @@ EXAMPLE_FILE = Path("example.pf")
 # both parsers but produce structurally different ASTs today. Keeping the
 # baseline explicit makes any new drift fail CI, and also fails when a listed
 # file becomes equivalent so the list gets smaller over time.
-PARSER_EQUIV_EXPECTED_DIVERGENCES = frozenset({
-    "./lib/List.pf",
-    "./lib/MultiSet.pf",
-    "./lib/Set.pf",
-    "./test/should-validate/all-elim-types-tlet.pf",
-    "./test/should-validate/bicond2.pf",
-    "./test/should-validate/expand-repeat.pf",
-    "./test/should-validate/inst3.pf",
-    "./test/should-validate/map_append_cross_type.pf",
-})
+PARSER_EQUIV_EXPECTED_DIVERGENCES: frozenset[str] = frozenset()
 
 
 # Most ``test/should-error`` files fail in later phases (type-check,
@@ -280,6 +271,16 @@ PARSER_ROUND_TRIP_FILES = (
     # `subject:type ^ ...` previously reparsed as `subject : (type ^ ...)`
     # and the leftover operator tripped the next statement.
     "./test/should-validate/int_pow.pf",
+    # LALR's `all_elim_types` transformer was passing the Lark `Tree`
+    # instead of the loop index `i` as the first slot of `AllElimTypes.pos`,
+    # so the canonical AST drifted (and `__str__` would `TypeError` on a
+    # `Tree + 1` comparison). Each of these files exercises `proof<T>` /
+    # `proof<T1, T2>` in some surface context.
+    "./test/should-validate/inst3.pf",                # `prem<UInt>[...]`
+    "./test/should-validate/bicond2.pf",              # `empty_iff_0<E>` inside `apply`
+    "./test/should-validate/expand-repeat.pf",        # `reverse_append<U>` chain
+    "./test/should-validate/all-elim-types-tlet.pf",  # `bleh<T>` term-let
+    "./test/should-validate/map_append_cross_type.pf",  # multi-arg `proof<UInt, bool>`
 )
 
 


### PR DESCRIPTION
## Summary

- Fix a single-character LALR typo (`e` → `i`) in `parse_tree_to_ast`'s `all_elim_types` branch: the loop was passing the Lark `Tree` instead of the loop index into the first slot of `AllElimTypes.pos`.
- Add the five `should-validate` files exercising `all_elim_types` (`prem<T>[...]` / `prem<T1, T2>` shapes) to `PARSER_ROUND_TRIP_FILES`.
- Drop `PARSER_EQUIV_EXPECTED_DIVERGENCES` to the empty set — `lib/List.pf`, `lib/MultiSet.pf`, `lib/Set.pf` were all in there for the same reason, and now match.

`AllElimTypes.pos` is typed `Tuple[int, int]` (carrying `(index, total)`), but `parser.py`'s LALR transformer was building it as `(e, len(type_args))` where `e` is the Lark `Tree`. RD's `rec_desc_parser.py` correctly passes `(j, len(type_list))`. With the typo, every LALR-parsed `proof<T>` / `proof<T1, T2>` produced a `Tree` in `pos[0]`, drifting the canonical AST and crashing `__str__` (`s + 1 == e` over a `Tree`).

Repro on `main` before the fix:

```
$ python3.13 -c "
import sys; sys.setrecursionlimit(10000); sys.path.insert(0, '.')
from flags import init_import_directories, add_import_directory
init_import_directories(); add_import_directory('./lib')
import parser as lalr
lalr.set_deduce_directory('.'); lalr.set_filename('<t>'); lalr.init_parser()
print(lalr.parse('theorem t: if (<T> all xs:T. xs = xs) then 0 = 0\nproof\n  suppose prem\n  prem<UInt>[0]\nend\n')[0])
"
TypeError: unsupported operand type(s) for +: 'Tree' and 'int'
```

After the fix the same input pretty-prints cleanly, and the equivalence + round-trip sweep over `lib/` + `should-validate/` passes.

Refs #931.

## Test plan

- [x] `python3.13 test-deduce.py --equiv` (lib + should-validate + should-error AST equivalence + the round-trip sweep) passes locally — `PARSER_EQUIV_EXPECTED_DIVERGENCES` is now empty.
- [x] Local sweep over `test/should-validate/*.pf` confirms the 5 newly-listed files round-trip cleanly under both source × reparse parser combos.
- [x] `make static` (ruff + mypy) passes.
- [ ] CI: `make tests` + `python3.13 test-deduce.py`.

[Claude session](claude://resume?session=09ce6cd5-2733-4725-9350-ed750ada250f) — fallback UUID: `09ce6cd5-2733-4725-9350-ed750ada250f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
