### PR TITLE
Fix remaining should-validate round-trip drift

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -828,5 +828,5 @@ class RewriteFact(Proof):
   equations: List[Proof]
 
   def __str__(self) -> str:
-      return 'replace ' + ','.join([str(eqn) for eqn in self.equations]) \
+      return 'replace ' + ' | '.join([str(eqn) for eqn in self.equations]) \
         + ' in ' + str(self.subject)

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -322,6 +322,9 @@ class PatternTerm(Pattern):
     return PatternTerm(self.location, self.term, params)
 
   def __str__(self) -> str:
+    if len(self.parameters) > 0:
+      return 'with ' + ', '.join([base_name(p) for p in self.parameters]) \
+        + '. ' + str(self.term)
     return str(self.term)
     
 ################ Terms ######################################

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -287,6 +287,9 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/contradict-tlet.pf",      # term-let under `and`
     "./test/should-validate/define_cases.pf",         # term-let under `and`/`or`
     "./test/should-validate/extensionality-tlet.pf",  # term-let equality args
+    # Remaining issue #931 AST-drift fixes:
+    "./test/should-validate/custom_induction.pf",     # `with xs. term` pattern
+    "./test/should-validate/theorem_false2.pf",       # `replace p | q in ...`
 )
 
 


### PR DESCRIPTION
## Summary

- Preserve `with <params>. <term>` syntax when pretty-printing `PatternTerm` cases.
- Pretty-print rewrite facts with `|`-separated proof lists so `replace p | q in h` reparses as the same proof list.
- Add `custom_induction.pf` and `theorem_false2.pf` to the parser round-trip corpus.

## Tests

- `make tests`

## Issue

Progress on #931. This fixes the remaining `test/should-validate` round-trip AST drift cases identified after the latest merged slices. The umbrella remains open for the broader `lib/` round-trip set.

## Codex session

codex://threads/019ebee9-371c-7e61-861f-81d5374f7008

```bash
open 'codex://threads/019ebee9-371c-7e61-861f-81d5374f7008'
```
