### PR TITLE
Reject import using/hiding of private (non-exported) names (closes #1011)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1728,10 +1728,27 @@ class Import(Declaration):
       return name in using
     return name not in cast(List[str], hiding)
 
-  def _validate_filter(self, new_ast: List[Statement]) -> None:
+  def _validate_filter(self, new_ast: List[Statement],
+                       importing_module: str) -> None:
     if self.using is None and self.hiding is None:
       return
-    exported = {n for n in (_stmt_primary_name(s) for s in new_ast) if n is not None}
+    # Build the set of names actually exported to the importing module by
+    # replaying collect_exports over the module body. A statement's primary
+    # name counts only when that statement contributes at least one visible
+    # name to the importer, so private (non-exported) declarations are
+    # rejected the same way an unknown name is. `module`/`import` statements
+    # thread the current-module context exactly as the real export loop does,
+    # so we restore it before returning.
+    saved_module = get_current_module()
+    exported: set[str] = set()
+    for s in new_ast:
+      name = _stmt_primary_name(s)
+      probe: UniquifyEnv = {'no overload': {}}
+      s.collect_exports(probe, importing_module)
+      if name is not None and any(
+          k != 'no overload' and not k.startswith('__module__') for k in probe):
+        exported.add(name)
+    set_current_module(saved_module)
     requested = self.using if self.using is not None else self.hiding
     assert requested is not None
     for name in requested:
@@ -1752,36 +1769,41 @@ class Import(Declaration):
     if get_verbose() == VerboseLevel.CURR_ONLY:
       set_verbose(VerboseLevel.NONE)
 
-    global uniquified_modules
-    if self.name in uniquified_modules.keys():
-      new_ast = uniquified_modules[self.name]
-    else:
-      filename = find_file(self.location, self.name)
-      file = open(filename, 'r', encoding="utf-8")
-      src = file.read()
-      file.close()
-      if get_recursive_descent():
-        from rec_desc_parser import get_filename, set_filename, parse
+    # Restore the module/verbose globals even if an error (e.g. a bad
+    # using/hiding filter) aborts the import, so a later top-level check
+    # sharing this process does not inherit a stale current module.
+    try:
+      global uniquified_modules
+      if self.name in uniquified_modules.keys():
+        new_ast = uniquified_modules[self.name]
       else:
-        from parser import get_filename, set_filename, parse
-      old_filename = get_filename()
-      set_filename(filename)
-      parsed_ast = parse(src, trace=False)
-      set_filename(old_filename)
-      new_ast = uniquify_deduce(parsed_ast, ctx)
-      uniquified_modules[self.name] = new_ast
+        filename = find_file(self.location, self.name)
+        file = open(filename, 'r', encoding="utf-8")
+        src = file.read()
+        file.close()
+        if get_recursive_descent():
+          from rec_desc_parser import get_filename, set_filename, parse
+        else:
+          from parser import get_filename, set_filename, parse
+        old_filename = get_filename()
+        set_filename(filename)
+        parsed_ast = parse(src, trace=False)
+        set_filename(old_filename)
+        new_ast = uniquify_deduce(parsed_ast, ctx)
+        uniquified_modules[self.name] = new_ast
 
-    env['__module__' + self.name] = None
-    if get_verbose():
-        print('collecting exports from ' + self.name + ' for import to ' + importing_module + '\n')
-    self._validate_filter(new_ast)
-    for stmt in new_ast:
-      if self._filter_admits(stmt):
-        stmt.collect_exports(env, importing_module)
-    set_verbose(old_verbose)
-    if get_verbose():
-      print('\tuniquify finished import ' + self.name)
-    set_current_module(importing_module)
+      env['__module__' + self.name] = None
+      if get_verbose():
+          print('collecting exports from ' + self.name + ' for import to ' + importing_module + '\n')
+      self._validate_filter(new_ast, importing_module)
+      for stmt in new_ast:
+        if self._filter_admits(stmt):
+          stmt.collect_exports(env, importing_module)
+      if get_verbose():
+        print('\tuniquify finished import ' + self.name)
+    finally:
+      set_verbose(old_verbose)
+      set_current_module(importing_module)
     return Import(self.location, self.name, new_ast,
                   visibility=self.visibility,
                   using=self.using, hiding=self.hiding)

--- a/test/should-error/import_hiding_private_lemma.pf
+++ b/test/should-error/import_hiding_private_lemma.pf
@@ -1,0 +1,4 @@
+// A `hiding` filter that names a module-private lemma must be rejected the
+// same way an unknown name is (issue #1011). `cant_import_lemma` is a lemma
+// in test-imports/Private.pf, so it is not exported to importers.
+import Private hiding cant_import_lemma

--- a/test/should-error/import_hiding_private_lemma.pf.err
+++ b/test/should-error/import_hiding_private_lemma.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/import_hiding_private_lemma.pf:4.1-4.40: import hiding: 'cant_import_lemma' is not exported by module 'Private'

--- a/test/should-error/import_using_private.pf
+++ b/test/should-error/import_using_private.pf
@@ -1,0 +1,4 @@
+// A `using` filter that names a private (non-exported) declaration must be
+// rejected the same way an unknown name is (issue #1011). `Sign` is a
+// `private union` in test-imports/Private.pf, so it is not exported here.
+import Private using Sign

--- a/test/should-error/import_using_private.pf.err
+++ b/test/should-error/import_using_private.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/import_using_private.pf:4.1-4.26: import using: 'Sign' is not exported by module 'Private'


### PR DESCRIPTION
## Summary

Fixes #1011: an `import M using <name>` / `hiding <name>` filter that named a
declaration which exists in `M` but is **private** (not exported to the
importer) was silently accepted, even though naming a completely unknown name
errored with "is not exported by module". A private name is likewise not
exported, so the two cases were inconsistent.

## Root cause

`Import._validate_filter` (`abstract_syntax/declarations.py`) built its
`exported` set from `_stmt_primary_name(s)` over **every** statement in the
module, regardless of visibility. A private declaration's name therefore
passed the filter check; the subsequent `collect_exports` then dropped it, so
the name was accepted by validation but never actually imported.

## Fix

- Rebuild the `exported` set by replaying `collect_exports` over the module
  body against the real `importing_module`. A statement's primary name is
  counted only when that statement actually contributes at least one visible
  name to the importer — so `private union Sign`, module-private
  `lemma cant_import_lemma`, and a nonexistent name are now all rejected the
  same way. `module`/`import` statements thread the current-module context
  exactly as the real export loop does; the current module is restored before
  returning so the subsequent real export loop starts clean.

- Wrap the body of `Import.uniquify` in `try/finally` so the `current_module`
  and verbose globals are restored even when an import aborts (e.g. on a bad
  filter). Without this, a filter error left `current_module` pointing at the
  imported module; a later top-level check that shares the process (the test
  harness, the LSP) then treated that module as the current one and wrongly
  granted access to its private lemmas. This surfaced as `import_lemma.pf`
  flipping to "valid" once the new private-filter fixtures ran ahead of it in
  the same worker.

## Tests

- `test/should-error/import_using_private.pf` — `using` a `private union`.
- `test/should-error/import_hiding_private_lemma.pf` — `hiding` a module-private
  lemma.

Both reject with the same "is not exported by module 'Private'" message under
recursive-descent and LALR. `python3 test-deduce.py` (lib + should-validate +
should-error + should-warn + prelude + parser equivalence) passes.

Resume this session on ginger: `~/deduce-runner/resume.sh 7735f6aa-e1fc-4c34-bb19-c8ccf01dd790 routine/20260715-030202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
