### PR TITLE
Wire imperative declarations into imports, exports, and symbols (Phase 1i, closes #968)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -75,17 +75,8 @@ def process_declaration_visibility(decl: Declaration, env: Env,
                                    downstream_needs_checking: list[bool]
                                    ) -> tuple[Statement, Env]:
   match decl:
-    case ProcDecl(loc, name, _, _, _, _, _):
-      user_error(loc, 'imperative proc declarations are not supported yet: '
-                 + base_name(name))
-
-    case ObserverDecl(loc, name, _, _, _, _, _):
-      user_error(loc, 'imperative observer declarations are not supported yet: '
-                 + base_name(name))
-
-    case ResourceDecl(loc, name, _, _, _):
-      user_error(loc, 'imperative resource declarations are not supported yet: '
-                 + base_name(name))
+    case ProcDecl() | ObserverDecl() | ResourceDecl():
+      return decl, env
 
     case Define(loc, name, ty, body):
       if ty == None:
@@ -291,6 +282,7 @@ def process_declaration_visibility(decl: Declaration, env: Env,
 
           ast2 = []
           assert ast is not None
+          check_exported_contract_visibility(ast)
           for s in ast:
             new_s, env = process_declaration(s, env, module_chain, needs_checking)
             ast2.append(new_s)
@@ -852,9 +844,12 @@ def type_check_stmt(stmt: Statement, env: Env,
     case ViewDecl():
       return stmt
 
-    case ObjectDecl():
+    case ObjectDecl() | ProcDecl() | ObserverDecl() | ResourceDecl():
+      # Phase 1 imperative declarations (issue #854): recognized for module
+      # boundaries and tooling, but their bodies and specs are not verified
+      # here -- pass them through unchanged.
       return stmt
-    
+
     case Trace(loc, var):
       var_ty = env.get_type_of_term_var(var)
       match var_ty:
@@ -870,9 +865,6 @@ def type_check_stmt(stmt: Statement, env: Env,
     case TypeAlias():
       return stmt
 
-    case ObjectDecl():
-      return stmt
-  
     case Export(loc, name):
         return stmt
     
@@ -954,9 +946,9 @@ def collect_env(stmt: Statement, env: Env) -> Env:
     case TypeAlias():
       return env
 
-    case ObjectDecl():
+    case ObjectDecl() | ProcDecl() | ObserverDecl() | ResourceDecl():
       return env
-          
+
     case Theorem(loc, name, frm, _, _):
       return env.declare_proof_var(loc, name, frm)
 
@@ -1230,7 +1222,7 @@ def check_proofs(stmt: Statement, env: Env) -> None:
     case TypeAlias():
       pass
 
-    case ObjectDecl():
+    case ObjectDecl() | ProcDecl() | ObserverDecl() | ResourceDecl():
       pass
 
     case ViewDecl():
@@ -1314,6 +1306,70 @@ def check_proofs(stmt: Statement, env: Env) -> None:
   if _dbg is not None:
     _dbg.after_statement(stmt, env)
 
+def _referenced_names(node: object) -> set[str]:
+  # Collect every resolved name referenced anywhere inside `node` by walking
+  # its dataclass fields (the same generic traversal as
+  # checker_logic._ast_mentions_any, but gathering names instead of testing
+  # membership). Used by the exported-contract visibility check.
+  names: set[str] = set()
+  seen: set[int] = set()
+  stack: list[object] = [node]
+  while stack:
+    n = stack.pop()
+    if isinstance(n, (list, tuple)):
+      stack.extend(n)
+      continue
+    if isinstance(n, dict):
+      stack.extend(n.values())
+      continue
+    nid = id(n)
+    if nid in seen:
+      continue
+    seen.add(nid)
+    if isinstance(n, OverloadedVar):
+      names.update(n.resolved_names)
+    elif isinstance(n, VarRef):
+      names.add(n.get_name())
+    if hasattr(n, '__dict__'):
+      for v in vars(n).values():
+        if v is not None and not isinstance(v, (str, int, float, bool)):
+          stack.append(v)
+  return names
+
+def check_exported_contract_visibility(ast: List[Statement]) -> None:
+  # Phase 1 module-boundary check (issue #854/#968). An exported imperative
+  # contract may only mention names that are themselves visible to importing
+  # modules. A `private` declaration in the same module resolves fine
+  # internally but is dropped from the module's exports, so exposing it in a
+  # public `proc`/`observer` contract would leave importers unable to state or
+  # use that contract. We reject it here rather than letting importers hit a
+  # confusing "undefined name" later. The declaration body stays hidden, so a
+  # private name used only in a body (not the contract) is fine.
+  private: dict[str, str] = {}
+  for s in ast:
+    if isinstance(s, Declaration) and s.visibility == 'private':
+      private[s.name] = base_name(s.name)
+  if not private:
+    return
+  for s in ast:
+    match s:
+      case ProcDecl() if s.visibility != 'private':
+        contract: list[object] = [*s.params, *s.specs]
+        if s.return_type is not None:
+          contract.append(s.return_type)
+        kind = 'proc'
+      case ObserverDecl() if s.visibility != 'private':
+        contract = [*s.params, s.return_type, *s.reads]
+        kind = 'observer'
+      case _:
+        continue
+    for ref in sorted(_referenced_names(contract) & private.keys()):
+      user_error(s.location,
+                 'exported ' + kind + " '" + base_name(s.name)
+                 + "' mentions the private name '" + private[ref]
+                 + "' in its contract; a public contract may only mention "
+                 + 'names visible to importing modules.')
+
 def check_deduce(ast: List[Statement], module_name: str, modified: bool,
                  tracing_functions: List[str],
                  error_sink: Optional[ErrorSink] = None) -> List[Statement]:
@@ -1373,6 +1429,11 @@ def _check_deduce_body(ast: list[Statement], module_name: str, modified: bool,
   # ``ast2_pairs`` collects (post-decl AST, hash) pairs only for
   # statements whose declaration phase succeeded; failed statements
   # are dropped here so they don't show up in later phases.
+  try:
+    check_exported_contract_visibility(ast)
+  except Diagnostic as e:
+    _collect_diagnostic(e)
+
   ast2_pairs = []
   for s in ast:
     sh = _hash_ast(s)

--- a/lsp/lsp_server.py
+++ b/lsp/lsp_server.py
@@ -230,6 +230,10 @@ _SYMBOL_KIND_MAP: dict[_query.SymbolKind, lsp_types.SymbolKind] = {
     _query.SymbolKind.PREDICATE: lsp_types.SymbolKind.Function,
     _query.SymbolKind.POSTULATE: lsp_types.SymbolKind.Function,
     _query.SymbolKind.IMPORT: lsp_types.SymbolKind.Module,
+    _query.SymbolKind.OBJECT: lsp_types.SymbolKind.Class,
+    _query.SymbolKind.PROC: lsp_types.SymbolKind.Method,
+    _query.SymbolKind.OBSERVER: lsp_types.SymbolKind.Function,
+    _query.SymbolKind.RESOURCE: lsp_types.SymbolKind.Struct,
     _query.SymbolKind.OTHER: lsp_types.SymbolKind.Variable,
 }
 

--- a/lsp/query.py
+++ b/lsp/query.py
@@ -145,6 +145,10 @@ class SymbolKind(Enum):
     PREDICATE = "predicate"
     POSTULATE = "postulate"
     IMPORT = "import"
+    OBJECT = "object"
+    PROC = "proc"
+    OBSERVER = "observer"
+    RESOURCE = "resource"
     OTHER = "other"
 
 
@@ -1754,9 +1758,13 @@ def _symbol_info_for(stmt: "Statement", path: str) -> Optional[SymbolInfo]:
         Define,
         GenRecFun,
         Import,
+        ObjectDecl,
+        ObserverDecl,
         Postulate,
         Predicate,
+        ProcDecl,
         RecFun,
+        ResourceDecl,
         Theorem,
         Union,
         base_name,
@@ -1807,6 +1815,40 @@ def _symbol_info_for(stmt: "Statement", path: str) -> Optional[SymbolInfo]:
     elif isinstance(stmt, Import):
         kind = SymbolKind.IMPORT
         signature = f"import {stmt.name}"
+    elif isinstance(stmt, ObjectDecl):
+        kind = SymbolKind.OBJECT
+        typarams = (
+            f"<{', '.join(base_name(t) for t in stmt.type_params)}>"
+            if stmt.type_params else ""
+        )
+        signature = f"object {base_name(stmt.name)}{typarams}"
+    elif isinstance(stmt, ProcDecl):
+        kind = SymbolKind.PROC
+        typarams = (
+            f"<{', '.join(base_name(t) for t in stmt.type_params)}>"
+            if stmt.type_params else ""
+        )
+        params = ", ".join(str(p) for p in stmt.params)
+        ret = f" -> {stmt.return_type}" if stmt.return_type is not None else ""
+        signature = f"proc {base_name(stmt.name)}{typarams}({params}){ret}"
+    elif isinstance(stmt, ObserverDecl):
+        kind = SymbolKind.OBSERVER
+        typarams = (
+            f"<{', '.join(base_name(t) for t in stmt.type_params)}>"
+            if stmt.type_params else ""
+        )
+        params = ", ".join(str(p) for p in stmt.params)
+        signature = (
+            f"observer {base_name(stmt.name)}{typarams}({params}) -> {stmt.return_type}"
+        )
+    elif isinstance(stmt, ResourceDecl):
+        kind = SymbolKind.RESOURCE
+        typarams = (
+            f"<{', '.join(base_name(t) for t in stmt.type_params)}>"
+            if stmt.type_params else ""
+        )
+        params = ", ".join(str(p) for p in stmt.params)
+        signature = f"resource {base_name(stmt.name)}{typarams}({params})"
     elif isinstance(stmt, Auto):
         # Auto declares an auto-rewrite rule and doesn't introduce a
         # named symbol of its own; skip it from the outline.

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -220,9 +220,14 @@ end
 """
 
 EXPERIMENTAL_IMPERATIVE_FILES = frozenset({
-    "./test/should-error/proc_declarations.pf",
-    "./test/should-error/observer_declarations.pf",
+    "./test/should-validate/proc_declarations.pf",
+    "./test/should-validate/observer_declarations.pf",
+    "./test/should-validate/imperative_import.pf",
     "./test/should-error/resource_declarations.pf",
+    "./test/should-error/imperative_import_unknown.pf",
+    "./test/should-error/imperative_import_field.pf",
+    "./test/should-error/imperative_export_private_contract.pf",
+    "./test/test-imports/ImpExports.pf",
 })
 
 
@@ -461,19 +466,19 @@ PARSER_ROUND_TRIP_FILES = (
     # ``UIntAdd.pf`` exercises the ``apply f to a, apply g to b`` tuple.
     "./lib/Set.pf",
     "./lib/UIntAdd.pf",
-    # Parser/AST-only imperative procedure declarations. The checker
-    # intentionally rejects these until the verifier exists, but both parsers
-    # must agree on the AST and the pretty-printer must preserve the header and
-    # repeated specification clauses.
-    "./test/should-error/proc_declarations.pf",
-    # Parser/AST-only imperative observer declarations. Checker rejection is
-    # intentional; both parsers must agree on the AST and the pretty-printer
-    # must preserve repeated `reads` clauses and the optional body.
-    "./test/should-error/observer_declarations.pf",
-    # Parser/AST-only separation-resource declarations (#854 Phase 1h). Checker
-    # rejection is intentional; both parsers must agree on the AST and the
-    # pretty-printer must round-trip the `emp`, `**`, and `|->` connectives and
-    # the `p.f` field-access address form.
+    # Imperative procedure declarations (recognized in Phase 1i, #968; bodies
+    # not verified). Both parsers must agree on the AST and the pretty-printer
+    # must preserve the header and repeated specification clauses.
+    "./test/should-validate/proc_declarations.pf",
+    # Imperative observer declarations. Both parsers must agree on the AST and
+    # the pretty-printer must preserve repeated `reads` clauses and the optional
+    # body.
+    "./test/should-validate/observer_declarations.pf",
+    # Separation-resource declarations (#854 Phase 1h). The declarations are
+    # recognized (Phase 1i) but the file stays in should-error because resource
+    # formulas have no term semantics; both parsers must agree on the AST and
+    # the pretty-printer must round-trip the `emp`, `**`, and `|->` connectives
+    # and the `p.f` field-access address form.
     "./test/should-error/resource_declarations.pf",
     # `import M using ... | operator≲` stored the operator name bare (`≲`),
     # but a using/hiding list only accepts an operator behind the `operator`
@@ -587,7 +592,11 @@ def _worker_validate(task: tuple[str, bool]) -> tuple[str, bool, str, str]:
     f, recursive_descent = task
     set_recursive_descent(recursive_descent)
     label = "recursive-descent" if recursive_descent else "lalr"
-    result = check_file(f, prewarm_modules=_WORKER_PREWARM)
+    set_experimental_imperative(_uses_experimental_imperative(f))
+    try:
+        result = check_file(f, prewarm_modules=_WORKER_PREWARM)
+    finally:
+        set_experimental_imperative(False)
     return (f, result.ok, label, result.error_message or "")
 
 
@@ -1149,20 +1158,17 @@ def run_experimental_imperative_parser_test() -> list[tuple[str, str, str]]:
             label = "recursive-descent" if recursive_descent else "lalr"
             set_recursive_descent(recursive_descent)
             set_experimental_imperative(True)
+            # Phase 1i (issue #968): proc/observer/resource declarations are
+            # recognized as first-class for module boundaries and tooling.
+            # Their bodies and specs are not verified yet (Phase 2+), so a file
+            # that only declares them checks successfully.
             checked = check_file(path, content=IMPERATIVE_SYNTAX_SOURCE,
                                  prelude=())
-            if checked.ok:
+            if not checked.ok:
                 failures.append((
                     path, label,
-                    "imperative proc unexpectedly checked successfully",
-                ))
-            elif "imperative proc declarations are not supported yet" not in (
-                checked.error_message or ""
-            ):
-                failures.append((
-                    path, label,
-                    "expected unsupported-proc diagnostic, got:\n"
-                    f"{(checked.error_message or '')[:500]}",
+                    "imperative declarations should now be recognized, "
+                    f"but checking failed:\n{(checked.error_message or '')[:500]}",
                 ))
 
             pure_new = check_file(

--- a/test/lsp/test_query.py
+++ b/test/lsp/test_query.py
@@ -160,6 +160,10 @@ def test_symbol_kinds_cover_top_level_forms():
         "predicate",
         "postulate",
         "import",
+        "object",
+        "proc",
+        "observer",
+        "resource",
         "other",
     }
     assert {k.value for k in SymbolKind} == expected

--- a/test/lsp/test_symbols.py
+++ b/test/lsp/test_symbols.py
@@ -86,6 +86,55 @@ def test_list_symbols_collects_all_top_level_kinds() -> None:
     assert by_name["p1"].signature.startswith("p1:")
 
 
+def test_list_symbols_includes_imperative_declarations() -> None:
+    # Phase 1i (issue #968): proc/observer/object/resource declarations show
+    # up in the outline like any other top-level declaration.
+    from flags import set_experimental_imperative
+
+    src = (
+        "object Box<T> {\n"                    # line 1: object
+        "  var data : T\n"
+        "}\n"
+        "\n"
+        "proc do_nothing(x: bool)\n"           # line 5: proc
+        "  ensures x = x\n"
+        "{\n"
+        "}\n"
+        "\n"
+        "observer peek(x: bool) -> bool\n"     # line 10: observer
+        "  reads x\n"
+        "{\n"
+        "  x\n"
+        "}\n"
+        "\n"
+        "resource cell(p: bool, v: bool)\n"    # line 16: resource
+    )
+    set_experimental_imperative(True)
+    try:
+        syms = list_symbols("test.pf", src)
+    finally:
+        set_experimental_imperative(False)
+    by_name = {s.name: s for s in syms}
+
+    assert set(by_name) == {"Box", "do_nothing", "peek", "cell"}
+    assert by_name["Box"].kind is SymbolKind.OBJECT
+    assert by_name["do_nothing"].kind is SymbolKind.PROC
+    assert by_name["peek"].kind is SymbolKind.OBSERVER
+    assert by_name["cell"].kind is SymbolKind.RESOURCE
+
+    assert by_name["Box"].signature.startswith("object Box")
+    assert by_name["do_nothing"].signature.startswith("proc do_nothing")
+    assert by_name["peek"].signature.startswith("observer peek")
+    assert by_name["cell"].signature.startswith("resource cell")
+
+    # User-visible names only (no .NNN uniquify suffix leaks into signatures).
+    assert ".uniquify" not in by_name["do_nothing"].signature
+    assert by_name["Box"].location.range.start.line == 1
+    assert by_name["do_nothing"].location.range.start.line == 5
+    assert by_name["peek"].location.range.start.line == 10
+    assert by_name["cell"].location.range.start.line == 16
+
+
 def test_list_symbols_returns_empty_on_parse_error() -> None:
     # Truncated source: parser error before any declaration is built.
     src = "theorem t: true\nproof\n"

--- a/test/should-error/imperative_export_private_contract.pf
+++ b/test/should-error/imperative_export_private_contract.pf
@@ -1,0 +1,13 @@
+// Phase 1i (issue #968): an exported imperative contract may only mention
+// names that are visible to importing modules. Here a public `proc` requires a
+// `private` resource, which importers could never state or satisfy, so it is
+// rejected at the module boundary.
+module PrivateContract
+
+private resource rep(x: bool)
+
+public proc op(x: bool)
+  requires rep(x)
+  ensures x = x
+{
+}

--- a/test/should-error/imperative_export_private_contract.pf.err
+++ b/test/should-error/imperative_export_private_contract.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/imperative_export_private_contract.pf:9.8-13.2: exported proc 'op' mentions the private name 'rep' in its contract; a public contract may only mention names visible to importing modules.

--- a/test/should-error/imperative_import_field.pf
+++ b/test/should-error/imperative_import_field.pf
@@ -1,0 +1,4 @@
+// Phase 1i (issue #968): an object's fields are not top-level exported names,
+// so they cannot be selected in an import `using` filter. `data` is a field of
+// the exported `Box` object in ImpExports, not a declaration of its own.
+import ImpExports using data

--- a/test/should-error/imperative_import_field.pf.err
+++ b/test/should-error/imperative_import_field.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/imperative_import_field.pf:4.1-4.29: import using: 'data' is not exported by module 'ImpExports'

--- a/test/should-error/imperative_import_unknown.pf
+++ b/test/should-error/imperative_import_unknown.pf
@@ -1,0 +1,3 @@
+// Phase 1i (issue #968): an import `using` filter rejects a name the module
+// does not declare, the same way it rejects any unknown name.
+import ImpExports using no_such_proc

--- a/test/should-error/imperative_import_unknown.pf.err
+++ b/test/should-error/imperative_import_unknown.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/imperative_import_unknown.pf:3.1-3.37: import using: 'no_such_proc' is not exported by module 'ImpExports'

--- a/test/should-error/observer_declarations.pf.err
+++ b/test/should-error/observer_declarations.pf.err
@@ -1,1 +1,0 @@
-./test/should-error/observer_declarations.pf:3.8-10.2: imperative observer declarations are not supported yet: all_zero

--- a/test/should-error/proc_declarations.pf.err
+++ b/test/should-error/proc_declarations.pf.err
@@ -1,1 +1,0 @@
-./test/should-error/proc_declarations.pf:1.8-33.2: imperative proc declarations are not supported yet: identity

--- a/test/should-error/resource_declarations.pf
+++ b/test/should-error/resource_declarations.pf
@@ -1,9 +1,11 @@
-// Phase 1h (issue #854): separation-resource surface syntax. Parser/AST only
-// -- the checker rejects the first `resource` declaration before any
-// resource-aware proof checking, so this file lives in should-error. The point
-// of the fixture is that every form below PARSES, that the recursive-descent
-// and LALR parsers agree on the AST, and that the pretty-printer round-trips
-// the `emp`, `**`, and `|->` connectives (see PARSER_ROUND_TRIP_FILES).
+// Phase 1h (issue #854): separation-resource surface syntax. The resource
+// *declarations* below are now recognized (Phase 1i, issue #968) as first-class
+// for module boundaries -- their bodies are not checked. This file stays in
+// should-error because resource *formulas* (`emp`, `**`, `|->`) have no term
+// semantics yet, so the `assert`/`theorem` uses below (in ordinary term
+// positions) are rejected. The fixture still pins that every form PARSES, that
+// the recursive-descent and LALR parsers agree on the AST, and that the
+// pretty-printer round-trips the connectives (see PARSER_ROUND_TRIP_FILES).
 
 type Ref<T> = T
 type Cell<T> = T

--- a/test/should-error/resource_declarations.pf.err
+++ b/test/should-error/resource_declarations.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/resource_declarations.pf:15.8-15.65: imperative resource declarations are not supported yet: cell
+./test/should-error/resource_declarations.pf:46.28-46.44: cannot synthesize a type for ((p |-> v) ** emp)

--- a/test/should-validate/imperative_import.pf
+++ b/test/should-validate/imperative_import.pf
@@ -1,0 +1,4 @@
+// Phase 1i (issue #968): a module can public-import another module and select
+// its exported imperative declarations (object, observer, proc, resource) by
+// name in a `using` filter. `public import` re-exports them transitively.
+public import ImpExports using Box | peek | reset | owns

--- a/test/should-validate/observer_declarations.pf
+++ b/test/should-validate/observer_declarations.pf
@@ -1,3 +1,6 @@
+// Observer declarations with read frames. Phase 1i (issue #968) recognizes
+// them as first-class for module boundaries and tooling, so this file
+// validates; the read frames and bodies are not verified yet (Phase 2/3).
 type Ref<T> = T
 
 public observer all_zero<T>(a: [T]!, i: T, ghost limit: T) -> bool

--- a/test/should-validate/proc_declarations.pf
+++ b/test/should-validate/proc_declarations.pf
@@ -1,3 +1,7 @@
+// Procedure declarations, specs, imperative bodies, proof clauses, proof
+// slots, and call labels. Phase 1i (issue #968) recognizes proc declarations
+// as first-class for module boundaries and tooling, so this file validates;
+// the bodies and specs are not verified yet (Phase 2 adds the verifier).
 public proc identity<T>(x: T, ghost witness: T) -> T
   requires x = x
   requires witness = witness
@@ -41,8 +45,10 @@ opaque proc hidden()
 {
 }
 
-// Proof clauses, proof slots, and call labels (Phase 1e). Parser/AST only;
-// the checker still rejects the procedure above before reaching this one.
+// Proof clauses, proof slots, and call labels (Phase 1e). Phase 1i (issue
+// #968) recognizes proc declarations as first-class for module boundaries and
+// tooling, so this file validates; the bodies below are not verified yet
+// (Phase 2 adds the verifier).
 proc driver(n: bool)
   requires n = n
   ensures n = n

--- a/test/test-imports/ImpExports.pf
+++ b/test/test-imports/ImpExports.pf
@@ -1,0 +1,24 @@
+// Auxiliary module for the imperative import/export tests (issue #968).
+// Exports one of each imperative declaration form so an importing module can
+// filter and re-export them by name. The `private` proc is intentionally not
+// exported.
+module ImpExports
+
+public object Box {
+  var data : bool
+}
+
+public observer peek(b: bool) -> bool
+  reads b
+
+public proc reset(x: bool)
+  ensures x = x
+{
+}
+
+public resource owns(x: bool)
+
+private proc secret(x: bool)
+  ensures x = x
+{
+}


### PR DESCRIPTION
## Summary

Closes #968. Refs #854.

Phase 1i of the imperative verification layer (#854). Makes `proc`,
`observer`, `object`, and `resource` behave like first-class top-level
declarations for module boundaries and tooling, **without adding any
verifier** — Phase 1 is parser/AST + declaration plumbing only, so bodies
and specs stay inert.

Before this change the checker rejected every `proc`/`observer`/`resource`
declaration up front with a "not supported yet" user error, which meant a
module containing one could not even be imported.

## What changed

- **Declaration processing** (`checker_pipeline.py`): recognize
  `ProcDecl`/`ObserverDecl`/`ResourceDecl` in `process_declaration_visibility`
  and add matching arms in `type_check_stmt`, `collect_env`, and
  `check_proofs`, so they no longer hit the blanket rejection or the
  `case _: internal_error` fall-through. Bodies/specs are passed through
  unchecked (`ObjectDecl` was already threaded; a stale duplicate
  `case ObjectDecl()` is removed while here).
- **Imports/exports**: `using`/`hiding` filtering and `public import`
  re-export of imperative names already worked via each declaration's
  `collect_exports` and the name-based filter; this PR relies on that and
  locks it with fixtures. Object fields and proc proof-slot labels are not
  top-level names, so they can't be selected in an import filter.
- **Visibility diagnostic** (`check_exported_contract_visibility`): an
  exported (`public`/`opaque`) `proc`/`observer` whose contract — params,
  specs, `reads`, return type — mentions a `private` name of the same
  module is rejected with a user-facing error, since importers could never
  state or satisfy that contract. A private name used only in a *body* (not
  the contract) is fine.
- **LSP outline** (`lsp/query.py`, `lsp/lsp_server.py`): new `SymbolKind`
  values (`object`/`proc`/`observer`/`resource`) and kind-map entries so all
  four forms show up in `textDocument/documentSymbol`.

## Acceptance criteria (from #968)

- [x] A module can `public import` another module using an exported proc,
  observer, object, or resource name — `test/should-validate/imperative_import.pf`.
- [x] Import filters reject unknown imperative names like any unknown name —
  `test/should-error/imperative_import_unknown.pf`,
  `test/should-error/imperative_import_field.pf` (object field not selectable).
- [x] A public proc contract that mentions a private resource/observer is
  rejected with a visibility error —
  `test/should-error/imperative_export_private_contract.pf`.
- [x] LSP symbol tests include one proc, observer, object, and resource —
  `test/lsp/test_symbols.py::test_list_symbols_includes_imperative_declarations`.
- [x] Unsupported imperative bodies produce user-facing errors, not internal
  errors — recognizing the forms removes the `internal_error` path;
  `resource_declarations.pf` now fails cleanly on its resource-formula
  `assert`s (`|->`/`**`/`emp` still have no term semantics) rather than on the
  declarations.

## Test moves

`proc_declarations.pf` and `observer_declarations.pf` move from
`should-error` to `should-validate` (they now check). `resource_declarations.pf`
stays in `should-error` — only its top-level resource-formula asserts fail now,
not the declarations. The synthetic `run_experimental_imperative_parser_test`
and `_worker_validate` were updated for the new "recognized" behavior.

## Verification

- `python3 test-deduce.py` (lib + should-validate + should-error + should-warn
  + prelude + parser equivalence, both parsers): all pass.
- `python3 test-deduce.py --equiv-full`: all pass (278 files).
- `python3 run_lsp_tests.py` (with `pygls`/`lsprotocol`/`mcp` installed): all pass.
- `ruff check .` and `mypy .`: clean.

## Notes for resuming

Optional LSP test deps (`pygls`, `lsprotocol`, `mcp`) and `pytest`/`ruff`/`mypy`
were pip-installed in the container to run the LSP suite and static gate; CI has
these. No verifier work here — that is Phase 2+ (#854).

Resume this session on ginger: `~/deduce-runner/resume.sh cca0cc20-536f-41b4-a31e-6b8453defc36 routine/20260715-020202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
