### PR TITLE
Fix recall pretty-print in proof lists (Refs #931)

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -417,7 +417,7 @@ class PTuple(Proof):
       return str(self)
 
   def __str__(self) -> str:
-    return ', '.join([str(arg) for arg in self.args])
+    return ', '.join(_proof_list_item_str(arg) for arg in self.args)
 
 def extract_tuple(pf: Proof) -> List[Proof]:
     match pf:
@@ -788,6 +788,43 @@ class EvaluateFact(Proof):
   def __str__(self) -> str:
     return 'evaluate in ' + str(self.subject)
 
+def _proof_tail_is_term_greedy(p: Proof) -> bool:
+  """Whether the printed form of ``p`` ends with a term that can
+  greedily consume following separators or keywords at term-parse
+  level. The canonical case is ``PRecall``'s trailing
+  ``parse_nonempty_term_list`` -- it swallows outer commas across
+  ``recall`` items, and the embedded ``parse_term`` happily reads
+  ``in`` (a compare-level operator) and ``|`` (an add-level operator
+  aliased to ``∪``). Any proof shape that just prepends a keyword to a
+  sub-proof inherits the same greediness when that sub-proof is itself
+  greedy, so recurse through the trailing sub-proof.
+  """
+  while True:
+    if isinstance(p, PRecall):
+      return True
+    if isinstance(p, PSymmetric):
+      p = p.body
+    elif isinstance(p, PTransitive):
+      p = p.second
+    elif isinstance(p, PHelpUse):
+      p = p.proof
+    else:
+      return False
+
+
+def _proof_list_item_str(p: Proof) -> str:
+  """String form of a proof when it appears as an element of a
+  ``,``- or ``|``-separated proof list, or just before a context-
+  introducing keyword such as the ``in`` of ``replace ... in ...``.
+  Wraps proofs whose printed form is term-greedy in parens so
+  ``LPAR proof RPAR`` fences the outer separator. The wrapping is a
+  no-op for the parser, so the canonical AST is unaffected.
+  """
+  if _proof_tail_is_term_greedy(p):
+    return '(' + str(p) + ')'
+  return str(p)
+
+
 @dataclass
 class SimplifyGoal(Proof):
   body: Proof
@@ -796,7 +833,8 @@ class SimplifyGoal(Proof):
   def __str__(self) -> str:
       head = 'simplify'
       if self.givens:
-        head += ' with ' + ' | '.join([str(p) for p in self.givens])
+        head += ' with ' + ' | '.join(
+            _proof_list_item_str(p) for p in self.givens)
       return head + '\n' + str(self.body)
 
 
@@ -811,7 +849,8 @@ class SimplifyFact(Proof):
   def __str__(self) -> str:
     head = 'simplify'
     if self.givens:
-      head += ' with ' + ' | '.join([str(p) for p in self.givens])
+      head += ' with ' + ' | '.join(
+          _proof_list_item_str(p) for p in self.givens)
     return head + ' in ' + str(self.subject)
 
 @dataclass
@@ -844,11 +883,12 @@ class RewriteGoal(Proof):
 
   def pretty_print(self, indent: int) -> str:
       return indent*' ' + 'replace ' \
-        + ' | '.join([str(eqn) for eqn in self.equations]) + '\n' \
-        + maybe_pretty_print(self.body, indent)
+        + ' | '.join(_proof_list_item_str(eqn) for eqn in self.equations) \
+        + '\n' + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
-      return 'replace ' + '|'.join([str(eqn) for eqn in self.equations]) \
+      return 'replace ' \
+        + '|'.join(_proof_list_item_str(eqn) for eqn in self.equations) \
         + '\n' + str(self.body)
 
 @dataclass
@@ -857,5 +897,6 @@ class RewriteFact(Proof):
   equations: List[Proof]
 
   def __str__(self) -> str:
-      return 'replace ' + ' | '.join([str(eqn) for eqn in self.equations]) \
+      return 'replace ' \
+        + ' | '.join(_proof_list_item_str(eqn) for eqn in self.equations) \
         + ' in ' + str(self.subject)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -327,6 +327,20 @@ PARSER_ROUND_TRIP_FILES = (
     # ModusPonens pretty-printing (`arbitrary ... assume ...` needs
     # separators/braces when used after `apply ... to`).
     "./test/should-validate/apply_to_intro_roundtrip.pf",
+    # `PRecall`'s textual tail (`recall <fact1>, <fact2>, ...`) is
+    # greedy at the term parser level. When it appears as an element
+    # of a `|`-separated proof list (`simplify with`, `replace`), a
+    # `,`-separated proof tuple (`apply ... to A, B`), or just before
+    # an `in` keyword (`replace ... in ...`), it must be parenthesized
+    # so the outer separator/keyword isn't consumed by the inner
+    # `parse_nonempty_term_list` / `parse_term`. Also covers proofs
+    # that delegate to a trailing `PRecall` (`symmetric recall ...`).
+    # Adds the four `lib/` files that round-tripped after the fix:
+    "./lib/IntAddSub.pf",
+    "./lib/Maps.pf",
+    "./lib/NatLess.pf",
+    "./lib/UIntLess.pf",
+    "./test/should-validate/recall_list_roundtrip.pf",
     # Parser/AST-only imperative procedure declarations. The checker
     # intentionally rejects these until the verifier exists, but both parsers
     # must agree on the AST and the pretty-printer must preserve the header and

--- a/test/should-validate/recall_list_roundtrip.pf
+++ b/test/should-validate/recall_list_roundtrip.pf
@@ -11,6 +11,8 @@
 // omitted the source parens would re-parse as something else (or fail
 // outright on a `recall` that appears where a term is expected).
 
+import UInt
+
 theorem recall_replace_pipe:
   all x:UInt, y:UInt. if x = 1 then if y = 2 then x + y = 1 + 2
 proof

--- a/test/should-validate/recall_list_roundtrip.pf
+++ b/test/should-validate/recall_list_roundtrip.pf
@@ -1,0 +1,43 @@
+// Exercises the pretty-printer parenthesization of `PRecall` (and the
+// proofs that delegate to a trailing `PRecall`, such as `symmetric`)
+// when they appear in `|`-separated proof lists, `,`-separated proof
+// tuples, or just before a context-introducing keyword such as the
+// `in` of `replace ... in ...`.
+//
+// `recall <fact1>, <fact2>, ...` is term-greedy at the parser level —
+// `parse_term`'s add-level operators include `|` (aliased to `∪`) and
+// its compare-level operators include `in`, and the embedded
+// `parse_nonempty_term_list` is `,`-greedy. So a pretty-printer that
+// omitted the source parens would re-parse as something else (or fail
+// outright on a `recall` that appears where a term is expected).
+
+theorem recall_replace_pipe:
+  all x:UInt, y:UInt. if x = 1 then if y = 2 then x + y = 1 + 2
+proof
+  arbitrary x:UInt, y:UInt
+  assume x1
+  assume y2
+  replace (recall x = 1) | (recall y = 2).
+end
+
+theorem recall_tuple_in_apply:
+  all P: fn UInt, UInt -> bool, x:UInt, y:UInt.
+    if (all a:UInt, b:UInt. if a = x then if b = y then P(a, b))
+    then P(x, y)
+proof
+  arbitrary P: fn UInt, UInt -> bool, x:UInt, y:UInt
+  assume H
+  have xx: x = x by .
+  have yy: y = y by .
+  apply H[x, y] to (recall x = x), (recall y = y)
+end
+
+theorem recall_replace_symmetric_in:
+  all k:UInt, j:UInt, P: fn UInt -> bool.
+    if k = j then if P(j) then P(k)
+proof
+  arbitrary k:UInt, j:UInt, P: fn UInt -> bool
+  assume kj
+  assume pj
+  replace symmetric (recall k = j) in recall P(j)
+end


### PR DESCRIPTION
Refs #931

## Summary

Picking up the next sub-bug from the remaining `lib/` parse-fail set. A fresh local sweep of `lib/*.pf` round-trip on today's `main` showed 7 parse-fails, of which 5 share a root cause in `PRecall`'s pretty-printer being too lax.

`PRecall.__str__` produces `recall <fact1>, <fact2>, ...` which is term-greedy at the parser level: its `parse_nonempty_term_list` is comma-greedy, and the embedded `parse_term` happily reads `|` (an add-level operator aliased to `∪`) and `in` (a compare-level operator, used for set membership). So when the pretty-printer emits a `PRecall` inside a `|`-separated proof list, a `,`-separated proof tuple, or just before an `in` keyword, the next separator gets consumed by the inner term parse and reparsing trips with `expected a term, not "recall"`. Concrete repros from `lib/`:

- `lib/IntAddSub.pf`: source `simplify with (recall y < x) | (recall not (x < y))` was pretty-printed without the parens.
- `lib/NatDiv.pf`: source `apply less_trans to (recall k' < m), (recall m < j')` was pretty-printed as bare `apply less_trans to recall k' < m, recall m < j'`.
- `lib/NatDiv.pf` (later): `replace symmetric (recall k = j') in recall P(j')` lost the parens around the `symmetric (recall ...)` argument, so the `in` was consumed by the inner term parse at compare level.

Fix: add a `_proof_list_item_str` helper in `abstract_syntax/proofs.py` that wraps such proofs in parens when emitted as an element of a `|`-separated proof list (`SimplifyGoal`/`SimplifyFact`/`RewriteGoal`/`RewriteFact`), a `,`-separated proof tuple (`PTuple`), or just before an `in` keyword (`replace ... in ...` already wraps the equations list). The helper recurses through `PSymmetric`/`PTransitive`/`PHelpUse` so a proof whose trailing sub-proof is `PRecall` is also wrapped. Parens are a no-op for the parser (`LPAR proof RPAR` returns the inner proof unchanged), so the canonical AST is unaffected.

Four `lib/` files (`IntAddSub.pf`, `Maps.pf`, `NatLess.pf`, `UIntLess.pf`) move from parse-fail to OK on the round-trip sweep and join `PARSER_ROUND_TRIP_FILES`, together with a synthetic `recall_list_roundtrip.pf` fixture covering the three surface shapes (`replace ... | ...`, `apply ... to ..., ...`, `replace symmetric ... in ...`).

Remaining `lib/` parse-fails after this PR: `IntMult.pf` (a `Cases` proof falls back to the dataclass `repr` for lack of a `__str__`) and `NatDiv.pf` (an `obtain ... where ... from ...; choose ...` block is being flattened with semicolons by the pretty-printer). Both are independent pretty-printer bugs that #931 already tracks; this PR doesn't try to address them. `UIntAdd.pf` transitions from parse-fail to AST-drift (its `apply ... to (X), (Y)` PTuple is now pretty-printable but a separate ModusPonens-vs-PTuple bug surfaces — also a follow-up).

## Test plan

- [x] `python3.13 deduce.py test/should-validate/recall_list_roundtrip.pf` validates
- [x] `python3.13 test-deduce.py --equiv --serial` passes (parser equivalence + round-trip)
- [x] `make static` passes
- [x] `python3.13 test-deduce.py` passes
- [x] Local sweep: `lib/` round-trip parse-fails drop from 7 to 2

[Claude session](claude://resume?session=fb5a58da-9dd0-4c1f-a373-595087fe7edb) — fallback UUID: `fb5a58da-9dd0-4c1f-a373-595087fe7edb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
