### PR TITLE
Parse observer declarations with read frames

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -395,6 +395,14 @@ identifier: IDENT              -> identifier
 ?proc_spec_list:                                   -> empty
     | proc_spec proc_spec_list                     -> push
 
+?observer_reads: "reads" frame_list                -> observer_reads
+
+?observer_reads_list:                              -> empty
+    | observer_reads observer_reads_list           -> push
+
+?observer_body_opt:                                -> no_observer_body
+    | "{" term "}"                                 -> observer_body
+
 ?view_inverse_opt:                                 -> no_view_inverse
     | "inverse" identifier                         -> view_inverse
 
@@ -407,6 +415,7 @@ identifier: IDENT              -> identifier
  | visibility "fun" identifier type_params_opt "(" variable_list ")" "{" term "}" -> fun
  | visibility "recfun" identifier type_params_opt "(" variable_list ")" "->" type "measure" term "of" type "{" term "}" "terminates" proof -> general_recursive_function
  | visibility "proc" identifier type_params_opt "(" proc_param_list ")" proc_return_opt proc_spec_list "{" "}" -> proc_decl
+ | visibility "observer" identifier type_params_opt "(" proc_param_list ")" "->" type observer_reads_list observer_body_opt -> observer_decl
  | visibility "view" IDENT type_params_opt "{" "source" type "target" type "into" identifier "out" identifier "roundtrip" identifier view_inverse_opt "}" -> view_declaration
  | definition
  | "associative" identifier type_params_opt "in" type -> associative_declaration

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -3,8 +3,9 @@
 Scope: every dataclass node that can appear at the top level of a ``.pf``
 file, together with the bookkeeping that supports them across imports.
 This covers the ``Declaration`` family (``Theorem``, ``Postulate``,
-``Predicate``, ``Union``, ``TypeAlias``, ``ObjectDecl``, ``RecFun``,
-``GenRecFun``, ``ViewRecFun``, ``ViewDecl``, ``Define``, ``Import``) and the non-``Declaration``
+``Predicate``, ``Union``, ``TypeAlias``, ``ObjectDecl``, ``ObserverDecl``,
+``RecFun``, ``GenRecFun``, ``ViewRecFun``, ``ViewDecl``, ``Define``,
+``Import``) and the non-``Declaration``
 statements (``Auto``, ``Inductive``, ``Module``, ``Export``,
 ``Associative``, ``Trace``, ``Assert``, ``Print``). Their AST helpers
 (``Constructor``, ``Rule``, ``FunCase``) also live here because they only
@@ -663,8 +664,91 @@ class ObjectDecl(Declaration):
       params = '<' + ','.join(self.type_params) + '>' if self.type_params else ''
       return 'object ' + self.name + params
     return base_name(self.name)
