### PR TITLE
Sync codeKeywords export name with sandbox import (closes #1007)

### DIFF
--- a/gh_pages/js/codeKeywords.js
+++ b/gh_pages/js/codeKeywords.js
@@ -6,7 +6,7 @@ const types = ['fn', 'bool', 'type']
 
 const keywords = ['[ℕ](?:[0-9])+', '[\\-\\+∸*%=≠<>≤≥&∘∪∩⊆∈⨄⊝\\^≲≈]', 'and', 'or', 'in', 'case', 'not', 'fun', 'generic', 'switch', 'all', 'some', 'define', 'if', 'then', 'else', 'suppose', 'assume', 'by', 'proof', 'end', 'conclude', 'apply', 'to', 'contradict', 'conjunct', 'of', 'cases', 'induction', 'rule', 'inversion', 'expand', 'replace', 'evaluate', 'simplify', 'for', 'equations', 'recall', 'reflexive', 'symmetric', 'transitive', 'help', 'sorry', 'with', 'arbitrary', 'choose', 'show', 'extensionality', 'have', 'injective', 'obtain', 'where', 'from', 'stop', 'suffices', 'theorem', 'lemma', 'postulate', 'public', 'private', 'opaque', 'union', 'predicate', 'relation', 'recursive', 'recfun', 'view', 'source', 'target', 'into', 'out', 'roundtrip', 'measure', 'terminates', 'import', 'using', 'hiding', 'export', 'assert', 'print', 'associative', 'auto', 'module', 'trace', 'inductive', 'object', 'proc', 'observer', 'resource', 'ghost', 'var', 'requires', 'ensures', 'reads', 'modifies', 'footprint', 'invariant', 'decreases', 'established', 'preserved', 'while', 'call', 'as', 'return', 'new', 'inverse']
 
-const idents = ["(?:[A-Z]|[a-z]|_)(?:(?:[₀₁₂₃₄₅₆₇₈₉!?']|[A-Z]|[a-z]|[0-9]|_))*"]
+const identifiers = ["(?:[A-Z]|[a-z]|_)(?:(?:[₀₁₂₃₄₅₆₇₈₉!?']|[A-Z]|[a-z]|[0-9]|_))*"]
 
 const operators = ['\\-&gt;', 'iff', '&lt;&equals;&gt;', '⇔', ':', '&equals;', '≠', '&sol;&equals;', '&lt;', '&gt;', '≤', '&lt;&equals;', '≥', '&gt;&equals;', '⊆', '\\(&equals;', '∈', '≲', '≈', '\\+', '∪', '\\|', '∩', '\\&amp;', '⨄', '\\.\\+\\.', '\\+\\+', '\\-', '∸', '\\.\\-\\.', '⊝', '&sol;', '%', '\\*', '∘', '\\.o\\.', '\\^', '\\{', '\\}', 'operator', '@', 'array', '\\(', '\\)', '\\[', '\\]', 'λ', '\\.', '&semi;', '\\?', '─', '__', '\\#', ',', '\\.\\.\\.', '\\$', '!', '\\*\\*', '\\|\\-&gt;', ':&equals;']
 
@@ -14,4 +14,4 @@ const comments = ['&sol;&sol;[^\n]*', '\\&sol;\\*(\\*(?!\\&sol;)|[^*])*\\*\\&sol
 
 const libs = ['UIntDefs', 'NatPowLog', 'UIntMult', 'UIntMonus', 'MultiSet', 'UIntToFrom', 'Set', 'NatAdd', 'UInt', 'NatDefs', 'Int', 'UIntPowLog', 'Base', 'Pair', 'NatDiv', 'NatMult', 'NatEvenOdd', 'NatSum', 'Maps', 'UIntEvenOdd', 'NatMonus', 'IntMult', 'IntAddSub', 'List', 'BigO', 'Option', 'NatLess', 'IntDefs', 'UIntLess', 'UIntDiv', 'Nat', 'UIntAdd']
 
-export { prims, whitespaces, types, keywords, idents, operators, comments, libs }
+export { prims, whitespaces, types, keywords, identifiers, operators, comments, libs }

--- a/gh_pages/js/sandbox.js
+++ b/gh_pages/js/sandbox.js
@@ -1,4 +1,4 @@
-import { idents, types, prims, operators, keywords, whitespaces, comments, libs } from './codeKeywords.js'
+import { identifiers, types, prims, operators, keywords, whitespaces, comments, libs } from './codeKeywords.js'
 
 const isMobile = window.innerWidth < 990;
 


### PR DESCRIPTION
Closes #1007

## Summary

Fixes the deployed-sandbox load failure described in #1007.

The Pages deploy workflow (`.github/workflows/static.yml`) regenerates
`gh_pages/js/codeKeywords.js` via `code_block_syntax_generator.py` before
uploading `./gh_pages`. Because `keywords.py` maps `IDENT` to the token type
`identifier`, the generator names the exported list **`identifiers`**. The
committed `codeKeywords.js` and `sandbox.js`, however, still used the older
name **`idents`**. Under ES modules, importing a name the module does not
export is a load-time error, so the *deployed* sandbox threw
`"The requested module does not provide an export named 'idents'"` and never
loaded.

## Fix

Align both consumers on `identifiers` — the name the generator actually emits —
so the committed snapshot, `sandbox.js`, and the deploy-time regeneration all
agree:

- `gh_pages/js/codeKeywords.js`: rename the `const idents` list and its `export`
  entry to `identifiers`.
- `gh_pages/js/sandbox.js`: rename the import from `idents` to `identifiers`
  (it was imported but otherwise unused, so only the load-time binding
  mattered).

`codeUtils.js` does not import this list, so it is unaffected.

## Verification

- Confirmed the generator (`python3 gh_pages/scripts/code_block_syntax_generator.py`)
  emits an `export { … identifiers … }` line, matching the committed file and
  both JS consumers after this change.
- Checked that every name imported by `sandbox.js` and `codeUtils.js` is present
  in the committed file's `export { … }` — no missing bindings.
- `python3 gh_pages/scripts/keywords.py` (known-token check) still passes.

## Notes / relationship to #1004 and #1006

The sibling bug #1004 (char class mis-highlighting single letters) was fixed
independently by #1006 while this work was in flight; #1004 is already closed.
#1006 surgically patched only the OPERATOR char class in the committed
`codeKeywords.js`, leaving the `idents`/`identifiers` drift in place — this PR
clears that remaining drift.

Resume this session on ginger: `~/deduce-runner/resume.sh 3fa83168-f855-4f4e-acf8-3fcc95c3626e routine/20260715-000202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
