### PR TITLE
Sync RD/LALR on trailing-comma call args and empty switch bodies (closes #1037)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -102,7 +102,7 @@ POINTSTO: "|->"
 
 ?switch_case: "case" pattern "{" term "}"           -> switch_case
 
-?switch_list: switch_case                           -> single
+?switch_list:                                       -> empty
     | switch_case switch_list                       -> push
 
 identifier: IDENT              -> identifier
@@ -158,8 +158,9 @@ identifier: IDENT              -> identifier
     | "%" type
     
 ?term_list:                                        -> empty
-    | term                                         -> single
-    | term "," term_list                           -> push
+    | ne_term_list
+?ne_term_list: term                                -> single
+    | term "," ne_term_list                        -> push
     
 ?identifier_list:                                       -> empty
     | identifier                                        -> single

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -2727,7 +2727,7 @@ atomic_term ::= "switch" term "{" switch_list "}"
 ```
 
 ```deduce-grammar
-switch_list ::= switch_case
+switch_list ::= ε
 switch_list ::= switch_case switch_list
 switch_case ::= "case" pattern "{" term "}"
 ```
@@ -2871,12 +2871,14 @@ lemma), plus `<pred>_rule_induction` and `<pred>_rule_inversion`.
 
 ## Term List
 
-A term list is a comma-separated sequence of zero or more terms.
+A term list is a comma-separated sequence of zero or more terms. A trailing
+comma is not allowed.
 
 ```deduce-grammar
 term_list ::= ε
-term_list ::= term
-term_list ::= term "," term_list
+term_list ::= ne_term_list
+ne_term_list ::= term
+ne_term_list ::= term "," ne_term_list
 ```
 
 ## Trace (Statement)

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -264,6 +264,7 @@ PARSER_EQUIV_EXPECTED_DIVERGENCES: frozenset[str] = frozenset()
 SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/all5.pf",
     "./test/should-error/apply_to_error.pf",
+    "./test/should-error/call_trailing_comma.pf",
     "./test/should-error/cases_error.pf",
     "./test/should-error/conjunct.pf",
     "./test/should-error/deep_error.pf",

--- a/test/should-error/call_trailing_comma.pf
+++ b/test/should-error/call_trailing_comma.pf
@@ -1,0 +1,10 @@
+union Bit {
+  bit_lo
+  bit_hi
+}
+
+fun snd(x : Bit, y : Bit) {
+  y
+}
+
+define d = snd(bit_lo, bit_hi,)

--- a/test/should-error/call_trailing_comma.pf.err
+++ b/test/should-error/call_trailing_comma.pf.err
@@ -1,0 +1,12 @@
+./test/should-error/call_trailing_comma.pf:10.1-10.31: while parsing
+	proof_stmt ::= "define" identifier "=" term
+
+./test/should-error/call_trailing_comma.pf:10.12-10.31: while parsing function call
+	term ::= term "(" term_list ")"
+
+
+define d = snd(bit_lo, bit_hi,)
+                              ^
+
+./test/should-error/call_trailing_comma.pf:10.31-10.32: expected a term, not
+	")"

--- a/test/should-error/switch_empty_body.pf
+++ b/test/should-error/switch_empty_body.pf
@@ -1,0 +1,8 @@
+union Bit {
+  bit_lo
+  bit_hi
+}
+
+define b = bit_lo
+
+assert switch b { }

--- a/test/should-error/switch_empty_body.pf.err
+++ b/test/should-error/switch_empty_body.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/switch_empty_body.pf:8.8-8.20: missing a case for:
+	bit_lo


### PR DESCRIPTION
Closes #1037.

Two RD/LALR parse-acceptance divergences (both surfaced by the RD-vs-LALR
snippet sweep run for #473). In each case one parser accepts a form at
parse time that the other rejects, so the parsers disagree on the accepted
language.

## (a) Trailing comma in a call-argument / term list

`f(1,)` and `[1,2,]` parsed under `--lalr` (as `f(1)` / `[1,2]`, failing
only later at name resolution) but were a parse error under
`--recursive-descent`. The LALR `term_list` allowed a trailing comma
because `term "," term_list` could recurse into the empty tail.

Fix: split a non-empty `ne_term_list` out of `term_list`, so the tail
after a comma must be another term. The empty list/call form (`[]`,
`f()`) still parses via the `empty` alternative. Both parsers now reject
the trailing comma at parse time (RD's original behavior, which the
grammar's comma-separated `term_list` intends).

## (b) Empty `switch` body

`switch x { }` parsed under `--recursive-descent` and deferred to the
exhaustiveness check ("missing a case for ...") but was a parse error
under `--lalr`. Fix: give `switch_list` an `empty` base case so LALR also
parses the empty body and reports the nicer exhaustiveness error, matching
RD.

## Tests

- New regression fixtures `test/should-error/call_trailing_comma.pf` and
  `test/should-error/switch_empty_body.pf`.
- `call_trailing_comma.pf` is a parse error in both parsers, so it joins
  `SHOULD_ERROR_PARSER_EQUIV_SKIP`; `switch_empty_body.pf` parses cleanly
  in both and adds AST-equivalence coverage (it stays out of the skip set).
- `python3 test-deduce.py` (full suite, both parsers) passes; `--equiv`
  and `--errors` pass.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh b5555ae7-04b9-4f75-9e21-a145495f0889 routine/20260716-080202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
