### PR TITLE
Fix term-let round-trip parenthesization

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -85,14 +85,18 @@ class PLet(Proof):
   because: Proof
   body: Proof
 
+  def _proved_str(self) -> str:
+      proved = str(self.proved)
+      return '(' + proved + ')' if isinstance(self.proved, TLet) else proved
+
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
-      return indent*' ' + 'have ' + base_name(self.label) + ': ' + str(self.proved) + ' by {\n' \
+      return indent*' ' + 'have ' + base_name(self.label) + ': ' + self._proved_str() + ' by {\n' \
           + self.because.pretty_print(indent+2) + '\n' \
           + indent*' ' + '}\n' \
           + maybe_pretty_print(self.body, indent)
   
   def __str__(self) -> str:
-      return 'have ' + base_name(self.label) + ': ' + str(self.proved) \
+      return 'have ' + base_name(self.label) + ': ' + self._proved_str() \
         + ' by ' + str(self.because) + (' ' + str(self.body) if self.body else '')
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> PLet:

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -968,11 +968,10 @@ def op_arg_str(trm: Term, arg: Term) -> str:
       return "(" + str(arg) + ")"
     elif arg_precedence == trm_precedence: # and left_child(trm, arg):
       return "(" + str(arg) + ")"
-  # TAnnote's `:` binds looser than every operator (the parsers consume
-  # `:` only after the full operator chain), so a TAnnote arg of an
-  # operator Call must always be parenthesized -- otherwise the printed
-  # form `subject:type ^ ...` reparses as `subject : (type ^ ...)`.
-  if trm_precedence is not None and isinstance(arg, TAnnote):
+  # TAnnote's `:` and TLet's `define ...; ...` bind looser than every
+  # operator, so operator-call operands with either shape must be grouped
+  # to round-trip through the parsers without re-association.
+  if trm_precedence is not None and isinstance(arg, (TAnnote, TLet)):
     return "(" + str(arg) + ")"
   return str(arg)
 
@@ -990,6 +989,8 @@ def _connective_arg_str(connective: str, arg: 'str | Formula') -> str:
   # connective itself, so the goal printer never hides this trap.
   if isinstance(arg, str):
     return arg
+  if isinstance(arg, TLet):
+    return '(' + str(arg) + ')'
   conn_prec = infix_precedence.get(connective)
   if isinstance(arg, Call) and conn_prec is not None:
     arg_prec = precedence(arg)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -281,6 +281,12 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/expand-repeat.pf",        # `reverse_append<U>` chain
     "./test/should-validate/all-elim-types-tlet.pf",  # `bleh<T>` term-let
     "./test/should-validate/map_append_cross_type.pf",  # multi-arg `proof<UInt, bool>`
+    # TLet's `define ...; ...` binds looser than operators/connectives, so
+    # term-let operands must be parenthesized when pretty-printed in those
+    # contexts.
+    "./test/should-validate/contradict-tlet.pf",      # term-let under `and`
+    "./test/should-validate/define_cases.pf",         # term-let under `and`/`or`
+    "./test/should-validate/extensionality-tlet.pf",  # term-let equality args
 )
 
 


### PR DESCRIPTION
## Summary

- Parenthesize `TLet` operands when pretty-printing operator and logical-connective expressions.
- Parenthesize `have` formula annotations when the annotation is a term-let formula.
- Add #931 parser round-trip coverage for the remaining `TLet` AST-drift cluster.

## Tests

- `python3.13 test-deduce.py --equiv --serial`
- `make tests`

## Codex session

codex://threads/019ebe78-fcb6-7812-b3ad-a4bf2c5bfd2a

```bash
open 'codex://threads/019ebe78-fcb6-7812-b3ad-a4bf2c5bfd2a'
```
