### PR TITLE
Drop instantiation suffix from rewrite_subterm insert-lemma template (closes #993)

### DIFF
--- a/lsp/query.py
+++ b/lsp/query.py
@@ -3936,9 +3936,11 @@ def _insert_lemma_template(
     forall-instantiation suffix: when the unifier resolved every
     all-bound variable of the lemma, the splice writes
     ``name[t1, ..., tN]`` instead of bare ``name`` so the resulting
-    ``apply ... to ?`` (or ``conclude``/``replace``) elaborates with
-    the right inner subgoal. Empty tuple ``()`` means either no
-    forall to instantiate, or the unifier didn't resolve all vars.
+    ``apply ... to ?`` (or ``conclude``) elaborates with the right
+    inner subgoal. Empty tuple ``()`` means either no forall to
+    instantiate, or the unifier didn't resolve all vars. The
+    ``rewrite_subterm`` (``replace``) tier is the exception: it always
+    drops the suffix so the rewrite engine pattern-matches (issue #734).
     """
     name_inst = f"{name}[{', '.join(instantiations)}]" if instantiations else name
     if tier == "full":
@@ -3951,7 +3953,10 @@ def _insert_lemma_template(
     if tier == "premises_remain":
         return f"apply {name_inst} to ?"
     if tier == "rewrite_subterm":
-        return f"replace {name_inst}"
+        # No instantiation suffix: ``replace`` pattern-matches the
+        # equation across the goal, so a fixed ``[t1, ..., tN]`` splice
+        # would only narrow the rewrite to one instance (issue #734).
+        return f"replace {name}"
     if tier == "disjunctive_split":
         return f"cases {name_inst}"
     return name


### PR DESCRIPTION
## Summary

Fixes #993 — `test_insert_lemma.py::test_rewrite_subterm_tier_emits_replace`
failed on `main` because the `rewrite_subterm` tier of `insert_lemma_at`
emitted `replace not_not[P]` where the test (and #734) expect a bare
`replace not_not`.

## Root cause

The `rewrite_subterm` branch of `_insert_lemma_template` (`lsp/query.py`)
used the shared `name_inst` (`<name>[t1, ..., tN]`) rendering. Since #896
taught `_equation_subterm_match` to skip a bare forall-var equation side
and match the *structured* side against a goal subterm, that tier now
resolves a real substitution (e.g. `P → P`). The template then spliced it
as an instantiation suffix.

That contradicts #734: `replace` pattern-matches the equation across the
whole goal, so pinning it to a single instantiation is both unnecessary and
narrows the rewrite. The other tiers (`full`, `premises_remain`,
`disjunctive_split`) still keep the suffix.

## Fix

The `rewrite_subterm` tier now emits `replace <name>` (bare), dropping the
instantiation suffix. Docstring updated to record the exception.

## Testing

- `python3 -m pytest test/lsp/test_insert_lemma.py` — 11 passed (was 1 failing).
- `python3 -m pytest test/lsp` — full LSP suite passes.
- `python3 test-deduce.py --equiv` — parser equivalence + round-trip pass.

[Claude session](claude://resume?session=c505dc8d-df15-4a6a-9793-c8d85652c8d7) — fallback UUID: `c505dc8d-df15-4a6a-9793-c8d85652c8d7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
