### PR TITLE
Dedup the "did you intend" edit-distance hint + rule-name resolution (refs #813)

### DIFF
--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -50,7 +50,7 @@ from flags import (
     view_aliasing_suppressed,
 )
 from pathlib import Path
-from edit_distance import edit_distance
+from edit_distance import did_you_mean_hint, edit_distance
 from math import ceil
 import os
 

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -65,12 +65,7 @@ class PVar(Proof):
                + " from other modules. To make it accessible here, change"
                + " `lemma` to `theorem` there.")
         user_error(self.location, msg)
-      from edit_distance import edit_distance
-      from math import ceil
-      close = [v for v in env.keys()
-               if edit_distance(self.name, v)
-                  <= ceil(len(self.name) / 5)]
-      hint = '\n\tdid you intend: ' + ', '.join(close) if close else ''
+      hint = did_you_mean_hint(self.name, env.keys())
       env_str = ('\n' + ', '.join(env.keys())) if get_verbose() else ''
       user_error(self.location,
                  "undefined proof variable " + self.name + hint + env_str)
@@ -611,6 +606,21 @@ class Induction(Proof):
     return 'induction ' + str(self.typ) + '\n' \
       + '\n'.join([str(c) for c in self.cases])
 
+def resolve_uniquify_name(loc: Meta, name: str, env_map: UniquifyEnv,
+                          not_found_msg: str) -> str:
+  """Resolve `name` to its canonical uniquified form via the uniquify env.
+
+  Reports `not_found_msg` (which must already include `name`) plus a
+  did-you-mean hint when `name` is absent. Shared by the rule-name lookups
+  in `RuleInductionCase`/`RuleInduction`/`RuleInversion.uniquify`.
+  """
+  if name not in env_map.keys():
+    user_error(loc, not_found_msg + did_you_mean_hint(name, env_map.keys()))
+  resolved = env_map[name]
+  if isinstance(resolved, list) and len(resolved) >= 1:
+    return cast(str, resolved[0])
+  return name
+
 @dataclass
 class RuleInductionCase(AST):
   # `case <rule_name> { <proof> }` from a `rule induction` block.
@@ -634,19 +644,9 @@ class RuleInductionCase(AST):
     # Resolve the rule name against the env so we can match against the
     # uniquified rule names later. Wrong names are reported with a
     # did-you-mean message.
-    if self.rule_name not in env_map.keys():
-      from edit_distance import edit_distance
-      from math import ceil
-      close = [v for v in env_map.keys()
-               if edit_distance(self.rule_name, v)
-                  <= ceil(len(self.rule_name) / 5)]
-      hint = '\n\tdid you intend: ' + ', '.join(close) if close else ''
-      user_error(self.location,
-                 "no such rule '" + self.rule_name + "'" + hint)
-    resolved = env_map[self.rule_name]
-    new_rule_name = self.rule_name
-    if isinstance(resolved, list) and len(resolved) >= 1:
-      new_rule_name = resolved[0]
+    new_rule_name = resolve_uniquify_name(
+        self.location, self.rule_name, env_map,
+        "no such rule '" + self.rule_name + "'")
     return RuleInductionCase(self.location, new_rule_name,
                              self.body.uniquify(env_map, uniq_ctx))
 
@@ -670,20 +670,9 @@ class RuleInduction(Proof):
   def uniquify(self, env: object, ctx: object) -> RuleInduction:
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
-    if self.hyp_name not in env_map.keys():
-      from edit_distance import edit_distance
-      from math import ceil
-      close = [v for v in env_map.keys()
-               if edit_distance(self.hyp_name, v)
-                  <= ceil(len(self.hyp_name) / 5)]
-      hint = '\n\tdid you intend: ' + ', '.join(close) if close else ''
-      user_error(self.location,
-                 "rule induction: no such predicate '"
-                 + self.hyp_name + "'" + hint)
-    resolved = env_map[self.hyp_name]
-    new_hyp_name = self.hyp_name
-    if isinstance(resolved, list) and len(resolved) >= 1:
-      new_hyp_name = resolved[0]
+    new_hyp_name = resolve_uniquify_name(
+        self.location, self.hyp_name, env_map,
+        "rule induction: no such predicate '" + self.hyp_name + "'")
     return RuleInduction(self.location, new_hyp_name,
                          [c.uniquify(env_map, uniq_ctx) for c in self.cases])
 
@@ -707,20 +696,9 @@ class RuleInversion(Proof):
   def uniquify(self, env: object, ctx: object) -> RuleInversion:
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
-    if self.hyp_name not in env_map.keys():
-      from edit_distance import edit_distance
-      from math import ceil
-      close = [v for v in env_map.keys()
-               if edit_distance(self.hyp_name, v)
-                  <= ceil(len(self.hyp_name) / 5)]
-      hint = '\n\tdid you intend: ' + ', '.join(close) if close else ''
-      user_error(self.location,
-                 "rule inversion: no such predicate '"
-                 + self.hyp_name + "'" + hint)
-    resolved = env_map[self.hyp_name]
-    new_hyp_name = self.hyp_name
-    if isinstance(resolved, list) and len(resolved) >= 1:
-      new_hyp_name = resolved[0]
+    new_hyp_name = resolve_uniquify_name(
+        self.location, self.hyp_name, env_map,
+        "rule inversion: no such predicate '" + self.hyp_name + "'")
     return RuleInversion(self.location, new_hyp_name,
                          [c.uniquify(env_map, uniq_ctx) for c in self.cases])
 

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -539,16 +539,10 @@ class Var(VarRef):
       if import_advice != '':
           static_error(self.location, import_advice)
 
