### PR TITLE
Share the equations-chain proof builder between both parsers (refs #813)

### DIFF
--- a/abstract_syntax/rewrite.py
+++ b/abstract_syntax/rewrite.py
@@ -252,7 +252,25 @@ def remove_mark(formula: Formula) -> Formula:
             internal_error(loc, 'in remove_mark, find_mark failed on formula:\n\t' + str(formula))
         except MarkException as ex:
             return replace_mark(formula, ex.subject)
-      
+
+def build_equations_proof(loc: Meta, eqs: list[tuple[Term, Term, Proof]]) -> Proof:
+    """Fold a list of ``(lhs, rhs, reason)`` equation steps into a single
+    proof, right to left, via transitivity. Shared by both parsers."""
+    result: Proof | None = None
+    for (lhs, rhs, reason) in reversed(eqs):
+        num_marks = count_marks(lhs) + count_marks(rhs)
+        if num_marks == 0 and get_default_mark_LHS():
+            new_lhs: Term = Mark(loc, None, lhs)
+        else:
+            new_lhs = lhs
+        eq_proof = PAnnot(loc, mkEqualVar(loc, new_lhs, rhs), reason)
+        if result == None:
+            result = eq_proof
+        else:
+            result = PTransitive(loc, eq_proof, result)
+    assert result is not None  # the equations grammar yields >= 1 step
+    return result
+
 def extract_and(frm: Formula) -> list[Formula]:
     match frm:
       case And(_, _, args):

--- a/parser.py
+++ b/parser.py
@@ -18,10 +18,10 @@ from abstract_syntax import (
     RewriteFact, RewriteGoal,
     Rule, RuleInduction, RuleInductionCase, RuleInversion, SepConj, SimplifyFact,
     SimplifyGoal, Some, SomeElim, SomeIntro, Statement, Suffices, Switch,
-    SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, Term, TermInst,
-    Theorem, Trace, Proof, TypeAlias, TypeInst, TypeType, Union, Var,
-    ViewDecl, count_marks, extract_and, extract_or, extract_tuple,
-    get_default_mark_LHS, listToNodeList, mkEqualVar, mkIntLit,
+    SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, TermInst,
+    Theorem, Trace, TypeAlias, TypeInst, TypeType, Union, Var,
+    ViewDecl, build_equations_proof, extract_and, extract_or,
+    extract_tuple, listToNodeList, mkIntLit,
     mkLitNat, mkUIntLit, remove_mark,
 )
 import re
@@ -224,24 +224,7 @@ def set_visibility(statement: Any, visibility: str) -> None:
         statement.visibility = 'public'
     else:
         statement.visibility = 'public'
-        
-def build_equations_proof(loc: Meta, eqs: list[tuple[Term, Term, Proof]]) -> Proof:
-    result: Proof | None = None
-    for (lhs, rhs, reason) in reversed(eqs):
-        num_marks = count_marks(lhs) + count_marks(rhs)
-        if num_marks == 0 and get_default_mark_LHS():
-            new_lhs = Mark(loc, None, lhs)
-        else:
-            new_lhs = lhs
 
-        eq_proof = PAnnot(loc, mkEqualVar(loc, new_lhs, rhs), reason)
-        if result == None:
-            result = eq_proof
-        else:
-            result = PTransitive(loc, eq_proof, result)
-    assert result is not None  # the equations grammar yields >= 1 step
-    return result
-        
 # Any: the lark-tree -> AST dispatch boundary. This is dispatched on the
 # grammar rule name and so is polymorphic over every node kind the grammar
 # can produce (Term/Formula/Proof/Type/Pattern/Statement, plus bare str

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -26,8 +26,8 @@ from abstract_syntax import (
     Statement, Suffices, Switch, SwitchCase, SwitchProof, SwitchProofCase,
     TAnnote, TLet, Term, TermInst,
     Theorem, Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, ViewDecl,
-    count_marks, extract_and, extract_or, extract_tuple, get_default_mark_LHS,
-    listToNodeList, mkEqualVar, mkIntLit, mkLitNat, mkUIntLit, remove_mark,
+    build_equations_proof, extract_and, extract_or, extract_tuple,
+    listToNodeList, mkIntLit, mkLitNat, mkUIntLit, remove_mark,
 )
 from lark import Lark, Token, exceptions
 from lark.tree import Meta
@@ -861,22 +861,7 @@ def parse_proof_hi() -> Proof:
             # the mark.
             lhs = remove_mark(eqs[-1][1])
         eqs.append((lhs, rhs, reason))
-    result: Proof | None = None
-    meta = meta_from_tokens(token, token)
-    for (lhs, rhs, reason) in reversed(eqs):
-        num_marks = count_marks(lhs) + count_marks(rhs)
-        if num_marks == 0 and get_default_mark_LHS():
-            new_lhs = Mark(meta, None, lhs)
-        else:
-            new_lhs = lhs
-
-        eq_proof = PAnnot(meta, mkEqualVar(meta, new_lhs, rhs), reason)
-        if result == None:
-            result = eq_proof
-        else:
-            result = PTransitive(meta, eq_proof, result)
-    assert result is not None
-    return result
+    return build_equations_proof(meta_from_tokens(token, token), eqs)
 
   elif token.type == 'RECALL':
     return parse_recall()


### PR DESCRIPTION
## What

Both parsers held a byte-for-byte copy of the loop that folds a list of
`(lhs, rhs, reason)` equation steps into a single transitive proof:

- `parser.py`'s `build_equations_proof` (called from the `equation_proof` /
  `equations_proof` tree handlers), and
- the inline loop in `rec_desc_parser.py`'s `parse_proof_hi` EQUATIONS branch.

The only difference was the local location variable name (`loc` vs `meta`).

This PR extracts the loop as a single `build_equations_proof(loc, eqs)` helper
in `abstract_syntax/rewrite.py` — the module that already owns the mark
helpers it depends on (`count_marks`, `get_default_mark_LHS`, `Mark`), so no
circular imports are introduced (`proofs.py` would have, since `rewrite.py`
imports from it). Both parsers now import and call it, and their now-unused
`count_marks` / `get_default_mark_LHS` / `mkEqualVar` (and `Term`/`Proof` in
`parser.py`) imports are dropped.

Net: duplication removed, −14 lines overall, no behavior change.

## Testing

- `python3 -m ruff check .` and `python3 -m mypy .` (both `--no-site-packages` too) — clean.
- `python3 test-deduce.py` — full suite passes (lib, should-validate × 2 parsers, should-error, should-warn, parser equivalence, round-trip).
- `python3 test-deduce.py --equiv-full` — 518-file pretty-print round-trip over both parsers passes.

## Notes for resuming

Refs #813 (umbrella: reduce code duplication). This is one focused slice; the
umbrella stays open for further duplication-reduction opportunities (the
Explore pass also flagged the comma-separated-list parsers, the
left-assoc-binop parsers, the parser error-wrapping epilogue, and the
equation-marked-side detection in `checker_logic.py` as future candidates).

Resume this session on ginger: `~/deduce-runner/resume.sh c453e1d8-e6bf-4b54-b60a-ccf59eca1c46 routine/20260715-230202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
