### PR TITLE
Dedup alpha-equiv binder helpers and check_implies error context (refs #813)

### DIFF
--- a/abstract_syntax/ops.py
+++ b/abstract_syntax/ops.py
@@ -375,7 +375,7 @@ def _alpha_equiv(t1: object, t2: object,
   if isinstance(t1, Lambda):
     if not isinstance(t2, Lambda):
       return False
-    return _alpha_equiv_lambda(t1, t2, env1, env2)
+    return _alpha_equiv_binders(t1, t2, env1, env2)
   if isinstance(t1, All):
     if not isinstance(t2, All):
       return False
@@ -383,7 +383,7 @@ def _alpha_equiv(t1: object, t2: object,
   if isinstance(t1, Some):
     if not isinstance(t2, Some):
       return False
-    return _alpha_equiv_some(t1, t2, env1, env2)
+    return _alpha_equiv_binders(t1, t2, env1, env2)
   if isinstance(t1, TLet):
     if not isinstance(t2, TLet):
       return False
@@ -485,8 +485,12 @@ def _bind_all(env: dict[str, object],
   return new
 
 
-def _alpha_equiv_lambda(t1:Lambda, t2:Lambda,
-                        env1:dict[str,object], env2:dict[str,object]) -> bool:
+def _alpha_equiv_binders(t1:Lambda | Some, t2:Lambda | Some,
+                         env1:dict[str,object], env2:dict[str,object]) -> bool:
+  # Shared by `Lambda` and `Some`: both bind a list of `.vars` (each an
+  # optionally-typed `(name, type?)` pair) over a `.body`. Check the
+  # binder types agree, then compare the bodies with a fresh tag bound
+  # per position so the comparison is insensitive to the bound names.
   if not _alpha_equiv_binder_types(t1.vars, t2.vars, env1, env2):
     return False
   tags = [object() for _ in t1.vars]
@@ -505,16 +509,6 @@ def _alpha_equiv_all(t1:All, t2:All,
   return _alpha_equiv(t1.body, t2.body, _bind(env1, x, tag), _bind(env2, y, tag))
 
 
-def _alpha_equiv_some(t1:Some, t2:Some,
-                      env1:dict[str,object], env2:dict[str,object]) -> bool:
-  if not _alpha_equiv_binder_types(t1.vars, t2.vars, env1, env2):
-    return False
-  tags = [object() for _ in t1.vars]
-  new_env1 = _bind_all(env1, [(x, tag) for ((x, _), tag) in zip(t1.vars, tags)])
-  new_env2 = _bind_all(env2, [(y, tag) for ((y, _), tag) in zip(t2.vars, tags)])
-  return _alpha_equiv(t1.body, t2.body, new_env1, new_env2)
-
-
 def _alpha_equiv_tlet(t1:TLet, t2:TLet,
                       env1:dict[str,object], env2:dict[str,object]) -> bool:
   if not _alpha_equiv(t1.rhs, t2.rhs, env1, env2):
@@ -530,7 +524,7 @@ def _alpha_equiv_function_type(t1: FunctionType, t2: object,
                                env2: dict[str, object]) -> bool:
   # The only `Type`-level binder: `type_params` is a list of names
   # bound in `param_types` and `return_type`. Same parallel-walk
-  # pattern as `_alpha_equiv_lambda`, but `type_params` carries no
+  # pattern as `_alpha_equiv_binders`, but `type_params` carries no
   # per-parameter type annotation -- it's just names.
   if not isinstance(t2, FunctionType):
     return False

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -58,9 +58,8 @@ if TYPE_CHECKING:
     )
     from .ops import (
         _alpha_equiv_all,
+        _alpha_equiv_binders,
         _alpha_equiv_function_type,
-        _alpha_equiv_lambda,
-        _alpha_equiv_some,
         _alpha_equiv_tlet,
         callable_name,
         explicit_term_inst,
@@ -794,7 +793,7 @@ class Lambda(Term):
   def __eq__(self, other: object) -> bool:
       if not isinstance(other, Lambda):
         return False
-      return _alpha_equiv_lambda(self, other, {}, {})
+      return _alpha_equiv_binders(self, other, {}, {})
 
   def reduce(self, env: Env) -> Lambda:
     if get_eval_all():
@@ -2080,5 +2079,5 @@ class Some(Formula):
   def __eq__(self, other: object) -> bool:
     if not isinstance(other, Some):
       return False
-    return _alpha_equiv_some(self, other, {}, {})
+    return _alpha_equiv_binders(self, other, {}, {})
   

--- a/checker_logic.py
+++ b/checker_logic.py
@@ -124,6 +124,12 @@ def commute_diff_hint(frm: Formula) -> str:
           + 'See CheatSheet.md "Equations involving `+` that look trivial".')
 
 
+def _implies_context(frm1: Formula, frm2: Formula) -> str:
+  # The "while proving frm1 implies frm2" note appended to a nested
+  # failure so the reported error keeps the enclosing implication goal.
+  return '\n\nWhile trying to prove that\n\t' + str(frm1) \
+      + '\nimplies\n' + '\t' + str(frm2)
+
 def check_implies(loc: Meta, frm1: Formula, frm2: Formula) -> None:
   if get_verbose():
     print('check_implies? ' + str(frm1) + ' => ' + str(frm2))
@@ -136,20 +142,14 @@ def check_implies(loc: Meta, frm1: Formula, frm2: Formula) -> None:
         for arg2 in args:
           check_implies(loc, frm1, arg2)
       except UserError as e:
-          context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
-              + '\nimplies\n'\
-              + '\t' + str(frm2)
-          raise wrap_user_error(e, context) from e
+          raise wrap_user_error(e, _implies_context(frm1, frm2)) from e
 
     case(Or(_, _, args1), _):
       for arg1 in args1:
         try:
           check_implies(loc, arg1, frm2)
         except UserError as e:
-          context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
-              + '\nimplies\n'\
-              + '\t' + str(frm2)
-          raise wrap_user_error(e, context) from e
+          raise wrap_user_error(e, _implies_context(frm1, frm2)) from e
       
     case (Bool(loc2, tyof2, False), _):
       return
@@ -203,10 +203,7 @@ def check_implies(loc: Meta, frm1: Formula, frm2: Formula) -> None:
         check_implies(loc, prem2, prem1)
         check_implies(loc, conc1, conc2)
       except UserError as e:
-        context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
-            + '\nimplies\n'\
-            + '\t' + str(frm2)
-        raise wrap_user_error(e, context) from e
+        raise wrap_user_error(e, _implies_context(frm1, frm2)) from e
 
     case (All(_, _, var1, _, body1), All(loc2, tyof2, var2, _, body2)):
       try:
@@ -214,10 +211,7 @@ def check_implies(loc: Meta, frm1: Formula, frm2: Formula) -> None:
           body2a = cast(Formula, body2.substitute(sub))
           check_implies(loc, body1, body2a)
       except UserError as e:
-        context = '\n\nWhile trying to prove that\n\t' + str(frm1) \
-            + '\nimplies\n'\
-            + '\t' + str(frm2)
-        raise wrap_user_error(e, context) from e
+        raise wrap_user_error(e, _implies_context(frm1, frm2)) from e
 
     case (All(_, _, _, _, body1), _):
        matching:dict[str, Term] = {}

--- a/test/properties/test_post_uniquify.py
+++ b/test/properties/test_post_uniquify.py
@@ -159,7 +159,7 @@ post_term_st = st.recursive(
 
 
 # Lambda body generator: keeps the body in the post-uniquify shape so
-# that ``Lambda.__eq__`` (which delegates to ``_alpha_equiv_lambda``)
+# that ``Lambda.__eq__`` (which delegates to ``_alpha_equiv_binders``)
 # is well-defined.
 def _lambda_with_binder(binder, body):
     return Lambda(_m(), None, [(binder, None)], body)


### PR DESCRIPTION
## What

Two small, behavior-preserving duplication removals under the #813 umbrella.

### 1. Merge byte-identical alpha-equivalence binder helpers (`abstract_syntax/ops.py`)

`_alpha_equiv_lambda` and `_alpha_equiv_some` had **byte-identical** bodies — both check that a binder list (`.vars`, a list of optionally-typed `(name, type?)` pairs) matches and then compare the `.body` under a fresh tag per bound position. They are collapsed into one `_alpha_equiv_binders(t1: Lambda | Some, t2: Lambda | Some, ...)`.

Call sites updated:
- the two dispatch arms in `_alpha_equiv` (`ops.py`),
- `Lambda.__eq__` and `Some.__eq__` in `abstract_syntax/terms.py` (and the corresponding import).

The companion `_alpha_equiv_binder_types` helper is already documented as "shared by Lambda / Some", so this just finishes that consolidation.

### 2. Extract the repeated `check_implies` error-context string (`checker_logic.py`)

The `"While trying to prove that … implies …"` context appended to a nested `UserError` was copy-pasted into four `except` handlers in `check_implies`. It is now a single `_implies_context(frm1, frm2)` helper. The produced message is unchanged (byte-for-byte), so `should-error` diagnostics are unaffected.

Net: −36 / +23 lines, no behavior change.

## Testing

- `python3 test-deduce.py` — full default suite (lib × both parsers, should-validate, should-error, should-warn, prelude, parser equivalence): **all tests passed**.
- Directly exercised the merged helper: alpha-equivalent `λx.x`/`λy.y` and `some x.x`/`some y.y` compare equal; non-equivalent variants compare unequal, for both `Lambda` and `Some`.
- `ruff`/`mypy` are not installed in the run container; the changes are written to be mypy-clean (the merged helper is typed `Lambda | Some`; both node types expose the `.vars`/`.body` fields it uses, matching the arguments already passed to `_alpha_equiv_binder_types`).

## Resuming this session

<!-- for a human picking this up (e.g. to fix CI) -->
Resume this session on ginger: `~/deduce-runner/resume.sh 5704c451-c90a-434b-9d27-501546cdfc16 routine/20260715-220202`

Refs #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
