### PR TITLE
Cut CI runtime: trim unary-literal outlier test + add harness sharding (refs #1049)

### DIFF
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -52,6 +52,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Long categories are fanned across parallel shards with ``--shard
+        # i/n`` so no single leg dominates wall-clock; every item lands in
+        # exactly one shard, so coverage is unchanged. ``test/prelude`` is its
+        # own leg (``--prelude``) because it needs the expensive stdlib
+        # bootstrap that should-validate does not. Bump a shard count if a leg
+        # creeps back over budget. (See issue #1049.)
         include:
           - name: site
             args: --site
@@ -60,13 +66,22 @@ jobs:
             args: --parser
             requirements: core
           - name: lib-1
-            args: --lib --shard 1/2
+            args: --lib --shard 1/3
             requirements: core
           - name: lib-2
-            args: --lib --shard 2/2
+            args: --lib --shard 2/3
             requirements: core
-          - name: passable
-            args: --passable --cli
+          - name: lib-3
+            args: --lib --shard 3/3
+            requirements: core
+          - name: passable-1
+            args: --passable --cli --shard 1/2
+            requirements: core
+          - name: passable-2
+            args: --passable --shard 2/2
+            requirements: core
+          - name: prelude
+            args: --prelude
             requirements: core
           - name: errors
             args: --errors

--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -59,8 +59,11 @@ jobs:
           - name: parser
             args: --parser
             requirements: core
-          - name: lib
-            args: --lib
+          - name: lib-1
+            args: --lib --shard 1/2
+            requirements: core
+          - name: lib-2
+            args: --lib --shard 2/2
             requirements: core
           - name: passable
             args: --passable --cli
@@ -71,8 +74,14 @@ jobs:
           - name: warns
             args: --warns
             requirements: core
-          - name: equiv
-            args: --equiv
+          - name: equiv-1
+            args: --equiv --shard 1/3
+            requirements: core
+          - name: equiv-2
+            args: --equiv --shard 2/3
+            requirements: core
+          - name: equiv-3
+            args: --equiv --shard 3/3
             requirements: core
           - name: examples
             args: --examples

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -63,6 +63,15 @@ Pool sizing:
     --workers N         Worker count (default ``os.cpu_count()``).
     --max-threads N     Alias for ``--workers`` (legacy).
     --serial            Equivalent to ``--workers 1``.
+
+Sharding:
+    --shard i/n         Process only stride ``i`` of ``n`` of each selected
+                        category's work list (``i`` is 1-based). Every item
+                        lands in exactly one shard, so running all ``n`` shards
+                        covers the whole corpus with no loss -- this is how CI
+                        fans the long categories (should-validate, lib, equiv)
+                        across parallel matrix legs. Corpus-wide invariant
+                        checks in ``--equiv`` run only on shard 1.
 """
 
 from __future__ import annotations
@@ -79,7 +88,7 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import fields as dc_fields, is_dataclass
 from pathlib import Path
 from signal import signal, SIGINT
-from typing import Callable, Iterable, TypeVar, TypedDict, cast
+from typing import Callable, Iterable, Optional, TypeVar, TypedDict, cast
 from lark import Token
 
 # Work around macOS sandbox profiles (notably Claude Code's seatbelt
@@ -572,6 +581,7 @@ class ParsedFlags(TypedDict):
     regen_warn_files: list[str]
     gen_parse: bool
     workers: int
+    shard: Optional[tuple[int, int]]
 
 
 T = TypeVar("T")
@@ -584,6 +594,23 @@ S = TypeVar("S")
 # copy-on-write. Avoids pickling a 32-entry tuple per task.
 _WORKER_PREWARM: tuple[str, ...] = ()
 _WORKER_PRELUDE: tuple[str, ...] = ()
+
+# When set by ``--shard i/n`` the run functions process only their stride of
+# the work list, so CI can fan a long category (e.g. should-validate) across n
+# parallel matrix legs without any coverage loss -- every item lands in exactly
+# one shard. ``None`` means "run everything" (the default / local behaviour).
+_SHARD: tuple[int, int] | None = None
+
+
+def shard(items: list[T]) -> list[T]:
+    """Return this shard's slice of ``items`` (round-robin by stride).
+
+    Striding rather than contiguous chunks keeps the shards balanced even
+    when per-item cost is uneven across the (sorted) list."""
+    if _SHARD is None:
+        return items
+    idx, count = _SHARD
+    return items[idx::count]
 
 
 def handle_sigint(signum: int, frame: object) -> None:
@@ -789,7 +816,7 @@ def _parser_workers(workers: int, task_count: int) -> int:
 def run_lib_parallel(workers: int) -> list[tuple[str, str, str]]:
     """``lib/*.pf`` × both parsers with no shared cache."""
     files = list_pf(LIB_DIR)
-    tasks = [(f, p) for f in files for p in (True, False)]
+    tasks = shard([(f, p) for f in files for p in (True, False)])
     failures: list[tuple[str, str, str]] = []
     for f, ok, label, msg in _map_or_serial(workers, _worker_lib, tasks, 2):
         if not ok:
@@ -800,7 +827,7 @@ def run_lib_parallel(workers: int) -> list[tuple[str, str, str]]:
 def run_validate_parallel(workers: int) -> list[tuple[str, str, str]]:
     """``test/should-validate`` + ``example.pf`` × both parsers."""
     files = list_pf(PASS_DIR) + [f"./{EXAMPLE_FILE.as_posix()}"]
-    tasks = [(f, p) for f in files for p in (True, False)]
+    tasks = shard([(f, p) for f in files for p in (True, False)])
     failures: list[tuple[str, str, str]] = []
     for f, ok, label, msg in _map_or_serial(workers, _worker_validate, tasks, 4):
         if not ok:
@@ -811,7 +838,7 @@ def run_validate_parallel(workers: int) -> list[tuple[str, str, str]]:
 def run_prelude_parallel(workers: int) -> list[tuple[str, str, str]]:
     """``test/prelude`` × both parsers (uses ``prelude=`` bootstrap)."""
     files = list_pf(PRELUDE_DIR)
-    tasks = [(f, p) for f in files for p in (True, False)]
+    tasks = shard([(f, p) for f in files for p in (True, False)])
     failures: list[tuple[str, str, str]] = []
     for f, ok, label, msg in _map_or_serial(workers, _worker_prelude, tasks, 2):
         if not ok:
@@ -822,7 +849,7 @@ def run_prelude_parallel(workers: int) -> list[tuple[str, str, str]]:
 def run_err_diff_parallel(directory: Path, label: str,
                           workers: int) -> list[tuple[str, str, str]]:
     """Run ``.err``-fixture tests in ``directory`` (RD only)."""
-    files = list_pf(directory)
+    files = shard(list_pf(directory))
     failures: list[tuple[str, str, str]] = []
     for f, ok, msg in _map_or_serial(workers, _check_against_err, files, 4):
         if not ok:
@@ -832,7 +859,7 @@ def run_err_diff_parallel(directory: Path, label: str,
 
 def run_warn_diff_parallel(workers: int) -> list[tuple[str, str, str]]:
     """Run ``.warn``-fixture tests in ``test/should-warn`` (RD only)."""
-    files = list_pf(WARN_DIR)
+    files = shard(list_pf(WARN_DIR))
     failures: list[tuple[str, str, str]] = []
     for f, ok, msg in _map_or_serial(workers, _check_against_warn, files, 4):
         if not ok:
@@ -1017,11 +1044,12 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     down beginner-facing RD diagnostics, while the LALR parser is kept as an
     executable grammar spec.
     """
-    files = tuple(dict.fromkeys(
+    all_files = tuple(dict.fromkeys(
         PARSER_EQUIV_FILES
         + should_error_equiv_files()
         + tuple(sorted(PARSER_EQUIV_EXPECTED_DIVERGENCES))
     ))
+    files = shard(list(all_files))
     failures: list[tuple[str, str, str]] = []
     seen_divergences: set[str] = set()
     for path, ok, msg, expected_diverged in _map_or_serial(
@@ -1036,13 +1064,17 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
             failures.append((path, "parser-equivalence",
                              msg))
 
-    failures.extend(_check_should_error_skip_set())
-    failures.extend(_check_keyword_name_rejection())
-
-    stale = PARSER_EQUIV_EXPECTED_DIVERGENCES - seen_divergences - set(files)
-    for path in sorted(stale):
-        failures.append((path, "parser-equivalence",
-                         "expected divergence path no longer exists"))
+    # Global invariant checks are corpus-wide, not per-file: run them once
+    # (on the sole/first shard) so a fan-out neither duplicates their failures
+    # nor trips the staleness check on paths another shard owns.
+    if _SHARD is None or _SHARD[0] == 0:
+        failures.extend(_check_should_error_skip_set())
+        failures.extend(_check_keyword_name_rejection())
+        stale = (PARSER_EQUIV_EXPECTED_DIVERGENCES
+                 - seen_divergences - set(all_files))
+        for path in sorted(stale):
+            failures.append((path, "parser-equivalence",
+                             "expected divergence path no longer exists"))
     return failures
 
 
@@ -1143,11 +1175,12 @@ def _check_should_error_skip_set() -> list[tuple[str, str, str]]:
 
 def run_parser_round_trip(workers: int) -> list[tuple[str, str, str]]:
     """Pretty-print representative ASTs and re-parse with both parsers."""
+    files = shard(list(PARSER_ROUND_TRIP_FILES))
     failures: list[tuple[str, str, str]] = []
     for file_failures in _map_or_serial(
-        _parser_workers(workers, len(PARSER_ROUND_TRIP_FILES)),
+        _parser_workers(workers, len(files)),
         _worker_parser_round_trip,
-        PARSER_ROUND_TRIP_FILES,
+        files,
         1,
     ):
         failures.extend(file_failures)
@@ -1361,7 +1394,7 @@ def run_examples_parallel(workers: int) -> list[tuple[str, str, str]]:
     ``deduce.py`` runs them.
     """
     files = list_pf(EXAMPLES_DIR)
-    tasks = [(f, True) for f in files]
+    tasks = shard([(f, True) for f in files])
     failures: list[tuple[str, str, str]] = []
     for f, ok, label, msg in _map_or_serial(workers, _worker_prelude, tasks, 4):
         if not ok:
@@ -1437,6 +1470,25 @@ def time_section(label: str, fn: Callable[[], S]) -> tuple[float, S]:
     return dt, result
 
 
+def _parse_shard(spec: str) -> tuple[int, int]:
+    """Parse a ``--shard i/n`` spec into a 0-based ``(index, count)``.
+
+    ``i`` is 1-based on the command line (``1/6`` .. ``6/6``) to read
+    naturally in CI matrix definitions."""
+    try:
+        i_str, n_str = spec.split("/", 1)
+        index, count = int(i_str), int(n_str)
+    except ValueError:
+        print(f"invalid --shard spec {spec!r} (expected i/n, e.g. 2/6)",
+              file=sys.stderr)
+        sys.exit(2)
+    if count < 1 or not (1 <= index <= count):
+        print(f"invalid --shard {spec}: need 1 <= i <= n and n >= 1",
+              file=sys.stderr)
+        sys.exit(2)
+    return (index - 1, count)
+
+
 def parse_args(argv: list[str]) -> ParsedFlags:
     """Return a dict of flag → value. Tolerates the legacy long-form
     arguments still in scripts / muscle memory."""
@@ -1447,6 +1499,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         "examples": False, "regen_all": False, "regen_files": [],
         "regen_all_warns": False, "regen_warn_files": [],
         "gen_parse": False, "workers": max(1, (os.cpu_count() or 4)),
+        "shard": None,
     }
     i = 0
     while i < len(argv):
@@ -1473,6 +1526,9 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         elif a == "--serial": flags["workers"] = 1
         elif a in ("--workers", "--max-threads"):
             flags["workers"] = max(1, int(argv[i + 1]))
+            i += 1
+        elif a == "--shard":
+            flags["shard"] = _parse_shard(argv[i + 1])
             i += 1
         else:
             print(f"unknown argument: {a}", file=sys.stderr)
@@ -1538,6 +1594,12 @@ def main(argv: list[str]) -> int:
     setup_paths()
     lib_modules = discover_lib_modules()
     workers = flags["workers"]
+
+    global _SHARD
+    _SHARD = flags["shard"]
+    if _SHARD is not None:
+        print(f"[shard {_SHARD[0] + 1}/{_SHARD[1]}] "
+              "processing this stride of each category's work list")
 
     total_failures: list[tuple[str, str, str]] = []
     total_t0 = time.perf_counter()

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -8,16 +8,20 @@ via copy-on-write and run ``lsp.library.check_file`` directly.
 
 Modes
 -----
-Default (no flags): runs ``--cli + --lib + --passable + --errors +
---warns + --equiv``.
+Default (no flags): runs ``--cli + --lib + --passable + --prelude +
+--errors + --warns + --equiv``.
 
 Per-category flags (combinable):
     --cli          One subprocess invocation of ``deduce.py`` on a tiny
                    no-stdlib proof to sanity-check the CLI entry point
                    itself.
     --lib          ``lib/`` with both parsers, no shared cache.
-    --passable     ``test/should-validate``, ``example.pf``,
-                   ``test/prelude`` with both parsers.
+    --passable     ``test/should-validate`` + ``example.pf`` with both
+                   parsers (uses the cheap ``prewarm`` bootstrap).
+    --prelude      ``test/prelude`` with both parsers. Separate from
+                   ``--passable`` because it needs the full ``prelude=``
+                   bootstrap (checks the stdlib, ~100s cold on CI); keeping
+                   it its own leg lets should-validate shards stay cheap.
     --errors       ``test/should-error`` (RD only, ``.err`` diff).
     --warns        ``test/should-warn`` (RD only, ``.warn`` diff): files
                    that must validate AND emit specific warning text.
@@ -568,6 +572,7 @@ class ParsedFlags(TypedDict):
     cli: bool
     lib: bool
     passable: bool
+    prelude: bool
     errors: bool
     warns: bool
     equiv: bool
@@ -1493,7 +1498,8 @@ def parse_args(argv: list[str]) -> ParsedFlags:
     """Return a dict of flag → value. Tolerates the legacy long-form
     arguments still in scripts / muscle memory."""
     flags: ParsedFlags = {
-        "cli": False, "lib": False, "passable": False, "errors": False,
+        "cli": False, "lib": False, "passable": False, "prelude": False,
+        "errors": False,
         "warns": False, "equiv": False, "equiv_full": False, "site": False,
         "parser": False,
         "examples": False, "regen_all": False, "regen_files": [],
@@ -1507,6 +1513,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         if a == "--cli": flags["cli"] = True
         elif a == "--lib": flags["lib"] = True
         elif a == "--passable": flags["passable"] = True
+        elif a == "--prelude": flags["prelude"] = True
         elif a == "--errors": flags["errors"] = True
         elif a == "--warns": flags["warns"] = True
         elif a == "--equiv": flags["equiv"] = True
@@ -1537,7 +1544,8 @@ def parse_args(argv: list[str]) -> ParsedFlags:
 
     # If no flags at all, default to the per-PR regression sweep.
     if not (
-        flags["cli"] or flags["lib"] or flags["passable"] or flags["errors"]
+        flags["cli"] or flags["lib"] or flags["passable"] or flags["prelude"]
+        or flags["errors"]
         or flags["warns"] or flags["site"] or flags["parser"]
         or flags["examples"] or flags["equiv"] or flags["equiv_full"]
         or flags["regen_all"]
@@ -1545,6 +1553,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         or flags["regen_files"] or flags["regen_warn_files"]
     ):
         flags["cli"] = flags["lib"] = flags["passable"] = True
+        flags["prelude"] = True
         flags["errors"] = flags["warns"] = flags["equiv"] = True
 
     # Standalone modes are mutually exclusive with everything else.
@@ -1552,6 +1561,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         ("cli", flags["cli"]),
         ("lib", flags["lib"]),
         ("passable", flags["passable"]),
+        ("prelude", flags["prelude"]),
         ("errors", flags["errors"]),
         ("warns", flags["warns"]),
         ("equiv", flags["equiv"]),
@@ -1686,8 +1696,12 @@ def main(argv: list[str]) -> int:
                                 lambda: run_lib_parallel(workers))
         total_failures.extend(fails)
 
-    # Prelude pool: prelude-injection bootstrap.
-    if flags["passable"]:
+    # Prelude pool: prelude-injection bootstrap. This is a separate leg from
+    # ``--passable`` because the ``prelude=`` bootstrap fully checks the stdlib
+    # (~100s cold on CI), whereas should-validate needs only the cheap
+    # ``prewarm`` bootstrap -- bundling them made every should-validate shard
+    # pay the expensive bootstrap. See issue #1049.
+    if flags["prelude"]:
         reset_prelude_cache()
         t0 = time.perf_counter()
         bootstrap_prelude(lib_modules)

--- a/test/should-validate/large_numeric_literals.pf
+++ b/test/should-validate/large_numeric_literals.pf
@@ -1,11 +1,17 @@
 import Nat
 import UInt
 
-// Large-but-supported numeric literals check without crashing.
-// Regression test for issue #1021: literals up to MAX_LITERAL (4000)
-// must type-check rather than blow the recursion limit.
-assert 3000 = 3000
-assert 3000 < 4000
-assert 4000 = 4000
+// Large-but-supported numeric literals must *type-check* near MAX_LITERAL
+// (4000) without blowing the recursion limit -- the regression from #1021.
+//
+// Type-checking a large literal is cheap; it is runtime *evaluation* of UInt
+// arithmetic on such values that is pathologically slow under the unary
+// literal representation (see #1050, and the binary-literal work in #1025),
+// and it was making this one file dominate CI (~100s/parser). So we keep the
+// type-check coverage for both Nat and UInt large literals and arithmetic
+// expressions, and evaluate only on the cheap Nat path.
+define _big_uint : UInt = 4000
+define _sum_uint : UInt = 1500 + 1500
+define _lt_uint  : bool = 3000 < 4000
+define _big_nat  : Nat  = ℕ4000
 assert ℕ3000 = ℕ3000
-assert 1500 + 1500 = 3000


### PR DESCRIPTION
## Summary

`Refs #1049`. CI (`Run Tests`) wall-clock was ~13 min, and per-job timing showed
it was *entirely* the unsharded `regression (passable)` leg — every other job
finished in ≤5 min. This PR attacks the root cause and adds the infrastructure to
keep the remaining legs in budget.

## What the profiling found

Timing each `test/should-validate/*.pf` file individually surfaced a single
outlier:

| file | time (RD, one parser) |
|------|-----------------------|
| **`large_numeric_literals.pf`** | **107.3s** |
| `uint_replicate.pf` | 2.2s |
| everything else | < 1.4s |

That one file was ~107s **per parser** — ~214s of the ~224s local
`should-validate` run, i.e. essentially the whole 13-min CI bottleneck.

Root cause: numeric literals are unary, so runtime **evaluation** of `UInt`
arithmetic near `MAX_LITERAL` (4000) is O(n):

| expression | time |
|------------|------|
| `define big : UInt = 4000` (type-check only) | 0.51s |
| `assert 4000 = 4000` (UInt eval) | 37.3s |
| `assert 1500 + 1500 = 3000` (UInt eval) | 16.1s |
| `assert ℕ3000 = ℕ3000` (Nat eval) | 0.39s |

The #1021 regression this file guards is about *type-checking* a large literal
not blowing the recursion limit — which is cheap. The 100s was incidental
runtime-eval cost.

## Changes

1. **Trim `large_numeric_literals.pf`** to keep type-check coverage of large
   `Nat`/`UInt` literals and arithmetic expressions, and evaluate only on the
   cheap `Nat` path. Local `should-validate` drops **~224s → ~16s**; the full
   default `test-deduce.py` run drops **~320s → ~112s**. The dropped large-`UInt`
   runtime-eval coverage is tracked in **#1050** (with `Refs #1025`).

2. **Add a generic `--shard i/n` option** to `test-deduce.py`. Each run function
   processes only its round-robin stride of the work list, so a category can be
   fanned across parallel CI matrix legs with **zero coverage loss** (every item
   lands in exactly one shard). Corpus-wide invariant checks in `--equiv`
   (skip-set staleness, keyword rejection, stale-divergence) run only on shard 1
   so they are neither duplicated nor falsely tripped across the fan-out.

## ⚠️ Manual step: apply the CI matrix patch

The workflow file (`.github/workflows/test_deduce.yml`) could **not** be pushed —
this routine's token lacks the `workflow` scope. Apply this patch with a
`workflow`-scoped token (it shards `lib` into 2 and `equiv` into 3; `passable` is
now fast enough as a single leg). **#1049 is fully resolved only once this is
applied** — without it, CI still drops from ~13 min to ~5 min (the trim fixes
`passable`), but `lib`/`equiv` keep it above the 3-min target.

```diff
--- a/.github/workflows/test_deduce.yml
+++ b/.github/workflows/test_deduce.yml
@@ -52,6 +52,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The long categories are fanned across parallel shards with
+        # ``--shard i/n`` so no single leg dominates wall-clock. Every item
+        # lands in exactly one shard, so coverage is unchanged; bump a shard
+        # count if a leg creeps back over budget. (See issue #1049.)
         include:
           - name: site
             args: --site
@@ -59,8 +63,11 @@ jobs:
           - name: parser
             args: --parser
             requirements: core
-          - name: lib
-            args: --lib
+          - name: lib-1
+            args: --lib --shard 1/2
+            requirements: core
+          - name: lib-2
+            args: --lib --shard 2/2
             requirements: core
           - name: passable
             args: --passable --cli
@@ -71,8 +78,14 @@ jobs:
           - name: warns
             args: --warns
             requirements: core
-          - name: equiv
-            args: --equiv
+          - name: equiv-1
+            args: --equiv --shard 1/3
+            requirements: core
+          - name: equiv-2
+            args: --equiv --shard 2/3
+            requirements: core
+          - name: equiv-3
+            args: --equiv --shard 3/3
             requirements: core
           - name: examples
             args: --examples
```

## Projected CI after both this PR and the matrix patch

| leg | before | after |
|-----|--------|-------|
| passable | ~13 min | ~1.5 min (trim) |
| lib | ~3.6 min | ~1.8 min ×2 shards |
| equiv | ~5 min | shard 1 ~2 min, shards 2–3 ~1 min |
| errors / examples / site / parser / warns | ≤2.6 min | unchanged |

New wall-clock ≈ the slowest leg, targeting ~3 min.

## Testing

- Full default `python3 test-deduce.py` — all pass, ~112s (was ~320s).
- `--shard` partition verified a perfect cover (no gaps/overlap) across 6 shards;
  `lib`/`equiv` shards run green and balanced locally.
- Trimmed file validates under both `--recursive-descent` and `--lalr`.
- `ruff check .` and `mypy test-deduce.py` clean.

Resume this session on ginger: `~/deduce-runner/resume.sh 0f147613-2a67-4b88-9f24-517785350e22 routine/ci-speedup-1049`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
