### PR TITLE
Fix RD parser EOF crash on bodyless object declaration (refs #931)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -2288,7 +2288,7 @@ def parse_statement() -> Statement:
           'expected a statement, not\n\t' + token.value)
 
 def parse_type_parameters() -> list[str]:
-  if current_token().type == 'LESSTHAN':
+  if not end_of_file() and current_token().type == 'LESSTHAN':
       advance()
       ident_list = parse_ident_list()
       consume_token('MORETHAN', '>', context='after type parameters of "fn"')

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -470,6 +470,13 @@ PARSER_ROUND_TRIP_FILES = (
     # reparse. Covers the pattern (`size(empty(b)) = ...`) and term
     # (`flip(empty(b)) = empty(b)`) occurrences.
     "./test/should-error/induction2.pf",
+    # A bodyless `object` with no type parameters, as the final statement of
+    # the file, hit EOF inside `parse_type_parameters`, which called
+    # `current_token()` with no end-of-file guard. RD raised "Expected a
+    # token, got end of file" while LALR accepted it, so the pretty-printed
+    # `object Empty` at EOF did not reparse under RD. Fixed by guarding the
+    # `LESSTHAN` lookahead with `not end_of_file()`.
+    "./test/should-validate/object_bodyless_eof.pf",
 )
 
 

--- a/test/should-validate/object_bodyless_eof.pf
+++ b/test/should-validate/object_bodyless_eof.pf
@@ -1,0 +1,6 @@
+// A bodyless object declaration with no type parameters, appearing as the
+// final statement of the file, exercises the recursive-descent parser at
+// end-of-file: `parse_type_parameters` used to call `current_token()` with
+// no EOF guard, so `object Empty` at EOF raised "Expected a token" under RD
+// while LALR accepted it. Regression coverage for that parser divergence.
+object Empty


### PR DESCRIPTION
## Summary

A fresh full-corpus round-trip audit (over `lib/`, `test/should-validate/`, `test/should-error/`, `test/should-warn/`, `test/prelude/`, and the `gh_pages/doc/` code blocks) found the reachable corpus round-tripping cleanly, but a targeted probe of the recently-added experimental imperative surface surfaced one parser divergence.

**Bug:** A bodyless `object` declaration with **no type parameters**, appearing as the final statement of a file (e.g. `object Empty` at EOF), raised `ParseError: Expected a token, got end of file` under the recursive-descent parser, while LALR accepted it. `object Empty<T>` (type params) and `object Empty { }` (body) both parsed fine; only the no-type-params + no-body + at-EOF combination failed.

**Root cause:** `parse_type_parameters` in `rec_desc_parser.py` checked `current_token().type == 'LESSTHAN'` with no end-of-file guard. `object` is the only declaration where both the type-parameter list *and* the trailing part (body) are optional, so it is the only form that can reach `parse_type_parameters` with the input exhausted. `object Empty` mid-file worked (the next statement's token was present), which is why the existing `object_syntax.pf` fixture — whose bodyless `public object Root` sits mid-file — never exposed it. The pretty-printer emits `object Empty` verbatim, so any file ending in such an object failed to round-trip under RD.

## Fix

- Guard the `LESSTHAN` lookahead in `parse_type_parameters` with `not end_of_file()`.
- Add `test/should-validate/object_bodyless_eof.pf`, a file whose final statement is a bodyless, no-type-param object.
- Register it in `PARSER_ROUND_TRIP_FILES`.

## Testing

- `python3 test-deduce.py --equiv` — parser equivalence + round-trip pass.
- `python3 test-deduce.py` — full suite (lib + should-validate ×2 parsers + should-error + should-warn + prelude + equiv) passes.
- Both parsers validate the new fixture (`deduce.py` and `deduce.py --lalr`).
- ruff/mypy not run locally (not installed in the container); CI covers them. The change is a one-token EOF guard.

Refs #931 (this umbrella stays open for ongoing round-trip coverage work).

[Claude session](claude://resume?session=11e46bb2-3f8d-46e7-8369-aadcb34f1b10) — fallback UUID: `11e46bb2-3f8d-46e7-8369-aadcb34f1b10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
