### PR TITLE
Fold parseable should-error fixtures into --equiv-full round-trip audit (refs #931)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -41,8 +41,10 @@ Standalone modes (mutually exclusive with the above):
     --equiv-full       Pretty-print → reparse round-trip over EVERY
                        accepted-syntax ``.pf`` file (``lib/``,
                        ``test/should-validate``, ``example.pf``,
-                       ``test/should-warn``, ``test/prelude``, ``examples/``)
-                       with both parsers. This is the opt-in full-corpus audit
+                       ``test/should-warn``, ``test/prelude``, ``examples/``,
+                       and the ``test/should-error`` fixtures both parsers
+                       accept at parse time) with both parsers. This is the
+                       opt-in full-corpus audit
                        from issue #931 -- broader than the curated
                        ``PARSER_ROUND_TRIP_FILES`` set that ``--equiv`` runs in
                        CI, and intentionally NOT part of the default sweep so
@@ -1020,18 +1022,32 @@ def run_parser_round_trip(workers: int) -> list[tuple[str, str, str]]:
 
 
 # Accepted-syntax directories swept by the opt-in ``--equiv-full`` audit.
-# ``test/should-error`` and ``test/parse`` are excluded on purpose: those
-# fixtures are meant to fail (at parse time or later), so round-tripping them
-# is not meaningful. This is the full-corpus counterpart to the curated
-# ``PARSER_ROUND_TRIP_FILES`` set (issue #931).
+# ``test/parse`` is excluded on purpose: those fixtures are deliberately
+# malformed and RD-only, so round-tripping them is not meaningful.
+# ``test/should-error`` files are meant to fail, but most fail in a *later*
+# phase (type/proof check) while parsing cleanly under both parsers -- their
+# surface syntax is a legitimate round-trip subject and exercises constructs
+# the validating corpus may not. Those are folded in below; the ones that at
+# least one parser rejects at parse time are the ``SHOULD_ERROR_PARSER_EQUIV_
+# SKIP`` baseline and stay out (the ``--equiv`` staleness check shrinks that
+# set as parsers converge). This is the full-corpus counterpart to the curated
+# ``PARSER_ROUND_TRIP_FILES`` set (issues #931, #473).
 FULL_ROUND_TRIP_DIRS = (LIB_DIR, PASS_DIR, WARN_DIR, PRELUDE_DIR, EXAMPLES_DIR)
 
 
 def full_round_trip_files() -> tuple[str, ...]:
-    """Every accepted-syntax ``.pf`` file, deduped and order-preserving."""
+    """Every accepted-syntax ``.pf`` file, deduped and order-preserving.
+
+    Includes ``test/should-error`` fixtures that both parsers accept at parse
+    time (i.e. everything except the ``SHOULD_ERROR_PARSER_EQUIV_SKIP``
+    baseline), since those round-trip meaningfully even though they fail a
+    later semantic phase.
+    """
     files: list[str] = []
     for d in FULL_ROUND_TRIP_DIRS:
         files.extend(list_pf(d))
+    files.extend(p for p in list_pf(ERROR_DIR)
+                 if p not in SHOULD_ERROR_PARSER_EQUIV_SKIP)
     files.append(f"./{EXAMPLE_FILE.as_posix()}")
     return tuple(dict.fromkeys(files))
 


### PR DESCRIPTION
## What

Extend the opt-in `--equiv-full` full-corpus round-trip audit to include the
`test/should-error` fixtures that both parsers accept at parse time.

## Why

`--equiv-full` (added in #1009) pretty-prints every accepted-syntax `.pf`,
reparses with both parsers, and asserts the canonical AST is unchanged. It was
excluding *all* of `test/should-error` wholesale, with the rationale that
"fixtures meant to fail aren't meaningful round-trip subjects."

That rationale only holds for fixtures that fail at *parse* time. Most
should-error files parse cleanly under both parsers and fail in a later
(type/proof) phase — their surface syntax is a legitimate round-trip subject,
and it exercises constructs the validating corpus may not.

I ran a fresh audit over the 202 should-error fixtures outside the existing
`SHOULD_ERROR_PARSER_EQUIV_SKIP` baseline (the set `--equiv` already maintains
for "at least one parser rejects at parse time"):

- **cross-parser (RD vs LALR) AST comparison:** 0 differ, 0 parse-fail-in-one
- **pretty-print → reparse round-trip (both parsers as source and target):** 0 issues

So folding them in keeps the audit green while broadening coverage: a future
round-trip regression in a should-error-only surface construct is now caught.

## Change

`full_round_trip_files()` now also yields `list_pf(ERROR_DIR)` minus
`SHOULD_ERROR_PARSER_EQUIV_SKIP`. The skip set stays authoritative for the
parse-time-divergent fixtures and is already kept honest by the `--equiv`
staleness check, so as the parsers converge those files graduate into this
audit automatically. Comment and `--equiv-full` help text updated to match.

Corpus grows **275 → 477** files; `python3 test-deduce.py --equiv-full` passes.
`ruff check` and `mypy` on `test-deduce.py` are clean. No CI behavior changes —
`--equiv-full` remains opt-in and out of the default sweep.

## Testing

```
python3 test-deduce.py --equiv-full   # 477 files, All tests passed.
python3 -m ruff check test-deduce.py  # All checks passed!
python3 -m mypy test-deduce.py        # Success: no issues found
```

Refs #931 (round-trip coverage umbrella; stays open for further coverage work).
Addresses #473 (settles the recurring "decide how much of `test/should-error/`
should participate in parser equivalence checks" open item — they participate
in the non-CI full round-trip audit).

Resume this session on ginger: `~/deduce-runner/resume.sh adfbf43d-6f9d-4ddb-92ff-5470e7f0e653 routine/20260715-050202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
