### PR TITLE
Reject reserved keywords in identifier positions under LALR (closes #1032)

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -66,12 +66,34 @@ def _require_experimental_imperative(meta: Meta) -> None:
             'experimental imperative syntax requires --experimental-imperative',
         )
 
+# Reserved keyword words that must never be used as identifiers. The LALR
+# parser's contextual lexer relabels a keyword as IDENT whenever the keyword
+# terminal is not expected in the current state, which let keywords slip into
+# name/binding positions (issue #1032). The recursive-descent parser lexes
+# non-contextually (via `Lark.lex`) and so rejects every keyword there; we
+# reproduce that by rejecting any IDENT token whose text is one of these words.
+# Populated from the grammar in `init_parser` so it stays in sync automatically.
+reserved_ident_keywords: frozenset[str] = frozenset()
+
 def init_parser() -> None:
-  global lark_parser
+  global lark_parser, reserved_ident_keywords
   lark_file = get_deduce_directory() + "/Deduce.lark"
   lark_parser = Lark(open(lark_file, encoding="utf-8").read(),
                      start='program', parser='lalr',
                      debug=True, propagate_positions=True)
+  # A string terminal whose text is itself a valid IDENT is a reserved keyword:
+  # lark's basic lexer gives it priority over the IDENT regex, so RD always
+  # tokenizes it as that keyword. Collect exactly that set here.
+  ident_regexp = re.compile(
+      next(t for t in lark_parser.terminals
+           if t.name == 'IDENT').pattern.to_regexp())
+  # `__` (the omitted-term placeholder) and `operator` are the two words RD's
+  # `parse_identifier` accepts as identifiers despite being keyword terminals,
+  # so they are not reserved in name position under either parser.
+  reserved_ident_keywords = frozenset(
+      t.pattern.value for t in lark_parser.terminals
+      if t.pattern.type == 'str' and ident_regexp.fullmatch(t.pattern.value)
+      and t.pattern.value not in ('__', 'operator'))
 
 ##################################################
 # Parsing Concrete to Abstract Syntax
@@ -1249,8 +1271,41 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
 def token_str(token: Token, program_text: str) -> str:
     return program_text[token.start_pos:token.end_pos]
 
+def meta_from_token(token: Token) -> Meta:
+    meta = Meta()  # type: ignore[no-untyped-call,unused-ignore]
+    meta.empty = False
+    setattr(meta, 'filename', get_filename())
+    assert (token.line is not None and token.column is not None
+            and token.start_pos is not None and token.end_line is not None
+            and token.end_column is not None and token.end_pos is not None)
+    meta.line = token.line
+    meta.column = token.column
+    meta.start_pos = token.start_pos
+    meta.end_line = token.end_line
+    meta.end_column = token.end_column
+    meta.end_pos = token.end_pos
+    return meta
+
 def parse_program_tree(parse_tree: Tree[Token]) -> list[Statement]:
     return cast(list[Statement], parse_tree_to_ast(parse_tree, None))
