### PR TITLE
Dedup literal-construction helpers (_resolved_or_var, mkLitNat) (refs #813)

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -304,26 +304,22 @@ def intToUInt(loc: Meta, n: int, bzero: str = 'bzero',
     else:
         return uint_inc(loc, intToUInt(loc, n - 1, bzero, dubinc, incdub, uint_ty))
     
-def mkZero(loc: Meta, zname: str | bool = 'zero',
-           ty: Type | None = None) -> VarRef:
-  # Use OverloadedVar when the name is already uniquified (contains
-  # '.'), otherwise a pre-uniquify Var. Fast-arithmetic call sites
+def _resolved_or_var(loc: Meta, ty: Type | None, name: str) -> VarRef:
+  # A ``ResolvedVar`` when ``name`` is already uniquified (contains a
+  # '.'), otherwise a pre-uniquify ``Var``. Fast-arithmetic call sites
   # in the type checker pass uniquified names extracted from the
   # existing AST; parser call sites pass the bare source name.
-  zname = str(zname)
-  if '.' in zname:
-    return ResolvedVar(loc, ty, zname)
-  return Var(loc, ty, zname)
+  if '.' in name:
+    return ResolvedVar(loc, ty, name)
+  return Var(loc, ty, name)
+
+def mkZero(loc: Meta, zname: str | bool = 'zero',
+           ty: Type | None = None) -> VarRef:
+  return _resolved_or_var(loc, ty, str(zname))
 
 def mkSuc(loc: Meta, arg: Term, sname: str | bool = 'suc',
           ty: Type | None = None) -> Call:
-  sname = str(sname)
-  rator: VarRef
-  if '.' in sname:
-    rator = ResolvedVar(loc, None, sname)
-  else:
-    rator = Var(loc, None, sname)
-  return Call(loc, ty, rator, [arg])
+  return Call(loc, ty, _resolved_or_var(loc, None, str(sname)), [arg])
 
 def intToNat(
     loc: Meta,
@@ -526,11 +522,7 @@ def try_fast_lit_nat_arith(loc: Meta, rator: Term, args: list[Term],
     return None
   inner = intToNat(loc, result_int, zname=zero_name,
                    sname=suc_name or 'suc')
-  if '.' in lit_name:
-    lit_var: Term = ResolvedVar(loc, None, lit_name)
-  else:
-    lit_var = Var(loc, None, lit_name)
-  return Call(loc, ty, lit_var, [inner])
+  return Call(loc, ty, _resolved_or_var(loc, None, lit_name), [inner])
 
 def _same_numeric_literal(t1: AST, t2: AST) -> bool:
   if not isinstance(t1, Term) or not isinstance(t2, Term):
@@ -581,10 +573,13 @@ def formulas_equal_modulo_numeric_literals(frm1: AST, frm2: AST) -> bool:
     case _:
       return False
 
+def mkLitNat(loc: Meta, num: int) -> Term:
+    # The ``lit(ℕnum)`` surface form shared by the parsers' Nat literals
+    # and the Nat payload of a UInt literal (below).
+    return Call(loc, None, Var(loc, None, 'lit'), [intToNat(loc, num)])
+
 def mkUIntLit(loc: Meta, num: int) -> Term:
-    return Call(loc, None, Var(loc, None, 'fromNat'),
-                [Call(loc, None, Var(loc, None, 'lit'),
-                      [intToNat(loc, num)])])
+    return Call(loc, None, Var(loc, None, 'fromNat'), [mkLitNat(loc, num)])
   
 def mkPos(loc: Meta, arg: Term) -> Term:
   return Call(loc, None, Var(loc, None, 'pos'), [arg])

--- a/parser.py
+++ b/parser.py
@@ -21,8 +21,8 @@ from abstract_syntax import (
     SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, Term, TermInst,
     Theorem, Trace, Proof, TypeAlias, TypeInst, TypeType, Union, Var,
     ViewDecl, count_marks, extract_and, extract_or, extract_tuple,
-    get_default_mark_LHS, intToNat, listToNodeList, mkEqualVar, mkIntLit,
-    mkUIntLit, remove_mark,
+    get_default_mark_LHS, listToNodeList, mkEqualVar, mkIntLit,
+    mkLitNat, mkUIntLit, remove_mark,
 )
 import re
 from lark import Lark, Token, Tree, exceptions
@@ -625,8 +625,7 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
         num = int(_token_text(e, 0))
         return mkUIntLit(e.meta, num)
     elif e.data == 'nat':
-        return Call(e.meta, None, Var(e.meta, None, 'lit'),
-                    [intToNat(e.meta, int(_token_text(e, 0)[1:]))])
+        return mkLitNat(e.meta, int(_token_text(e, 0)[1:]))
     elif e.data == 'pos_int':
         return mkIntLit(e.meta, int(_token_text(e, 0)), 'PLUS')
     elif e.data == 'neg_int':

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -27,7 +27,7 @@ from abstract_syntax import (
     TAnnote, TLet, Term, TermInst,
     Theorem, Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, ViewDecl,
     count_marks, extract_and, extract_or, extract_tuple, get_default_mark_LHS,
-    intToNat, listToNodeList, mkEqualVar, mkIntLit, mkUIntLit, remove_mark,
+    listToNodeList, mkEqualVar, mkIntLit, mkLitNat, mkUIntLit, remove_mark,
 )
 from lark import Lark, Token, exceptions
 from lark.tree import Meta
@@ -260,8 +260,7 @@ def parse_term_hi() -> Term:
   elif token.type == 'NAT' or token.value == '0':
     advance()
     meta = meta_from_tokens(token,token)
-    return Call(meta, None, Var(meta, None, 'lit'),
-                [intToNat(meta, int(token.value[1:]))])
+    return mkLitNat(meta, int(token.value[1:]))
 
   elif token.type == 'PLUS':
     advance()


### PR DESCRIPTION
## What

A self-contained duplication-reduction slice for the #813 umbrella, in
`abstract_syntax/literals.py` and both parsers.

- **`_resolved_or_var(loc, ty, name)`** — a private helper that returns a
  `ResolvedVar` when `name` is already uniquified (contains a `.`) and a
  pre-uniquify `Var` otherwise. This idiom was copy-pasted in three places
  (`mkZero`, `mkSuc`, and `try_fast_lit_nat_arith`); all three now call the
  helper.
- **`mkLitNat(loc, num)`** — the `lit(ℕnum)` construction was written out
  inline in `mkUIntLit` and in the `Nat`-literal branch of *both* parsers
  (`rec_desc_parser.py` and `parser.py`). Extracted into one helper next to
  `mkUIntLit`; the parsers now import `mkLitNat` and no longer import
  `intToNat` (which they no longer reference directly).

Net −7 lines, no behavioral change.

## Verification

Run locally against Python 3.12 + lark 1.2.2:

- `python3 -m ruff check .` — clean
- `python3 -m mypy .` and `mypy . --no-site-packages` — clean (53 files)
- `python3 test-deduce.py` (lib + should-validate ×2 parsers + should-error +
  should-warn + prelude + `--equiv`) — all passed
- `python3 test-deduce.py --equiv-full` (275-file round-trip) — all passed
- `gh_pages/scripts/keywords.py` and `reference_grammar.py` — clean

The `--equiv` RD-vs-LALR AST comparison and the pretty-print round-trip
confirm the produced ASTs are byte-identical to before.

## Noticed in passing

While auditing literal handling I found and filed **#1021**: large integer
literals crash with `maximum recursion depth exceeded` because they desugar to
a *unary* `suc^n(zero)` term whose size (and construction depth) is
proportional to the literal's value (`assert 1500 = 1500` validates,
`assert 3000 = 3000` crashes). That is a deeper design question (flagged
"is this intentional?") and is intentionally **not** touched by this PR.

Refs #813. Refs #1021.

Resume this session on ginger: `~/deduce-runner/resume.sh 675e6d02-66ac-43a6-8299-8fd80ae2c398 routine/20260715-110201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
