### PR TITLE
Fold whole should-error corpus into --equiv AST-equivalence sweep (refs #473)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -21,11 +21,13 @@ Per-category flags (combinable):
     --errors       ``test/should-error`` (RD only, ``.err`` diff).
     --warns        ``test/should-warn`` (RD only, ``.warn`` diff): files
                    that must validate AND emit specific warning text.
-    --equiv        Parse a curated grammar-coverage corpus with both parsers
-                   and compare structural ASTs. Known historical divergences
-                   and parser-error fixtures are allowlisted so CI catches new
-                   drift. Also round-trip representative ASTs through the
-                   pretty-printer and both parsers.
+    --equiv        Parse a grammar-coverage corpus with both parsers and
+                   compare structural ASTs. The corpus is a curated stdlib /
+                   accepted / warning selection plus every ``test/should-error``
+                   fixture both parsers accept at parse time. Known historical
+                   divergences and parse-time-rejected fixtures are allowlisted
+                   so CI catches new drift. Also round-trip representative ASTs
+                   through the pretty-printer and both parsers.
 
 Standalone modes (mutually exclusive with the above):
     --site             Generate ``doc_*.pf`` from ``gh_pages/doc/``
@@ -502,19 +504,27 @@ PARSER_EQUIV_FILES = PARSER_ROUND_TRIP_FILES + (
     "./lib/Nat.pf",
     "./lib/UInt.pf",
     "./lib/Int.pf",
-    # Warning and later-phase error fixtures add syntax that is not always
-    # present in validating examples while staying much smaller than the full
-    # should-error directory sweep.
+    # Warning fixtures add syntax that is not always present in validating
+    # examples. The ``test/should-error`` corpus is folded in wholesale by
+    # ``should_error_equiv_files`` below (everything both parsers accept at
+    # parse time), so individual should-error paths are not listed here.
     "./test/should-warn/replace_auto_handled_922.pf",
-    "./test/should-error/advice_and.pf",
-    "./test/should-error/import_using_unknown.pf",
-    "./test/should-error/opaque_define_use_in_theorem.pf",
-    "./test/should-error/overload_return_type.pf",
-    "./test/should-error/predicate_negative_position.pf",
-    "./test/should-error/private_import1.pf",
-    "./test/should-error/recursive_import_one.pf",
-    "./test/should-error/replace_match_failure.pf",
 )
+
+
+def should_error_equiv_files() -> tuple[str, ...]:
+    """``test/should-error`` fixtures both parsers accept at parse time.
+
+    Most should-error files fail in a *later* phase (type-check/proof-check)
+    while parsing cleanly under both parsers, so their surface syntax is a
+    legitimate RD-vs-LALR drift sample -- and exercises constructs the
+    validating corpus may not. Everything except the
+    ``SHOULD_ERROR_PARSER_EQUIV_SKIP`` baseline (fixtures at least one parser
+    rejects at parse time) participates; that baseline shrinks over time via
+    ``_check_should_error_skip_set``.
+    """
+    return tuple(p for p in list_pf(ERROR_DIR)
+                 if p not in SHOULD_ERROR_PARSER_EQUIV_SKIP)
 
 
 class ParsedFlags(TypedDict):
@@ -899,18 +909,21 @@ def _worker_parser_equivalence(
 def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     """Compare RD and LALR ASTs for parseable syntax.
 
-    Covers a curated corpus spanning stdlib, accepted, warning, and
-    later-phase error fixtures. ``should-error`` files fail in later phases,
-    so their ASTs are still meaningful surface-syntax samples; the
-    ``SHOULD_ERROR_PARSER_EQUIV_SKIP`` baseline excludes the fixtures where
-    at least one parser rejects at parse time today.
+    Covers a curated corpus spanning stdlib, accepted, and warning fixtures,
+    plus the entire ``test/should-error`` directory: those files fail in a
+    later phase but parse cleanly under both parsers, so their ASTs are still
+    meaningful surface-syntax samples. The ``SHOULD_ERROR_PARSER_EQUIV_SKIP``
+    baseline excludes only the fixtures where at least one parser rejects at
+    parse time today.
 
     ``test/parse`` remains RD-only because those fixtures intentionally lock
     down beginner-facing RD diagnostics, while the LALR parser is kept as an
     executable grammar spec.
     """
     files = tuple(dict.fromkeys(
-        PARSER_EQUIV_FILES + tuple(sorted(PARSER_EQUIV_EXPECTED_DIVERGENCES))
+        PARSER_EQUIV_FILES
+        + should_error_equiv_files()
+        + tuple(sorted(PARSER_EQUIV_EXPECTED_DIVERGENCES))
     ))
     failures: list[tuple[str, str, str]] = []
     seen_divergences: set[str] = set()
@@ -1502,7 +1515,7 @@ def main(argv: list[str]) -> int:
 
     if flags["equiv"]:
         print("\n=== parser equivalence (RD vs LALR ASTs) ===")
-        _, fails = time_section("curated grammar corpus",
+        _, fails = time_section("grammar + should-error corpus",
                                 lambda: run_parser_equivalence(workers))
         total_failures.extend(fails)
         _, fails = time_section("pretty-print round trip",


### PR DESCRIPTION
## Summary

Folds the entire `test/should-error/` corpus into the default `--equiv`
parser-equivalence (RD vs LALR AST comparison) sweep, closing the
long-standing "decide whether and how much of `test/should-error/` should
participate in parser equivalence checks" item from #473.

## Background

The default `--equiv` sweep compared RD/LALR ASTs for a curated corpus that
included only ~9 hand-picked `should-error` fixtures. But the code already
carried the full machinery for wholesale inclusion:

- a comment promising "180+ extra surface-syntax samples for drift detection"
  from the should-error directory, and
- the `SHOULD_ERROR_PARSER_EQUIV_SKIP` baseline plus `_check_should_error_skip_set`
  staleness check, whose only purpose is to subtract the parse-time-rejected
  fixtures from a full should-error sweep.

The subtraction was maintained, but the full sweep it was meant to feed never
happened — the equivalence run kept using the small curated list.

## Change

- Add `should_error_equiv_files()`: every `test/should-error/*.pf` file except
  the `SHOULD_ERROR_PARSER_EQUIV_SKIP` baseline.
- Feed it into `run_parser_equivalence` so all parse-clean should-error
  fixtures participate in RD-vs-LALR AST comparison.
- Remove the now-redundant hand-listed should-error entries from
  `PARSER_EQUIV_FILES` (all still covered by the dynamic corpus).
- Update the `--equiv` docstrings and the phase label
  (`grammar + should-error corpus`).

This is complementary to #1014, which folds parseable should-error fixtures
into the opt-in `--equiv-full` pretty-print round-trip; this PR covers them in
the default CI RD/LALR AST-equivalence sweep instead.

## Verification

- All 202 non-skip should-error fixtures parse cleanly under both parsers and
  produce **identical** RD/LALR ASTs — so no `PARSER_EQUIV_EXPECTED_DIVERGENCES`
  baseline is needed and the sweep stays green.
- `python3 test-deduce.py --equiv` → all tests pass. The AST-equivalence phase
  grows from ~13s to ~21.6s (≈190 added files); total `--equiv` wall time
  ~27s → ~36s.
- `ruff check test-deduce.py` and `mypy test-deduce.py` both clean.
- `_check_should_error_skip_set()` reports no staleness failures.

Refs #473 (the remaining part-B Reference.md↔LALR grammar checker is already
wired into CI and `make`, and passes; other umbrella items — pretty-printer
round-trip expansion — remain open, so this does not close the issue).

Resume this session on ginger: `~/deduce-runner/resume.sh 3d3b25b5-af76-46aa-80c2-867a9d0c15fa routine/20260715-070202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