+
+def reject_reserved_identifiers(parse_tree: Tree[Token],
+                                program_text: str) -> None:
+    """Reject a reserved keyword used as an identifier (issue #1032).
+
+    The contextual LALR lexer relabels a keyword as IDENT in name/binding
+    slots where the keyword terminal is not expected; the recursive-descent
+    parser never does. Rejecting these IDENT tokens keeps the two parsers in
+    sync -- a reserved word can never be an identifier under either.
+    """
+    for token in parse_tree.scan_values(
+            lambda v: isinstance(v, Token)
+            and v.type == 'IDENT'
+            and v.value in reserved_ident_keywords):
+        raise ParseError(
+            meta_from_token(token),
+            'expected an identifier, not the reserved keyword\n\t'
+            + token_str(token, program_text))
 
 def parse(program_text: str,
           trace: "bool | VerboseLevel" = False,
@@ -1278,6 +1333,7 @@ def parse(program_text: str,
         print('parse tree: ')
         print(parse_tree)
         print('')
+    reject_reserved_identifiers(parse_tree, program_text)
     ast = parse_program_tree(parse_tree)
     if trace:
         print('abstract syntax tree: ')
@@ -1320,15 +1376,7 @@ def parse(program_text: str,
                           'or use `fun`/`recursive`:\n'
                           '\tfun ' + name + '<T>(...) { ... }\n'
                           '\trecursive ' + name + '<T>(...) -> ... { ... }')
-          meta = Meta()  # type: ignore[no-untyped-call,unused-ignore]
-          meta.empty = False
-          setattr(meta, 'filename', get_filename())
-          meta.line = t.token.line
-          meta.column = t.token.column
-          meta.start_pos = t.token.start_pos
-          meta.end_line = t.token.end_line
-          meta.end_column = t.token.end_column
-          meta.end_pos = t.token.end_pos
+          meta = meta_from_token(t.token)
           msg = ("error in parsing, unexpected token: "
                  + token_str(t.token, program_text) + '\n'
                  + "(The error may be immediately before this token.)"

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -953,6 +953,42 @@ def _worker_parser_equivalence(
     return path, False, "RD and LALR ASTs differ", False
 
 
+# Reserved keywords must not be usable as identifiers in name/binding
+# positions under either parser (issue #1032). RD lexes non-contextually so it
+# always rejected these; the LALR parser used to lex a keyword as IDENT
+# whenever the keyword terminal was not expected in the current state, letting
+# it slip through until `parser.reject_reserved_identifiers` closed the gap.
+# One representative keyword per binding position from the issue's table is
+# enough to catch a regression of that fix.
+KEYWORD_NAME_REJECTION_CASES = (
+    "define if = true",                 # define name
+    "theorem if: true proof . end",     # theorem name
+    "fun and(x:bool) { x }",            # fun name
+    "union theorem { foo }",            # union name
+    "fun f(then:bool) { then }",        # fun parameter
+    "define d = all if:bool. true",     # all-bound variable
+)
+
+
+def _check_keyword_name_rejection() -> list[tuple[str, str, str]]:
+    """Both parsers must reject reserved keywords in name/binding positions."""
+    failures: list[tuple[str, str, str]] = []
+    for src in KEYWORD_NAME_REJECTION_CASES:
+        for recursive_descent in (True, False):
+            label = "recursive-descent" if recursive_descent else "lalr"
+            try:
+                _parse_text_for_equivalence(
+                    "<keyword-name-rejection>", src,
+                    recursive_descent=recursive_descent,
+                )
+                failures.append((src, "parser-equivalence",
+                                 f"{label} accepted a reserved keyword as an "
+                                 f"identifier; both parsers must reject"))
+            except Exception:
+                pass
+    return failures
+
+
 def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     """Compare RD and LALR ASTs for parseable syntax.
 
@@ -987,6 +1023,7 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
                              msg))
 
     failures.extend(_check_should_error_skip_set())
+    failures.extend(_check_keyword_name_rejection())
 
     stale = PARSER_EQUIV_EXPECTED_DIVERGENCES - seen_divergences - set(files)
     for path in sorted(stale):


### PR DESCRIPTION
## Summary

Closes #1032.

The LALR parser accepted reserved keywords (`if`, `define`, `theorem`, `and`, …) as ordinary identifiers in name/binding positions, whereas the recursive-descent (RD) parser correctly rejected them:

```
$ echo 'define define = true' > /tmp/x.pf
$ python3 deduce.py --lalr /tmp/x.pf          # was: valid
$ python3 deduce.py --recursive-descent /tmp/x.pf  # error: expected an identifier
```

**Root cause.** The LALR parser uses lark's *contextual* lexer, which only considers terminals valid in the current parser state. In an identifier slot the keyword terminal is not expected, so the word is lexed as `IDENT`. The RD parser lexes with lark's non-contextual `Lark.lex`, so a keyword is always a keyword.

## Approach

Switching the LALR parser to a non-contextual (`basic`) lexer was the obvious idea but breaks the grammar — the contextual lexer is load-bearing for parsing valid programs (e.g. numeric literals inside `A[0]`). So instead:

- **`parser.reject_reserved_identifiers`** walks the LALR parse tree after it is built and rejects any `IDENT` token whose text is a reserved keyword. This uniformly covers every binding position (define/theorem/fun/union names, function parameters, bound variables) with one check.
- The reserved set is **derived from the grammar** in `init_parser` (string terminals whose text is itself a valid `IDENT`), so it stays in sync as the grammar changes. `__` (the omitted-term placeholder) and `operator` are excluded because RD's `parse_identifier` explicitly accepts those two — keeping the parsers in agreement.
- The duplicated token→`Meta` construction in the `UnexpectedToken` handler is folded into a shared `meta_from_token` helper.

## Testing

- `_check_keyword_name_rejection` added to `--equiv` (in CI): asserts both parsers reject one representative keyword per binding position from the issue's table.
- `python3 test-deduce.py` (full default suite): **all tests passed**.
- `python3 test-deduce.py --equiv` and `--equiv-full`: **all tests passed** (no new RD/LALR divergence; `__`-as-name and other tolerated forms still round-trip).
- `ruff check .` and `mypy . --strict`: clean.

## Resume

Resume this session on ginger: `~/deduce-runner/resume.sh 67bc54a6-69b5-4453-aeb4-27dfe02553a7 routine/20260716-020201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
