### PR TITLE
Gate imperative syntax behind experimental flag

### DIFF
--- a/deduce.py
+++ b/deduce.py
@@ -5,6 +5,7 @@ from flags import (
     set_check_imports,
     set_quiet_mode,
     set_recursive_descent,
+    set_experimental_imperative,
     set_unique_names,
     set_verbose,
 )
@@ -146,6 +147,8 @@ Options:
   --no-stdlib               do not auto-include the standard library
   --recursive-descent       use the recursive descent parser (default)
   --lalr                    use the Lark LALR parser
+  --experimental-imperative enable parser support for experimental
+                            imperative syntax
   -r, --recursive-directories
                             descend into subdirectories of supplied paths
   --quiet                   suppress informational output
@@ -233,6 +236,8 @@ if __name__ == "__main__":
             set_recursive_descent(True)
         elif argument == '--lalr':
             set_recursive_descent(False)
+        elif argument == '--experimental-imperative':
+            set_experimental_imperative(True)
         elif argument == '--quiet':
             set_quiet_mode(True)
         elif argument == '--trace':

--- a/flags.py
+++ b/flags.py
@@ -106,6 +106,18 @@ def set_recursive_descent(b: bool) -> None:
   global recursive_descent
   recursive_descent = b
 
+# flag for experimental imperative syntax
+
+experimental_imperative: bool = False
+
+def get_experimental_imperative() -> bool:
+  global experimental_imperative
+  return experimental_imperative
+
+def set_experimental_imperative(b: bool) -> None:
+  global experimental_imperative
+  experimental_imperative = b
+
 # flag for quiet mode (primarily for testing errors)
 
 quiet_mode: bool = False

--- a/gh_pages/doc/GettingStarted.md
+++ b/gh_pages/doc/GettingStarted.md
@@ -424,6 +424,12 @@ Tells Deduce to use the recursive descent (default) parser. If
 `--lalr` is also supplied, then only the recursive descent parser will
 be used.
 
+`--experimental-imperative`
+
+Enables parser support for experimental imperative syntax under
+development. This flag is intended for parser fixtures and design work;
+ordinary Deduce files do not need it.
+
 `--recursive-directories` or `-r`
 
 Instead of only processing files in the specified directories, Deduce

--- a/imperative_syntax.py
+++ b/imperative_syntax.py
@@ -1,0 +1,40 @@
+import re
+
+from lark.tree import Meta
+
+from error import ParseError
+
+
+_PROC_DECL_RE = re.compile(
+    r"(?m)^[ \t]*(?:(?:public|private|opaque)[ \t]+)?(?P<keyword>proc)\b"
+)
+
+
+def _meta_for_span(program_text: str, filename: str, start: int, end: int) -> Meta:
+    meta = Meta()  # type: ignore[no-untyped-call,unused-ignore]
+    meta.empty = False
+    setattr(meta, "filename", filename)
+    meta.line = program_text.count("\n", 0, start) + 1
+    line_start = program_text.rfind("\n", 0, start) + 1
+    meta.column = start - line_start + 1
+    meta.start_pos = start
+    meta.end_line = meta.line
+    meta.end_column = meta.column + max(1, end - start)
+    meta.end_pos = end
+    return meta
+
+
+def reject_unimplemented_imperative_syntax(
+    program_text: str, filename: str
+) -> None:
+    """Recognize gated imperative syntax before full parser support lands."""
+    match = _PROC_DECL_RE.search(program_text)
+    if match is None:
+        return
+
+    start, end = match.span("keyword")
+    raise ParseError(
+        _meta_for_span(program_text, filename, start, end),
+        "experimental imperative parser path reached for `proc`; "
+        "`proc` declarations are not implemented yet",
+    )

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -85,7 +85,12 @@ from abstract_syntax import (
     get_uniquified_modules,
 )
 from error import ErrorSink
