### PR TITLE
Drop stale empty_switch_no_annotation.pf from parser-equiv skip set (closes #1054)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -287,7 +287,6 @@ SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/define_type.pf",
     "./test/should-error/define_with_type_params.pf",
     "./test/should-error/double_private.pf",
-    "./test/should-error/empty_switch_no_annotation.pf",
     "./test/should-error/fn_missing_arrow.pf",
     "./test/should-error/fun_params_trailing_comma.pf",
     "./test/should-error/function_case_missing_equal.pf",


### PR DESCRIPTION
## Summary

`test-deduce.py --equiv` fails on current `main` because
`test/should-error/empty_switch_no_annotation.pf` is still listed in
`SHOULD_ERROR_PARSER_EQUIV_SKIP`. That file now parses cleanly under **both**
RD and LALR — empty `union`/`switch` bodies were accepted in #1043/#1044 — and
only errors later at type-check time (`cannot infer the type of an empty
switch`). `_check_should_error_skip_set` asserts that every skip-set entry is
still rejected at parse time by at least one parser, so the stale entry made
`--equiv` fail on a clean tree.

## Fix

Remove the single stale entry from `SHOULD_ERROR_PARSER_EQUIV_SKIP`. The file
now participates in the main parser-equivalence sweep, where both parsers
produce the same AST and it passes. It remains a `should-error` fixture (its
type-check-time error is unchanged).

## Verification

- `python3 test-deduce.py --equiv` — green (was 1 failure before)
- `python3 test-deduce.py --errors` — green (fixture still errors as expected)

Closes #1054.

Resume this session on ginger: `~/deduce-runner/resume.sh 29d1c05a-2193-4477-b9cf-b91a20f2560a routine/20260717-190202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
