### PR TITLE
Stop RD reserving experimental-imperative keywords as identifiers (refs #473)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -71,6 +71,26 @@ to_unicode = {'.o.': '∘', '|': '∪', '&': '∩', '.+.': '⨄', '.-.': '∸',
 
 accessiblity_keywords = {'OPAQUE', 'PRIVATE', 'PUBLIC'}
 
+# Keyword tokens that belong exclusively to the experimental imperative
+# layer (#854): every recursive-descent parse path that consumes one is
+# gated behind ``require_experimental_imperative``. Because RD tokenizes
+# with lark's *non-contextual* ``.lex()`` (unlike the LALR parser's
+# contextual lexer), these words would otherwise be reserved globally and
+# rejected as ordinary identifiers even when ``--experimental-imperative``
+# is off -- a divergence from the LALR parser, which accepts them as
+# identifiers in that mode (issue #473). When the flag is off we demote
+# these tokens to ``IDENT`` so both parsers agree.
+#
+# Excluded on purpose: ``VAR``/``GHOST`` (also used by the stable ``object``
+# field syntax) and ``VIEW``/``SOURCE``/``TARGET``/``INTO``/``OUT``/
+# ``ROUNDTRIP``/``INVERSE`` (the ``view`` declaration is not gated in RD),
+# since those are reachable with the flag off and must stay reserved.
+experimental_imperative_keywords = frozenset({
+    'EMP', 'NEW', 'PROC', 'OBSERVER', 'RESOURCE', 'REQUIRES', 'ENSURES',
+    'READS', 'MODIFIES', 'DECREASES', 'INVARIANT', 'ESTABLISHED',
+    'PRESERVED', 'CALL', 'WHILE', 'RETURN', 'AS', 'FOOTPRINT',
+})
+
 lark_parser: Optional[Lark] = None
 
 def init_parser() -> None:
@@ -152,6 +172,11 @@ def parse(program_text: str,
       for token in lexed:
         if trace:
           print(repr(token))
+        if not experimental_imperative_enabled \
+           and token.type in experimental_imperative_keywords:
+          # See ``experimental_imperative_keywords``: with the flag off,
+          # this word is an ordinary identifier, matching the LALR parser.
+          token = Token.new_borrow_pos('IDENT', token.value, token)
         token_list.append(token)
     except exceptions.UnexpectedCharacters as e:
       raise lark_unexpected_chars_to_parse_error(e, get_filename())

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -508,6 +508,14 @@ PARSER_ROUND_TRIP_FILES = (
     # `object Empty` at EOF did not reparse under RD. Fixed by guarding the
     # `LESSTHAN` lookahead with `not end_of_file()`.
     "./test/should-validate/object_bodyless_eof.pf",
+    # The experimental-imperative keyword vocabulary (`call`, `return`,
+    # `while`, `emp`, `reads`, ...) is only reserved with
+    # `--experimental-imperative` on. RD tokenizes with lark's
+    # non-contextual lexer, so it used to reserve those words globally and
+    # reject them as ordinary identifiers, diverging from the LALR parser
+    # (which accepts them as identifiers when the flag is off). RD now
+    # demotes them to `IDENT` in that mode. Refs #473.
+    "./test/should-validate/experimental_imperative_keywords_as_identifiers.pf",
 )
 
 

--- a/test/should-validate/experimental_imperative_keywords_as_identifiers.pf
+++ b/test/should-validate/experimental_imperative_keywords_as_identifiers.pf
@@ -1,0 +1,31 @@
+// Regression test for issue #473: the experimental-imperative keyword
+// vocabulary (`call`, `return`, `while`, `emp`, `reads`, `modifies`, ...) must
+// be usable as ordinary identifiers when `--experimental-imperative` is off,
+// matching the LALR parser. Before the fix, the recursive-descent parser
+// tokenized with lark's non-contextual lexer and reserved these words
+// globally, rejecting them as identifiers and diverging from the LALR parser.
+
+define call = true
+define return = false
+define reads = true
+define modifies = false
+define decreases = true
+define emp = false
+define requires = true
+define ensures = false
+define invariant = true
+define preserved = true
+define established = false
+define observer = true
+define resource = false
+
+// `while` in binding position (a parameter) and in reference position.
+fun negate(while : bool) {
+  if while then false else true
+}
+
+theorem experimental_keywords_are_identifiers:
+  negate(call) = return
+proof
+  evaluate
+end


### PR DESCRIPTION
## Summary

The recursive-descent (RD) parser and the LALR parser diverged on whether
the **experimental-imperative** keyword vocabulary can be used as ordinary
identifiers when `--experimental-imperative` is *off*:

```
$ echo 'define call = true' > /tmp/x.pf
$ python3 deduce.py --recursive-descent /tmp/x.pf
/tmp/x.pf:1.8-1.12: expected an identifier, not
	"call"
$ python3 deduce.py --lalr /tmp/x.pf
/tmp/x.pf is valid          # LALR accepts it
```

**Root cause.** RD tokenizes with lark's *non-contextual* `.lex()`, so every
keyword introduced for the experimental imperative layer (#854) — `call`,
`return`, `while`, `emp`, `reads`, `modifies`, `decreases`, `invariant`,
`requires`, `ensures`, `established`, `preserved`, `proc`, `observer`,
`resource`, `as`, `new`, `footprint` — is reserved *globally*. The LALR
parser uses a contextual lexer that only treats these as keywords in the
grammar states that expect them, so it accepts them as identifiers when the
flag is off. Issue #473's core requirement is "both parsers must stay in
sync."

Affected words are natural identifier names (`view`, `return`, `call`,
`source`, `out`, …), so on the default parser a user could not name a
definition, function parameter, or variable after any of them even though
the imperative layer they belong to was disabled.

## Fix

When `--experimental-imperative` is off, the RD lexer now demotes the
experimental-only keyword tokens to `IDENT`, matching the LALR spec. Only
tokens whose **every** RD parse path is gated behind
`require_experimental_imperative` are demoted. Deliberately kept reserved:

- `VAR` / `GHOST` — also used by the stable `object` field syntax.
- `VIEW` / `SOURCE` / `TARGET` / `INTO` / `OUT` / `ROUNDTRIP` / `INVERSE` —
  the `view` declaration is not gated in RD, so those remain reachable with
  the flag off.

With `--experimental-imperative` **on**, behavior is unchanged: the keywords
stay reserved and imperative programs parse exactly as before (verified
against `proc_declarations.pf`).

## Tests

- New `test/should-validate/experimental_imperative_keywords_as_identifiers.pf`
  uses the freed words as define names, a function parameter (`while`), and a
  variable reference; it validates under **both** parsers and is wired into
  the round-trip / parser-equivalence corpus (`PARSER_ROUND_TRIP_FILES`).
- Full `python3 test-deduce.py` (both parsers, `--equiv`, `--equiv-full`)
  passes.

## A note for the maintainer (design intent)

This aligns RD to the LALR parser, which the repo treats as the executable
grammar spec, so I'm confident it's the intended direction. But since the
imperative layer (#854) is actively in progress: if you *deliberately* want
the experimental vocabulary reserved even when the flag is off (e.g. as
forward-compat so enabling the layer later can't shadow user identifiers),
then the LALR side should be tightened to match instead, and this PR should
be closed. Flagging so the choice is explicit.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 29ecf986-1f7a-47d9-a8cc-a7ef8c10d27a routine/20260716-010202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