-from flags import get_verbose, get_debugger, set_debugger
+from flags import (
+    get_experimental_imperative,
+    get_verbose,
+    get_debugger,
+    set_debugger,
+)
 from proof_checker import check_deduce, uniquify_deduce
 
 
@@ -338,8 +343,10 @@ def _check_file_impl(
         # cached entry may have been produced by the *other* parser,
         # and the whole point of the explicit choice is to actually
         # run that parser on this file.
+        experimental_imperative = get_experimental_imperative()
         use_cache = (
             parser is None
+            and not experimental_imperative
             and (content is None or _content_matches_file(filename, content))
         )
         if use_cache and module_name in cached:
@@ -362,14 +369,16 @@ def _check_file_impl(
                 _rd_parser.set_filename(filename)
                 _rd_parser.init_parser()
                 ast = _rd_parser.parse(
-                    program_text, trace=get_verbose(), error_expected=False
+                    program_text, trace=get_verbose(), error_expected=False,
+                    experimental_imperative=experimental_imperative,
                 )
             else:
                 _lark_parser.set_deduce_directory(deduce_dir)
                 _lark_parser.set_filename(filename)
                 _lark_parser.init_parser()
                 ast = _lark_parser.parse(
-                    program_text, trace=get_verbose(), error_expected=False
+                    program_text, trace=get_verbose(), error_expected=False,
+                    experimental_imperative=experimental_imperative,
                 )
 
             if len(prelude) > 0:

--- a/parser.py
+++ b/parser.py
@@ -22,8 +22,9 @@ import re
 from lark import Lark, Token, Tree, exceptions
 from lark.tree import Meta
 from typing import Any, TypeAlias as TypingTypeAlias, cast
-from flags import VerboseLevel
+from flags import VerboseLevel, get_experimental_imperative
 from error import ParseError, lark_unexpected_chars_to_parse_error
+from imperative_syntax import reject_unimplemented_imperative_syntax
 
 filename: str = '???'
 
@@ -951,8 +952,13 @@ def parse_program_tree(parse_tree: Tree[Token]) -> list[Statement]:
 
 def parse(program_text: str,
           trace: "bool | VerboseLevel" = False,
-          error_expected: bool = False) -> "list[Statement]":
+          error_expected: bool = False,
+          experimental_imperative: bool | None = None) -> "list[Statement]":
   try:    
+    if experimental_imperative is None:
+        experimental_imperative = get_experimental_imperative()
+    if experimental_imperative:
+        reject_unimplemented_imperative_syntax(program_text, get_filename())
     # if trace:
     #     print('lexing!')
     # lexed = lark_parser.lex(program_text)

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -25,7 +25,8 @@ from abstract_syntax import (
 from lark import Lark, Token, exceptions
 from lark.tree import Meta
 from error import ParseError, error_header, lark_unexpected_chars_to_parse_error
-from flags import VerboseLevel
+from flags import VerboseLevel, get_experimental_imperative
+from imperative_syntax import reject_unimplemented_imperative_syntax
 from edit_distance import closest_keyword, edit_distance
 
 filename: str = '???'
@@ -116,9 +117,14 @@ check_closest_kwd = False
 
 def parse(program_text: str,
           trace: "bool | VerboseLevel" = False,
-          error_expected: bool = False) -> "list[Statement]":
+          error_expected: bool = False,
+          experimental_imperative: bool | None = None) -> "list[Statement]":
   global token_list, current_position, check_closest_kwd
   try:
+    if experimental_imperative is None:
+      experimental_imperative = get_experimental_imperative()
+    if experimental_imperative:
+      reject_unimplemented_imperative_syntax(program_text, get_filename())
     assert lark_parser is not None, "init_parser() must be called before parse()"
     lexed = lark_parser.lex(program_text)
     token_list = []

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -104,7 +104,11 @@ sys.setrecursionlimit(10000)
 sys.argv = [str(REPO_ROOT / "deduce.py")] + sys.argv[1:]
 
 from abstract_syntax import add_import_directory, init_import_directories
-from flags import set_quiet_mode, set_recursive_descent
+from flags import (
+    set_experimental_imperative,
+    set_quiet_mode,
+    set_recursive_descent,
+)
 from lsp.library import check_file, reset_prelude_cache
 import parser as _equiv_lark_parser
 import rec_desc_parser as _equiv_rd_parser
@@ -794,6 +798,70 @@ def run_cli_test() -> list[tuple[str, str, str]]:
             cli_path, "cli",
             f"unexpected stdout:\n{cp.stdout[:500]}",
         ))
