### PR TITLE
Treat OverloadType as first-class: allow overloaded-function defines, fix its equality (closes #1040, #1048)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -115,12 +115,16 @@ class OverloadType(Type):
                              for (x,ty) in self.types]) + ')'
 
   def __eq__(self, other: object) -> bool:
+    # ``&'' is an unordered set of overloads, so equality is size-sensitive
+    # but order-independent: the two must have the same number of members and
+    # every member type of one must appear in the other, and vice versa.
     match other:
       case OverloadType(_, types2):
-        ret = True
-        for ((x,t1), (y,t2)) in zip(self.types, types2):
-          ret = ret and t1 == t2
-        return ret
+        ts1 = [t for (_, t) in self.types]
+        ts2 = [t for (_, t) in types2]
+        return len(ts1) == len(ts2) \
+           and all(any(a == b for b in ts2) for a in ts1) \
+           and all(any(b == a for a in ts1) for b in ts2)
       case _:
         return False
 

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -82,6 +82,12 @@ def process_declaration_visibility(decl: Declaration, env: Env,
       if ty == None:
         new_body = type_synth_term(body, env, None, [])
         new_ty = new_body.typeof
+        if isinstance(new_ty, OverloadType):
+          user_error(loc, "the value of '" + base_name(name)
+                     + "' is ambiguous because it could have any of these types:\n\t"
+                     + '\n\t'.join(str(t) for (_, t) in new_ty.types)
+                     + "\nAdd a type annotation to disambiguate, e.g. "
+                     + "define " + base_name(name) + " : <type> = ...")
       else:
         new_ty = check_type(ty, env)
         new_body = body

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -82,7 +82,13 @@ def process_declaration_visibility(decl: Declaration, env: Env,
       if ty == None:
         new_body = type_synth_term(body, env, None, [])
         new_ty = new_body.typeof
-        if isinstance(new_ty, OverloadType):
+        # An unresolved overload is only meaningful as a define value when
+        # every candidate is a function: such a name can still be narrowed at
+        # each call site. A non-function overload (e.g. an overloaded nullary
+        # constructor) has no use-site type to disambiguate it, so require an
+        # annotation rather than storing an ambiguous value.
+        if isinstance(new_ty, OverloadType) \
+           and not all(isinstance(t, FunctionType) for (_, t) in new_ty.types):
           user_error(loc, "the value of '" + base_name(name)
                      + "' is ambiguous because it could have any of these types:\n\t"
                      + '\n\t'.join(str(t) for (_, t) in new_ty.types)
@@ -756,7 +762,13 @@ def type_check_stmt(stmt: Statement, env: Env,
         new_ty = body.typeof
       else:
         new_ty = check_type(ty, env)
-        new_body = type_check_term(body, new_ty, env, None, [])
+        if isinstance(new_ty, OverloadType):
+          # An unresolved overloaded value (all-function, per
+          # process_declaration): there is no single type to check the body
+          # against here -- it is resolved at each use site instead.
+          new_body = body
+        else:
+          new_body = type_check_term(body, new_ty, env, None, [])
       return Define(loc, name, new_ty, new_body, visibility=stmt.visibility)
         
     case Theorem(loc, name, frm, pf, isLemma):

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -93,7 +93,8 @@ def process_declaration_visibility(decl: Declaration, env: Env,
                      + "' is ambiguous because it could have any of these types:\n\t"
                      + '\n\t'.join(str(t) for (_, t) in new_ty.types)
                      + "\nAdd a type annotation to disambiguate, e.g. "
-                     + "define " + base_name(name) + " : <type> = ...")
+                     + "define " + base_name(name) + " : <type> = ..."
+                     + "\nOverloading is only allowed for function types.")
       else:
         new_ty = check_type(ty, env)
         new_body = body

--- a/checker_types.py
+++ b/checker_types.py
@@ -772,6 +772,11 @@ def check_type(typ: TypeExpr, env: Env, arity_required: bool = True) -> TypeExpr
       return ArrayType(loc, check_type(elt_type, env))
     case MutableArrayType(loc, elt_type):
       return MutableArrayType(loc, check_type(elt_type, env))
+    case OverloadType(loc, overloads):
+      # An unresolved overloaded reference (e.g. an overloaded function name
+      # not yet narrowed by a call/expected type). Validate each candidate
+      # type; the overload itself is resolved later at the use site.
+      return OverloadType(loc, [(x, check_type(t, env)) for (x, t) in overloads])
     case _:
       internal_error(typ.location, 'error in check_type: unhandled type ' + repr(typ) + ' ' + str(type(typ)))
 

--- a/test/should-error/define_overloaded_ambiguous.pf
+++ b/test/should-error/define_overloaded_ambiguous.pf
@@ -1,0 +1,9 @@
+union Apple {
+  gala
+}
+
+union Berry {
+  gala
+}
+
+define x = gala

--- a/test/should-error/define_overloaded_ambiguous.pf.err
+++ b/test/should-error/define_overloaded_ambiguous.pf.err
@@ -2,3 +2,4 @@
 	Apple
 	Berry
 Add a type annotation to disambiguate, e.g. define x : <type> = ...
+Overloading is only allowed for function types.

--- a/test/should-error/define_overloaded_ambiguous.pf.err
+++ b/test/should-error/define_overloaded_ambiguous.pf.err
@@ -1,0 +1,4 @@
+./test/should-error/define_overloaded_ambiguous.pf:9.1-9.16: the value of 'x' is ambiguous because it could have any of these types:
+	Apple
+	Berry
+Add a type annotation to disambiguate, e.g. define x : <type> = ...

--- a/test/should-validate/define_overloaded_function.pf
+++ b/test/should-validate/define_overloaded_function.pf
@@ -1,0 +1,27 @@
+// A define bound to an overloaded *function* name is allowed: the alias
+// stays overloaded and is narrowed at each call site. (A define bound to a
+// non-function overload is rejected -- see
+// test/should-error/define_overloaded_ambiguous.pf.)
+
+union Color {
+  red
+  green
+}
+
+union Shape {
+  circle
+  square
+}
+
+fun paint(c : Color) { c }
+fun paint(s : Shape) { s }
+
+define mypaint = paint
+
+assert mypaint(red) = red
+assert mypaint(circle) = circle
+
+// aliases chain, and resolve against an expected type too
+define mypaint2 = mypaint
+define use_color : fn Color -> Color = mypaint2
+assert use_color(green) = green


### PR DESCRIPTION
## Summary

Fixes #1040 and #1048. A top-level `define` whose body was an unresolved
overloaded name (one colliding with multiple constructors/functions) got an
`OverloadType` as its inferred type, which then reached `check_type` — which had
no case for it and hit `internal_error`, leaking a raw `OverloadType(...)` repr
(with `lark.tree.Meta` objects) at the user.

This started as a clean-error fix and, per review discussion, grew into treating
`OverloadType` as a first-class transient type rather than something to reject
on sight.

## Changes

- **`check_type` now handles `OverloadType`** (checker_types.py): it validates
  each candidate type and returns the overload, instead of falling through to
  `internal_error`. An unresolved overload is a legitimate transient type that
  is narrowed later at the use site (call site or expected-type context).

- **A `define` bound to an overloaded *function* name is now allowed**
  (checker_pipeline.py): the alias stays overloaded and resolves at each call
  site — `define myg = g` then `myg(x)` works, including chained aliases
  (`define myg2 = myg`) and resolution against an expected type. Only
  *non-function* overloads (e.g. an overloaded nullary constructor, which has no
  use-site type to disambiguate it) are rejected, with a located error listing
  the candidate types and suggesting a type annotation. `type_check_stmt` no
  longer re-checks such a body against the `OverloadType` itself, since there is
  no single type to check against.

- **`OverloadType.__eq__` fixed** (abstract_syntax/terms.py, #1048): it zipped
  the two candidate lists positionally with no length check, so it was
  order-sensitive and, worse, `A & B` compared **equal** to the superset
  `A & B & C` (the `zip` truncated). Observable via the conditional
  branch-type-equality check: `if c then g else h` with `g`/`h` of different
  overload arity silently type-checked. `&` is an unordered set of overloads, so
  equality is now size-checked and order-independent.

## Before / after

Before (#1040):
```
error in check_type: unhandled type OverloadType(location=<lark.tree.Meta object at 0x...>, ...)
```
After — non-function overload:
```
.../define_overloaded_ambiguous.pf:9.1-9.16: the value of 'x' is ambiguous because it could have any of these types:
	Apple
	Berry
Add a type annotation to disambiguate, e.g. define x : <type> = ...
```
After — overloaded-function alias (now accepted):
```
define mypaint = paint   // paint : (fn Color -> Color) & (fn Shape -> Shape)
assert mypaint(red) = red
assert mypaint(circle) = circle
```

## Testing

- New `test/should-validate/define_overloaded_function.pf` — overloaded-function
  define, chained aliases, and expected-type resolution (self-contained, no
  stdlib dependency; validates under both parsers).
- `test/should-error/define_overloaded_ambiguous.pf` (+ `.err`) — still covers
  the rejected non-function case.
- `python3 test-deduce.py` (full suite: lib + should-validate ×2 parsers +
  should-error + should-warn + parser equivalence) — all pass. The `__eq__`
  change does not disturb stdlib overload resolution.
- Verified overloaded-function defines resolve end-to-end under both
  `--recursive-descent` and `--lalr`.

Resume this session on ginger: `~/deduce-runner/resume.sh 0f147613-2a67-4b88-9f24-517785350e22 routine/20260716-090202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)