### PR TITLE
Extract shared parser state/helpers into parser_common.py (refs #813)

### DIFF
--- a/lsp/debugger.py
+++ b/lsp/debugger.py
@@ -1029,9 +1029,9 @@ class Debugger:
         import rec_desc_parser as _p
         from abstract_syntax.core import Term as TermClass, UniquifyContext, base_name
 
+        saved_filename = _p.get_filename()
         saved = (
-            _p.token_list, _p.current_position,
-            _p.filename, _p.check_closest_kwd,
+            _p.token_list, _p.current_position, _p.check_closest_kwd,
         )
         try:
             _p.set_filename("<debugger>")
@@ -1043,8 +1043,9 @@ class Debugger:
             parse_term = cast(Callable[[], TermClass], getattr(_p, "parse_term"))
             term = parse_term()
         finally:
+            _p.set_filename(saved_filename)
             (_p.token_list, _p.current_position,
-             _p.filename, _p.check_closest_kwd) = saved
+             _p.check_closest_kwd) = saved
 
         # Build a uniquify env from the proof-checker env.  Each base
         # name maps to a list of the uniquified candidates -- which

--- a/parser.py
+++ b/parser.py
@@ -31,8 +31,8 @@ from typing import Any, TypeAlias as TypingTypeAlias, cast
 from flags import VerboseLevel, get_experimental_imperative
 from error import ParseError, lark_unexpected_chars_to_parse_error
 from parser_common import (
-    get_experimental_imperative_enabled, make_lark_parser,
-    set_experimental_imperative,
+    experimental_imperative_keywords, get_experimental_imperative_enabled,
+    make_lark_parser, set_experimental_imperative,
 )
 from parser_common import require_experimental_imperative as _require_experimental_imperative
 # Re-exported so ``parser.<name>`` stays a valid module attribute for the
@@ -56,9 +56,14 @@ lark_parser = None
 # reproduce that by rejecting any IDENT token whose text is one of these words.
 # Populated from the grammar in `init_parser` so it stays in sync automatically.
 reserved_ident_keywords: frozenset[str] = frozenset()
+# The subset of `reserved_ident_keywords` that belongs to the experimental
+# imperative layer. These are only reserved when `--experimental-imperative`
+# is on; with the flag off they are ordinary identifiers (issue #473, matching
+# the recursive-descent parser's `experimental_imperative_keywords` demotion).
+experimental_ident_keywords: frozenset[str] = frozenset()
 
 def init_parser() -> None:
-  global lark_parser, reserved_ident_keywords
+  global lark_parser, reserved_ident_keywords, experimental_ident_keywords
   lark_parser = make_lark_parser(lalr=True)
   # A string terminal whose text is itself a valid IDENT is a reserved keyword:
   # lark's basic lexer gives it priority over the IDENT regex, so RD always
@@ -73,6 +78,11 @@ def init_parser() -> None:
       t.pattern.value for t in lark_parser.terminals
       if t.pattern.type == 'str' and ident_regexp.fullmatch(t.pattern.value)
       and t.pattern.value not in ('__', 'operator'))
+  # The concrete words for the experimental-imperative keyword terminals,
+  # recovered from the grammar so they track it automatically.
+  experimental_ident_keywords = frozenset(
+      t.pattern.value for t in lark_parser.terminals
+      if t.name in experimental_imperative_keywords and t.pattern.type == 'str')
 
 ##################################################
 # Parsing Concrete to Abstract Syntax
