### PR TITLE
Fix associative declaration pretty-printing

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1177,9 +1177,9 @@ class Associative(Statement):
   typeof: Type
 
   def __str__(self) -> str:
-    return 'associative ' + str(self.op) \
-      + ('<' + ','.join(self.type_params) + '>' if len(self.type_params) > 0 else '') \
-      + ' ' + str(self.typeof)
+    op_name = complete_name(self.op.get_name()) if isinstance(self.op, VarRef) else str(self.op)
+    type_params = ' <' + ','.join(self.type_params) + '>' if len(self.type_params) > 0 else ''
+    return 'associative ' + op_name + type_params + ' in ' + str(self.typeof)
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Associative:
     new_op = self.op.uniquify(env, ctx)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -294,6 +294,9 @@ PARSER_ROUND_TRIP_FILES = (
     # Remaining issue #931 AST-drift fixes:
     "./test/should-validate/custom_induction.pf",     # `with xs. term` pattern
     "./test/should-validate/theorem_false2.pf",       # `replace p | q in ...`
+    # `Associative.__str__` must preserve the grammar's `in` keyword and
+    # operator identifier spelling.
+    "./test/should-validate/associative_roundtrip.pf",
 )
 
 

--- a/test/should-validate/associative_roundtrip.pf
+++ b/test/should-validate/associative_roundtrip.pf
@@ -1,0 +1,12 @@
+union AssocItem {
+  assoc_item
+}
+
+fun operator ⊝(x:AssocItem, y:AssocItem) {
+  x
+}
+
+postulate assoc_custom: all x:AssocItem, y:AssocItem, z:AssocItem.
+  (x ⊝ y) ⊝ z = x ⊝ (y ⊝ z)
+
+associative operator ⊝ in AssocItem


### PR DESCRIPTION
## Summary

- Fix `Associative.__str__` to print the parser-accepted `associative <identifier> ... in <type>` form.
- Add a focused `associative_roundtrip.pf` fixture to the curated parser round-trip corpus.

## Validation

- `python3.13 deduce.py test/should-validate/associative_roundtrip.pf`
- `python3.13 test-deduce.py --equiv --serial`
- `make tests`

## Notes

- A targeted all-`lib/*.pf` round-trip sweep improved from 29 failing modules to 25 by removing the associative-declaration parse-error category.

## Codex session

codex://threads/019ebf12-a704-7fd0-a204-44edfba7b6fb

```bash
open 'codex://threads/019ebf12-a704-7fd0-a204-44edfba7b6fb'
```
