### PR TITLE
Dedup custom-induction advice + view-call helpers into checker_common (refs #813)

### DIFF
--- a/checker_common.py
+++ b/checker_common.py
@@ -118,3 +118,53 @@ def switch_pattern_could_match_alts(
   else:
     return False
   return any(alt.name in candidates for alt in alts)
+
+
+def gen_conjunct_advice(conjunct: Formula, arbs: list[str], ihs: list[str]) -> str:
+  """Render one custom-induction conjunct as a suggested ``case`` skeleton.
+
+  Used to build the "Expected a case shaped like ..." advice shown when a
+  custom induction proof is missing or malformed. Shared by ordinary proof
+  dispatch (``checker_proofs``) and custom-induction body generation
+  (``checker_induction``). Unrecognized conjunct shapes yield the empty
+  string so advice generation never crashes while a user error is being
+  assembled.
+  """
+  match conjunct:
+    case All(_, _, (n, _), _, b):
+      return gen_conjunct_advice(b, arbs + [base_name(n)], ihs)
+    case IfThen(_, _, _, b):
+      return gen_conjunct_advice(b, arbs, ihs + [f"IH{len(ihs)}"])
+    case Call(_, _, _, [arg]):
+      withs = ""
+      if arbs:
+        withs = "with " + ", ".join(arbs) + ". "
+      assumes = ""
+      if ihs:
+        assumes = "assume " + ", ".join(ihs) +" "
+      return f"\t\tcase {withs}{arg} {assumes} {'{'}\n\t\t\t?\n{'\t\t}'}"
+  return ""
+
+def gen_custom_induction_advice(conjuncts: list[Formula]) -> str:
+  return "\n".join([gen_conjunct_advice(c, [], []) for c in conjuncts])
+
+def custom_induction_expected_cases(conjuncts: list[Formula]) -> str:
+  return gen_custom_induction_advice(conjuncts).replace('\t\t', '\t')
+
+def custom_induction_case_hint(conjunct: Formula) -> str:
+  return gen_conjunct_advice(conjunct, [], []).replace('\t\t', '\t')
+
+
+def view_call(loc: Meta, name: str, arg: Term,
+              type_args: Optional[List[Type]] = None) -> Call:
+  """Build a single-argument call to view function ``name`` applied to ``arg``.
+
+  Shared by view checking (``checker_pipeline``, ``checker_types``) and view
+  proof generation (``checker_proofs``). When ``type_args`` is non-empty the
+  operator is instantiated with a ``TermInst``; otherwise it is a bare
+  ``ResolvedVar``.
+  """
+  rator: Term = ResolvedVar(loc, None, name)
+  if type_args:
+    rator = TermInst(loc, None, rator, type_args)
+  return Call(loc, None, rator, [arg])

--- a/checker_induction.py
+++ b/checker_induction.py
@@ -51,31 +51,6 @@ from error import UserError, internal_error, user_error
 from flags import get_verbose
 
 
-def gen_conjunct_advice(conjunct: Formula, arbs: list[str], ihs: list[str]) -> str:
-  match conjunct:
-    case All(_, _, (n, _), _, b):
-      return gen_conjunct_advice(b, arbs + [base_name(n)], ihs)
-    case IfThen(_, _, _, b):
-      return gen_conjunct_advice(b, arbs, ihs + [f"IH{len(ihs)}"])
-    case Call(_, _, _, [arg]):
-      withs = ""
-      if arbs:
-        withs = "with " + ", ".join(arbs) + ". "
-      assumes = ""
-      if ihs:
-        assumes = "assume " + ", ".join(ihs) +" "
-      return f"\t\tcase {withs}{arg} {assumes} {'{'}\n\t\t\t?\n{'\t\t}'}"
-  raise AssertionError(f"unsupported conjunct shape: {conjunct!r}")
-
-def gen_custom_induction_advice(conjuncts: list[Formula]) -> str:
-  return "\n".join([gen_conjunct_advice(c, [], []) for c in conjuncts])
-
-def _custom_induction_expected_cases(conjuncts: list[Formula]) -> str:
-  return gen_custom_induction_advice(conjuncts).replace('\t\t', '\t')
-
-def _custom_induction_case_hint(conjunct: Formula) -> str:
-  return gen_conjunct_advice(conjunct, [], []).replace('\t\t', '\t')
-
 def validate_conjunct(loc: Meta, conj: Formula, fun: str) -> Formula:
   match conj:
     case All(loc1, _, (_, ty), _, body):
@@ -115,7 +90,7 @@ def generate_conjunct_body(
   if get_verbose():
     print("generate_conjunct_body", conjunct)
   if case_hint is None:
-    case_hint = _custom_induction_case_hint(conjunct)
+    case_hint = custom_induction_case_hint(conjunct)
   match conjunct:
     case All(_, _, (name, ty), _, body):
       if len(case.pattern.parameters) <= param_i:

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -510,7 +510,7 @@ def type_check_view_recursive_fun(stmt: RecFun, env: Env,
   case_env = case_env.declare_term_vars(loc, param_pairs)
 
   checked_subject = ResolvedVar(loc, checked_params[0], param_names[0])
-  checked_view = type_check_term(_view_call(loc, view_decl.into,
+  checked_view = type_check_term(view_call(loc, view_decl.into,
                                            checked_subject),
                                  view_ty, case_env, None, [])
   cases_present: PatternCoverage = {}
@@ -623,15 +623,12 @@ def _check_view_function_type(loc: Meta, name: str, expected: Type,
                + " has type\n\t" + str(actual)
                + "\nbut expected\n\t" + str(expected))
 
-def _view_call(loc: Meta, fun_name: str, arg: Term) -> Call:
-  return Call(loc, None, ResolvedVar(loc, None, fun_name), [arg])
-
 def _view_roundtrip_formula(loc: Meta, view: ViewDecl) -> Formula:
   value_name = generate_proof_name("v")
   value = ResolvedVar(loc, view.target, value_name)
   formula = mkEqual(loc,
-                    _view_call(loc, view.into,
-                               _view_call(loc, view.out, value)),
+                    view_call(loc, view.into,
+                               view_call(loc, view.out, value)),
                     value)
   formula = All(loc, None, (value_name, view.target), (0, 1), formula)
   for i, tp in enumerate(reversed(view.type_params)):
@@ -643,8 +640,8 @@ def _view_inverse_formula(loc: Meta, view: ViewDecl) -> Formula:
   value_name = generate_proof_name("v")
   value = ResolvedVar(loc, view.source, value_name)
   formula = mkEqual(loc,
-                    _view_call(loc, view.out,
-                               _view_call(loc, view.into, value)),
+                    view_call(loc, view.out,
+                               view_call(loc, view.into, value)),
                     value)
   formula = All(loc, None, (value_name, view.source), (0, 1), formula)
   for i, tp in enumerate(reversed(view.type_params)):
@@ -719,7 +716,7 @@ def type_check_viewrec(stmt: ViewRecFun, env: Env) -> GenRecFun:
                + " but view " + base_name(view_name)
                + " views " + str(source_ty))
   checked_subject = type_check_term(view_subject, source_ty, case_env, None, [])
-  checked_view = type_check_term(_view_call(loc, view_decl.into,
+  checked_view = type_check_term(view_call(loc, view_decl.into,
                                            checked_subject),
                                  view_ty, case_env, None, [])
   cases_present: PatternCoverage = {}

--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -680,41 +680,6 @@ def update_all_head(r: Formula) -> Formula:
       case _:
         return r
 
-def gen_conjunct_advice(conjunct: Formula, arbs: list[str], ihs: list[str]) -> str:
-  match conjunct:
-    case All(_, _, (n, _), _, b):
-      return gen_conjunct_advice(b, arbs + [base_name(n)], ihs)
-    case IfThen(_, _, _, b):
-      return gen_conjunct_advice(b, arbs, ihs + [f"IH{len(ihs)}"])
-    case Call(_, _, _, [arg]):
-      withs = ""
-      if arbs:
-        withs = "with " + ", ".join(arbs) + ". "
-      assumes = ""
-      if ihs:
-        assumes = "assume " + ", ".join(ihs) +" "
-      return f"\t\tcase {withs}{arg} {assumes} {'{'}\n\t\t\t?\n{'\t\t}'}"
-  return ""
-
-def gen_custom_induction_advice(conjuncts: list[Formula]) -> str:
-  return "\n".join([gen_conjunct_advice(c, [], []) for c in conjuncts])
-
-def _custom_induction_expected_cases(conjuncts: list[Formula]) -> str:
-  return gen_custom_induction_advice(conjuncts).replace('\t\t', '\t')
-
-def _custom_induction_case_hint(conjunct: Formula) -> str:
-  return gen_conjunct_advice(conjunct, [], []).replace('\t\t', '\t')
-
-def _proof_view_callable(loc: Meta, name: str, type_args: list[Type]) -> Term:
-  rator: Term = ResolvedVar(loc, None, name)
-  if type_args:
-    rator = TermInst(loc, None, rator, type_args)
-  return rator
-
-def _proof_view_call(loc: Meta, name: str, arg: Term,
-                     type_args: list[Type]) -> Call:
-  return Call(loc, None, _proof_view_callable(loc, name, type_args), [arg])
-
 def _bijective_view_for_source_type(loc: Meta, ty: Type, env: Env
                                     ) -> ViewMatch | None:
   for binding in env.dict.values():
@@ -771,7 +736,7 @@ def _check_induction_via_custom_induction(
   if len(cases) != len(conjuncts):
     plural = '' if len(conjuncts) == 1 else 's'
     if expected_cases is None:
-      expected_cases = _custom_induction_expected_cases(conjuncts)
+      expected_cases = custom_induction_expected_cases(conjuncts)
     add_diagnostic(loc, 'expected ' + str(len(conjuncts)) \
           + ' case' + plural + ' for custom induction on ' + str(typ) \
           + ', but have ' + str(len(cases)) \
@@ -857,7 +822,7 @@ def _check_induction_via_view(loc: Meta, typ: Type,
         pattern_term = pattern_to_term(indcase.pattern)
         checked_pattern = type_check_term(pattern_term, target_ty, body_env, None, [])
         out_term = type_check_term(
-            _proof_view_call(loc, view.out, checked_pattern, type_args),
+            view_call(loc, view.out, checked_pattern, type_args),
             source_ty, body_env, None, [])
         old_reduce_only = get_reduce_only()
         set_reduce_only(old_reduce_only + [ResolvedVar(loc, None, view.out)])
@@ -919,7 +884,7 @@ def _check_switch_via_view(loc: Meta, new_subject: Term,
 
   view_value_name = generate_proof_name('v')
   view_value = ResolvedVar(loc, target_ty, view_value_name)
-  out_value = _proof_view_call(loc, view.out, view_value, type_args)
+  out_value = view_call(loc, view.out, view_value, type_args)
   view_formula_body = cast(
       CheckedFormula,
       formula.substitute({new_subject.get_name(): out_value}),
@@ -933,7 +898,7 @@ def _check_switch_via_view(loc: Meta, new_subject: Term,
   ]
   prove_view_formula = PAnnot(loc, view_formula,
                               Induction(loc, target_ty, ind_cases))
-  into_subject = _proof_view_call(loc, view.into, new_subject, type_args)
+  into_subject = view_call(loc, view.into, new_subject, type_args)
   prove_out_into = AllElim(loc, prove_view_formula, into_subject, (0, 1))
 
   try:
@@ -995,7 +960,7 @@ def _check_switch_via_custom_induction(loc: Meta, new_subject: Term,
     add_diagnostic(loc, 'expected ' + str(len(conjuncts))
           + ' case' + plural + ' in switch on `' + str(ty) + '`,'
           + ' but have ' + str(len(cases))
-          + '\nExpected cases:\n' + _custom_induction_expected_cases(conjuncts)
+          + '\nExpected cases:\n' + custom_induction_expected_cases(conjuncts)
           + givens_str(env))
     return
 

--- a/checker_types.py
+++ b/checker_types.py
@@ -197,9 +197,6 @@ def _instantiate_view_type(
   return cast(ViewInstantiation | None,
               checker_pipeline._instantiate_view_type(loc, typ, env))
 
-def _view_call(loc: Meta, fun_name: str, arg: Term) -> Call:
-  return Call(loc, None, ResolvedVar(loc, None, fun_name), [arg])
-
 def _term_bijective_view_for_source_type(
     loc: Meta, typ: TypeExpr, env: Env
 ) -> ViewMatch | None:
@@ -243,7 +240,7 @@ def _switch_subject_via_bijective_view(
              for c in cases):
     return None
   checked_view = type_check_term(
-      _view_call(loc, view.into, new_subject), target_ty, env, recfun,
+      view_call(loc, view.into, new_subject), target_ty, env, recfun,
       subterms)
   return checked_view, target_ty
 


### PR DESCRIPTION
## Summary

Another duplication-reduction slice for #813. Two helper families that were
copied across checker modules are now single definitions in `checker_common.py`
(the shared home both consumers already pull in via `from checker_common import *`).

### 1. Custom-induction advice generators

`gen_conjunct_advice`, `gen_custom_induction_advice`, and the expected-cases /
case-hint wrappers were duplicated **whole** between `checker_induction.py` and
`checker_proofs.py`. The two copies were byte-for-byte identical except for
`gen_conjunct_advice`'s fallback on an unrecognized conjunct shape: the
induction copy raised `AssertionError`, the proofs copy returned `""`.

Unified on the lenient `""` fallback, since these functions only build the
"Expected a case shaped like …" hint text embedded in a user error — an empty
hint is a safe degradation, whereas raising would turn a helpful diagnostic into
an internal crash. The underscore-prefixed wrappers were renamed to public names
(`custom_induction_expected_cases`, `custom_induction_case_hint`) so they flow
through the existing `import *`.

### 2. View-application constructor

The single-argument view-call constructor was duplicated as `_view_call` in
`checker_pipeline.py` and `checker_types.py`, and as the type-argument superset
`_proof_view_call` / `_proof_view_callable` in `checker_proofs.py`. The two-file
version is exactly the `type_args == []` case of the proofs version, so all
three now call one `view_call(loc, name, arg, type_args=None)` in
`checker_common.py`.

Net: −16 lines, no behavior change on any tested path (the induction-advice text
is exercised by `test/should-error/induction_advice_custom.pf`,
`induction_advice_partial.pf`, and `induction_custom_missing_case.pf`, which all
still match their fixtures).

## Testing

`python3 test-deduce.py` passes in full: `lib`, `should-validate` (× both
parsers), `should-error`, `should-warn`, and parser equivalence (curated corpus
+ pretty-print round-trip). `ruff`/`mypy` were not runnable in the container
(not installed), so CI is the authoritative static-check gate for this PR.

Refs #813 (umbrella stays open for further duplication-reduction slices).

Resume this session on ginger: `~/deduce-runner/resume.sh fc69a699-96e1-4f98-b951-d886c1eac929 routine/20260715-060201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
