### PR TITLE
Align RD not/comparison/equality operator grouping with LALR (refs #473)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -361,7 +361,10 @@ def parse_term_hi() -> Term:
 
   elif token.type == 'NOT':
     advance()
-    subject = parse_term_equal()
+    # `not` is a prefix at the atomic level (LALR: `"not" atomic_term`;
+    # Reference.md level 0), so it applies only to the immediately following
+    # atom -- `not P = Q` is `(not P) = Q`, not `not (P = Q)`.
+    subject = parse_call()
     meta = meta_from_tokens(token, previous_token())
     return IfThen(meta, None, subject, Bool(meta, None, False))
 
@@ -574,7 +577,10 @@ def parse_term_compare() -> Term:
     rator = Var(meta_from_tokens(current_token(), current_token()),
                 None, to_unicode.get(current_token().value, current_token().value))
     advance()
-    right = parse_term_compare()
+    # Left-associative, matching the LALR grammar
+    # (`comparison_term "<" additive_term`): recurse into the tighter level,
+    # not back into `parse_term_compare`, so `a < b < c` is `(a < b) < c`.
+    right = parse_term_add()
     term = Call(meta_from_tokens(token, previous_token()), None,
                 rator, [term,right])
 
@@ -587,7 +593,9 @@ def parse_term_equal() -> Term:
     meta = meta_from_tokens(current_token(), current_token())
     opr = current_token().value
     advance()
-    right = parse_term_equal()
+    # Left-associative, matching the LALR grammar
+    # (`equality_term "=" comparison_term`): `a = b = c` is `(a = b) = c`.
+    right = parse_term_compare()
     call_meta = meta_from_tokens(token, previous_token())
     if opr == '≠' or opr == '/=':
       term = IfThen(call_meta, None,

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -516,6 +516,11 @@ PARSER_ROUND_TRIP_FILES = (
     # (which accepts them as identifiers when the flag is off). RD now
     # demotes them to `IDENT` in that mode. Refs #473.
     "./test/should-validate/experimental_imperative_keywords_as_identifiers.pf",
+    # RD used to make `not` bind looser than `=` (its `NOT` branch consumed
+    # `parse_term_equal`) and parse `=`/comparison operators right-associatively,
+    # diverging from the LALR grammar and Reference.md. `not P = false` and
+    # `a = b = c` now group as `(not P) = false` / `(a = b) = c` under both.
+    "./test/should-validate/operator_precedence_rd_lalr.pf",
 )
 
 

--- a/test/should-validate/not_paren_roundtrip.pf
+++ b/test/should-validate/not_paren_roundtrip.pf
@@ -1,11 +1,12 @@
 // Regression coverage for the pretty-printer's handling of `not X`
 // (encoded as `IfThen(_, _, _, Bool false)`) as an operand of `=` and
-// other infix operators. In both parsers, `not` binds *looser* than
-// `=` (the `NOT` branch of `parse_term_hi` consumes
-// `parse_term_equal`), so the printer must parenthesize a `not X`
-// argument of `=`. De Morgan's laws are the canonical witness: their
-// stated equation `(not (P and Q)) = ((not P) or (not Q))` would
-// otherwise reparse as `not ((P and Q) = ((not P) or (not Q)))`.
+// other infix operators. `not` binds *tighter* than `=` in both
+// parsers (it is a level-0 atomic prefix: LALR `"not" atomic_term`,
+// RD's `NOT` branch consumes `parse_call`), so `not (P and Q)` as the
+// left side of `=` must keep its parentheses -- otherwise the printer
+// would emit `not (P and Q) = ...`, which reparses as
+// `(not (P and Q)) = ...` only because the argument is already
+// parenthesized. De Morgan's laws are the canonical witness.
 
 theorem not_paren_and: all P:bool, Q:bool.
   (not (P and Q)) = ((not P) or (not Q))

--- a/test/should-validate/operator_precedence_rd_lalr.pf
+++ b/test/should-validate/operator_precedence_rd_lalr.pf
@@ -1,0 +1,28 @@
+// Regression coverage for RD/LALR operator-grouping agreement (#473).
+//
+// Before the fix, three unparenthesized forms parsed to different ASTs
+// under recursive-descent vs LALR:
+//
+//   * `not` bound *looser* than `=` in RD (the `NOT` branch of
+//     `parse_term_hi` consumed a whole `parse_term_equal`), whereas the
+//     LALR grammar and Reference.md make `not` a level-0 atomic prefix,
+//     so `not P = Q` is `(not P) = Q`, not `not (P = Q)`.
+//   * `=`/`≠` and the comparison operators recursed rightward in RD,
+//     making them right-associative, whereas the grammar is
+//     left-associative: `a = b = c` is `(a = b) = c`.
+//
+// These theorems state those forms without disambiguating parentheses,
+// so the file lives in the `--equiv` corpus to keep RD and LALR pinned
+// to the documented grouping.
+
+theorem not_binds_tighter_than_eq: all P:bool. (not P = false) = P
+proof
+  arbitrary P:bool
+  switch P { case true { . } case false { . } }
+end
+
+theorem eq_left_associative: all P:bool. true = P = P
+proof
+  arbitrary P:bool
+  switch P { case true { . } case false { . } }
+end


### PR DESCRIPTION
## Summary

Fixes three recursive-descent (RD) operator-grouping divergences from the LALR grammar and the `Reference.md` precedence table — a concrete instance of the #473 "both parsers must stay in sync" goal, found by an in-process RD-vs-LALR snippet sweep.

| form | RD (before) | LALR / Reference.md | RD (after) |
| --- | --- | --- | --- |
| `not P = Q` | `not (P = Q)` | `(not P) = Q` | `(not P) = Q` |
| `a = b = c` | `a = (b = c)` | `(a = b) = c` | `(a = b) = c` |
| `a < b < c` | `a < (b < c)` | `(a < b) < c` | `(a < b) < c` |

Root causes in `rec_desc_parser.py`:

- The `NOT` branch of `parse_term_hi` consumed a whole `parse_term_equal`, making `not` bind *looser* than `=`. But `not` is a level-0 atomic prefix (`Reference.md` level 0; LALR `logical_not: "not" atomic_term`), so it applies only to the immediately following atom. It now consumes `parse_call`, exactly like the `-` (`MINUS`) prefix beside it.
- `parse_term_compare` and `parse_term_equal` recursed back into themselves on the right operand, making the comparison and equality operators right-associative. The grammar is left-associative (`comparison_term "<" additive_term`, `equality_term "=" comparison_term`), so each loop now recurses into the next-tighter level.

## Why this is safe for the corpus

The existing `lib/` and `test/should-validate/` corpus already parenthesizes every `not (x = y)` (De Morgan's laws, `NatLess.pf`, `NatDiv.pf`, `IntAbs.pf`, …) and never chains comparison/equality operators. A grep for unparenthesized `not <atom> <compare/eq>` and for chained comparisons found no accepted program that changes meaning — the fix only removes RD/LALR AST divergence, it does not reinterpret any existing proof. `--equiv`, `--errors`, `--warns`, `--lib`, and `--passable` (both parsers) all pass.

## Tests

- New `test/should-validate/operator_precedence_rd_lalr.pf` states `not P = false` and `a = b = c` without disambiguating parentheses and is added to the `--equiv` corpus, so future RD/LALR grouping drift is caught.
- Corrected the now-stale precedence note in `not_paren_roundtrip.pf` (it claimed `not` binds *looser* than `=` in both parsers — that was the RD bug).

## Noticed in passing

Filed #1037 for two unrelated RD/LALR parse-acceptance divergences surfaced by the same sweep (LALR accepts a trailing comma in call args; RD accepts an empty `switch` body). Not addressed here.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 854b0769-a1db-4f91-8eb6-8c41105fe97f routine/20260716-070202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
