### PR TITLE
Clear 'in progress' label when a routine PR closes

### DIFF
--- a/.github/workflows/clear_in_progress.yml
+++ b/.github/workflows/clear_in_progress.yml
@@ -1,0 +1,41 @@
+name: Clear "in progress" when a routine PR closes
+
+# The deduce-runner routine labels an issue "in progress" when it starts work,
+# but nothing removes that label afterward. When the routine's PR is merged or
+# closed, drop "in progress" from every issue the PR references, so the issue is
+# selectable again (for partial/umbrella work) and doesn't linger as in progress.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  clear-in-progress:
+    # Only routine branches carry this label convention.
+    if: startsWith(github.event.pull_request.head.ref, 'routine/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove "in progress" from referenced issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Passed via env (not inline ${{ }}) so PR-authored text can't inject shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -e
+          # Every #N mentioned in the title or body (closing keyword or plain "Refs #N").
+          nums=$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true)
+          [ -n "$nums" ] || { echo "No issue references in this PR."; exit 0; }
+          for n in $nums; do
+            # `gh issue view` on a PR number errors out (PRs/issues share numbering);
+            # the guard below simply finds no label and skips those.
+            if gh issue view "$n" --repo "$REPO" --json labels --jq '.labels[].name' 2>/dev/null \
+                 | grep -qx 'in progress'; then
+              gh issue edit "$n" --repo "$REPO" --remove-label 'in progress'
+              echo "Removed 'in progress' from #$n."
+            fi
+          done


### PR DESCRIPTION
## Problem

The `deduce-runner` routine labels an issue **`in progress`** when it selects it,
but nothing ever removes that label. Because the routine's selection step skips
issues already labeled `in progress`, this permanently excludes any issue it has
touched — even long-running umbrella issues where only *part* of the work landed.

Concrete case: umbrella **#931** stayed `in progress` after four `Refs #931` PRs
merged (#942, #957, #986, #998), which blocked the routine from ever picking it
up again to continue the remaining categories.

## Fix

A workflow that fires on `pull_request: [closed]` for `routine/*` branches and
removes `in progress` from every issue the PR references (parsed from title +
body, so it covers both `Closes #N` and `Refs #N`). This handles merges, partial
umbrella work, and abandoned PRs uniformly, and is decoupled from the routine
(the label is cleared when work actually concludes, not when the PR is opened —
so a still-open PR keeps its issue reserved against the next hourly run).

PR-authored text is passed through `env`, not inline `${{ }}`, to avoid shell
injection from untrusted PR bodies.

## Notes

- Scoped to `routine/*` head branches, since the label is a routine-internal
  convention.
- #931's stale label was cleared manually; this prevents recurrence.

[Claude session](claude://resume?session=73275a29-d138-4910-af96-b830c6a0a7f5) — fallback UUID: `73275a29-d138-4910-af96-b830c6a0a7f5`
