### PR TITLE
Extract shared bijective-view lookup into abstract_syntax/ops.py (refs #813)

### DIFF
--- a/abstract_syntax/ops.py
+++ b/abstract_syntax/ops.py
@@ -93,6 +93,41 @@ def type_match(
         match_failed(loc, str(arg_ty) + " does not match " + str(param_ty))
 
 
+def bijective_view_for_source_type(
+    loc: Meta, ty: Type, env: Env
+) -> tuple[ViewDecl, Type, Type, dict[str, Type | VarRef]] | None:
+  """Find an in-scope invertible (bijective) view whose source matches ``ty``.
+
+  Shared by term type-checking (``checker_types``) and proof checking
+  (``checker_proofs``): scan the environment for a ``ViewBinding`` whose
+  view has an ``inverse``, unify its source type with ``ty``, and return
+  the matched view along with the instantiated source and target types
+  and the resulting type substitution. Callers derive the concrete type
+  arguments from that substitution. Returns ``None`` when no such view
+  matches.
+  """
+  for binding in env.dict.values():
+    if not isinstance(binding, ViewBinding):
+      continue
+    view = binding.view
+    if view.inverse is None:
+      continue
+    matching: dict[str, Type | VarRef | None] = {}
+    try:
+      type_match(loc, type_names(loc, view.type_params),
+                 view.source, ty, matching)
+    except MatchFailed:
+      continue
+    sub: dict[str, Type | VarRef] = {
+        name: value for name, value in matching.items()
+        if value is not None
+    }
+    source_ty = view.source.substitute(sub)
+    target_ty = view.target.substitute(sub)
+    return view, source_ty, target_ty, sub
+  return None
+
+
 def is_associative(loc: Meta, opname: str, typ: Type | None, env: Env) -> bool:
   for (typarams, ty) in env.get_assoc_types(opname):
     type_params = type_names(loc, typarams)

--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -30,10 +30,11 @@ from abstract_syntax import (
     RewriteFact, RewriteGoal, RuleInduction, RuleInversion,
     SimplifyFact, SimplifyGoal, Some, SomeElim, SomeIntro, Suffices,
     SwitchProof, SwitchProofCase, TLet, Term, TermInst, Type, TypeInst, TypeType,
-    Union, Var, VarRef, ViewBinding, ViewDecl, base_name, callable_name, formula_match,
+    Union, Var, VarRef, ViewDecl, base_name, bijective_view_for_source_type,
+    callable_name, formula_match,
     get_predicate_decl, get_type_name, is_constructor, is_equation, is_true,
     mkEqual, remove_mark, set_dont_reduce_opaque, set_reduce_all,
-    get_reduce_only, set_reduce_only, split_equation, type_match, type_names,
+    get_reduce_only, set_reduce_only, split_equation, type_match,
 )
 from checker_common import *
 from checker_logic import (
@@ -682,27 +683,12 @@ def update_all_head(r: Formula) -> Formula:
 
 def _bijective_view_for_source_type(loc: Meta, ty: Type, env: Env
                                     ) -> ViewMatch | None:
-  for binding in env.dict.values():
-    if not isinstance(binding, ViewBinding):
-      continue
-    view = binding.view
-    if view.inverse is None:
-      continue
-    matching: dict[str, Type | VarRef | None] = {}
-    try:
-      type_match(loc, type_names(loc, view.type_params),
-                 view.source, ty, matching)
-    except MatchFailed:
-      continue
-    sub: Substitution = {
-        name: value for name, value in matching.items()
-        if value is not None
-    }
-    type_args = [cast(Type, sub[name]) for name in view.type_params]
-    source_ty = cast(Type, view.source.substitute(sub))
-    target_ty = cast(Type, view.target.substitute(sub))
-    return view, source_ty, target_ty, type_args
-  return None
+  match = bijective_view_for_source_type(loc, ty, env)
+  if match is None:
+    return None
+  view, source_ty, target_ty, sub = match
+  type_args = [cast(Type, sub[name]) for name in view.type_params]
+  return view, source_ty, target_ty, type_args
 
 def _view_switch_expected_cases(alts: list[Constructor], env: Env) -> str:
   lines = []

--- a/checker_types.py
+++ b/checker_types.py
@@ -68,9 +68,9 @@ from abstract_syntax import (
     Union,
     Var,
     VarRef,
-    ViewBinding,
     ViewDecl,
     base_name,
+    bijective_view_for_source_type,
     callable_name,
     is_associative,
     type_match,
@@ -88,7 +88,6 @@ PatternCoverage: TypingTypeAlias = dict[str, bool]
 RecursiveName: TypingTypeAlias = str | None
 SubtermNames: TypingTypeAlias = Sequence[str]
 ParamBindings: TypingTypeAlias = list[tuple[str, Type]]
-Substitution: TypingTypeAlias = dict[str, Term | Type | RecFun | GenRecFun]
 
 _NAT_LITERAL_HINT_PREFIX = (
     "\n\tnumeric literals default to `UInt`; for a `Nat` literal write "
@@ -200,26 +199,11 @@ def _instantiate_view_type(
 def _term_bijective_view_for_source_type(
     loc: Meta, typ: TypeExpr, env: Env
 ) -> ViewMatch | None:
-  for binding in env.dict.values():
-    if not isinstance(binding, ViewBinding):
-      continue
-    view = binding.view
-    if view.inverse is None:
-      continue
-    matching: TypeMatching = {}
-    try:
-      type_match(loc, type_names(loc, view.type_params),
-                 view.source, typ, matching)
-    except MatchFailed:
-      continue
-    sub = cast(Substitution, {
-        name: value for name, value in matching.items()
-        if value is not None
-    })
-    source_ty = cast(TypeExpr, view.source.substitute(sub))
-    target_ty = cast(TypeExpr, view.target.substitute(sub))
-    return view, source_ty, target_ty
-  return None
+  match = bijective_view_for_source_type(loc, cast(Type, typ), env)
+  if match is None:
+    return None
+  view, source_ty, target_ty, _ = match
+  return view, source_ty, target_ty
 
 def _switch_subject_via_bijective_view(
     loc: Meta,


### PR DESCRIPTION
## Summary

Extracts the duplicated invertible-view (bijective view) lookup shared by
term type-checking and proof checking into a single helper, addressing an
opportunity under the code-duplication umbrella #813.

The scan — walk the environment for a `ViewBinding` whose view has an
`inverse`, unify its `source` type against a given type via `type_match`,
and return the instantiated `source`/`target` types — appeared near-verbatim
in two places, each with its own conflicting `ViewMatch` type alias:

- `checker_types._term_bijective_view_for_source_type` (returned a 3-tuple)
- `checker_proofs._bijective_view_for_source_type` (returned a 4-tuple that
  additionally carried the concrete `type_args`)

## Change

- New `abstract_syntax.ops.bijective_view_for_source_type(loc, ty, env)`
  returns `(view, source_ty, target_ty, sub)` where `sub` is the type
  substitution produced by the match. `ops.py` already owns `type_match`
  and `type_names`, so this introduces no import cycle (the checker modules
  sit *above* `abstract_syntax`).
- Both original functions become thin wrappers over the shared helper:
  - the proof checker derives `type_args = [sub[name] for name in
    view.type_params]` exactly as before, keeping its 4-tuple `ViewMatch`;
  - the type checker drops the substitution, keeping its 3-tuple `ViewMatch`.
- Removes the now-unused `Substitution` type alias and `ViewBinding` import
  from `checker_types.py`, and the now-unused `type_names`/`ViewBinding`
  imports from `checker_proofs.py`.

Behavior is unchanged; this is a pure deduplication.

## Testing

- `python3 -m ruff check .` — clean
- `python3 -m mypy .` and `python3 -m mypy . --no-site-packages` — clean
- `python3 test-deduce.py` — full suite passes (lib, should-validate across
  both parsers, should-error, should-warn, parser equivalence). The
  refactored path is exercised by the dedicated view-inverse fixtures
  (`switch_uint_view_inverse.pf`, `induction_uint_view_inverse.pf`,
  `switch_uint_term_view_inverse.pf`, `switch_uint_public_view.pf`,
  `view_inverse_decl.pf`).

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh d3cee0ef-ad79-46cf-bc6b-ffb40f3ce2f6 routine/20260716-000202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
