### PR TITLE
Fold token/grammar checks into make static; align mypy with CI (closes #1052)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ python deduce.py --recursive-descent file.pf
 python deduce.py --lalr file.pf
 
 # Make targets run static checks and BOTH parsers across the test/lib tree
-make static       # ruff + mypy
+make static       # ruff + mypy + token/grammar checks (matches CI "static checks")
 make tests        # static + should-validate + should-error + should-warn
 make tests-lib    # checks the stdlib itself
 make              # static + token checks + tests (default)

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,15 @@ default: check-settings static tests-tokens tests
 check-settings:
 	$(PYTHON) -c "import json; json.load(open('.claude/settings.json'))"
 
-static:
+# Mirrors the CI "static checks" job (.github/workflows/test_deduce.yml):
+# ruff + mypy + the token/grammar consistency scripts, so a green
+# ``make static`` predicts a green CI static job. ``tests-tokens`` is a
+# prerequisite rather than inlined so ``default:`` (which lists both) still
+# runs the scripts exactly once per build. mypy is run once (matching CI);
+# the extra ``--no-site-packages`` pass was dropped so the two stay aligned.
+static: tests-tokens
 	$(PYTHON) -m ruff check .
 	$(PYTHON) -m mypy .
-	$(PYTHON) -m mypy . --no-site-packages
 
 tests-tokens:
 	$(PYTHON) ./gh_pages/scripts/keywords.py

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -287,7 +287,6 @@ SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/define_type.pf",
     "./test/should-error/define_with_type_params.pf",
     "./test/should-error/double_private.pf",
-    "./test/should-error/empty_switch_no_annotation.pf",
     "./test/should-error/fn_missing_arrow.pf",
     "./test/should-error/fun_params_trailing_comma.pf",
     "./test/should-error/function_case_missing_equal.pf",


### PR DESCRIPTION
## Summary

`make static` ran only `ruff` + `mypy`, but the CI **"static checks"** job also runs `keywords.py` and `reference_grammar.py`, so a green `make static` did not predict a green CI static job (this bit PR #1043: a `Deduce.lark` change with no matching `Reference.md` snippet passed `make static` locally but failed CI's "Check reference grammar snippets" step).

## Changes

- **Makefile:** `static` now depends on `tests-tokens`, so `make static` runs the same set as the CI static job (ruff + mypy + `keywords.py` + `reference_grammar.py`). `default:` lists both `static` and `tests-tokens`, but make builds each target once per run, so no work is duplicated.
- **Makefile:** dropped the Makefile-only `mypy . --no-site-packages` pass so the mypy invocation matches CI's single `mypy .`, removing the one intentional discrepancy the issue called out. (The alternative — adding `--no-site-packages` to the CI workflow — was not viable here: the routine's PAT lacks `workflow` scope, so `.github/workflows/` cannot be modified. Aligning on the Makefile side keeps the two identical without touching CI.)
- **CLAUDE.md:** updated the `make static` description to note it matches the CI "static checks" job.
- **test-deduce.py (drive-by, unblocks CI):** removed the stale `./test/should-error/empty_switch_no_annotation.pf` entry from `SHOULD_ERROR_PARSER_EQUIV_SKIP`. This was a **pre-existing red on `main`**, not introduced by this PR — since the RD/LALR empty-switch sync (#1039, #1044) both parsers parse it identically and it now errors uniformly at type-check time, so the skip-set verifier (`verify_should_error_skip_still_diverges`) fails on it and reddens the `equiv-1` leg. The equiv-1 failure on this PR's first CI run was this, not the Makefile change.

## Verification

- `keywords.py` and `reference_grammar.py` pass locally (`Checked 177 reference grammar rule(s)`).
- `python3 test-deduce.py --equiv` -> `All tests passed` after the skip-set removal (fails before it, with the exact CI message).
- Both parsers produce the identical `cannot infer the type of an empty switch` error for the fixture, confirming it no longer diverges at parse time.
- `make` is not installed in this container, so the target-dedup behavior was reasoned from make semantics (a target is built at most once per invocation) rather than executed.

Closes #1052

Resume this session on ginger: `~/deduce-runner/resume.sh 8093ebb4-8fcc-4337-9376-7a19eefa9769 routine/20260717-170202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
