### PR TITLE
Fix Cases proof round-trip in str-cascading contexts (Refs #931)

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -190,7 +190,13 @@ class Cases(Proof):
             + indent*' ' + '}'
           )
       return '\n'.join(lines) + '\n'
-      
+
+  def __str__(self) -> str:
+      parts = ['cases ' + str(self.subject)]
+      for (label, frm, body) in self.cases:
+          parts.append(self._case_header(label, frm) + ' { ' + str(body) + ' }')
+      return ' '.join(parts)
+
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Cases:
     new_subject = self.subject.uniquify(env, ctx)
     new_cases = []
@@ -830,12 +836,19 @@ class SimplifyGoal(Proof):
   body: Proof
   givens: List[Proof]
 
-  def __str__(self) -> str:
+  def _head(self) -> str:
       head = 'simplify'
       if self.givens:
         head += ' with ' + ' | '.join(
             _proof_list_item_str(p) for p in self.givens)
-      return head + '\n' + str(self.body)
+      return head
+
+  def pretty_print(self, indent: int) -> str:
+      return indent*' ' + self._head() + '\n' \
+        + maybe_pretty_print(self.body, indent)
+
+  def __str__(self) -> str:
+      return self._head() + '\n' + str(self.body)
 
 
 @dataclass

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -341,6 +341,13 @@ PARSER_ROUND_TRIP_FILES = (
     "./lib/NatLess.pf",
     "./lib/UIntLess.pf",
     "./test/should-validate/recall_list_roundtrip.pf",
+    # `Cases.__str__` was missing (the dataclass repr leaked through any
+    # `__str__`-cascading body chain — `simplify ... \n` + `str(body)`,
+    # `expand ... ` + `str(body)`, `replace ... \n` + `str(body)`).
+    # `SimplifyGoal` was also missing `pretty_print`, so the cascade kicked
+    # in even for a top-level `simplify` whose body needed indentation.
+    "./lib/IntMult.pf",
+    "./test/should-validate/cases_in_simplify_roundtrip.pf",
     # Parser/AST-only imperative procedure declarations. The checker
     # intentionally rejects these until the verifier exists, but both parsers
     # must agree on the AST and the pretty-printer must preserve the header and

--- a/test/should-validate/cases_in_simplify_roundtrip.pf
+++ b/test/should-validate/cases_in_simplify_roundtrip.pf
@@ -1,0 +1,27 @@
+// Round-trip fixture: a `cases` proof embedded inside the body of
+// `simplify` / `replace` exercises both Cases.__str__ and
+// SimplifyGoal.pretty_print. Before the fix, the cascading __str__
+// dropped indentation and Cases fell back to a Python dataclass repr.
+
+theorem cases_in_simplify_roundtrip: all P:bool, Q:bool.
+  if (P or Q) then (P or Q)
+proof
+  arbitrary P:bool, Q:bool
+  assume prem
+  simplify with prem
+  cases prem
+  case lp: P { lp }
+  case rq: Q { rq }
+end
+
+theorem cases_in_replace_roundtrip: all P:bool, Q:bool, R:bool.
+  if R = (P or Q) then if (P or Q) then R
+proof
+  arbitrary P:bool, Q:bool, R:bool
+  assume eq
+  assume prem
+  replace eq
+  cases prem
+  case lp: P { lp }
+  case rq: Q { rq }
+end


### PR DESCRIPTION
## Summary

Fixes the `lib/IntMult.pf` round-trip slice of #931. Two related defects in the pretty-printer were producing a Python dataclass `repr` (`Cases(location=<lark.tree.Meta object at 0x…>, …)`) instead of a parseable `cases ...` proof:

- `Cases` had no `__str__`. When a parent's `__str__` cascaded (e.g. `SimplifyGoal.__str__` → `ApplyDefsGoal.__str__` → `RewriteGoal.__str__`, each emitting `head + str(body)` rather than `pretty_print(indent)` on its body), `str(Cases(...))` fell back to the dataclass repr.
- `SimplifyGoal` had no `pretty_print`. The default `Proof.pretty_print` returns `str(self)`, so the cascade kicked in even for an outer `simplify` whose body should have stayed on the indented `pretty_print` chain.

After the fix:
- `Cases.__str__` emits `cases <subject> case <l1> { <body1> } case <l2> { <body2> } ...`, mirroring `RuleInduction.__str__`.
- `SimplifyGoal.pretty_print` emits `indent*' ' + 'simplify[ with …]\n' + maybe_pretty_print(body, indent)`, keeping the chain in indented mode.
- A small `_head()` helper factors the `simplify[ with …]` head out of `SimplifyGoal` so both methods stay in sync and `_proof_list_item_str` (from #984) is still applied to the givens.

`lib/IntMult.pf` and a new `test/should-validate/cases_in_simplify_roundtrip.pf` synthetic fixture (covers `cases` inside both `simplify with` and `replace`) are added to `PARSER_ROUND_TRIP_FILES`.

Refs #931.

## Test plan

- [x] `make static` (ruff + mypy, both passes)
- [x] Full `PARSER_ROUND_TRIP_FILES` sweep (89 files, 0 failures including the two new entries)
- [x] `python deduce.py test/should-validate/cases_in_simplify_roundtrip.pf` passes
- [ ] `make tests` locally
- [ ] CI green

[Claude session](claude://resume?session=6b3a576c-3b86-4482-a242-015c5341691e) — fallback UUID: `6b3a576c-3b86-4482-a242-015c5341691e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
