### PR TITLE
Pretty-printer: parenthesize `not X` operands of infix ops (closes #987)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -970,6 +970,15 @@ def precedence(trm: Term) -> int | None:
         return prefix_precedence.get(op_name, None)
       else:
         return None
+    case IfThen(_, _, _, Bool(_, _, False)):
+      # `not X` (and the `X ≠ Y` sugar that desugars to `not (X = Y)`)
+      # bind looser than every infix operator in the parser: the `NOT`
+      # branch of `parse_term_hi` consumes `parse_term_equal`, so the
+      # printed `not X = Y` reparses as `not (X = Y)`. Returning a
+      # precedence strictly less than every `infix_precedence` value
+      # makes `op_arg_str` parenthesize a `not X` operand of `=`, `<`,
+      # `+`, etc. so the original `(not X) = Y` shape round-trips.
+      return 0
     case _:
       return None
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -348,6 +348,17 @@ PARSER_ROUND_TRIP_FILES = (
     # in even for a top-level `simplify` whose body needed indentation.
     "./lib/IntMult.pf",
     "./test/should-validate/cases_in_simplify_roundtrip.pf",
+    # `not X` (`IfThen(_, _, _, Bool false)`) had no entry in
+    # `precedence`, so an outer infix operator like `=` would print
+    # `(not (P and Q)) = (not P or not Q)` as `not (P and Q) = ...`,
+    # which reparses with `=` inside `not` (since the parser's `NOT`
+    # branch consumes `parse_term_equal`). Covers De Morgan's laws
+    # which were the original lib/Base.pf drift.
+    "./test/should-validate/not_paren_roundtrip.pf",
+    # lib/Base.pf round-trips cleanly once the `not X` precedence
+    # case is added (`not_and`, `not_or`, `double_neg` were the three
+    # drift sites).
+    "./lib/Base.pf",
     # Parser/AST-only imperative procedure declarations. The checker
     # intentionally rejects these until the verifier exists, but both parsers
     # must agree on the AST and the pretty-printer must preserve the header and
@@ -363,7 +374,6 @@ PARSER_ROUND_TRIP_FILES = (
 PARSER_EQUIV_FILES = PARSER_ROUND_TRIP_FILES + (
     # Small representative stdlib modules. Avoid large semantic proof corpora
     # such as BigO; parser equivalence only needs surface-syntax coverage.
-    "./lib/Base.pf",
     "./lib/List.pf",
     "./lib/Nat.pf",
     "./lib/UInt.pf",

--- a/test/should-validate/not_paren_roundtrip.pf
+++ b/test/should-validate/not_paren_roundtrip.pf
@@ -1,0 +1,28 @@
+// Regression coverage for the pretty-printer's handling of `not X`
+// (encoded as `IfThen(_, _, _, Bool false)`) as an operand of `=` and
+// other infix operators. In both parsers, `not` binds *looser* than
+// `=` (the `NOT` branch of `parse_term_hi` consumes
+// `parse_term_equal`), so the printer must parenthesize a `not X`
+// argument of `=`. De Morgan's laws are the canonical witness: their
+// stated equation `(not (P and Q)) = ((not P) or (not Q))` would
+// otherwise reparse as `not ((P and Q) = ((not P) or (not Q)))`.
+
+theorem not_paren_and: all P:bool, Q:bool.
+  (not (P and Q)) = ((not P) or (not Q))
+proof
+  arbitrary P:bool, Q:bool
+  switch P {
+    case true { . }
+    case false { . }
+  }
+end
+
+theorem not_paren_or: all P:bool, Q:bool.
+  (not (P or Q)) = ((not P) and (not Q))
+proof
+  arbitrary P:bool, Q:bool
+  switch P {
+    case true { . }
+    case false { . }
+  }
+end


### PR DESCRIPTION
## Summary

`precedence` returned `None` for the `IfThen(_, _, _, Bool false)` AST
that desugars `not X` (and the `X ≠ Y` sugar). So `op_arg_str` never
wrapped a `not X` argument of `=`, `<`, `+`, etc. — but the parsers'
`NOT` branch consumes `parse_term_equal`, meaning the printed
`(not (P and Q)) = (...)` reparsed as `not ((P and Q) = (...))` with
the outer connective flipping from `=` to `not`. De Morgan's laws
(`lib/Base.pf:not_and`, `not_or`, `double_neg`) were the canonical
witnesses; the sweep found the same drift in 14 other `lib/` files.

Return `0` from `precedence` for the `not X` shape so it is strictly
below every `infix_precedence` value (1..8), forcing parens in
`op_arg_str`.

- `test/should-validate/not_paren_roundtrip.pf`: De Morgan-shaped
  regression fixture covering `(not (P and Q)) = ((not P) or (not Q))`
  and the dual.
- `test-deduce.py`: register the new fixture under
  `PARSER_ROUND_TRIP_FILES` and promote `lib/Base.pf` from the
  equivalence-only block into the round-trip block (it round-trips
  cleanly with the fix).

Closes #987. Refs #931.

The sweep also surfaced four other unrelated drift categories in
`lib/` (public-import visibility, `apply IH[…] to …` AllElim/
ApplyDefsFact nesting, the `∅` set literal, and `apply f to a, apply g
to b` PTuple flattening); those are tracked together in #988 and not
touched here.

## Test plan

- [x] `make static` — ruff + mypy (incl. `--no-site-packages`) clean
- [x] `python3.13 test-deduce.py --equiv` — passes (curated grammar
      corpus + pretty-print round trip)
- [x] `python3.13 test-deduce.py` — full local suite passes
      (`cli + lib + passable + errors + warns + equiv`, 141s)

[Claude session](claude://resume?session=c957d956-19db-4a98-882f-cc68756db73b) — fallback UUID: `c957d956-19db-4a98-882f-cc68756db73b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