-  
-  
+
+
+@dataclass
+class ObserverDecl(Declaration):
+  type_params: List[str]
+  params: List[ProcParam]
+  return_type: Type
+  reads: List[List[FrameExpr]]
+  body: Optional[Term] = None
+
+  def reduce(self, env: object) -> Self:
+    return self
+
+  def substitute(self, sub: object) -> Self:
+    return self
+
+  def uniquify(self, env: object, ctx: object) -> ObserverDecl:
+    env_map = cast(UniquifyEnv, env)
+    uniq_ctx = cast(UniquifyContext, ctx)
+    if self.name in env_map.keys():
+      user_error(self.location,
+                 "observer names may not be overloaded: "
+                 + base_name(self.name))
+    new_name = generate_name(self.name, uniq_ctx)
+    overwrite(env_map, self.name, new_name, self.location)
+    env_map['no overload'][self.name] = 'observer'
+
+    body_env = copy_dict(env_map)
+    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
+    for (old, new) in zip(self.type_params, new_type_params):
+      overwrite(body_env, old, new, self.location)
+
+    new_params = []
+    for param in self.params:
+      new_typ = param.typ.uniquify(body_env, uniq_ctx)
+      new_param_name = generate_name(param.name, uniq_ctx)
+      overwrite(body_env, param.name, new_param_name, param.location)
+      new_params.append(ProcParam(param.location, new_param_name,
+                                  new_typ, param.ghost))
+
+    new_return_type = self.return_type.uniquify(body_env, uniq_ctx)
+    new_reads = [
+      [frame.uniquify(body_env, uniq_ctx) for frame in clause]
+      for clause in self.reads
+    ]
+    new_body = (self.body.uniquify(body_env, uniq_ctx)
+                if self.body is not None else None)
+    return ObserverDecl(self.location, new_name, new_type_params,
+                        new_params, new_return_type, new_reads,
+                        new_body, visibility=self.visibility)
+
+  def collect_exports(
+      self,
+      export_env: UniquifyEnv,
+      importing_module: str,
+  ) -> None:
+    if self.visibility == 'private' and importing_module != get_current_module():
+      return
+    export_env[base_name(self.name)] = [self.name]
+
+  def __str__(self) -> str:
+    if get_verbose():
+      shown_name = self.name
+      typarams = self.type_params
+    else:
+      shown_name = base_name(self.name)
+      typarams = [base_name(t) for t in self.type_params]
+    header = self.visibility_prefix() + 'observer ' + shown_name
+    if typarams:
+      header += '<' + ','.join(typarams) + '>'
+    header += '(' + ', '.join(str(p) for p in self.params) + ')'
+    header += ' -> ' + str(self.return_type)
+    lines = [header]
+    for clause in self.reads:
+      lines.append('  reads ' + ', '.join(str(f) for f in clause))
+    s = '\n'.join(lines)
+    if self.body is not None:
+      s += '\n{\n  ' + str(self.body) + '\n}'
+    return s
+
+  def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
+    return indent * ' ' \
+      + str(self).replace('\n', '\n' + indent * ' ').rstrip() + '\n'
+
+
 @dataclass
 class FunCase(AST):
   rator: Term

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -23,7 +23,7 @@ from abstract_syntax import (
     Call, Conditional, Constructor, Declaration, Define, Env, Export,
     Formula, FunCase, FunctionType, GenRecFun, Generic, GenericUnknownInst,
     Hole, IfThen, Import, Inductive, Lambda, MakeArray, Module, ObjectDecl,
-    ObjectField, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
+    ObjectField, ObserverDecl, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
     PatternBool, PatternCons, Postulate, Predicate, Print, ProcDecl, RecFun,
     ResolvedVar, Rule, Some,
     Statement, Switch, SwitchCase, TAnnote, TLet, Term, TermInst, Theorem,
@@ -77,6 +77,10 @@ def process_declaration_visibility(decl: Declaration, env: Env,
   match decl:
     case ProcDecl(loc, name, _, _, _, _):
       user_error(loc, 'imperative proc declarations are not supported yet: '
+                 + base_name(name))
+
+    case ObserverDecl(loc, name, _, _, _, _, _):
+      user_error(loc, 'imperative observer declarations are not supported yet: '
                  + base_name(name))
 
     case Define(loc, name, ty, body):

--- a/gh_pages/scripts/keywords.py
+++ b/gh_pages/scripts/keywords.py
@@ -86,6 +86,7 @@ known_tokens = {
     'NOT': 'keyword',
     'NAT': 'keyword',
     'OBJECT': 'keyword',
+    'OBSERVER': 'keyword',
     'OBTAIN': 'keyword',
     'OF': 'keyword',
     'OPAQUE': 'keyword',

--- a/parser.py
+++ b/parser.py
@@ -7,7 +7,7 @@ from abstract_syntax import (
     Hole, IfThen, ImpIntro, Import,
     IndCase, Induction, Inductive, IntType, Lambda, MakeArray,
     Mark, Module, ModusPonens, MutableArrayType, ObjectDecl, ObjectField,
-    Omitted, Or, PAndElim, PAnnot, PExtensionality, PHelpUse, PHole,
+    ObserverDecl, Omitted, Or, PAndElim, PAnnot, PExtensionality, PHelpUse, PHole,
     PInjective, PLet, PRecall, PReflexive, PSorry, PSymmetric, PTLetNew,
     PTransitive, PTrue, PTuple, PVar, PatternBool, PatternCons, PatternTerm,
     Postulate, Predicate, Print, ProcDecl, ProcParam, ProcSpec, RecFun,
@@ -389,6 +389,26 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
                              parse_tree_to_list(e.children[3], e),
                              parse_tree_to_ast(e.children[4], e),
                              parse_tree_to_list(e.children[5], e))
+        set_visibility(statement, visibility)
+        return statement
+    elif e.data == 'observer_reads':
+        _require_experimental_imperative(e.meta)
+        return parse_tree_to_list(e.children[0], e)
+    elif e.data == 'observer_body':
+        _require_experimental_imperative(e.meta)
+        return parse_tree_to_ast(e.children[0], e)
+    elif e.data == 'no_observer_body':
+        return None
+    elif e.data == 'observer_decl':
+        _require_experimental_imperative(e.meta)
+        visibility = parse_tree_to_ast(e.children[0], e)
+        statement = ObserverDecl(e.meta,
+                                 parse_tree_to_ast(e.children[1], e),
+                                 parse_tree_to_list(e.children[2], e),
+                                 parse_tree_to_list(e.children[3], e),
+                                 parse_tree_to_ast(e.children[4], e),
+                                 parse_tree_to_list(e.children[5], e),
+                                 parse_tree_to_ast(e.children[6], e))
         set_visibility(statement, visibility)
         return statement
     # terms

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -11,7 +11,8 @@ from abstract_syntax import (
     FrameFootprint, FrameTerm, FunCase, FunctionType,
     GenRecFun, Generic, Hole, IfThen, ImpIntro, Import,
     IndCase, Induction, Inductive, Lambda, MakeArray, Mark,
-    Module, ModusPonens, MutableArrayType, ObjectDecl, ObjectField, Omitted,
+    Module, ModusPonens, MutableArrayType, ObjectDecl, ObjectField,
+    ObserverDecl, Omitted,
     Or, PAndElim, PAnnot, PExtensionality, PHelpUse, PHole, PInjective, PLet,
     PRecall, PReflexive, PSorry, PSymmetric, PTLetNew, PTransitive, PTrue,
     PTuple, PVar, Pattern, PatternBool, PatternCons, PatternTerm, Postulate,
@@ -1886,7 +1887,38 @@ def parse_proc_decl(visibility: str) -> Statement:
   return ProcDecl(meta_from_tokens(start, previous_token()), name, typarams,
                   params, return_type, specs, visibility=visibility)
 
+def parse_observer_reads_list() -> list[list[FrameTerm | FrameField | FrameFootprint | FrameEmpty]]:
+  clauses: list[list[FrameTerm | FrameField | FrameFootprint | FrameEmpty]] = []
+  while not end_of_file() and current_token().value == 'reads':
+    require_experimental_imperative(
+        meta_from_tokens(current_token(), current_token()))
+    advance()
+    clauses.append(parse_frame_list())
+  return clauses
+
+def parse_observer_decl(visibility: str) -> Statement:
+  require_experimental_imperative(meta_from_tokens(current_token(), current_token()))
+  start = current_token()
+  advance()
+  name = parse_identifier()
+  typarams = parse_type_parameters()
+  consume_token('LPAR', '"("', context='after observer name')
+  params = parse_proc_param_list()
+  consume_token('RPAR', '")"', context='after observer parameters')
+  consume_token('ARROW', '"->"', context='after observer parameters')
+  return_type = parse_type()
+  reads = parse_observer_reads_list()
+  body = None
+  if not end_of_file() and current_token().type == 'LBRACE':
+    advance()
+    body = parse_term()
+    consume_token('RBRACE', '"}"', context='after observer body')
+  return ObserverDecl(meta_from_tokens(start, previous_token()), name,
+                      typarams, params, return_type, reads, body,
+                      visibility=visibility)
+
 statement_keywords = {'assert', 'define', 'import', 'inductive', 'object',
+                      'observer',
                       'print',
                       'theorem', 'lemma', 'postulate', 'predicate', 'recursive',
                       'relation', 'fun', 'trace', 'type', 'union', 'view',
@@ -1926,6 +1958,9 @@ def parse_statement() -> Statement:
 
   elif token.type == 'OBJECT':
     return parse_object(visibility)
+
+  elif token.type == 'OBSERVER':
+    return parse_observer_decl(visibility)
 
   elif token.type == 'PREDICATE':
     return parse_predicate(visibility, 'predicate')

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -146,6 +146,7 @@ proc touch<T>(a: [T]!, xs: [List<T>]!, i: T, ghost p: T) -> [T]!
 
 EXPERIMENTAL_IMPERATIVE_FILES = frozenset({
     "./test/should-error/proc_declarations.pf",
+    "./test/should-error/observer_declarations.pf",
 })
 
 
@@ -331,6 +332,10 @@ PARSER_ROUND_TRIP_FILES = (
     # must agree on the AST and the pretty-printer must preserve the header and
     # repeated specification clauses.
     "./test/should-error/proc_declarations.pf",
+    # Parser/AST-only imperative observer declarations. Checker rejection is
+    # intentional; both parsers must agree on the AST and the pretty-printer
+    # must preserve repeated `reads` clauses and the optional body.
+    "./test/should-error/observer_declarations.pf",
 )
 
 

--- a/test/should-error/observer_declarations.pf
+++ b/test/should-error/observer_declarations.pf
@@ -1,0 +1,18 @@
+type Ref<T> = T
+
+public observer all_zero<T>(a: [T]!, i: T, ghost limit: T) -> bool
+  reads a
+  reads a[i]
+  reads footprint(a)
+  reads {}
+{
+  true
+}
+
+private observer ref_holder<T>(r: Ref<T>) -> bool
+  reads r
+
+opaque observer hidden_no_body() -> bool
+  reads {}
+
+observer default_visibility() -> bool

--- a/test/should-error/observer_declarations.pf.err
+++ b/test/should-error/observer_declarations.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/observer_declarations.pf:3.8-10.2: imperative observer declarations are not supported yet: all_zero


### PR DESCRIPTION
## Summary

Phase 1f of the imperative verification plan: introduce `observer`
declarations as pure specification functions over mutable state, with
explicit `reads` frame clauses available to later verifier phases.

- Add `ObserverDecl` AST node with visibility, type parameters,
  parameters, return type, repeated `reads` clauses, and an optional
  brace-wrapped body; preserves stable pretty-printing.
- Teach the LALR and recursive-descent parsers to accept observer
  declarations with type parameters, ghost params, mutable-array and
  `Ref`-style parameter types, every `reads` frame variant (`a`, `a[i]`,
  `footprint(x)`, `{}`), and bodied/bodyless forms.
- Reject observer declarations during checking with a clear parser/AST-only
  unsupported diagnostic, mirroring the existing proc rejection.
- Register `OBSERVER` in the site keyword table and add round-trip and
  experimental-imperative test coverage so both parsers agree on the AST.

Closes #965 (Refs #854).

## Tests

- `make static` — ruff + mypy (clean + `--no-site-packages` clean).
- `python3.13 test-deduce.py` — full suite (lib, should-validate × 2
  parsers, should-error, should-warn, parser equivalence including the
  new `observer_declarations.pf` round-trip).

## Test plan

- [ ] `make static` clean on CI.
- [ ] `python3.13 test-deduce.py --errors` accepts the rejection
      diagnostic for `test/should-error/observer_declarations.pf`.
- [ ] `python3.13 test-deduce.py --equiv` confirms RD and LALR ASTs
      match and the pretty-printer round-trip preserves repeated `reads`
      clauses plus the optional body.

[Claude session](claude://resume?session=b9b43cf7-00f8-409a-a5b5-d7c8dfd9d8ac) — fallback UUID: `b9b43cf7-00f8-409a-a5b5-d7c8dfd9d8ac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