+
+    help_cp = subprocess.run(
+        [sys.executable, "deduce.py", "--help"],
+        capture_output=True, text=True,
+    )
+    if help_cp.returncode != 0:
+        failures.append((
+            "deduce.py --help", "cli",
+            f"exit {help_cp.returncode}\nstderr: {help_cp.stderr[:500]}\n"
+            f"stdout: {help_cp.stdout[:500]}",
+        ))
+    elif "--experimental-imperative" not in help_cp.stdout:
+        failures.append((
+            "deduce.py --help", "cli",
+            "--experimental-imperative missing from help output",
+        ))
+    return failures
+
+
+def run_experimental_imperative_parser_test() -> list[tuple[str, str, str]]:
+    source = "module Test\nproc p() {}\n"
+    failures: list[tuple[str, str, str]] = []
+    try:
+        for recursive_descent in (True, False):
+            parser_label = "recursive-descent" if recursive_descent else "lalr"
+            set_recursive_descent(recursive_descent)
+
+            set_experimental_imperative(False)
+            disabled = check_file(
+                "__experimental_proc__.pf", content=source, prelude=(),
+            )
+            if disabled.ok:
+                failures.append((
+                    "__experimental_proc__.pf", parser_label,
+                    "proc syntax unexpectedly parsed with the flag disabled",
+                ))
+            elif "experimental imperative parser path" in (
+                disabled.error_message or ""
+            ):
+                failures.append((
+                    "__experimental_proc__.pf", parser_label,
+                    "disabled flag still reached the experimental parser path",
+                ))
+
+            set_experimental_imperative(True)
+            enabled = check_file(
+                "__experimental_proc__.pf", content=source, prelude=(),
+            )
+            if enabled.ok:
+                failures.append((
+                    "__experimental_proc__.pf", parser_label,
+                    "proc syntax unexpectedly parsed before Proc AST support",
+                ))
+            elif "experimental imperative parser path reached" not in (
+                enabled.error_message or ""
+            ):
+                failures.append((
+                    "__experimental_proc__.pf", parser_label,
+                    "enabled flag did not reach the experimental parser path:\n"
+                    f"{(enabled.error_message or '')[:500]}",
+                ))
+    finally:
+        set_experimental_imperative(False)
+        set_recursive_descent(True)
     return failures
 
 
@@ -1037,6 +1105,11 @@ def main(argv: list[str]) -> int:
         print("\n=== --cli: deduce.py CLI sanity check ===")
         _, fails = time_section(
             "deduce.py --no-stdlib theorem_true.pf", run_cli_test
+        )
+        total_failures.extend(fails)
+        _, fails = time_section(
+            "experimental imperative parser flag",
+            run_experimental_imperative_parser_test,
         )
         total_failures.extend(fails)
 


### PR DESCRIPTION
## Summary

- Add `--experimental-imperative` and a global parser flag.
- Thread the flag through library-mode parser selection and both RD/LALR parser entry points.
- Add a gated `proc` parser-path diagnostic plus regression coverage and CLI help/docs updates.

Fixes #960.

## Tests

- `make tests`

## Codex session

codex://threads/019ebeb6-aad6-7e63-b10e-6331195ed267

```bash
open 'codex://threads/019ebeb6-aad6-7e63-b10e-6331195ed267'
```
