### PR TITLE
Phase 1j: document resources/operators and sync highlighting (closes #969)

### DIFF
--- a/editor/emacs/deduce-mode.el
+++ b/editor/emacs/deduce-mode.el
@@ -241,13 +241,17 @@ by `electric-indent-mode' on RET."
     "fn" "array"
     ;; experimental imperative surface (Phase 1, issue #854 — parser/AST
     ;; only; the checker rejects these until later phases land).
-    "proc" "observer" "object" "ghost" "var"
+    "proc" "observer" "object" "resource" "ghost" "var"
     "requires" "ensures" "reads" "modifies" "decreases"
-    "footprint" "new")
+    "footprint" "invariant" "established" "preserved" "while"
+    "call" "as" "return" "new")
   "Deduce keywords highlighted with `font-lock-keyword-face'.")
 
 (defconst deduce-mode--constants
-  '("true" "false")
+  '("true" "false"
+    ;; experimental imperative surface (Phase 1, issue #854): the empty
+    ;; resource `emp'.
+    "emp")
   "Deduce literal constants highlighted with `font-lock-constant-face'.")
 
 (defconst deduce-mode--types

--- a/editor/vscode/syntaxes/deduce.tmLanguage.json
+++ b/editor/vscode/syntaxes/deduce.tmLanguage.json
@@ -95,7 +95,12 @@
         {
           "comment": "Experimental imperative surface (Phase 1, issue #854): parser/AST only.",
           "name": "keyword.other.imperative.deduce",
-          "match": "\\b(proc|observer|object|ghost|var|requires|ensures|reads|modifies|decreases|footprint|new)\\b"
+          "match": "\\b(proc|observer|object|resource|ghost|var|requires|ensures|reads|modifies|decreases|footprint|invariant|established|preserved|while|call|as|return|new|emp)\\b"
+        },
+        {
+          "comment": "Experimental imperative operators (Phase 1, issue #854): separating conjunction, points-to, assignment.",
+          "name": "keyword.operator.imperative.deduce",
+          "match": "\\*\\*|\\|->|:="
         }
       ]
     },

--- a/gh_pages/doc/ImperativeReference.md
+++ b/gh_pages/doc/ImperativeReference.md
@@ -6,10 +6,10 @@ design is described in
 and tracked by [issue #854](https://github.com/jsiek/deduce/issues/854).
 
 **Status:** Phase 1 (parser/AST only). The grammar entries below are
-recognized by both parsers, the pretty-printer round-trips them, and
-import/export plumbing accepts the new declaration names. The
+recognized by both parsers and the pretty-printer round-trips them. The
 imperative verifier itself does not exist yet — the checker rejects
-every `proc` and `observer` declaration until later phases land.
+every `proc`, `observer`, and `resource` declaration until later phases
+land.
 
 Most of the surface lives behind the `--experimental-imperative`
 flag. The exceptions are noted per-section.
@@ -21,6 +21,8 @@ flag. The exceptions are noted per-section.
 - [Object (Statement)](#object-statement)
 - [Observer (Statement)](#observer-statement)
 - [Procedure (Statement)](#procedure-statement)
+- [Resource (Statement)](#resource-statement)
+- [Resource Formulas](#resource-formulas)
 
 ## Frame Expression
 
@@ -237,6 +239,58 @@ proc_proof_entry ::= identifier "{" proof "}"
 This is parser/AST only: proof-slot goal generation, ambiguity checking
 between theorem names and slot labels, and tying `h.valid_post` to a
 call label all land with the verifier in a later phase.
+
+## Resource (Statement)
+
+```deduce-grammar
+statement ::= visibility "resource" identifier type_params_opt "(" proc_param_list ")" resource_body_opt
+resource_body_opt ::= ε
+resource_body_opt ::= "{" term "}"
+```
+
+A `resource` declares a named separation-logic predicate over mutable
+state. Its parameters reuse the [Procedure](#procedure-statement)
+parameter grammar. The optional body, when present, is a
+[resource formula](#resource-formulas) describing the heap ownership the
+resource stands for; a bodyless resource is an abstract predicate whose
+definition is supplied elsewhere.
+
+```deduce
+resource list_seg(p: Node, q: Node)
+{
+  p = q ** emp
+  or (p ≠ q ** p |-> q ** list_seg(q, q))
+}
+```
+
+Resource declarations require `--experimental-imperative`. The checker
+rejects them until the imperative verifier exists.
+
+## Resource Formulas
+
+```deduce-grammar
+atomic_term ::= "emp"
+sep_term ::= sep_term "**" pointsto_term
+sep_term ::= pointsto_term
+pointsto_term ::= equality_term "|->" equality_term
+pointsto_term ::= equality_term
+```
+
+Resource formulas extend the ordinary term grammar with three
+separation-logic connectives, gated behind `--experimental-imperative`:
+
+- `emp` is the empty resource — a heap owning no locations.
+- `p ** q` is the *separating conjunction*: the heap splits into two
+  disjoint parts, one satisfying `p` and the other `q`. It is
+  left-associative, looser than `|->` but tighter than `and`/`or`.
+- `a |-> b` is the *points-to* assertion: a heap owning exactly the
+  single cell at address `a`, holding value `b`. It is non-associative,
+  so `a |-> b |-> c` must be parenthesized. A field-access address such
+  as `p.f` is an ordinary atomic term, so it needs no extra syntax on
+  the left of `|->`.
+
+These connectives parse into ordinary `Term` nodes; they have no proof
+rules or runtime meaning yet.
 
 <!--
 ```{.deduce^file=ImperativeReference.pf}

--- a/gh_pages/doc/SyntaxGrammar.md
+++ b/gh_pages/doc/SyntaxGrammar.md
@@ -25,8 +25,9 @@ A deduce file contains a list of statements. Each statement can be one of:
 10. [Print](./Reference.md#print-statement)
 
 Deduce also has an experimental imperative surface — `proc`,
-`observer`, `object`, mutable arrays `[T]!`, and frame expressions —
-documented separately in the
+`observer`, `object`, `resource`, mutable arrays `[T]!`, imperative
+procedure bodies with proof slots, and separation-resource formulas
+(`emp`, `**`, `|->`) — documented separately in the
 [Experimental Imperative Reference](./ImperativeReference.md). Those
 forms are parser/AST only today and most require
 `--experimental-imperative`.

--- a/gh_pages/js/codeKeywords.js
+++ b/gh_pages/js/codeKeywords.js
@@ -1,14 +1,14 @@
-const prims = ['(?:[0-9])+', 'true', 'false', '∅', '\\.0\\.', '0']
+const prims = ['(?:[0-9])+', 'true', 'false', '∅', '\\.0\\.', 'emp', '0']
 
 const whitespaces = ['(?:[ \t\x0c\r\n])+']
 
 const types = ['fn', 'bool', 'type']
 
-const keywords = ['[ℕ](?:[0-9])+', '[\\-\\+∸*%&equals;≠&lt;&gt;≤≥&amp;∘∪∩⊆∈⨄⊝\\^≲≈]', 'and', 'or', 'in', 'case', 'not', 'fun', 'generic', 'switch', 'all', 'some', 'define', 'if', 'then', 'else', 'suppose', 'assume', 'by', 'proof', 'end', 'conclude', 'apply', 'to', 'contradict', 'conjunct', 'of', 'cases', 'induction', 'rule', 'inversion', 'expand', 'replace', 'evaluate', 'simplify', 'for', 'equations', 'recall', 'reflexive', 'symmetric', 'transitive', 'help', 'sorry', 'with', 'arbitrary', 'choose', 'show', 'extensionality', 'have', 'injective', 'obtain', 'where', 'from', 'stop', 'suffices', 'theorem', 'lemma', 'postulate', 'public', 'private', 'opaque', 'union', 'predicate', 'relation', 'recursive', 'recfun', 'view', 'source', 'target', 'into', 'out', 'roundtrip', 'measure', 'terminates', 'import', 'using', 'hiding', 'export', 'assert', 'print', 'associative', 'auto', 'module', 'trace', 'inductive']
+const keywords = ['[ℕ](?:[0-9])+', '[\\-\\+∸*%&equals;≠&lt;&gt;≤≥&amp;∘∪∩⊆∈⨄⊝\\^≲≈]', 'and', 'or', 'in', 'case', 'not', 'fun', 'generic', 'switch', 'all', 'some', 'define', 'if', 'then', 'else', 'suppose', 'assume', 'by', 'proof', 'end', 'conclude', 'apply', 'to', 'contradict', 'conjunct', 'of', 'cases', 'induction', 'rule', 'inversion', 'expand', 'replace', 'evaluate', 'simplify', 'for', 'equations', 'recall', 'reflexive', 'symmetric', 'transitive', 'help', 'sorry', 'with', 'arbitrary', 'choose', 'show', 'extensionality', 'have', 'injective', 'obtain', 'where', 'from', 'stop', 'suffices', 'theorem', 'lemma', 'postulate', 'public', 'private', 'opaque', 'union', 'predicate', 'relation', 'recursive', 'recfun', 'view', 'source', 'target', 'into', 'out', 'roundtrip', 'measure', 'terminates', 'import', 'using', 'hiding', 'export', 'assert', 'print', 'associative', 'auto', 'module', 'trace', 'inductive', 'object', 'proc', 'observer', 'resource', 'ghost', 'var', 'requires', 'ensures', 'reads', 'modifies', 'footprint', 'invariant', 'decreases', 'established', 'preserved', 'while', 'call', 'as', 'return', 'new', 'inverse']
 
 const idents = ["(?:[A-Z]|[a-z]|_)(?:(?:[₀₁₂₃₄₅₆₇₈₉!?']|[A-Z]|[a-z]|[0-9]|_))*"]
 
-const operators = ['\\-&gt;', 'iff', '&lt;&equals;&gt;', '⇔', ':', '&equals;', '≠', '&sol;&equals;', '&lt;', '&gt;', '≤', '&lt;&equals;', '≥', '&gt;&equals;', '⊆', '\\(&equals;', '∈', '≲', '≈', '\\+', '∪', '\\|', '∩', '\\&amp;', '⨄', '\\.\\+\\.', '\\+\\+', '\\-', '∸', '\\.\\-\\.', '⊝', '&sol;', '%', '\\*', '∘', '\\.o\\.', '\\^', '\\{', '\\}', 'operator', '@', 'array', '\\(', '\\)', '\\[', '\\]', 'λ', '\\.', '&semi;', '\\?', '─', '__', '\\#', ',', '\\.\\.\\.', '\\$']
+const operators = ['\\-&gt;', 'iff', '&lt;&equals;&gt;', '⇔', ':', '&equals;', '≠', '&sol;&equals;', '&lt;', '&gt;', '≤', '&lt;&equals;', '≥', '&gt;&equals;', '⊆', '\\(&equals;', '∈', '≲', '≈', '\\+', '∪', '\\|', '∩', '\\&amp;', '⨄', '\\.\\+\\.', '\\+\\+', '\\-', '∸', '\\.\\-\\.', '⊝', '&sol;', '%', '\\*', '∘', '\\.o\\.', '\\^', '\\{', '\\}', 'operator', '@', 'array', '\\(', '\\)', '\\[', '\\]', 'λ', '\\.', '&semi;', '\\?', '─', '__', '\\#', ',', '\\.\\.\\.', '\\$', '!', '\\*\\*', '\\|\\-&gt;', ':&equals;']
 
 const comments = ['&sol;&sol;[^\n]*', '\\&sol;\\*(\\*(?!\\&sol;)|[^*])*\\*\\&sol;']
 


### PR DESCRIPTION
## Phase 1j: docs, highlighting, and syntax fixtures for imperative syntax

Closes #969.

Completes the Phase 1 syntax-change checklist for the experimental
imperative surface, now that the resource / proof-slot / call-label
parsers have landed (#1000, #1001, #1002). #985 documented and
highlighted only the syntax that existed then and deliberately deferred
the rest; this PR fills those gaps.

### Documentation (`gh_pages/doc/`)
- **ImperativeReference.md** — new **Resource (Statement)** and
  **Resource Formulas** sections covering `resource` declarations and the
  `emp` / `**` / `|->` separation-logic connectives. Both new
  `deduce-grammar` blocks are validated against `Deduce.lark` by
  `reference_grammar.py` (170 → 175 checked rules). The Status note now
  lists `resource` among the declarations the checker rejects, and drops
  the premature claim that import/export plumbing accepts the new names
  (that is #968, still open).
- **SyntaxGrammar.md** — the experimental-imperative pointer paragraph now
  names `resource`, imperative procedure bodies with proof slots, and the
  separation-resource formulas.

### Highlighting
- **gh_pages/js/codeKeywords.js** — add the imperative keywords, the `emp`
  prim, and the `**`, `|->`, `:=`, `!` operators. `**`/`|->`/`:=` are
  appended last so they win over `*`/`|`/`:` in the `getRegexSymbols`
  alternation (verified by simulating the `codeUtils.js` passes). This is
  a scoped merge, not a full regeneration: a clean regen renames the
  `idents` export (breaking the `sandbox.js` import) and rewrites base
  identifier/operator regexes unrelated to this issue.
- **editor/vscode/syntaxes/deduce.tmLanguage.json** — extend the
  imperative keyword group and add an imperative-operator pattern for
  `**`, `|->`, `:=`.
- **editor/emacs/deduce-mode.el** — extend the imperative keyword list and
  add `emp` as a constant.

`old` / `unchanged` from the issue's keyword list are intentionally
**omitted**: they are not tokens in `Deduce.lark`, so adding them to
`keywords.py` would fail the token-consistency check.

### Fixtures
`proc` / `observer` / `resource` declarations, imperative bodies, proof
slots, and call labels are already covered by the round-trip corpus
(`test/should-error/{proc,observer,resource}_declarations.pf` in
`PARSER_ROUND_TRIP_FILES`, gated by `EXPERIMENTAL_IMPERATIVE_FILES`), so
`--equiv` and `--parser` already exercise the Phase 1 syntax under both
parsers. No new fixtures were needed.

`docs/imperative-verification-plan.md` already names #854 as the tracking
issue, so no change was needed there.

### Verification
- `python3 gh_pages/scripts/keywords.py` (token consistency) — OK
- `python3 gh_pages/scripts/reference_grammar.py` — 175 rules OK
- `python3 test-deduce.py --equiv` — all pass
- `python3 test-deduce.py --parser` — all pass
- `python3 test-deduce.py --site` — all pass (requires the `markdown`
  package; not installed in the base container)

### Noticed in passing
Filed #1004: the site highlighter mis-colors single-letter identifiers
(`a`,`m`,`p`,`g`,`t`,`l`,`s`,`e`,`q`,`u`) as keywords because
`code_block_syntax_generator.py` HTML-escapes `&`/`=`/`<`/`>` inside a
regex character class. Pre-existing; not touched here.

Resume this session on ginger: `~/deduce-runner/resume.sh 83a1eb7a-34c5-4ef4-b564-845c97f7e1a3 routine/20260714-220201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
