### PR TITLE
Preserve `public` prefix when round-tripping Import declarations

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1322,7 +1322,8 @@ class Import(Declaration):
     return ''
 
   def __str__(self) -> str:
-    return 'import ' + self.name + self._filter_clause_str()
+    prefix = 'public ' if self.visibility == 'public' else ''
+    return prefix + 'import ' + self.name + self._filter_clause_str()
 
   def pretty_print(self, indent: int) -> str:
     return indent*' '  + str(self) + '\n'

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -224,6 +224,7 @@ PARSER_ROUND_TRIP_FILES = (
     "./test/should-validate/relation_basic.pf",    # `relation` declaration
     "./test/should-validate/opaque_define.pf",     # `opaque` visibility
     "./test/should-validate/import_using.pf",      # `import ... using ...`
+    "./test/should-validate/public_import_roundtrip.pf",  # `public import` prefix
     "./test/should-validate/auto_conditional.pf",  # `auto` + `postulate` decl
     "./test/should-validate/recall1.pf",           # `recall` proof
     "./test/should-validate/simplify1.pf",         # `simplify` proof

--- a/test/should-validate/public_import_roundtrip.pf
+++ b/test/should-validate/public_import_roundtrip.pf
@@ -1,0 +1,3 @@
+public import PublicImportNat
+
+assert (zero : Nat) = (zero : Nat)


### PR DESCRIPTION
## Summary

- Fixes category (a) of #988: `Import.__str__` now emits a `public ` prefix when `visibility == 'public'`. Previously, `public import IntDefs` round-tripped to plain `import IntDefs`, which both parsers re-interpret as a non-public (private/default) import, dropping the visibility from the canonical AST.
- Adds `test/should-validate/public_import_roundtrip.pf` and wires it into `PARSER_ROUND_TRIP_FILES` so the round-trip harness covers the `public import` surface form going forward.

Round-trip sweep over `lib/` + `test/should-validate/` now shows 10 mismatches (was 13); the three files that flipped to clean (`lib/Int.pf`, `lib/IntDefs.pf`, `lib/UInt.pf`) are exactly the ones whose only remaining drift was `public import …` per #988(a). The remaining 10 are the other three umbrella categories (b)/(c)/(d) and the `not X` precedence drift tracked separately in #987.

Addresses #988 (category (a)). Refs #931, #987.

## Test plan

- [x] `make static` (ruff + mypy + `mypy --no-site-packages`) — clean.
- [x] `python test-deduce.py --equiv` — passes, including the new `public_import_roundtrip.pf` entry in the round-trip list.
- [x] Manual repro on `lib/Int.pf`: `public import IntDefs` now pretty-prints as `public import IntDefs` under both RD and LALR parsers.
- [x] `python deduce.py --dir test/test-imports test/should-validate/public_import_roundtrip.pf` — `is valid`.

[Claude session](claude://resume?session=136d134c-5a7e-4ac6-9e7f-b7f1a6cdada5) — fallback UUID: `136d134c-5a7e-4ac6-9e7f-b7f1a6cdada5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
