### PR TITLE
Fix pretty-printer round-trip drift for ∅, apply-tuples, and postfix conjuncts (closes #988)

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -12,10 +12,9 @@ constructor stacks the language uses for its literals. Covers:
   * Lists (``empty``/``node``): ``mkEmpty``/``mkNode``,
     ``listToNodeList``, ``isNodeList``, ``nodeListToList``,
     ``nodeListToString``.
-  * Empty set, equation shape (``mkEqual``, ``split_equation``,
-    ``is_equation``, ``equation_vars``), and small constructor-name
-    predicates (``is_constructor``, ``constr_name``,
-    ``constructor_conflict``).
+  * Equation shape (``mkEqual``, ``split_equation``, ``is_equation``,
+    ``equation_vars``) and small constructor-name predicates
+    (``is_constructor``, ``constr_name``, ``constructor_conflict``).
 
 Goes here:
   * a new literal form whose surface syntax desugars to a constructor
@@ -722,12 +721,3 @@ def listToNodeList(loc: Meta, lst: Sequence[Term]) -> Term:
   else:
     return mkNode(loc, lst[0], listToNodeList(loc, lst[1:]))
 
-def isEmptySet(t: Term) -> bool:
-  match t:
-    case Call(_, _, fun,
-              [Lambda(_, _, _, Bool(_, _, False))]) \
-              if (name := callable_name(fun)) is not None \
-              and base_name(name) == 'char_fun':
-      return True
-    case _:
-      return False

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -315,6 +315,24 @@ class AllIntro(Proof):
     else:
       self.body = new_body
     
+def _postfix_base_str(p: Proof) -> str:
+  """Printed form of ``p`` as the base of a postfix ``[...]`` / ``<...>``
+  step. Wraps ``p`` in parens unless its printed form ends in a
+  self-contained token that ``parse_proof_med`` treats as a single unit
+  before applying the postfix. Names (``PVar``) and prior ``AllElim`` /
+  ``AllElimTypes`` chains (which already end in ``]`` / ``>``) qualify.
+  Anything whose printed form ends with a trailing ``parse_proof``
+  -consumable sub-proof (``conjunct N of P``, ``apply I to A``, ``expand
+  D in P``, ``replace E in P``, ``symmetric P``, ``transitive P Q``,
+  ``evaluate in P``, ``simplify with G in P``, …) does NOT qualify:
+  the postfix would nest inside that sub-proof instead of wrapping the
+  original ``p``.
+  """
+  if isinstance(p, (PVar, AllElim, AllElimTypes)):
+    return str(p)
+  return '(' + str(p) + ')'
+
+
 @dataclass
 class AllElimTypes(Proof):
   univ: Proof
@@ -329,11 +347,10 @@ class AllElimTypes(Proof):
 
   def __str__(self) -> str:
     s, e = self.pos
-    res = str(self.univ)
     if s == 0:
-      res += f"<{self.arg}"
+      res = _postfix_base_str(self.univ) + f"<{self.arg}"
     else:
-      res += f", {self.arg}"
+      res = str(self.univ) + f", {self.arg}"
 
     if s + 1 == e:
       res += ">"
@@ -354,11 +371,10 @@ class AllElim(Proof):
 
   def __str__(self) -> str:
     s, e = self.pos
-    res = str(self.univ)
     if s == 0:
-      res += f"[{self.arg}"
+      res = _postfix_base_str(self.univ) + f"[{self.arg}"
     else:
-      res += f", {self.arg}"
+      res = str(self.univ) + f", {self.arg}"
 
     if s + 1 == e:
       res += "]"
@@ -795,18 +811,36 @@ class EvaluateFact(Proof):
     return 'evaluate in ' + str(self.subject)
 
 def _proof_tail_is_term_greedy(p: Proof) -> bool:
-  """Whether the printed form of ``p`` ends with a term that can
-  greedily consume following separators or keywords at term-parse
-  level. The canonical case is ``PRecall``'s trailing
-  ``parse_nonempty_term_list`` -- it swallows outer commas across
-  ``recall`` items, and the embedded ``parse_term`` happily reads
-  ``in`` (a compare-level operator) and ``|`` (an add-level operator
-  aliased to ``∪``). Any proof shape that just prepends a keyword to a
-  sub-proof inherits the same greediness when that sub-proof is itself
-  greedy, so recurse through the trailing sub-proof.
+  """Whether the printed form of ``p`` can greedily consume a following
+  ``,`` / ``|`` separator or ``in`` keyword at parse time.
+
+  Two mechanisms produce this. ``PRecall``'s trailing
+  ``parse_nonempty_term_list`` swallows outer commas across ``recall``
+  items, and the embedded ``parse_term`` happily reads ``in`` (a
+  compare-level operator) and ``|`` (an add-level operator aliased to
+  ``∪``). The remaining shapes end with a trailing sub-proof that the
+  parser reads with ``parse_proof()`` — whose ``parse_finishing_proof``
+  layer loops on COMMA to build ``PTuple``s — so ``foo, bar`` gets
+  folded into that inner sub-proof instead of the outer proof list.
+  ``apply I to A, B`` reparsing as one ``ModusPonens`` whose arg is a
+  ``PTuple``, and ``conjunct 0 of prem, X`` reparsing as one
+  ``PAndElim`` whose subject is a ``PTuple``, are both instances.
+
+  Any proof shape that just prepends a keyword to a sub-proof inherits
+  the same greediness when that sub-proof is itself greedy, so recurse
+  through the trailing sub-proof.
   """
   while True:
-    if isinstance(p, PRecall):
+    if isinstance(p, (
+        PRecall,
+        ModusPonens,
+        PAndElim,
+        PAnnot,
+        EvaluateFact,
+        ApplyDefsFact,
+        SimplifyFact,
+        RewriteFact,
+    )):
       return True
     if isinstance(p, PSymmetric):
       p = p.body

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
         getZero,
         intToNat,
         isDeduceInt,
-        isEmptySet,
         isLitNat,
         isLitUInt,
         isNat,
@@ -1177,8 +1176,6 @@ class Call(Term):
       node_list = nodeListToString(self)
       assert node_list is not None
       return '[' + node_list[:-2] + ']'
-    elif isEmptySet(self) and not get_verbose():
-      return '∅'
     else:
       rator_str = str(self.rator)
       # The parser parses a Call's rator at the `parse_array_get` level,

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -360,6 +360,31 @@ PARSER_ROUND_TRIP_FILES = (
     # case is added (`not_and`, `not_or`, `double_neg` were the three
     # drift sites).
     "./lib/Base.pf",
+    # `Call.__str__` used to re-sugar `Call(char_fun, [Lambda(_, false)])`
+    # back to `∅` (`isEmptySet` matched the expanded `empty_set` body),
+    # but both parsers desugar `∅` to `Call(Var('empty_set'), [])`. So the
+    # `char_fun(λx{false})` shape drifted whenever it appeared as the body
+    # of `empty_set` itself or in `@char_fun<T>(λ_{false})` witnesses.
+    # Refs #988 category (c).
+    "./test/should-validate/empty_set_roundtrip.pf",
+    # `_proof_list_item_str` used to parenthesize only the ``PRecall``
+    # trailing-term-list shape and its ``symmetric`` / ``transitive`` /
+    # ``help`` recursion. But every proof whose parse rule ends with a
+    # ``parse_proof()`` call is comma-greedy at the tail: ``apply I to
+    # A``, ``conjunct N of P``, ``expand D in P``, ``replace E in P``,
+    # ``simplify with G in P``, ``evaluate in P``, ``conclude C by P``.
+    # ``PTuple([ModusPonens, ModusPonens])`` therefore drifted to one
+    # ``ModusPonens`` whose arg is a ``PTuple``, and same for
+    # ``PAndElim`` etc.  Symmetrically, ``AllElim`` / ``AllElimTypes``
+    # printed their ``univ`` unparenthesized so the postfix ``[...]`` /
+    # ``<...>`` nested inside a trailing sub-proof instead of wrapping
+    # the ``univ``. Refs #988 categories (b) and (d).
+    "./test/should-validate/apply_tuple_postfix_roundtrip.pf",
+    # lib/ modules now round-trip once (b), (c), (d) are all fixed.
+    # ``Set.pf`` exercises the ``∅`` and ``(conjunct N of P)[x]`` shapes;
+    # ``UIntAdd.pf`` exercises the ``apply f to a, apply g to b`` tuple.
+    "./lib/Set.pf",
+    "./lib/UIntAdd.pf",
     # Parser/AST-only imperative procedure declarations. The checker
     # intentionally rejects these until the verifier exists, but both parsers
     # must agree on the AST and the pretty-printer must preserve the header and
@@ -379,7 +404,6 @@ PARSER_EQUIV_FILES = PARSER_ROUND_TRIP_FILES + (
     "./lib/Nat.pf",
     "./lib/UInt.pf",
     "./lib/Int.pf",
-    "./lib/Set.pf",
     # Warning and later-phase error fixtures add syntax that is not always
     # present in validating examples while staying much smaller than the full
     # should-error directory sweep.

--- a/test/should-validate/apply_tuple_postfix_roundtrip.pf
+++ b/test/should-validate/apply_tuple_postfix_roundtrip.pf
@@ -1,0 +1,48 @@
+// Regression coverage for the pretty-printer's handling of proof forms
+// whose parse rule ends with a ``parse_proof()`` call — the
+// ``parse_finishing_proof`` layer loops on COMMA to build ``PTuple``s,
+// so an outer comma-list drifts if the item ends in one of these
+// forms without an intervening paren fence. And symmetrically, when an
+// ``AllElim`` postfix (``[...]`` / ``<...>``) is applied to such a
+// form, the postfix nests inside the trailing sub-proof instead of
+// wrapping the original base.
+//
+// Covers #988 categories (b) and (d):
+//   * ``apply f to a, apply g to b`` — ``PTuple([ModusPonens, ModusPonens])``
+//   * ``conjunct 0 of prem, conjunct 1 of prem`` — ``PTuple([PAndElim, PAndElim])``
+//   * ``(conjunct 0 of prem)[x]`` — ``AllElim(PAndElim(...), x)``
+//   * ``(apply IH to h)[k]`` — ``AllElim(ModusPonens, k)`` shape
+
+theorem apply_tuple_roundtrip: all P:bool, Q:bool.
+  if (if P then Q) and (if Q then P) and P and Q
+  then Q and P
+proof
+  arbitrary P:bool, Q:bool
+  assume prem: (if P then Q) and (if Q then P) and P and Q
+  have PQ: if P then Q  by conjunct 0 of prem
+  have QP: if Q then P  by conjunct 1 of prem
+  have hp: P  by conjunct 2 of prem
+  have hq: Q  by conjunct 3 of prem
+  conclude Q and P
+    by (apply PQ to hp), (apply QP to hq)
+end
+
+theorem conjunct_tuple_roundtrip: all P:bool, Q:bool.
+  if P and Q
+  then Q and P
+proof
+  arbitrary P:bool, Q:bool
+  assume prem: P and Q
+  conclude Q and P
+    by (conjunct 1 of prem), (conjunct 0 of prem)
+end
+
+theorem allelim_postfix_of_conjunct: all P: fn bool -> bool, Q: fn bool -> bool.
+  if (all x:bool. P(x)) and (all x:bool. Q(x))
+  then P(true) and Q(false)
+proof
+  arbitrary P: fn bool -> bool, Q: fn bool -> bool
+  assume prem: (all x:bool. P(x)) and (all x:bool. Q(x))
+  conclude P(true) and Q(false)
+    by (conjunct 0 of prem)[true], (conjunct 1 of prem)[false]
+end

--- a/test/should-validate/empty_set_roundtrip.pf
+++ b/test/should-validate/empty_set_roundtrip.pf
@@ -1,0 +1,50 @@
+// Regression coverage for the pretty-printer's handling of the `∅` set
+// literal. The parser (both RD and LALR) desugars `∅` to
+// `Call(Var('empty_set'), [])`, but `Call(char_fun, [Lambda(_, false)])`
+// used to be re-sugared back to `∅` by the pretty-printer. That
+// direction-mismatch collapsed the expanded body form back onto the
+// source-level `empty_set()` call, so any term that carried the
+// `char_fun(λx:T{false})` shape (in particular the body of `empty_set`
+// itself and any explicit `@char_fun<T>(λ_{false})` witnesses) drifted
+// on round-trip. Refs #988 category (c).
+
+opaque union Set<T> {
+  char_fun(fn (T) -> bool)
+}
+
+opaque fun rep<T>(S : Set<T>) {
+  switch S {
+    case char_fun(f) { f }
+  }
+}
+
+opaque fun empty_set<T>() {
+  char_fun(λx:T{false})
+}
+
+opaque fun operator ∈ <T>(x : T, S : Set<T>) {
+  rep(S)(x)
+}
+
+theorem empty_no_members: all T:type. all x:T.
+  not (x ∈ ∅)
+proof
+  arbitrary T:type, x:T
+  suppose x_in_empty: x ∈ ∅
+  evaluate in x_in_empty
+end
+
+theorem empty_no_members_ascii: all T:type. all x:T.
+  not (x in .0.)
+proof
+  arbitrary T:type, x:T
+  suppose x_in_empty: x in .0.
+  evaluate in x_in_empty
+end
+
+theorem empty_set_expansion: all T:type.
+  @empty_set<T>() = @char_fun<T>(λ_:T{false})
+proof
+  arbitrary T:type
+  expand empty_set.
+end

--- a/test/unit/test_abstract_syntax_annotations.py
+++ b/test/unit/test_abstract_syntax_annotations.py
@@ -37,7 +37,6 @@ def test_issue_586_abstract_syntax_function_parameters_are_annotated() -> None:
         (ast.mkEmpty, {"loc"}),
         (ast.mkNode, {"loc", "arg", "ls"}),
         (ast.listToNodeList, {"loc", "lst"}),
-        (ast.isEmptySet, {"t"}),
         (ast.type_params_str, {"type_params"}),
     ]
 


### PR DESCRIPTION
## Summary

Addresses categories (b), (c), and (d) of #988 in one pass:

- **(c) `∅` set-literal**: `Call.__str__` re-sugared `Call(char_fun, [Lambda(_, false)])` — the *expanded* body of `empty_set` — back to `∅`, but both parsers desugar `∅` to `Call(Var('empty_set'), [])`. That collapsed the `char_fun(λx{false})` shape onto a different AST on round-trip (the body of `empty_set` itself and any `@char_fun<T>(λ_{false})` witness). Drop the sugar entirely (the "safest, drops a display convenience" option in #988).
- **(d) `apply f to a, apply g to b`**: `APPLY`'s parser reads its arg with `parse_proof()`, whose `parse_finishing_proof` layer loops on COMMA to build `PTuple`s. `PTuple([ModusPonens, ModusPonens])` therefore reparsed as one `ModusPonens` whose arg is a `PTuple`. Same class of drift hits `PAndElim.subject`, and `EvaluateFact` / `ApplyDefsFact` / `SimplifyFact` / `RewriteFact` / `PAnnot` subject — all comma-greedy at the tail. Extend `_proof_tail_is_term_greedy` to cover them so `_proof_list_item_str` fences with parens.
- **(b) postfix `[...]` / `<...>` on a `parse_proof()`-tailed base**: `AllElim` / `AllElimTypes` printed `str(univ)` unparenthesized, so `(conjunct 0 of prem)[x]` reparsed as `conjunct 0 of (prem[x])` and the `AllElim(ApplyDefsFact(...), arg)` shape put the postfix inside the trailing sub-proof instead of wrapping the whole thing. Add `_postfix_base_str` that parens the base unless it's a name or a prior `AllElim` / `AllElimTypes` chain.

All 40 `lib/` files and all 190 `test/should-validate/` files now round-trip. Adds fixtures `empty_set_roundtrip.pf` and `apply_tuple_postfix_roundtrip.pf`, plus `lib/Set.pf` and `lib/UIntAdd.pf` to `PARSER_ROUND_TRIP_FILES`.

Only (a) was fixed in the umbrella earlier (#990); this PR clears (b), (c), and (d), so the umbrella should close.

Addresses #988 (categories (b), (c), (d)). Refs #931.

## Test plan

- [x] `python3.13 test-deduce.py` — full suite passes (parser equivalence, round-trip, should-validate/error/warn).
- [x] `make static` — ruff + mypy clean (both regular and `--no-site-packages`).
- [x] Local sweep: all 40 `lib/*.pf` round-trip; all 190 `test/should-validate/*.pf` round-trip.
- [ ] CI passes.

[Claude session](claude://resume?session=fb7a3ae7-45c1-40ab-acbf-013e5c4d3f2d) — fallback UUID: `fb7a3ae7-45c1-40ab-acbf-013e5c4d3f2d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
