### PR TITLE
Accept empty union bodies under LALR to match RD (refs #473)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -349,7 +349,7 @@ identifier: IDENT              -> identifier
 ?constructor: IDENT                                   -> constructor_id
     | IDENT "(" type_list ")"                    -> constructor_apply
 
-?constructor_list: constructor                             -> single
+?constructor_list:                                         -> empty
     | constructor constructor_list                         -> push
 
 ?object_field: "var" identifier ":" type                    -> object_field

--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -3005,14 +3005,16 @@ function.
 
 ```deduce-grammar
 statement ::= visibility "union" IDENT type_params_opt "{" constructor_list "}"
-constructor_list ::= constructor
+constructor_list ::= ε
 constructor_list ::= constructor constructor_list
 constructor ::= IDENT
 constructor ::= IDENT "(" type_list ")"
 ```
 
 The `union` statement defines a new type whose values are created by
-invoking one of the constructors declared inside the union.
+invoking one of the constructors declared inside the union. A union may
+declare zero constructors (an empty `{ }` body); the resulting type is
+uninhabited, and a value of it can be eliminated by a case-free `switch`.
 
 Example:
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -535,6 +535,12 @@ PARSER_ROUND_TRIP_FILES = (
     # diverging from the LALR grammar and Reference.md. `not P = false` and
     # `a = b = c` now group as `(not P) = false` / `(a = b) = c` under both.
     "./test/should-validate/operator_precedence_rd_lalr.pf",
+    # An empty (uninhabited) `union { }` body. RD documents the body as
+    # `constructor*` and accepted zero constructors, but the LALR
+    # `constructor_list` rule required at least one, so the pretty-printed
+    # empty union did not reparse under LALR. Fixed by admitting the empty
+    # production in `constructor_list`. Refs #473.
+    "./test/should-validate/empty_union.pf",
 )
 
 

--- a/test/should-validate/empty_union.pf
+++ b/test/should-validate/empty_union.pf
@@ -1,0 +1,13 @@
+// An empty (uninhabited) union has zero constructors.  Both parsers must
+// accept the empty `{ }` body: the recursive-descent grammar documents the
+// body as `constructor*` (zero or more), and the LALR grammar's
+// `constructor_list` admits the empty production to match it.  Refs #473.
+union Empty { }
+
+// An uninhabited type can be eliminated by a case-free `switch`, which is
+// vacuously exhaustive, so any goal follows from a value of the type.
+theorem empty_absurd: all x:Empty. false
+proof
+  arbitrary x:Empty
+  switch x { }
+end


### PR DESCRIPTION
## Summary

Another RD/LALR parse-acceptance divergence for the dual-parser equivalence goal (#473), found via an in-process snippet sweep comparing `rec_desc_parser.py` against `parser.py`:

- **Observed:** an empty (uninhabited) union body parses under the recursive-descent parser but is a parse error under LALR.

  ```
  $ printf 'union U { }\n' > /tmp/eu.pf
  $ python3 deduce.py --recursive-descent --no-stdlib /tmp/eu.pf
  /tmp/eu.pf is valid
  $ python3 deduce.py --lalr --no-stdlib /tmp/eu.pf
  /tmp/eu.pf:1.11-1.12: error in parsing, unexpected token: }
  ```

- **Cause:** the LALR grammar's `constructor_list` rule (`Deduce.lark`) only had `constructor -> single | constructor constructor_list -> push`, requiring at least one constructor. The recursive-descent parser documents the body as `constructor*` (zero or more) and accepts the empty form.

- **Fix:** admit the empty production in `constructor_list`, mirroring the `switch_list` shape used in PR #1039. `parser.py`'s `parse_tree_to_list` already maps an `empty` node to `[]`, and the `union` handler already routes the constructor list through it, so no Python change is needed. No LALR grammar conflicts are introduced.

Empty/uninhabited unions are logically meaningful (a `Void`/`False`-style type), and an empty union is usable today under RD for absurdity elimination via a case-free `switch`. This matches the precedent set in #1037/#1039 (accept the empty body and defer to later phases rather than diverge at parse time).

## Tests

- New `test/should-validate/empty_union.pf`: declares an empty `union Empty { }` and proves `all x:Empty. false` by a case-free `switch`. Validates under both parsers.
- Enrolled that fixture in `PARSER_ROUND_TRIP_FILES` so `--equiv` covers the empty-union pretty-print → reparse round trip.
- `python3 test-deduce.py --equiv`, `--passable`, `--errors`, and `--parser` all pass locally. (ruff/mypy not installed in this container; the change is a grammar tweak plus a tuple append.)

- Synced `gh_pages/doc/Reference.md`: the `constructor_list` grammar snippet now reads `constructor_list ::= ε` (matching `Deduce.lark` and the `switch_list` convention from #1039), and the Union prose notes that a zero-constructor (uninhabited) union is allowed. This keeps the reference-grammar CI check (`gh_pages/scripts/reference_grammar.py`) green.

## Bug filed in passing

While sweeping I hit a pre-existing, orthogonal crash and filed it as **#1042**: a top-level `fun` with an implicit return type whose body is an empty `switch` (over an uninhabited type) yields a `FunctionType` with `return_type = None` that reaches `check_type` and raises a bare `AttributeError` (`checker_types.py:760`→`792`, the same fall-through arm as #1040 but with `None` rather than an `OverloadType`). It is independent of this parser change (reproduces under RD on `main` today) and is not addressed here.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 647675f0-2233-4349-977b-a8360859c01c routine/20260716-100201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

