### PR TITLE
Assert pretty-printer idempotence and cross-parser text agreement in round-trip audit (refs #931)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -997,6 +997,7 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
 
 def _worker_parser_round_trip(path: str) -> list[tuple[str, str, str]]:
     failures: list[tuple[str, str, str]] = []
+    pretty_by_source: dict[str, str] = {}
     for source_rd in (True, False):
         source_label = "RD" if source_rd else "LALR"
         try:
@@ -1010,6 +1011,7 @@ def _worker_parser_round_trip(path: str) -> list[tuple[str, str, str]]:
                              f"{source_label} source parse/print: "
                              f"{type(exc).__name__}: {exc}"))
             continue
+        pretty_by_source[source_label] = pretty_source
 
         for roundtrip_rd in (True, False):
             roundtrip_label = "RD" if roundtrip_rd else "LALR"
@@ -1031,6 +1033,28 @@ def _worker_parser_round_trip(path: str) -> list[tuple[str, str, str]]:
                 failures.append((path, "parser-roundtrip",
                                  f"{source_label} pretty source changed "
                                  f"when parsed with {roundtrip_label}"))
+                continue
+
+            # Idempotence: the pretty-printer is meant to be a canonical
+            # fixpoint, so re-printing the reparsed AST must reproduce the
+            # exact same text. A drift here means the printed output depends
+            # on something the canonical-AST check normalizes away (source
+            # locations, Token-vs-str leaves, the ``default`` visibility
+            # sentinel) -- a latent formatting bug masked by that comparison.
+            if _pretty_print_program(reparsed) != pretty_source:
+                failures.append((path, "parser-roundtrip",
+                                 f"{source_label} pretty source is not "
+                                 f"idempotent under {roundtrip_label} "
+                                 f"(reprint differs)"))
+
+    # Cross-parser agreement: RD and LALR must pretty-print a file to byte
+    # identical text. They already produce canonically equal ASTs (checked by
+    # ``run_parser_equivalence``), so any text difference is the printer
+    # reading a field the canonical comparison ignores.
+    if ("RD" in pretty_by_source and "LALR" in pretty_by_source
+            and pretty_by_source["RD"] != pretty_by_source["LALR"]):
+        failures.append((path, "parser-roundtrip",
+                         "RD and LALR pretty-print to different text"))
     return failures
 
 


### PR DESCRIPTION
## What

Strengthen the pretty-printer/parser round-trip audit (`test-deduce.py`,
`_worker_parser_round_trip`) with two properties it did not previously check.

Until now the audit only compared **canonical ASTs** after a pretty-print →
reparse cycle. `_canonical_ast` deliberately normalizes away source locations,
Lark `Token`-vs-`str` leaves, and the RD parser's `default` visibility
sentinel. A pretty-printer regression that *reads* one of those fields could
destabilize the printed text while still round-tripping to a canonically equal
AST — and the audit would stay green.

This adds, for every file in both the curated `--equiv` CI corpus and the full
`--equiv-full` sweep:

- **Idempotence** — re-printing the reparsed AST must reproduce byte-identical
  text. The pretty-printer is meant to be a canonical fixpoint.
- **Cross-parser agreement** — the RD and LALR parsers must pretty-print each
  file to identical text. Their ASTs are already canonically equal (checked by
  `run_parser_equivalence`), so any text difference means the printer is reading
  a field the canonical comparison ignores.

## Why

This is the "broader round-trip coverage" remaining purpose of the #931
umbrella. A fresh full-corpus `--equiv-full` audit over all **518**
accepted-syntax files under both parsers is clean (zero AST drift), so there is
no outstanding drift category to fix — the useful next step is to lock in the
stronger invariants so future printer regressions that these checks catch don't
slip through the AST-only comparison.

## Verification

- Standalone probes over all 518 accepted-syntax files (both parsers) confirmed
  idempotence and cross-parser pretty-print agreement already hold everywhere,
  so this only tightens the invariant — it does not introduce failures.
- `python3 test-deduce.py --equiv` — passes.
- `python3 test-deduce.py --equiv-full` — passes (518 files).
- `ruff check` / `mypy` on `test-deduce.py` — clean.
- Fault injection (a deliberately non-idempotent printer) confirms both new
  assertions fire rather than being dead code.

## Scope

`Refs #931` (not `Closes`): #931 is the round-trip coverage umbrella and stays
open for future coverage work.

Resume this session on ginger: `~/deduce-runner/resume.sh 0f1e9885-1ef5-4e5f-aba4-c4af06335ec6 routine/20260716-050202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
