### PR TITLE
Give empty switch a clean type instead of crashing check_type (closes #1042)

### DIFF
--- a/checker_types.py
+++ b/checker_types.py
@@ -1078,6 +1078,13 @@ def type_synth_term(
             case _:
               user_error(loc, 'expected a union type, not ' + str(ty))
 
+      # An empty switch (over an uninhabited type) is vacuously exhaustive
+      # but has no inferrable result type; ask for an annotation.
+      if result_type[0] is None:
+        user_error(loc, 'cannot infer the type of an empty switch.\n'\
+              + 'Add a type annotation, e.g. "(switch ' + str(subject) \
+              + ' { } : T)".')
+
     case TermInst(loc, _, subject, tyargs, inferred) if isinstance(subject, VarRef):
       ret = type_check_term_inst_var(loc, subject, tyargs, inferred, env)
 
@@ -1276,6 +1283,10 @@ def type_check_term(
         return SwitchCase(c.location, c.pattern, new_body)
 
       new_cases = [process_case(c, result_type, cases_present) for c in cases]
+      # An empty switch (over an uninhabited type) runs no case, so
+      # `result_type` was never set; the switch has the expected type.
+      if result_type[0] is None:
+        result_type[0] = typ
 
       # Check case coverage
       match ty:

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -272,6 +272,7 @@ SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/define_type.pf",
     "./test/should-error/define_with_type_params.pf",
     "./test/should-error/double_private.pf",
+    "./test/should-error/empty_switch_no_annotation.pf",
     "./test/should-error/fn_missing_arrow.pf",
     "./test/should-error/function_case_missing_equal.pf",
     "./test/should-error/literal_too_large.pf",

--- a/test/should-error/empty_switch_no_annotation.pf
+++ b/test/should-error/empty_switch_no_annotation.pf
@@ -1,0 +1,5 @@
+union Empty { }
+
+fun absurd(x : Empty) {
+  switch x { }
+}

--- a/test/should-error/empty_switch_no_annotation.pf.err
+++ b/test/should-error/empty_switch_no_annotation.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/empty_switch_no_annotation.pf:4.3-4.15: cannot infer the type of an empty switch.
+Add a type annotation, e.g. "(switch x { } : T)".


### PR DESCRIPTION
## Summary

Fixes #1042: a top-level `fun` whose body is an empty `switch` (over an
uninhabited union) crashed with a bare `AttributeError` instead of type-checking
or giving a located error.

```
$ cat /tmp/crash.pf
union Empty { }

fun absurd(x : Empty) {
  switch x { }
}

$ python3 deduce.py --no-stdlib /tmp/crash.pf   # before
'NoneType' object has no attribute 'location'
```

## Root cause

An empty `switch` runs no case, so `result_type` in `type_synth_term` /
`type_check_term` was never set and the `Switch` node was built with
`typeof = None`. In type-**synthesis** position that `None` propagated up into
the enclosing `Lambda`'s `FunctionType` return type and reached `check_type`'s
`case _:` fall-through (`checker_types.py:792`), which dereferences
`typ.location` on `None` → `AttributeError`.

## Fix

- **Synthesis position** (no expected type to fall back on): emit a clean
  located error asking for a type annotation, e.g. `(switch x { } : T)`.
- **Checking position** (expected type known): give the empty switch the
  expected type so its node no longer carries `None`. This makes the annotation
  the synthesis-position error suggests actually work — `(switch x { } : bool)`
  now checks instead of crashing.

Non-empty unions with an empty switch still get the existing "missing a case
for ..." error in both positions.

```
$ python3 deduce.py --no-stdlib /tmp/crash.pf   # after
/tmp/crash.pf:4.3-4.15: cannot infer the type of an empty switch.
Add a type annotation, e.g. "(switch x { } : T)".
```

## Tests

- `test/should-error/empty_switch_no_annotation.pf` (+ `.err`) — the crash
  repro now produces the clean located error. Empty unions parse under
  recursive-descent only today (LALR rejects them at parse time; that is the
  separate #473 / #1037 work), so this fixture is RD-only and added to
  `SHOULD_ERROR_PARSER_EQUIV_SKIP`; the skip-set staleness check confirms it
  still belongs there.

`python3 test-deduce.py --errors`, `--passable`, and `--equiv` all pass.

## Notes

This is the `None`-typed variant of the shared `check_type` fall-through that
#1040 addresses for `OverloadType`; both are fixed at their source rather than
by hardening the fall-through arm.

Resume this session on ginger: `~/deduce-runner/resume.sh 812865ae-0eed-4a3e-8e0b-bc7f9957b02f routine/20260716-110202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
