### PR TITLE
Surface warning-severity diagnostics through lsp.query.check (fixes #991)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -54,7 +54,7 @@ from checker_types import (
 )
 from error import (
     Diagnostic, ErrorSink, MatchFailed, error_header, get_active_sink,
-    internal_error, set_active_sink, user_error,
+    get_active_warning_sink, internal_error, set_active_sink, user_error,
 )
 from flags import (
     get_check_imports, get_debugger, get_quiet_mode,
@@ -1485,6 +1485,11 @@ def _check_deduce_body(ast: list[Statement], module_name: str, modified: bool,
         try:
           _sink = get_active_sink()
           pre_n = len(_sink) if _sink is not None else 0
+          # Warning sink is separate from the error sink; track its
+          # size the same way so we can skip caching when a warning
+          # fired (see below). Issue #991.
+          _wsink = get_active_warning_sink()
+          pre_wn = len(_wsink) if _wsink is not None else 0
           # Phase 5 / Step 21: when a debugger is attached, every
           # ``check_proofs`` call must run its hooks -- a cache hit
           # would silently skip the trap.  Re-check unconditionally;
@@ -1502,9 +1507,16 @@ def _check_deduce_body(ast: list[Statement], module_name: str, modified: bool,
             check_proofs(s, env)
             # Don't cache if check_proofs absorbed errors into the
             # sink -- next run must re-check so the diagnostic is
-            # re-emitted.
+            # re-emitted. Same rule applies when a warning fired:
+            # ``lsp.query.check`` surfaces warnings as diagnostics
+            # (issue #991), so a cache hit that silently skipped the
+            # warning-emitting statement would drop the diagnostic on
+            # every subsequent run.
             _sink2 = get_active_sink()
-            if _sink2 is None or len(_sink2) == pre_n:
+            _wsink2 = get_active_warning_sink()
+            errors_absorbed = _sink2 is not None and len(_sink2) != pre_n
+            warnings_emitted = _wsink2 is not None and len(_wsink2) != pre_wn
+            if not errors_absorbed and not warnings_emitted:
               _stmt_cache[key] = True
             _record_miss("check_proofs")
         except Diagnostic as e:

--- a/error.py
+++ b/error.py
@@ -1,4 +1,5 @@
 import contextlib
+from dataclasses import dataclass
 from typing import Iterator, List, NoReturn, Optional, TYPE_CHECKING
 
 from lark.tree import Meta
@@ -162,7 +163,53 @@ def incomplete_error(location: Meta, msg: str, *,
   exc.env = env
   raise exc
 
+@dataclass
+class WarningRecord:
+  """A single ``warning()`` emission captured by an active warning sink.
+
+  Mirrors the ``(location, message_body)`` shape ``Diagnostic`` sub-
+  classes attach post-construction, so ``lsp.query.check`` can render
+  a warning entry with the same helpers it uses for errors.
+  """
+
+  location: Meta
+  message_body: str
+
+
+# When set, ``warning()`` records into this list *instead of* printing.
+# ``lsp.library.check_file(collect_errors=True)`` installs a sink for
+# the duration of one run so ``lsp.query.check`` can surface warnings
+# as ``Severity.WARNING`` diagnostics (issue #991). The CLI leaves this
+# ``None``, so ``deduce.py`` keeps printing warnings verbatim.
+_active_warning_sink: Optional[List[WarningRecord]] = None
+
+
+def set_active_warning_sink(
+    sink: Optional[List[WarningRecord]],
+) -> Optional[List[WarningRecord]]:
+  """Install ``sink`` as the active warning sink and return the
+  previously installed sink (so callers can restore it on exit
+  the way ``check_file`` does in its try/finally)."""
+  global _active_warning_sink
+  prev = _active_warning_sink
+  _active_warning_sink = sink
+  return prev
+
+
+def get_active_warning_sink() -> Optional[List[WarningRecord]]:
+  return _active_warning_sink
+
+
 def warning(location: Meta, msg: str) -> None:
+  sink = _active_warning_sink
+  if sink is not None:
+    # A caller (``lsp.library.check_file(collect_errors=True)``)
+    # asked to capture warnings instead of printing them. Skipping
+    # the print also keeps stdout clean for the stdio-based LSP
+    # server, where any extra bytes on stdout corrupt the JSON-RPC
+    # framing.
+    sink.append(WarningRecord(location=location, message_body=msg))
+    return
   print(error_header(location) + msg)
 
 def wrap_user_error(inner: BaseException, context: str) -> UserError:

--- a/lsp/library.py
+++ b/lsp/library.py
@@ -44,7 +44,7 @@ import os
 import sys
 import threading
 import traceback as _traceback
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Optional, Sequence, cast
@@ -84,7 +84,7 @@ from abstract_syntax import (
     get_recursive_descent,
     get_uniquified_modules,
 )
-from error import ErrorSink
+from error import ErrorSink, WarningRecord, set_active_warning_sink
 from flags import (
     get_experimental_imperative,
     get_debugger,
@@ -144,6 +144,11 @@ class CheckResult:
     # exceptions like ``InternalError``. Typed as ``BaseException`` so
     # both shapes flow through unchanged.
     errors: Optional[list[BaseException]] = None
+    # ``warning()`` emissions captured during this run. Only populated
+    # when ``check_file`` was called with ``collect_errors=True`` (the
+    # LSP/MCP path); the CLI leaves this empty because warnings were
+    # printed to stdout in the usual way.
+    warnings: list[WarningRecord] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.errors is None:
@@ -415,9 +420,21 @@ def _check_file_impl(
         # Var.resolved_names. On failure the variable retains the
         # post-uniquify ast for best-effort partial info.
         sink = ErrorSink() if collect_errors else None
-        typechecked_ast = check_deduce(
-            ast, module_name, True, list(tracing_functions), error_sink=sink
+        # Capture warnings alongside errors when the caller opted into
+        # collect-errors mode. ``lsp.query.check`` uses this to surface
+        # style hints (e.g. the auto-rule ``replace`` advice) as
+        # WARNING-severity diagnostics. Issue #991.
+        warning_sink: Optional[list[WarningRecord]] = (
+            [] if collect_errors else None
         )
+        prev_warning_sink = set_active_warning_sink(warning_sink)
+        try:
+            typechecked_ast = check_deduce(
+                ast, module_name, True, list(tracing_functions), error_sink=sink
+            )
+        finally:
+            set_active_warning_sink(prev_warning_sink)
+        captured_warnings = list(warning_sink) if warning_sink is not None else []
         if sink is not None and sink.errors:
             # collect-errors mode: at least one statement failed but
             # the pipeline kept running. Surface the full list while
@@ -432,6 +449,7 @@ def _check_file_impl(
                 module_name=module_name,
                 ast=typechecked_ast,
                 errors=list(sink.errors),
+                warnings=captured_warnings,
             )
         return CheckResult(
             ok=True,
@@ -440,6 +458,7 @@ def _check_file_impl(
             exception=None,
             module_name=module_name,
             ast=typechecked_ast,
+            warnings=captured_warnings,
         )
     except Exception as e:
         # ``DebuggerQuit`` is control flow (the user typed ``quit`` or

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
         ResolvedVar, Some, Statement, Term, Type,
     )
     from abstract_syntax import Union as UnionDecl
+    from error import WarningRecord
 
 
 __all__ = [
@@ -614,17 +615,27 @@ def check(
         path, content=content, prelude=prelude,
         collect_errors=True, parser=parser,
     )
-    if result.ok:
-        return []
-
-    if result.errors:
-        return [
-            _diagnostic_from_exception(exc, str_fallback=str(exc))
-            for exc in result.errors
-        ]
-    # Fallback: parse/uniquify failure (raised before check_deduce
-    # ever ran, so the sink stayed empty). Single-diagnostic path.
-    return [_diagnostic_from_exception(result.exception, str_fallback=result.error_message)]
+    diagnostics: list[Diagnostic] = []
+    if not result.ok:
+        if result.errors:
+            diagnostics.extend(
+                _diagnostic_from_exception(exc, str_fallback=str(exc))
+                for exc in result.errors
+            )
+        else:
+            # Fallback: parse/uniquify failure (raised before
+            # check_deduce ever ran, so the sink stayed empty).
+            diagnostics.append(
+                _diagnostic_from_exception(
+                    result.exception, str_fallback=result.error_message,
+                )
+            )
+    # Warnings — style hints, "unfinished proof" from ``sorry``, etc.
+    # Surfaced with ``Severity.WARNING`` alongside errors so the
+    # MCP/LSP diagnostic list matches what ``deduce.py`` prints. See
+    # issue #991.
+    diagnostics.extend(_diagnostic_from_warning(w) for w in result.warnings)
+    return diagnostics
 
 
 def _diagnostic_from_exception(
@@ -677,6 +688,28 @@ def _diagnostic_from_exception(
 
     return Diagnostic(
         severity=Severity.ERROR, range=rng, message=body, goal=goal
+    )
+
+
+def _diagnostic_from_warning(warning: "WarningRecord") -> Diagnostic:
+    """Build a ``Severity.WARNING`` Diagnostic from a captured warning.
+
+    Uses the same range-from-location logic as
+    :func:`_diagnostic_from_exception`. Warnings without an attached
+    location (rare, only from callers that pass an empty ``Meta``)
+    collapse to the file-start sentinel range.
+    """
+    sentinel = Range(Position(1, 1), Position(1, 1))
+    location = warning.location
+    if location is not None and not getattr(location, "empty", True):
+        rng = Range(
+            start=Position(location.line, location.column),
+            end=Position(location.end_line, location.end_column),
+        )
+    else:
+        rng = sentinel
+    return Diagnostic(
+        severity=Severity.WARNING, range=rng, message=warning.message_body,
     )
 
 

--- a/test/lsp/test_check.py
+++ b/test/lsp/test_check.py
@@ -354,3 +354,141 @@ def test_check_includes_traceback_for_unstructured_exception(
     assert "_boom" in msg, (
         f"expected the offending frame name in the traceback, got: {msg!r}"
     )
+
+
+# --------------------------------------------------------------------------
+# Warning-severity diagnostics (issue #991)
+# --------------------------------------------------------------------------
+#
+# ``deduce.py`` prints style warnings (e.g. "this ``replace`` argument
+# is handled automatically by an auto rule -- drop it") through
+# ``error.warning`` -> stdout. ``lsp.query.check`` used to swallow
+# those, so anyone using ``mcp__deduce__check_file`` never saw them.
+# ``check`` now captures warnings alongside errors and returns each as
+# a ``Diagnostic`` with ``Severity.WARNING``.
+
+
+def test_check_returns_warning_severity_for_style_warnings() -> None:
+    """A file with a redundant ``replace`` argument produces a
+    WARNING-severity diagnostic, not an error, and the file is still
+    valid (no ERROR diagnostics)."""
+    from lsp.mcp_server import _prelude_for
+
+    src = (
+        "import UInt\n"
+        "import List\n"
+        "\n"
+        "recursive product(List<UInt>) -> UInt {\n"
+        "  product(empty) = 1\n"
+        "  product(node(x, xs)) = x * product(xs)\n"
+        "}\n"
+        "\n"
+        "theorem product_one: all xs:List<UInt>.\n"
+        "  product(xs ++ empty) = product(xs)\n"
+        "proof\n"
+        "  induction List<UInt>\n"
+        "  case empty {\n"
+        "    conclude product(empty ++ empty) = product(empty)\n"
+        "    by expand product | operator++.\n"
+        "  }\n"
+        "  case node(x, xs') assume IH: (product(xs' ++ empty) = product(xs')) {\n"
+        "    expand product | operator++\n"
+        "    replace IH | uint_one_mult.\n"
+        "  }\n"
+        "end\n"
+    )
+    prelude = _prelude_for("test.pf")
+    diags = check("test.pf", src, prelude=prelude)
+
+    errors = [d for d in diags if d.severity is Severity.ERROR]
+    assert errors == [], (
+        f"expected no ERROR diagnostics, got: {[e.message for e in errors]}"
+    )
+
+    warnings = [d for d in diags if d.severity is Severity.WARNING]
+    assert len(warnings) >= 1, (
+        f"expected at least one WARNING diagnostic (redundant "
+        f"``uint_one_mult`` handled by an auto rule), got 0. All "
+        f"diagnostics: {[(d.severity.value, d.message) for d in diags]}"
+    )
+    # The warning identifies which ``replace`` argument was redundant.
+    assert any("uint_one_mult" in w.message for w in warnings), (
+        f"expected a warning mentioning ``uint_one_mult``, got: "
+        f"{[w.message for w in warnings]}"
+    )
+    # And the warning must anchor at the location the CLI prints
+    # (the ``uint_one_mult`` token, not the file-start sentinel).
+    for w in warnings:
+        assert w.range.start.line != 1 or w.range.start.column != 1, (
+            f"warning collapsed to sentinel range: {w}"
+        )
+
+
+def test_check_captured_warnings_do_not_reach_stdout(capsys) -> None:
+    """Once a warning is captured for a diagnostic, it must not also
+    leak to stdout — the stdio-based LSP server would otherwise
+    corrupt its JSON-RPC framing."""
+    from lsp.mcp_server import _prelude_for
+
+    src = (
+        "import UInt\n"
+        "import List\n"
+        "\n"
+        "recursive product(List<UInt>) -> UInt {\n"
+        "  product(empty) = 1\n"
+        "  product(node(x, xs)) = x * product(xs)\n"
+        "}\n"
+        "\n"
+        "theorem product_one: all xs:List<UInt>.\n"
+        "  product(xs ++ empty) = product(xs)\n"
+        "proof\n"
+        "  induction List<UInt>\n"
+        "  case empty {\n"
+        "    conclude product(empty ++ empty) = product(empty)\n"
+        "    by expand product | operator++.\n"
+        "  }\n"
+        "  case node(x, xs') assume IH: (product(xs' ++ empty) = product(xs')) {\n"
+        "    expand product | operator++\n"
+        "    replace IH | uint_one_mult.\n"
+        "  }\n"
+        "end\n"
+    )
+    prelude = _prelude_for("test.pf")
+    capsys.readouterr()  # drain any prior output
+    diags = check("test.pf", src, prelude=prelude)
+    captured = capsys.readouterr()
+    assert any(d.severity is Severity.WARNING for d in diags), (
+        f"expected at least one warning diagnostic, got "
+        f"{[(d.severity.value, d.message[:80]) for d in diags]}"
+    )
+    # The warning message text must NOT appear on stdout — the sink
+    # captured it, so the print path in ``error.warning`` is skipped.
+    assert "uint_one_mult" not in captured.out, (
+        f"warning text leaked to stdout while a sink was active:\n"
+        f"{captured.out!r}"
+    )
+
+
+def test_check_valid_file_with_warning_still_reports_warning() -> None:
+    """When the file has no errors, ``result.ok`` is True but a
+    captured warning must still appear in the diagnostics list —
+    otherwise the LSP client never gets to render it."""
+    from lsp.mcp_server import _prelude_for
+
+    src = (
+        "theorem t: true\n"
+        "proof\n"
+        "  sorry\n"
+        "end\n"
+    )
+    prelude = _prelude_for("test.pf")
+    diags = check("test.pf", src, prelude=prelude)
+    warnings = [d for d in diags if d.severity is Severity.WARNING]
+    assert warnings, (
+        f"expected at least one WARNING (``sorry`` -> unfinished "
+        f"proof), got: {[(d.severity.value, d.message) for d in diags]}"
+    )
+    assert any("unfinished proof" in w.message for w in warnings), (
+        f"expected an 'unfinished proof' warning from ``sorry``; got: "
+        f"{[w.message for w in warnings]}"
+    )


### PR DESCRIPTION
## Summary

Closes #991. `lsp.query.check` (and therefore `mcp__deduce__check_file`) used to swallow every `warning()` emission — auto-rule `replace`/`simplify` style hints, `sorry`'s "unfinished proof" heads-up, style hints on `predicate`/`relation` arity, and the like. `deduce.py` printed them to stdout; anyone driving Deduce through the MCP server or the LSP saw a clean `{"diagnostics": []}` and shipped redundant / sub-optimal proofs.

The fix threads a warning sink through the same `collect_errors=True` path we already use for multi-error collection:

- `error.py` gains a `WarningRecord` dataclass and a module-level `_active_warning_sink`. `warning()` records into the sink (and skips the print) when one is installed. Suppressing the print also keeps the stdio-based LSP server's JSON-RPC framing intact — any bytes on stdout would corrupt it.
- `lsp.library.check_file(collect_errors=True)` installs the sink for the duration of one run, exposes the captured records on `CheckResult.warnings`, and restores the previous sink in a `finally`.
- `lsp.query.check` builds a `Diagnostic(severity=Severity.WARNING, …)` per captured warning and appends them to its returned list — after the error diagnostics for a broken file, and even when `result.ok` is `True` for a clean-but-warned file.
- `checker_pipeline.py`'s stmt cache learns about warnings: cache-hits used to silently skip `check_proofs` on statements that emit warnings, so the second run of the same file would report zero warnings. It now refuses to cache a stmt whose check emitted a warning, mirroring the existing "don't cache if errors were absorbed" rule.

The CLI (`deduce.py`) doesn't set `collect_errors=True`, so its stdout warnings are unchanged.

## Verification

The repro from #991 (`replace uint_one_mult` / `replace uint_mult_assoc` on a redundant auto-rule equation) now produces two `severity: "warning"` diagnostics from `lsp.query.check`:

```
$ python3.13 tmp/check_warns.py
=== diagnostics (2) ===
warning 16 13 -> warning: `uint_one_mult` is handled automatically by an auto rule — drop it from the replace list …
warning 21 18 -> warning: `uint_mult_assoc` is handled automatically by an auto rule — drop it from the replace list …
```

CLI output for the same file is byte-identical to before:

```
$ python3.13 deduce.py tmp/product_warn.pf
tmp/product_warn.pf:16.13-16.26: warning: `uint_one_mult` is handled automatically by an auto rule — drop it from the replace list (it states: (all n:UInt. 1 * n = n))
tmp/product_warn.pf:21.18-21.33: warning: `uint_mult_assoc` is handled automatically by an auto rule — drop it from the replace list (it states: (all m:UInt, n:UInt, o:UInt. (m * n) * o = m * (n * o)))
tmp/product_warn.pf is valid
```

Three new tests in `test/lsp/test_check.py`:

- `test_check_returns_warning_severity_for_style_warnings` — repros the issue's redundant-replace scenario, asserts a `Severity.WARNING` diagnostic naming the redundant lemma and anchored at its source column (not the file-start sentinel).
- `test_check_captured_warnings_do_not_reach_stdout` — via `capsys`, asserts the warning text doesn't leak to stdout while a sink is active (LSP-stdio safety).
- `test_check_valid_file_with_warning_still_reports_warning` — `sorry`-only proof: `result.ok` is `True` but the "unfinished proof" warning still surfaces.

## Test plan

- [x] `make static` — ruff + mypy + `mypy --no-site-packages`, clean.
- [x] `python3.13 test-deduce.py` — 110s, all pass (lib + should-validate + should-error + should-warn + prelude + parser equivalence).
- [x] `python3.13 -m pytest test/unit test/lsp/test_check.py test/lsp/test_library.py test/lsp/test_query.py test/lsp/test_state_isolation.py test/lsp/test_check_proofs_cache.py` — 630 pass.
- [x] `python3.13 -m pytest test/lsp --ignore=test/lsp/test_debugger_repl.py --ignore=test/lsp/test_debugger.py --ignore=test/lsp/test_dap_server.py` — 444 pass; one unrelated pre-existing failure filed as #993 (reproducible on `main` before this change).
- [x] Manual repro of #991 (the `examples/product.pf`-style file with redundant `replace` arguments): `lsp.query.check` now returns two `Severity.WARNING` diagnostics whose ranges point at the redundant lemma names.

[Claude session](claude://resume?session=446d201e-02f8-4779-bee5-cdcd7af72102) — fallback UUID: `446d201e-02f8-4779-bee5-cdcd7af72102`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