-      close_matches = []
-      for var in env.keys():
-        if edit_distance(self.name, var) <= ceil(len(self.name) / 5):
-          close_matches.append(var)
-      if len(close_matches) > 0:
-        mispell_advice = '\n\tdid you intend: ' + ', '.join(close_matches) + '\n'
-      else:
-        mispell_advice = ''
-      static_error(self.location, 'undefined variable: ' + self.name \
-                   + mispell_advice + '' + env_str)
+      hint = did_you_mean_hint(self.name, env.keys())
+      mispell_advice = hint + '\n' if hint else ''
+      static_error(self.location, 'undefined variable: ' + self.name
+                   + mispell_advice + env_str)
 
     return OverloadedVar(self.location, self.typeof, env[self.name])
 

--- a/edit_distance.py
+++ b/edit_distance.py
@@ -20,6 +20,19 @@ def edit_distance(s1: str, s2: str) -> int:
             F[(i, j)] = min(match, delete, insert)
     return F[(m, n)]
 
+def did_you_mean_hint(name: str, candidates: Iterable[str]) -> str:
+    """Build a ``did you intend: ...`` suggestion for an undefined name.
+
+    Returns a newline-prefixed, tab-indented list of every candidate within
+    ``ceil(len(name) / 5)`` edits of ``name``, or the empty string when none
+    are close enough. Shared by the ``uniquify`` name-resolution error paths
+    for variables, proof variables, and rule-induction/inversion hypotheses.
+    """
+    close = [c for c in candidates
+             if edit_distance(name, c) <= ceil(len(name) / 5)]
+    return '\n\tdid you intend: ' + ', '.join(close) if close else ''
+
+
 def closest_keyword(word: str, keywords: Iterable[str]) -> Optional[str]:
     best_yet: Optional[tuple[str, int]] = None
     for kw in keywords:

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -287,7 +287,6 @@ SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/define_type.pf",
     "./test/should-error/define_with_type_params.pf",
     "./test/should-error/double_private.pf",
-    "./test/should-error/empty_switch_no_annotation.pf",
     "./test/should-error/fn_missing_arrow.pf",
     "./test/should-error/fun_params_trailing_comma.pf",
     "./test/should-error/function_case_missing_equal.pf",


### PR DESCRIPTION
## Summary

A focused code-duplication slice for the #813 umbrella, plus a one-line
test-harness fix that unblocks `test-deduce.py --equiv` on `main`.

### 1. Dedup the "did you intend" hint and rule-name resolution (refs #813)

The "find close names by edit distance, build a `did you intend: ...` hint"
block was repeated **five times**, four of them character-identical:

- `PVar.uniquify`, `RuleInductionCase.uniquify`, `RuleInduction.uniquify`,
  `RuleInversion.uniquify` in `abstract_syntax/proofs.py`
- `Var.uniquify` in `abstract_syntax/terms.py` (an explicit-loop variant with
  the same `ceil(len/5)` threshold and message, plus a trailing newline)

Extracted into `did_you_mean_hint(name, candidates)` in `edit_distance.py`
(already the home of `edit_distance`), imported in `abstract_syntax/core.py`
so it propagates through `from .core import *`. The `terms.py` call site keeps
its trailing newline locally so its message is byte-identical.

The three rule-induction/inversion `uniquify` methods also shared an identical
name-resolution tail (membership check + did-you-mean error + list-resolution
to the canonical uniquified name). Folded into a `resolve_uniquify_name`
helper in `proofs.py`; each method reduces to one call plus its constructor.

**Behavior is unchanged** — all five error messages render identically, as
confirmed by the unchanged `should-error` fixtures.

Net: `43 insertions(+), 59 deletions(-)` across the four files.

### 2. Drop stale `SHOULD_ERROR_PARSER_EQUIV_SKIP` entry (closes #1054)

While running `--equiv` as the pre-push gate I found it fails on a clean
`main`: `empty_switch_no_annotation.pf` now parses under both RD and LALR
(it errors only at type-check time after the empty-body work in #1043/#1044),
so `_check_should_error_skip_set` correctly flags its skip-set entry as stale.
Removing the entry makes `--equiv` green; the file passes the main
equivalence sweep. This is pre-existing and unrelated to the dedup (it
reproduces with the working tree stashed), filed as #1054 and fixed here so
this PR's parser-equivalence CI job is green.

## Testing

All local checks pass with both parsers:

- `ruff` + `mypy` (both `.` and `--no-site-packages`) clean
- `keywords.py` + `reference_grammar.py` clean
- `test-deduce.py --errors --warns --lib --passable --equiv` all pass
- Manually triggered the `did you intend` hint for an undefined variable and
  confirmed identical output

## Resuming this session

Resume this session on ginger: `~/deduce-runner/resume.sh 1e8bb489-0439-4053-aee3-ac4fc980e91e routine/20260717-180202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
