### PR TITLE
Fix round-trip drift: import operator names and applied `empty` constructor (refs #931)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1315,10 +1315,13 @@ class Import(Declaration):
   hiding: Optional[List[str]] = None    # blacklist; None means no blacklist
 
   def _filter_clause_str(self) -> str:
+    # Operator names are stored bare (`≲`), but the parser only accepts
+    # them in a using/hiding list behind the `operator` keyword, so print
+    # them with `complete_name` to keep the clause reparseable.
     if self.using is not None:
-      return ' using ' + ' | '.join(self.using)
+      return ' using ' + ' | '.join(complete_name(n) for n in self.using)
     if self.hiding is not None:
-      return ' hiding ' + ' | '.join(self.hiding)
+      return ' hiding ' + ' | '.join(complete_name(n) for n in self.hiding)
     return ''
 
   def __str__(self) -> str:

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -321,7 +321,8 @@ class PatternCons(Pattern):
 
   def __str__(self) -> str:
       if len(self.parameters) > 0:
-        return str(self.constructor) \
+        ctor = applied_head_str(self.constructor) or str(self.constructor)
+        return ctor \
           + '(' + ', '.join([base_name(p) for p in self.parameters]) + ')'
       else:
         return str(self.constructor)
@@ -934,6 +935,25 @@ def is_var_operator(trm: Term) -> bool:
   # through `is_operator_callable`, which would loop on TermInst(Var(...)).
   return isinstance(trm, VarRef) and is_operator_name(trm.get_name())
 
+def applied_head_str(rator: Term) -> Optional[str]:
+  """Printed name of a var that *heads an application* (a `Call` with
+  arguments, or a `PatternCons` with parameters), or `None` if `rator`
+  is not such a var. The `empty` -> `[]` list-nil sugar (`Var.__str__`
+  et al.) must be suppressed here: `empty` applied to arguments is a
+  user constructor that merely shares the name of `List`'s nil, and
+  `[](x)` does not reparse. Only the sugar differs from the ordinary
+  var spelling in the non-unique, non-verbose mode where it fires, so
+  outside that mode `str(rator)` is already correct and this returns
+  `None`."""
+  if not isinstance(rator, VarRef) or get_unique_names() or get_verbose():
+    return None
+  name = rator.get_name()
+  if base_name(name) != 'empty':
+    return None
+  if is_var_operator(rator):
+    return 'operator ' + name2str(name)
+  return name2str(name)
+
 def is_operator_callable(trm: Term | RecFun | GenRecFun) -> bool:
   name = callable_name(trm)
   return name is not None and is_operator_name(name)
@@ -1177,7 +1197,7 @@ class Call(Term):
       assert node_list is not None
       return '[' + node_list[:-2] + ']'
     else:
-      rator_str = str(self.rator)
+      rator_str = applied_head_str(self.rator) or str(self.rator)
       # The parser parses a Call's rator at the `parse_array_get` level,
       # which only accepts atoms, array accesses, and chained calls. An
       # operator-call rator (e.g. `f ∘ g`) must be parenthesized so the

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -394,6 +394,16 @@ PARSER_ROUND_TRIP_FILES = (
     # intentional; both parsers must agree on the AST and the pretty-printer
     # must preserve repeated `reads` clauses and the optional body.
     "./test/should-error/observer_declarations.pf",
+    # `import M using ... | operator≲` stored the operator name bare (`≲`),
+    # but a using/hiding list only accepts an operator behind the `operator`
+    # keyword, so `Import._filter_clause_str` must print `operator ≲`.
+    "./test/prelude/import_using_prelude.pf",
+    # A user constructor named `empty` (here `Tree.empty(bool)`) shares the
+    # base name of `List`'s nil, so the `empty` -> `[]` display sugar fired
+    # even in applied positions: `empty(b)` printed `[](b)`, which does not
+    # reparse. Covers the pattern (`size(empty(b)) = ...`) and term
+    # (`flip(empty(b)) = empty(b)`) occurrences.
+    "./test/should-error/induction2.pf",
 )
 
 


### PR DESCRIPTION
## Summary

Continues the pretty-printer/parser round-trip coverage work under #931. After #996 landed (fixing the `∅`, apply-tuple, and postfix-conjunct categories), I ran a fresh full-corpus round-trip audit over `lib/`, `test/should-validate/`, `test/should-error/`, and `test/prelude/`. It surfaced **two** remaining pretty-printed forms that fail to reparse; this PR fixes both and drives the audit to **0 drift across all 471 files** (ignoring the intentional `test/parse/` parse-error fixtures).

## Fix 1 — `import M using ... | operator≲`

An operator name in a `using`/`hiding` list is stored **bare** by the parser (`parse_identifier` strips the `operator` keyword, so `operator≲` → `≲`), but the list grammar only accepts an operator symbol behind the `operator` keyword. `Import._filter_clause_str` printed the bare name, so `import BigO using bigo_refl | operator≲` round-tripped to `... | ≲`, which no longer parses.

Fix: print each using/hiding name with the existing `complete_name` helper, so `≲` prints as `operator ≲`.

Surfaced by `test/prelude/import_using_prelude.pf`.

## Fix 2 — a user constructor named `empty` applied to arguments

`union Tree { empty(bool) ... }` defines a constructor `empty` that shares the base name of `List`'s nil, so the `empty` → `[]` display sugar fired even in **applied** positions: `empty(b)` printed as `[](b)`, which does not reparse (and semantically `[]` is `List`'s nil, not the `Tree` constructor).

Fix: a small `applied_head_str` helper suppresses the nil sugar when an `empty`-named var *heads an application* — a `Call` with arguments, or a `PatternCons` with parameters. A bare nil still prints `[]` (that form round-trips fine, since `[]` parses back to `empty`). The helper only fires in non-unique, non-verbose mode where the sugar exists; elsewhere it returns `None` and the ordinary spelling is used.

Surfaced by `test/should-error/induction2.pf` (both the pattern `size(empty(b)) = ...` and the term `flip(empty(b)) = empty(b)`).

## Testing

- `python3 test-deduce.py` (default: lib + should-validate + should-error + should-warn + prelude + parser equivalence) — all pass.
- `python3 test-deduce.py --equiv` and `--parser` — pass.
- Fresh full-corpus round-trip audit (lib + should-validate + should-error + prelude, 471 files): **0 real drift**.
- Added `test/prelude/import_using_prelude.pf` and `test/should-error/induction2.pf` to `PARSER_ROUND_TRIP_FILES` so both categories are guarded in CI.

Refs #931.

[Claude session](claude://resume?session=5a542ed0-955b-4b95-af78-5d499976f5d1) — fallback UUID: `5a542ed0-955b-4b95-af78-5d499976f5d1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
