### PR TITLE
Prove lcm divisibility characterization for UInt and Int (refs #720)

### DIFF
--- a/lib/IntDivides.pf
+++ b/lib/IntDivides.pf
@@ -298,3 +298,33 @@ proof
   arbitrary a:Int
   expand lcm.
 end
+
+// `a` divides `lcm(a, b)`. Lifts `uint_divides_lcm_left` through
+// `int_divides_iff_abs`, since `lcm` is defined on absolute values.
+theorem int_divides_lcm_left: all a:Int, b:Int. divides(a, lcm(a, b))
+proof
+  arbitrary a:Int, b:Int
+  expand lcm
+  have ul: divides(abs(a), lcm(abs(a), abs(b)))
+    by uint_divides_lcm_left[abs(a), abs(b)]
+  have unfold: abs(pos(lcm(abs(a), abs(b)))) = lcm(abs(a), abs(b))
+    by int_abs_pos[lcm(abs(a), abs(b))]
+  have ul2: divides(abs(a), abs(pos(lcm(abs(a), abs(b)))))
+    by replace symmetric unfold in ul
+  apply (conjunct 1 of int_divides_iff_abs[a, pos(lcm(abs(a), abs(b)))]) to ul2
+end
+
+// `b` divides `lcm(a, b)`. Mirrors `int_divides_lcm_left` through
+// `uint_divides_lcm_right`.
+theorem int_divides_lcm_right: all a:Int, b:Int. divides(b, lcm(a, b))
+proof
+  arbitrary a:Int, b:Int
+  expand lcm
+  have ul: divides(abs(b), lcm(abs(a), abs(b)))
+    by uint_divides_lcm_right[abs(a), abs(b)]
+  have unfold: abs(pos(lcm(abs(a), abs(b)))) = lcm(abs(a), abs(b))
+    by int_abs_pos[lcm(abs(a), abs(b))]
+  have ul2: divides(abs(b), abs(pos(lcm(abs(a), abs(b)))))
+    by replace symmetric unfold in ul
+  apply (conjunct 1 of int_divides_iff_abs[b, pos(lcm(abs(a), abs(b)))]) to ul2
+end

--- a/lib/UIntDiv.pf
+++ b/lib/UIntDiv.pf
@@ -984,3 +984,113 @@ proof
 end
 
 auto uint_lcm_zero_right
+
+// A positive first operand forces a positive gcd, since `gcd(a, b)`
+// divides `a` and only zero divides into zero.
+theorem uint_gcd_pos: all a:UInt, b:UInt. if 0 < a then 0 < gcd(a, b)
+proof
+  arbitrary a:UInt, b:UInt
+  assume a_pos
+  have g_div_a: divides(gcd(a, b), a) by uint_gcd_divides_left[a, b]
+  have g_ne_z: not (gcd(a, b) = 0) by {
+    assume g_z
+    have div0a: divides(0, a) by replace g_z in g_div_a
+    obtain j where z_a: 0 = a from expand divides in div0a
+    have a_ne: not (a = 0) by apply uint_pos_not_zero to a_pos
+    apply a_ne to (symmetric z_a)
+  }
+  apply uint_not_zero_pos to g_ne_z
+end
+
+// `a` divides its least common multiple with `b`. In the interesting
+// case `lcm(a, b) = (a * b) / gcd(a, b)`; since `gcd(a, b)` divides `b`
+// as `gcd(a, b) * k = b`, the quotient collapses to `a * k`.
+theorem uint_divides_lcm_left: all a:UInt, b:UInt. divides(a, lcm(a, b))
+proof
+  arbitrary a:UInt, b:UInt
+  cases uint_zero_or_positive[a]
+  case a_z {
+    replace a_z
+    uint_divides_zero[0]
+  }
+  case a_pos {
+    cases uint_zero_or_positive[b]
+    case b_z {
+      replace b_z
+      uint_divides_zero[a]
+    }
+    case b_pos {
+      have g_pos: 0 < gcd(a, b) by apply uint_gcd_pos[a, b] to a_pos
+      have g_div_b: divides(gcd(a, b), b) by uint_gcd_divides_right[a, b]
+      obtain k where gk_b: gcd(a, b) * k = b from expand divides in g_div_b
+      have a_ne: not (a = 0) by apply uint_pos_not_zero to a_pos
+      have b_ne: not (b = 0) by apply uint_pos_not_zero to b_pos
+      have cond_false: not (a = 0 or b = 0) by {
+        assume c
+        cases c
+        case l { apply a_ne to l }
+        case r { apply b_ne to r }
+      }
+      have lcm_eq: lcm(a, b) = a * k by {
+        expand lcm
+        replace (apply eq_false to cond_false)
+        have prod_eq: a * b = gcd(a, b) * (a * k) by {
+          have s1: a * b = a * (gcd(a, b) * k) by replace gk_b.
+          replace s1
+          replace uint_mult_commute[a, gcd(a, b)].
+        }
+        replace prod_eq
+        apply uint_mult_div_left_inverse[a * k, gcd(a, b)] to g_pos
+      }
+      expand divides
+      choose k
+      symmetric lcm_eq
+    }
+  }
+end
+
+// `b` divides its least common multiple with `a`. Mirrors
+// `uint_divides_lcm_left`, using that `gcd(a, b)` divides `a`.
+theorem uint_divides_lcm_right: all a:UInt, b:UInt. divides(b, lcm(a, b))
+proof
+  arbitrary a:UInt, b:UInt
+  cases uint_zero_or_positive[a]
+  case a_z {
+    replace a_z
+    uint_divides_zero[b]
+  }
+  case a_pos {
+    cases uint_zero_or_positive[b]
+    case b_z {
+      replace b_z
+      uint_divides_zero[0]
+    }
+    case b_pos {
+      have g_pos: 0 < gcd(a, b) by apply uint_gcd_pos[a, b] to a_pos
+      have g_div_a: divides(gcd(a, b), a) by uint_gcd_divides_left[a, b]
+      obtain j where gj_a: gcd(a, b) * j = a from expand divides in g_div_a
+      have a_ne: not (a = 0) by apply uint_pos_not_zero to a_pos
+      have b_ne: not (b = 0) by apply uint_pos_not_zero to b_pos
+      have cond_false: not (a = 0 or b = 0) by {
+        assume c
+        cases c
+        case l { apply a_ne to l }
+        case r { apply b_ne to r }
+      }
+      have lcm_eq: lcm(a, b) = j * b by {
+        expand lcm
+        replace (apply eq_false to cond_false)
+        have prod_eq: a * b = gcd(a, b) * (j * b) by {
+          have s1: a * b = (gcd(a, b) * j) * b by replace gj_a.
+          replace s1.
+        }
+        replace prod_eq
+        apply uint_mult_div_left_inverse[j * b, gcd(a, b)] to g_pos
+      }
+      expand divides
+      choose j
+      replace lcm_eq
+      uint_mult_commute[b, j]
+    }
+  }
+end


### PR DESCRIPTION
## Summary

Fills a concrete gap in the `lcm` story for issue #720: the greatest-common-divisor
side had `divides_left` / `divides_right` / `greatest`, but `lcm` had **no**
divisibility characterization at either the `UInt` or `Int` level — only the two
`lcm(0, ·) = 0` / `lcm(·, 0) = 0` cases. This PR proves that each operand divides
the least common multiple, the direct analogue of `gcd`'s `divides_left`/`divides_right`.

## What's added

**`lib/UIntDiv.pf`**
- `uint_gcd_pos` — `0 < a ⇒ 0 < gcd(a, b)` (since `gcd(a, b)` divides `a` and only `0` divides into `0`).
- `uint_divides_lcm_left` — `divides(a, lcm(a, b))`.
- `uint_divides_lcm_right` — `divides(b, lcm(a, b))`.

  Proof idea: for the interesting (both-nonzero) branch, `lcm(a, b) = (a * b) / gcd(a, b)`.
  Since `gcd(a, b)` divides an operand as `gcd(a, b) * k = b`, the product `a * b`
  factors through `gcd(a, b)` and `uint_mult_div_left_inverse` collapses the quotient
  to `a * k`, exhibiting the divisibility witness. The zero branches fall out of
  `uint_divides_zero`.

**`lib/IntDivides.pf`**
- `int_divides_lcm_left` — `divides(a, lcm(a, b))`.
- `int_divides_lcm_right` — `divides(b, lcm(a, b))`.

  Lifted through the existing `int_divides_iff_abs` bridge, exactly like
  `int_gcd_divides_left` / `int_gcd_divides_right`.

## Scope note (why `Refs`, not `Closes`)

Issue #720 is a multi-part umbrella (div/mod, `divides`, `gcd`, `lcm`). The
`div_mod` equation, `divides` closure lemmas, and the `gcd` divides/greatest
properties already landed (PR #1013 + surrounding work); this PR adds the missing
`lcm` divisibility properties. The universal `lcm_least` property
(`a | m ∧ b | m ⇒ lcm(a, b) | m`) still remains — a clean proof needs the
`gcd * lcm = a * b` identity or Euclid's-lemma-style coprimality infrastructure
that the library does not yet have — so the issue stays open. `Refs #720`.

## Testing

- `python3 deduce.py lib/UIntDiv.pf lib/IntDivides.pf` — both valid (RD parser).
- `python3 deduce.py --lalr lib/UIntDiv.pf` and `... lib/IntDivides.pf` — both valid.
- `python3 test-deduce.py --lib` — all passed (both parsers over the full stdlib).
- `python3 test-deduce.py --equiv` — parser equivalence + round-trip all passed.

Refs #720

Resume this session on ginger: `~/deduce-runner/resume.sh deda970a-6343-4fcc-a0cf-570b4ac6cffb routine/20260715-210202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
