### PR TITLE
Fix apply-to proof argument round-trip printing

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -209,10 +209,39 @@ class ModusPonens(Proof):
   arg: Proof
 
   def pretty_print(self, indent: int) -> str:
-      return str(self)
+      return indent*' ' + 'apply ' \
+          + _proof_arg_str(self.implication, indent) \
+          + ' to ' + _proof_arg_str(self.arg, indent)
 
   def __str__(self) -> str:
       return 'apply ' + str(self.implication) + ' to ' + str(self.arg)
+
+def _proof_arg_str(proof: Proof, indent: int) -> str:
+  if _proof_arg_needs_block(proof):
+    body = proof.pretty_print(indent + 2).rstrip()
+    return '{\n' + body + '\n' + indent*' ' + '}'
+  return str(proof)
+
+def _proof_arg_needs_block(proof: Proof) -> bool:
+  return isinstance(proof, (
+    AllIntro,
+    ImpIntro,
+    SomeIntro,
+    SomeElim,
+    PLet,
+    PTLetNew,
+    PAnnot,
+    Suffices,
+    Cases,
+    PInjective,
+    PExtensionality,
+    Induction,
+    RuleInduction,
+    RuleInversion,
+    SwitchProof,
+    ApplyDefsGoal,
+    RewriteGoal,
+  ))
 
 @dataclass
 class ImpIntro(Proof):

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -315,6 +315,10 @@ PARSER_ROUND_TRIP_FILES = (
     # `Associative.__str__` must preserve the grammar's `in` keyword and
     # operator identifier spelling.
     "./test/should-validate/associative_roundtrip.pf",
+    # Proof arguments with statement bodies must not be flattened by
+    # ModusPonens pretty-printing (`arbitrary ... assume ...` needs
+    # separators/braces when used after `apply ... to`).
+    "./test/should-validate/apply_to_intro_roundtrip.pf",
 )
 
 

--- a/test/should-validate/apply_to_intro_roundtrip.pf
+++ b/test/should-validate/apply_to_intro_roundtrip.pf
@@ -1,0 +1,8 @@
+theorem apply_to_intro_roundtrip:
+  if (if (all x:bool. if x = x then x = x) then true) then true
+proof
+  assume prem
+  apply prem to arbitrary x:bool
+    assume same: x = x
+    same
+end


### PR DESCRIPTION
## Summary

- Wrap complex proof arguments in braces when pretty-printing `apply ... to ...`, so proof statements such as `arbitrary ... assume ...` are not flattened into an unparsable token stream.
- Add a focused should-validate fixture to the parser round-trip corpus for `apply ... to arbitrary ... assume ...`.

Progresses #931.

## Validation

- `python3.13 deduce.py test/should-validate/apply_to_intro_roundtrip.pf`
- `python3.13 test-deduce.py --equiv --serial`
- `make tests`

## Codex session

codex://threads/019ebf3e-88c6-7b42-a2d9-afee9278e467

```bash
open 'codex://threads/019ebf3e-88c6-7b42-a2d9-afee9278e467'
```
