### PR TITLE
Document Int truncated division/modulo convention in Reference.md (closes #1024)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -842,6 +842,49 @@ assert 8 / 3 = 2
 assert 9 / 3 = 3
 ```
 
+### Rounding convention for signed division
+
+Division and modulo are also defined for `Nat` (`Nat.pf`) and `Int`
+(`IntDefs.pf` / `IntMod.pf`). For `Nat` and `UInt` both operands are
+non-negative, so every rounding convention agrees and there is nothing
+to choose.
+
+For `Int` the convention only matters when the dividend is negative, and
+Deduce uses **truncated** (round-toward-zero, "T-") division. `Int /` is
+defined in `IntDefs.pf` as
+
+```
+n / m = (sign(n) * sign(m)) * (abs(n) / abs(m))
+```
+
+so the quotient rounds toward zero and the remainder `n % m` (see
+[Modulo](#modulo)) takes the sign of the dividend. The two are linked by
+`int_div_mod`: for `m ≠ 0`,
+
+```
+(n / m) * m + (n % m) = n
+```
+
+and `int_mod_less_abs` bounds the remainder by `abs(n % m) < abs(m)`.
+
+Lean's `ediv` / `emod` instead use the **Euclidean** (E-) convention,
+whose remainder is always non-negative (`0 ≤ n % m < abs(m)`); the two
+conventions agree whenever the dividend is non-negative and differ in
+sign otherwise (e.g. `-7 / 2` is `-3` truncated but `-4` Euclidean, with
+remainders `-1` and `+1` respectively). Truncated division was chosen
+because it falls straight out of the sign/magnitude definition of `Int`,
+keeps the four `pos`/`negsuc` case lemmas symmetric, and matches the `/`
+and `%` of C, Java, Go, and Rust; the trade-off is that the remainder
+can be negative, so proofs that need a canonical non-negative residue
+must add `abs` or a case split. See issue #1024 for the discussion.
+
+```{.deduce^#int_division_example}
+assert pos(7) / pos(2) = pos(3)     // 7 / 2 = 3
+assert -pos(7) / pos(2) = -pos(3)   // -7 / 2 = -3 (toward zero)
+assert pos(7) / -pos(2) = -pos(3)   // 7 / -2 = -3
+assert -pos(7) / -pos(2) = pos(3)   // -7 / -2 = 3
+```
+
 ## GCD
 
 The `UInt` library provides Euclid's algorithm as `gcd(a, b)`. It is
@@ -1730,6 +1773,20 @@ assert 1 % 2 = 1
 assert 2 % 2 = 0
 assert 3 % 2 = 1
 assert 4 % 2 = 0
+```
+
+`Int %` is defined in `IntMod.pf` as `sign(n) * (abs(n) % abs(m))`, so it
+follows the same **truncated** convention as `Int /`
+(see [the rounding-convention note](#rounding-convention-for-signed-division)):
+the remainder takes the sign of the dividend rather than always being
+non-negative. Companion theorems include `int_div_mod`,
+`int_mod_less_abs`, `int_abs_mod`, and `int_mod_small`.
+
+```{.deduce^#int_mod_example}
+assert pos(7) % pos(2) = pos(1)     // 7 % 2 = 1
+assert -pos(7) % pos(2) = -pos(1)   // -7 % 2 = -1 (sign of dividend)
+assert pos(7) % -pos(2) = pos(1)    // 7 % -2 = 1
+assert -pos(7) % -pos(2) = -pos(1)  // -7 % -2 = -1
 ```
 
 ## Modus Ponens
@@ -3194,6 +3251,7 @@ import Pair
 <<expand_example>>
 <<expand_in_example>>
 <<division_example>>
+<<int_division_example>>
 <<gcd_example>>
 <<equations_example>>
 <<equations_expand_example>>
@@ -3210,6 +3268,7 @@ import Pair
 <<less_equal_example>>
 <<mark_example>>
 <<mod_example>>
+<<int_mod_example>>
 <<obtain_example>>
 <<or_example>>
 <<or_example_intro1>>


### PR DESCRIPTION
## Summary

Documents the rounding convention Deduce uses for signed division and
modulo, answering the design question in #1024.

The convention is already fixed in the code — it is not being changed
here. `Int /` (in `IntDefs.pf`) and `Int %` (in `IntMod.pf`) use the
**truncated** (round-toward-zero, "T-") convention:

- the quotient rounds toward zero, and
- the remainder `n % m` takes the sign of the *dividend*,

linked by `int_div_mod` (`(n / m) * m + (n % m) = n` for `m ≠ 0`) and
bounded by `int_mod_less_abs` (`abs(n % m) < abs(m)`). For `Nat` and
`UInt` both operands are non-negative, so every rounding convention
coincides and there is nothing to choose.

Previously the Reference manual documented only the `UInt` `/` and `%`
behavior and said nothing about the sign of a negative-dividend result,
which is exactly the gap #1024 flagged. This PR:

- adds a **"Rounding convention for signed division"** subsection to the
  *Divide* section, contrasting truncated with Lean's Euclidean
  `ediv`/`emod` (which keeps the remainder non-negative), stating the
  worked example `-7 / 2` (`-3` truncated vs `-4` Euclidean), and listing
  the pros/cons that motivated the truncated choice;
- adds a matching note to the *Modulo* section pointing at that
  subsection and the relevant `int_*` theorems;
- adds two verified example blocks (`int_division_example`,
  `int_mod_example`) wired into the generated `Reference.pf`, so the
  documented behavior is checked by `--site` under both parsers.

## Why document rather than switch to Euclidean

Switching `Int` division to the Euclidean convention would rework
`IntDiv.pf`, `IntMod.pf`, `IntDivides.pf`, and every downstream proof
that relies on the sign/magnitude case lemmas — a large semantic change
that is the maintainer's call, not an unattended one. The truncated
convention was already chosen and implemented (it falls straight out of
the sign/magnitude definition of `Int`, keeps the four `pos`/`negsuc`
case lemmas symmetric, and matches C/Java/Go/Rust); this PR makes that
decision discoverable in the user-facing reference. If a switch to
Euclidean is desired later, reopen #1024.

## Testing

- `python3 test-deduce.py --site` passes (generates and checks
  `doc_reference.pf` under both the recursive-descent and LALR parsers;
  the new signed `assert` examples validate).

Closes #1024.

Resume this session on ginger: `~/deduce-runner/resume.sh 1e70006f-aa11-447e-9476-f27ee2559312 routine/20260716-060202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
