### PR TITLE
Add Int modulo operator and division-algorithm theorems (refs #720)

### DIFF
--- a/lib/Int.pf
+++ b/lib/Int.pf
@@ -22,6 +22,7 @@ public import IntAbs
 public import IntSum
 public import IntPowLog
 public import IntDivides
+public import IntMod
 
 // The following exports are needed for integer literals: the
 // `lit`/`zero`/`suc` triple supplies the underlying numeric

--- a/lib/IntDivides.pf
+++ b/lib/IntDivides.pf
@@ -207,6 +207,21 @@ proof
   fwd, bwd
 end
 
+// Divisibility is antisymmetric up to absolute value: mutual divisibility
+// pins down the magnitude, but not the sign (e.g. `+3` and `-3` divide each
+// other). Lifts `uint_divides_antisymmetric` through `int_divides_iff_abs`.
+theorem int_divides_antisymmetric: all a:Int, b:Int.
+  if divides(a, b) and divides(b, a) then abs(a) = abs(b)
+proof
+  arbitrary a:Int, b:Int
+  assume prem
+  have ab: divides(abs(a), abs(b))
+    by apply (conjunct 0 of int_divides_iff_abs[a, b]) to conjunct 0 of prem
+  have ba: divides(abs(b), abs(a))
+    by apply (conjunct 0 of int_divides_iff_abs[b, a]) to conjunct 1 of prem
+  apply uint_divides_antisymmetric[abs(a), abs(b)] to ab, ba
+end
+
 // Greatest common divisor on Int, defined through `UInt.gcd` on
 // absolute values. The result is wrapped as `pos` so the gcd is always
 // nonnegative.

--- a/lib/IntMod.pf
+++ b/lib/IntMod.pf
@@ -1,0 +1,300 @@
+module Int
+
+import UInt
+import Base
+import IntDefs
+import IntAddSub
+import IntMult
+import IntLess
+import IntAbs
+import IntDiv
+
+/*
+  Integer modulo and the quotient/remainder story for `Int`.
+
+  `Int /` is defined in `IntDefs.pf` as
+
+      n / m = (sign(n) * sign(m)) * (abs(n) / abs(m))
+
+  i.e. the *truncated* convention: the quotient rounds toward zero and the
+  remainder takes the sign of the dividend. `%` is defined to match, so that
+  the division identity `(n / m) * m + (n % m) = n` holds:
+
+      n % m = sign(n) * (abs(n) % abs(m))
+
+  (This is the truncated / T-division convention. Lean's `ediv` / `emod`
+  use the Euclidean convention, which agrees on nonnegative dividends but
+  differs in sign on negative ones; see issue #720.)
+
+  The four `pos`/`negsuc` case lemmas below mirror `div_pos_pos` etc. in
+  `IntDiv.pf`, reducing each quadrant to the corresponding `UInt` remainder.
+*/
+
+opaque fun operator %(n : Int, m : Int) {
+  sign(n) * (abs(n) % abs(m))
+}
+
+// Both operands nonnegative: take the remainder as UInts.
+theorem mod_pos_pos: all au:UInt, bu:UInt.
+  pos(au) % pos(bu) = pos(au % bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  show #pos(au) % pos(bu)# = pos(au % bu)
+  expand operator%
+  replace sign_pos | mult_pos_uint.
+end
+
+auto mod_pos_pos
+
+// Nonnegative dividend, negative divisor: remainder still has the dividend's sign.
+theorem mod_pos_negsuc: all au:UInt, bu:UInt.
+  pos(au) % negsuc(bu) = pos(au % (1 + bu))
+proof
+  arbitrary au:UInt, bu:UInt
+  show #pos(au) % negsuc(bu)# = pos(au % (1 + bu))
+  expand operator%
+  replace sign_pos | mult_pos_uint.
+end
+
+auto mod_pos_negsuc
+
+// Negative dividend, nonnegative divisor: remainder is nonpositive.
+theorem mod_negsuc_pos: all au:UInt, bu:UInt.
+  negsuc(au) % pos(bu) = - pos((1 + au) % bu)
+proof
+  arbitrary au:UInt, bu:UInt
+  show #negsuc(au) % pos(bu)# = - pos((1 + au) % bu)
+  expand operator%
+  replace sign_negsuc | mult_neg_uint.
+end
+
+auto mod_negsuc_pos
+
+// Both operands negative: remainder is nonpositive.
+theorem mod_negsuc_negsuc: all au:UInt, bu:UInt.
+  negsuc(au) % negsuc(bu) = - pos((1 + au) % (1 + bu))
+proof
+  arbitrary au:UInt, bu:UInt
+  show #negsuc(au) % negsuc(bu)# = - pos((1 + au) % (1 + bu))
+  expand operator%
+  replace sign_negsuc | mult_neg_uint.
+end
+
+auto mod_negsuc_negsuc
+
+// The quotient and remainder reconstruct the dividend (division algorithm).
+theorem int_div_mod: all n:Int, m:Int.
+  if not (m = +0)
+  then (n / m) * m + (n % m) = n
+proof
+  arbitrary n:Int, m:Int
+  switch m {
+    case pos(bu) {
+      assume prem: not (pos(bu) = +0)
+      have bu_pos: 0 < bu by {
+        have nz: not (bu = 0) by {
+          assume buz: bu = 0
+          conclude false by apply prem to (replace buz.)
+        }
+        apply uint_not_zero_pos to nz
+      }
+      switch n {
+        case pos(au) {
+          have dm: (au / bu) * bu + au % bu = au
+            by apply uint_div_mod[au, bu] to bu_pos
+          replace mult_pos_pos | add_pos_pos | dm.
+        }
+        case negsuc(au) {
+          have dm: ((1 + au) / bu) * bu + (1 + au) % bu = 1 + au
+            by apply uint_div_mod[1 + au, bu] to bu_pos
+          equations
+            (- pos((1 + au) / bu)) * pos(bu) + (- pos((1 + au) % bu))
+                = -(pos((1 + au) / bu) * pos(bu)) + (- pos((1 + au) % bu))
+                    by replace symmetric dist_neg_mult[pos((1 + au) / bu), pos(bu)].
+            ... = - pos(((1 + au) / bu) * bu) + (- pos((1 + au) % bu))
+                    by replace mult_pos_pos.
+            ... = -(pos(((1 + au) / bu) * bu) + pos((1 + au) % bu))
+                    by symmetric neg_distr_add[pos(((1 + au) / bu) * bu), pos((1 + au) % bu)]
+            ... = - pos(((1 + au) / bu) * bu + (1 + au) % bu)
+                    by replace add_pos_pos.
+            ... = - pos(1 + au)   by replace dm.
+            ... = negsuc(au)      by neg_pos[au]
+        }
+      }
+    }
+    case negsuc(bu) {
+      have obu: 0 < 1 + bu by uint_zero_less_one_add[bu]
+      switch n {
+        case pos(au) {
+          have dm: (au / (1 + bu)) * (1 + bu) + au % (1 + bu) = au
+            by apply uint_div_mod[au, 1 + bu] to obu
+          have qeq: (au / (1 + bu)) + (au / (1 + bu)) * bu
+                    = (au / (1 + bu)) * (1 + bu)
+            by replace uint_dist_mult_add[au / (1 + bu), 1, bu].
+          equations
+            (- pos(au / (1 + bu))) * negsuc(bu) + pos(au % (1 + bu))
+                = -(pos(au / (1 + bu)) * negsuc(bu)) + pos(au % (1 + bu))
+                    by replace symmetric dist_neg_mult[pos(au / (1 + bu)), negsuc(bu)].
+            ... = -(- pos((au / (1 + bu)) + (au / (1 + bu)) * bu)) + pos(au % (1 + bu))
+                    by replace mult_pos_negsuc.
+            ... = pos((au / (1 + bu)) + (au / (1 + bu)) * bu) + pos(au % (1 + bu))
+                    by replace neg_involutive.
+            ... = pos((au / (1 + bu)) + (au / (1 + bu)) * bu + au % (1 + bu))
+                    by replace add_pos_pos.
+            ... = pos((au / (1 + bu)) * (1 + bu) + au % (1 + bu))
+                    by replace qeq.
+            ... = pos(au)   by replace dm.
+        }
+        case negsuc(au) {
+          have dm: ((1 + au) / (1 + bu)) * (1 + bu) + (1 + au) % (1 + bu) = 1 + au
+            by apply uint_div_mod[1 + au, 1 + bu] to obu
+          have qeq: ((1 + au) / (1 + bu)) + ((1 + au) / (1 + bu)) * bu
+                    = ((1 + au) / (1 + bu)) * (1 + bu)
+            by replace uint_dist_mult_add[(1 + au) / (1 + bu), 1, bu].
+          equations
+            pos((1 + au) / (1 + bu)) * negsuc(bu) + (- pos((1 + au) % (1 + bu)))
+                = - pos(((1 + au) / (1 + bu)) + ((1 + au) / (1 + bu)) * bu)
+                  + (- pos((1 + au) % (1 + bu)))
+                    by replace mult_pos_negsuc.
+            ... = -(pos(((1 + au) / (1 + bu)) + ((1 + au) / (1 + bu)) * bu)
+                    + pos((1 + au) % (1 + bu)))
+                    by symmetric neg_distr_add[pos(((1 + au) / (1 + bu)) + ((1 + au) / (1 + bu)) * bu), pos((1 + au) % (1 + bu))]
+            ... = - pos(((1 + au) / (1 + bu)) + ((1 + au) / (1 + bu)) * bu + (1 + au) % (1 + bu))
+                    by replace add_pos_pos.
+            ... = - pos(((1 + au) / (1 + bu)) * (1 + bu) + (1 + au) % (1 + bu))
+                    by replace qeq.
+            ... = - pos(1 + au)   by replace dm.
+            ... = negsuc(au)      by neg_pos[au]
+        }
+      }
+    }
+  }
+end
+
+// Absolute value commutes with modulo, mirroring `int_abs_div`.
+theorem int_abs_mod: all x:Int, y:Int. abs(x % y) = abs(x) % abs(y)
+proof
+  arbitrary x:Int, y:Int
+  switch x {
+    case pos(au) {
+      switch y {
+        case pos(bu) { . }
+        case negsuc(bu) { . }
+      }
+    }
+    case negsuc(au) {
+      switch y {
+        case pos(bu) { replace abs_neg. }
+        case negsuc(bu) { replace abs_neg. }
+      }
+    }
+  }
+end
+
+// The remainder is strictly smaller in magnitude than a nonzero divisor.
+theorem int_mod_less_abs: all n:Int, m:Int.
+  if not (m = +0) then abs(n % m) < abs(m)
+proof
+  arbitrary n:Int, m:Int
+  assume prem: not (m = +0)
+  have mpos: 0 < abs(m) by {
+    have nz: not (abs(m) = 0) by {
+      assume az: abs(m) = 0
+      conclude false
+        by apply prem to (apply int_abs_eq_zero_implies_zero[m] to az)
+    }
+    apply uint_not_zero_pos to nz
+  }
+  replace int_abs_mod[n, m]
+  apply uint_mod_less_divisor[abs(n), abs(m)] to mpos
+end
+
+// Reconstruction: an integer is its sign times its magnitude.
+lemma int_sign_mult_abs: all x:Int. sign(x) * abs(x) = x
+proof
+  arbitrary x:Int
+  switch x {
+    case pos(n) { replace sign_pos | mult_pos_uint. }
+    case negsuc(n) { replace sign_negsuc | mult_neg_uint | neg_pos. }
+  }
+end
+
+// When the dividend is smaller in magnitude, the remainder is the dividend.
+theorem int_mod_small: all n:Int, m:Int.
+  if abs(n) < abs(m) then n % m = n
+proof
+  arbitrary n:Int, m:Int
+  assume prem: abs(n) < abs(m)
+  have h: abs(n) % abs(m) = abs(n) by apply uint_mod_small[abs(n), abs(m)] to prem
+  show #n % m# = n
+  expand operator%
+  replace h
+  int_sign_mult_abs[n]
+end
+
+// Anything divides evenly into itself: the self-remainder is zero.
+theorem int_mod_self: all n:Int. n % n = +0
+proof
+  arbitrary n:Int
+  switch n {
+    case pos(au) { replace uint_mod_self_zero. }
+    case negsuc(au) { replace uint_mod_self_zero | neg_zero. }
+  }
+end
+
+// Modulo by one is always zero.
+theorem int_mod_one: all n:Int. n % +1 = +0
+proof
+  arbitrary n:Int
+  switch n {
+    case pos(au) { replace uint_mod_one. }
+    case negsuc(au) { replace uint_mod_one | neg_zero. }
+  }
+end
+
+// Division by one is the identity.
+theorem int_div_one: all n:Int. n / +1 = n
+proof
+  arbitrary n:Int
+  switch n {
+    case pos(au) { replace uint_div_one. }
+    case negsuc(au) { replace uint_div_one | neg_pos. }
+  }
+end
+
+// Truncated division by zero yields zero (following `UInt`).
+theorem int_div_zero: all n:Int. n / +0 = +0
+proof
+  arbitrary n:Int
+  switch n {
+    case pos(au) { replace uint_div_zero. }
+    case negsuc(au) { replace uint_div_zero | neg_zero. }
+  }
+end
+
+// Zero divided by anything is zero.
+theorem int_zero_div: all m:Int. +0 / m = +0
+proof
+  arbitrary m:Int
+  have zd: all x:UInt. 0 / x = 0 by {
+    arbitrary x:UInt
+    have d: x = 0 or 0 < x by uint_zero_or_positive[x]
+    cases d
+    case xz { replace xz  uint_div_zero[0] }
+    case xp { apply uint_zero_div[x] to xp }
+  }
+  switch m {
+    case pos(bu) { replace zd. }
+    case negsuc(bu) { replace zd | neg_zero. }
+  }
+end
+
+// Zero modulo anything is zero.
+theorem int_zero_mod: all m:Int. +0 % m = +0
+proof
+  arbitrary m:Int
+  switch m {
+    case pos(bu) { replace uint_zero_mod. }
+    case negsuc(bu) { replace uint_zero_mod. }
+  }
+end

--- a/test/should-validate/IntTests.pf
+++ b/test/should-validate/IntTests.pf
@@ -146,3 +146,71 @@ assert abs(+12 / +5) = abs(+12) / abs(+5)
 assert abs(-12 / +5) = abs(-12) / abs(+5)
 assert abs(+12 / -5) = abs(+12) / abs(-5)
 assert abs(-12 / -5) = abs(-12) / abs(-5)
+
+// === Modulo and the division algorithm (Issue #720) ===
+
+// Truncated remainder: the sign follows the dividend, |remainder| < |divisor|.
+assert +7 % +2 = +1
+assert +7 % -2 = +1       // sign follows dividend (positive)
+assert -7 % +2 = -1       // sign follows dividend (negative)
+assert -7 % -2 = -1
+assert +6 % +2 = +0       // exact division leaves no remainder
+assert +6 % +4 = +2
+assert +0 % +5 = +0
+assert +5 % +1 = +0
+
+// Each constructor pair reduces to the corresponding UInt remainder.
+theorem mod_pos_pos_sample: all au:UInt, bu:UInt.
+  pos(au) % pos(bu) = pos(au % bu)
+proof
+  mod_pos_pos
+end
+
+theorem mod_negsuc_negsuc_sample: all au:UInt, bu:UInt.
+  negsuc(au) % negsuc(bu) = - pos((1 + au) % (1 + bu))
+proof
+  mod_negsuc_negsuc
+end
+
+// The division algorithm: quotient and remainder reconstruct the dividend.
+theorem int_div_mod_sample: all n:Int, m:Int.
+  if not (m = +0) then (n / m) * m + (n % m) = n
+proof
+  int_div_mod
+end
+
+// The remainder is strictly smaller in magnitude than a nonzero divisor.
+theorem int_mod_less_abs_sample: all n:Int, m:Int.
+  if not (m = +0) then abs(n % m) < abs(m)
+proof
+  int_mod_less_abs
+end
+
+// Absolute value commutes with modulo.
+assert abs(+12 % +5) = abs(+12) % abs(+5)
+assert abs(-12 % +5) = abs(-12) % abs(+5)
+assert abs(+12 % -5) = abs(+12) % abs(-5)
+assert abs(-12 % -5) = abs(-12) % abs(-5)
+
+// Small-dividend, self, one, and zero laws.
+theorem int_mod_small_sample: all n:Int, m:Int.
+  if abs(n) < abs(m) then n % m = n
+proof
+  int_mod_small
+end
+
+assert (- +3) % +5 = - +3     // |−3| < |5|, so the remainder is the dividend
+assert +9 % +9 = +0           // int_mod_self
+assert (- +9) % (- +9) = +0
+assert +9 % +1 = +0           // int_mod_one
+assert +9 / +1 = +9           // int_div_one
+assert +9 / +0 = +0           // int_div_zero policy
+assert +0 / +9 = +0           // int_zero_div
+assert +0 % +9 = +0           // int_zero_mod
+
+// Divisibility antisymmetry pins down magnitude but not sign.
+theorem int_divides_antisymmetric_sample: all a:Int, b:Int.
+  if divides(a, b) and divides(b, a) then abs(a) = abs(b)
+proof
+  int_divides_antisymmetric
+end


### PR DESCRIPTION
## What

Adds the modulo operator and the quotient/remainder story for `Int`, the piece
of the #720 stdlib slice that was still missing. Division, divisibility, `gcd`,
and `lcm` for `Int` already landed (`IntDefs.pf`, `IntDiv.pf`, `IntDivides.pf`);
there was no `Int %` and no division-algorithm theorem.

### Rounding convention

`Int /` is already defined in `IntDefs.pf` as

```
n / m = (sign(n) * sign(m)) * (abs(n) / abs(m))
```

i.e. the **truncated** convention (rounds toward zero; the remainder takes the
sign of the dividend). `%` must agree with `/` for `div_mod` to hold, so `%` is
defined and documented as truncated:

```
n % m = sign(n) * (abs(n) % abs(m))
```

(Lean's `ediv`/`emod` use the Euclidean convention, which agrees on nonnegative
dividends but differs in sign on negative ones. Matching the pre-existing
truncated `/` is the only self-consistent choice here.)

Concrete behavior (locked by asserts in `IntTests.pf`):
`+7 % +2 = +1`, `+7 % -2 = +1`, `-7 % +2 = -1`, `-7 % -2 = -1`.

## Changes

- **`lib/IntMod.pf`** (new): `opaque fun operator %(Int, Int)`, the four
  `pos`/`negsuc` case lemmas (`mod_pos_pos`, …, mirroring `div_pos_pos` in
  `IntDiv.pf`), and:
  - `int_div_mod` — `(n / m) * m + (n % m) = n` for `m ≠ +0`
  - `int_mod_less_abs` — `abs(n % m) < abs(m)` for `m ≠ +0`
  - `int_abs_mod` — `abs(n % m) = abs(n) % abs(m)`
  - `int_mod_small`, `int_mod_self`, `int_mod_one`
  - `int_div_one`, `int_div_zero`, `int_zero_div`, `int_zero_mod`
- **`lib/IntDivides.pf`**: `int_divides_antisymmetric` — mutual divisibility
  pins down `abs` (the "antisymmetry up to absolute value" bullet of #720).
- **`lib/Int.pf`**: `public import IntMod`.
- **`test/should-validate/IntTests.pf`**: a modulo / division-algorithm section
  (concrete asserts + sample theorems).

## Testing

```
python3 test-deduce.py --lib --passable --equiv   # all pass, both parsers
python3 test-deduce.py --equiv-full               # 276 files round-trip
python3 deduce.py --lalr lib/IntMod.pf            # LALR parity
```

## Relation to #720 — why `Refs`, not `Closes`

This completes the div/mod half and adds divisibility antisymmetry, but the
issue also asks for the **rich `lcm` theorem set** (lcm divisibility / least-
common-multiple properties). Those don't exist yet even for `UInt`
(`lib/UIntDiv.pf` has only `lcm` and its zero cases), so building the `Int`
versions requires first adding `uint_lcm_divides` / `uint_lcm_least`, which is
out of scope for this PR. Leaving #720 open for that remaining `lcm` work.

Refs #720

## Resume

Resume this session on ginger: `~/deduce-runner/resume.sh 7ad85c0a-651a-464c-afc7-86024e0fa0ea routine/20260715-040202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