@@ -1259,11 +1269,19 @@ def reject_reserved_identifiers(parse_tree: Tree[Token],
     slots where the keyword terminal is not expected; the recursive-descent
     parser never does. Rejecting these IDENT tokens keeps the two parsers in
     sync -- a reserved word can never be an identifier under either.
+
+    The experimental-imperative keyword vocabulary is reserved only when
+    `--experimental-imperative` is on; with the flag off those words are
+    ordinary identifiers (issue #473), so they are dropped from the reject
+    set to match the recursive-descent parser.
     """
+    reserved = reserved_ident_keywords
+    if not get_experimental_imperative_enabled():
+        reserved = reserved - experimental_ident_keywords
     for token in parse_tree.scan_values(
             lambda v: isinstance(v, Token)
             and v.type == 'IDENT'
-            and v.value in reserved_ident_keywords):
+            and v.value in reserved):
         raise ParseError(
             meta_from_token(token),
             'expected an identifier, not the reserved keyword\n\t'

--- a/parser.py
+++ b/parser.py
@@ -25,46 +25,28 @@ from abstract_syntax import (
     mkLitNat, mkUIntLit, remove_mark,
 )
 import re
-from lark import Lark, Token, Tree, exceptions
+from lark import Token, Tree, exceptions
 from lark.tree import Meta
 from typing import Any, TypeAlias as TypingTypeAlias, cast
 from flags import VerboseLevel, get_experimental_imperative
 from error import ParseError, lark_unexpected_chars_to_parse_error
-
-filename: str = '???'
-
-def set_filename(fname: str) -> None:
-    global filename
-    filename = fname
-
-def get_filename() -> str:
-    global filename
-    return filename
-
-
-deduce_directory: str = '???'
-
-def set_deduce_directory(dir: str) -> None:
-    global deduce_directory
-    deduce_directory = dir
-
-def get_deduce_directory() -> str:
-    global deduce_directory
-    return deduce_directory
+from parser_common import (
+    get_experimental_imperative_enabled, make_lark_parser,
+    set_experimental_imperative,
+)
+from parser_common import require_experimental_imperative as _require_experimental_imperative
+# Re-exported so ``parser.<name>`` stays a valid module attribute for the
+# callers (LSP, declarations, tests) that reach through the active parser.
+from parser_common import get_deduce_directory as get_deduce_directory
+from parser_common import get_filename as get_filename
+from parser_common import set_deduce_directory as set_deduce_directory
+from parser_common import set_filename as set_filename
 
 ##################################################
 # Concrete Syntax Parser
 ##################################################
 
 lark_parser = None
-experimental_imperative_enabled = False
-
-def _require_experimental_imperative(meta: Meta) -> None:
-    if not experimental_imperative_enabled:
-        raise ParseError(
-            meta,
-            'experimental imperative syntax requires --experimental-imperative',
-        )
 
 # Reserved keyword words that must never be used as identifiers. The LALR
 # parser's contextual lexer relabels a keyword as IDENT whenever the keyword
@@ -77,10 +59,7 @@ reserved_ident_keywords: frozenset[str] = frozenset()
 
 def init_parser() -> None:
   global lark_parser, reserved_ident_keywords
-  lark_file = get_deduce_directory() + "/Deduce.lark"
-  lark_parser = Lark(open(lark_file, encoding="utf-8").read(),
-                     start='program', parser='lalr',
-                     debug=True, propagate_positions=True)
+  lark_parser = make_lark_parser(lalr=True)
   # A string terminal whose text is itself a valid IDENT is a reserved keyword:
   # lark's basic lexer gives it priority over the IDENT regex, so RD always
   # tokenizes it as that keyword. Collect exactly that set here.
@@ -257,7 +236,7 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
     if isinstance(e, Token):
         return e
     
-    setattr(e.meta, 'filename', filename)
+    setattr(e.meta, 'filename', get_filename())
 
     if e.data == 'nothing':
         return None
@@ -724,7 +703,7 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
         if len(e.children) == 1:
             meta: Any = Meta()  # type: ignore[no-untyped-call,unused-ignore]
             meta.empty = False
-            meta.filename = getattr(e.meta, 'filename', filename)
+            meta.filename = getattr(e.meta, 'filename', get_filename())
             meta.line = e.meta.end_line+1
             meta.column = 0
             meta.end_line = e.meta.end_line+1
@@ -1294,12 +1273,11 @@ def parse(program_text: str,
           trace: "bool | VerboseLevel" = False,
           error_expected: bool = False,
           experimental_imperative: bool | None = None) -> "list[Statement]":
-  global experimental_imperative_enabled
-  previous_experimental_imperative = experimental_imperative_enabled
+  previous_experimental_imperative = get_experimental_imperative_enabled()
   if experimental_imperative is None:
       experimental_imperative = get_experimental_imperative()
-  experimental_imperative_enabled = experimental_imperative
-  try:    
+  set_experimental_imperative(experimental_imperative)
+  try:
     # if trace:
     #     print('lexing!')
     # lexed = lark_parser.lex(program_text)
@@ -1366,5 +1344,5 @@ def parse(program_text: str,
                  + hint)
           raise ParseError(meta, msg)
   finally:
-      experimental_imperative_enabled = previous_experimental_imperative
+      set_experimental_imperative(previous_experimental_imperative)
         

--- a/parser_common.py
+++ b/parser_common.py
@@ -1,0 +1,64 @@
+# Parser state and helpers shared by both front ends: the LALR parser
+# (``parser.py``) and the recursive-descent parser
+# (``rec_desc_parser.py``). Both track the current source filename and
+# the Deduce install directory the same way, build their lark grammar
+# object from the same ``Deduce.lark`` file, and gate the experimental
+# imperative syntax behind the same flag. This module is the single
+# home for that shared state so the two parsers cannot drift apart.
+
+from lark import Lark
+from lark.tree import Meta
+
+from error import ParseError
+
+filename: str = '???'
+
+def set_filename(fname: str) -> None:
+    global filename
+    filename = fname
+
+def get_filename() -> str:
+    return filename
+
+
+deduce_directory: str = '???'
+
+def set_deduce_directory(dir: str) -> None:
+    global deduce_directory
+    deduce_directory = dir
+
+def get_deduce_directory() -> str:
+    return deduce_directory
+
+
+def make_lark_parser(lalr: bool) -> Lark:
+    """Build the lark grammar object from ``Deduce.lark``.
+
+    ``parser.py`` parses with the LALR algorithm; ``rec_desc_parser.py``
+    only uses the resulting object for its non-contextual ``.lex()``, so
+    it keeps lark's default parser.
+    """
+    lark_file = get_deduce_directory() + "/Deduce.lark"
+    grammar = open(lark_file, encoding="utf-8").read()
+    if lalr:
+        return Lark(grammar, start='program', parser='lalr',
+                    debug=True, propagate_positions=True)
+    return Lark(grammar, start='program',
+                debug=True, propagate_positions=True)
+
+
+experimental_imperative_enabled = False
+
+def set_experimental_imperative(enabled: bool) -> None:
+    global experimental_imperative_enabled
+    experimental_imperative_enabled = enabled
+
+def get_experimental_imperative_enabled() -> bool:
+    return experimental_imperative_enabled
+
+def require_experimental_imperative(loc: Meta) -> None:
+    if not experimental_imperative_enabled:
+        raise ParseError(
+            loc,
+            'experimental imperative syntax requires --experimental-imperative',
+        )

--- a/parser_common.py
+++ b/parser_common.py
@@ -62,3 +62,25 @@ def require_experimental_imperative(loc: Meta) -> None:
             loc,
             'experimental imperative syntax requires --experimental-imperative',
         )
+
+
+# Keyword tokens that belong exclusively to the experimental imperative
+# layer (#854): every recursive-descent parse path that consumes one is
+# gated behind ``require_experimental_imperative``. Because RD tokenizes
+# with lark's *non-contextual* ``.lex()`` (unlike the LALR parser's
+# contextual lexer), these words would otherwise be reserved globally and
+# rejected as ordinary identifiers even when ``--experimental-imperative``
+# is off -- a divergence from the LALR parser, which accepts them as
+# identifiers in that mode (issue #473). When the flag is off, RD demotes
+# these tokens to ``IDENT`` and the LALR parser skips them in
+# ``reject_reserved_identifiers`` so both parsers agree.
+#
+# Excluded on purpose: ``VAR``/``GHOST`` (also used by the stable ``object``
+# field syntax) and ``VIEW``/``SOURCE``/``TARGET``/``INTO``/``OUT``/
+# ``ROUNDTRIP``/``INVERSE`` (the ``view`` declaration is not gated in RD),
+# since those are reachable with the flag off and must stay reserved.
+experimental_imperative_keywords = frozenset({
+    'EMP', 'NEW', 'PROC', 'OBSERVER', 'RESOURCE', 'REQUIRES', 'ENSURES',
+    'READS', 'MODIFIES', 'DECREASES', 'INVARIANT', 'ESTABLISHED',
+    'PRESERVED', 'CALL', 'WHILE', 'RETURN', 'AS', 'FOOTPRINT',
+})

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -35,8 +35,9 @@ from error import ParseError, error_header, lark_unexpected_chars_to_parse_error
 from flags import VerboseLevel, get_experimental_imperative
 from edit_distance import closest_keyword, edit_distance
 from parser_common import (
-    get_experimental_imperative_enabled, make_lark_parser,
-    require_experimental_imperative, set_experimental_imperative,
+    experimental_imperative_keywords, get_experimental_imperative_enabled,
+    make_lark_parser, require_experimental_imperative,
+    set_experimental_imperative,
 )
 # Re-exported so ``rec_desc_parser.<name>`` stays a valid module attribute
 # for the callers (LSP, declarations, tests) that reach through the active
@@ -60,26 +61,6 @@ to_unicode = {'.o.': '∘', '|': '∪', '&': '∩', '.+.': '⨄', '.-.': '∸',
 
 
 accessiblity_keywords = {'OPAQUE', 'PRIVATE', 'PUBLIC'}
-
-# Keyword tokens that belong exclusively to the experimental imperative
-# layer (#854): every recursive-descent parse path that consumes one is
-# gated behind ``require_experimental_imperative``. Because RD tokenizes
-# with lark's *non-contextual* ``.lex()`` (unlike the LALR parser's
-# contextual lexer), these words would otherwise be reserved globally and
-# rejected as ordinary identifiers even when ``--experimental-imperative``
-# is off -- a divergence from the LALR parser, which accepts them as
-# identifiers in that mode (issue #473). When the flag is off we demote
-# these tokens to ``IDENT`` so both parsers agree.
-#
-# Excluded on purpose: ``VAR``/``GHOST`` (also used by the stable ``object``
-# field syntax) and ``VIEW``/``SOURCE``/``TARGET``/``INTO``/``OUT``/
-# ``ROUNDTRIP``/``INVERSE`` (the ``view`` declaration is not gated in RD),
-# since those are reachable with the flag off and must stay reserved.
-experimental_imperative_keywords = frozenset({
-    'EMP', 'NEW', 'PROC', 'OBSERVER', 'RESOURCE', 'REQUIRES', 'ENSURES',
-    'READS', 'MODIFIES', 'DECREASES', 'INVARIANT', 'ESTABLISHED',
-    'PRESERVED', 'CALL', 'WHILE', 'RETURN', 'AS', 'FOOTPRINT',
-})
 
 lark_parser: Optional[Lark] = None
 

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -34,27 +34,17 @@ from lark.tree import Meta
 from error import ParseError, error_header, lark_unexpected_chars_to_parse_error
 from flags import VerboseLevel, get_experimental_imperative
 from edit_distance import closest_keyword, edit_distance
-
-filename: str = '???'
-
-def set_filename(fname: str) -> None:
-    global filename
-    filename = fname
-
-def get_filename() -> str:
-    global filename
-    return filename
-
-
-deduce_directory: str = '???'
-
-def set_deduce_directory(dir: str) -> None:
-    global deduce_directory
-    deduce_directory = dir
-
-def get_deduce_directory() -> str:
-    global deduce_directory
-    return deduce_directory
+from parser_common import (
+    get_experimental_imperative_enabled, make_lark_parser,
+    require_experimental_imperative, set_experimental_imperative,
+)
+# Re-exported so ``rec_desc_parser.<name>`` stays a valid module attribute
+# for the callers (LSP, declarations, tests) that reach through the active
+# parser.
+from parser_common import get_deduce_directory as get_deduce_directory
+from parser_common import get_filename as get_filename
+from parser_common import set_deduce_directory as set_deduce_directory
+from parser_common import set_filename as set_filename
 
 expt_operators = { '^' }
 mult_operators = {'*', '/', '%', '∘', '.o.'}
@@ -95,10 +85,7 @@ lark_parser: Optional[Lark] = None
 
 def init_parser() -> None:
   global lark_parser
-  lark_file = get_deduce_directory() + "/Deduce.lark"
-  lark_parser = Lark(open(lark_file, encoding="utf-8").read(),
-                     start='program',
-                     debug=True, propagate_positions=True)
+  lark_parser = make_lark_parser(lalr=False)
 
 # The current_position needs to be a global so that the changes to the
 # current_position don't get discarded when an exception is
@@ -140,24 +127,16 @@ def consume_token(expected: str, display: str, context: str = "", advice: str = 
     advance()
 
 check_closest_kwd = False
-experimental_imperative_enabled = False
-
-def require_experimental_imperative(loc: Meta) -> None:
-  if not experimental_imperative_enabled:
-    raise ParseError(
-        loc,
-        'experimental imperative syntax requires --experimental-imperative',
-    )
 
 def parse(program_text: str,
           trace: "bool | VerboseLevel" = False,
           error_expected: bool = False,
           experimental_imperative: bool | None = None) -> "list[Statement]":
-  global token_list, current_position, check_closest_kwd, experimental_imperative_enabled
-  previous_experimental_imperative = experimental_imperative_enabled
+  global token_list, current_position, check_closest_kwd
+  previous_experimental_imperative = get_experimental_imperative_enabled()
   if experimental_imperative is None:
     experimental_imperative = get_experimental_imperative()
-  experimental_imperative_enabled = experimental_imperative
+  set_experimental_imperative(experimental_imperative)
   try:
     assert lark_parser is not None, "init_parser() must be called before parse()"
     lexed = lark_parser.lex(program_text)
@@ -172,7 +151,7 @@ def parse(program_text: str,
       for token in lexed:
         if trace:
           print(repr(token))
-        if not experimental_imperative_enabled \
+        if not get_experimental_imperative_enabled() \
            and token.type in experimental_imperative_keywords:
           # See ``experimental_imperative_keywords``: with the flag off,
           # this word is an ordinary identifier, matching the LALR parser.
@@ -206,7 +185,7 @@ def parse(program_text: str,
     # suggestions. The CLI never noticed because each invocation is
     # a fresh process.
     check_closest_kwd = False
-    experimental_imperative_enabled = previous_experimental_imperative
+    set_experimental_imperative(previous_experimental_imperative)
 
 
 def parse_identifier() -> str:


### PR DESCRIPTION
This PR now contains two commits.

## Commit 1 — Extract shared parser state/helpers into `parser_common.py` (refs #813)

The parser state and helpers that were duplicated **verbatim** between
`parser.py` (LALR) and `rec_desc_parser.py` (recursive descent) move into a
new shared module, `parser_common.py`:

- `filename` global + `set_filename` / `get_filename`
- `deduce_directory` global + `set_deduce_directory` / `get_deduce_directory`
- `make_lark_parser(lalr)` — the `Deduce.lark` grammar construction that
  `init_parser` reimplemented in each file (the only difference was
  `parser='lalr'`)
- the `experimental_imperative_enabled` flag + `require_experimental_imperative`
  guard (identical body in both files)

Both parsers delegate to `parser_common` and **re-export** the accessors so
external callers that reach through the active parser module
(`lsp/library.py`, `lsp/debugger.py`, `abstract_syntax/declarations.py`, the
parser unit/LSP tests) keep working unchanged. `init_parser` stays per-module
(each still owns its own `lark_parser`) and just calls `make_lark_parser`.
Two call sites that reached the module globals directly were moved to the
accessors (`parser.py`'s bare `filename` reads; `lsp/debugger.py`'s
save/restore of `_p.filename`).

Refs #813 (does not close the umbrella). Disjoint from the other in-flight
#813 PRs (#1028, #1029, #1030).

## Commit 2 — Fix LALR rejecting experimental-imperative keywords as identifiers (closes #1047)

Rebasing onto the post-#1033 `main` surfaced that **`main` is currently red**:
`regression (equiv)` and `regression (passable)` fail. #1033 made the LALR
parser reject every reserved keyword in an identifier position, but it swept
in the experimental-imperative keyword vocabulary (`call`, `return`, `while`,
`emp`, …). #1031 had just established that those words must be usable as
ordinary identifiers when `--experimental-imperative` is off (matching the
recursive-descent parser, which demotes them to `IDENT` in that mode). The
clash makes `test/should-validate/experimental_imperative_keywords_as_identifiers.pf`
fail under LALR.

The fix makes `reject_reserved_identifiers` flag-aware: the
experimental-imperative words are reserved only when `--experimental-imperative`
is on, and are dropped from the reject set otherwise. The keyword vocabulary
(`experimental_imperative_keywords`) moves into `parser_common.py` so both
parsers share one definition; `parser.py` recovers the concrete words from the
grammar terminals so the set tracks `Deduce.lark` automatically. Core
keywords (`define`, `theorem`, …) are still rejected as identifiers under
both parsers, so #1032's guarantee is preserved.

This unbreaks `main` on merge. Full details in #1047.

## Testing

- `python3 -m ruff check .` — clean
- `python3 -m mypy .` — clean (`--strict`; re-exports use the explicit
  `import X as X` form so `no_implicit_reexport` is satisfied)
- `python3 test-deduce.py` — **all passed** (should-validate × 2 parsers,
  should-error, should-warn, parser equivalence). Verified the real exit code
  is 0 (the equiv + passable jobs that are red on `main` are green here).
- Behavioral parity checks:
  - `define call = true` — valid under both parsers with the flag off,
    rejected under both with `--experimental-imperative`.
  - `define define = true` — rejected under both parsers (core keyword,
    #1032 guarantee intact).
  - `proc_declarations.pf` — experimental-imperative guard errors without the
    flag, valid with it, under both parsers.

Resume this session on ginger: `~/deduce-runner/resume.sh 6140a3ed-27c8-4926-b15b-79cdaeb83a08 routine/20260716-030202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
