### PR TITLE
lib: gcd/lcm commutativity + gcd-with-zero/self laws for UInt and Int (refs #720)

### DIFF
--- a/lib/IntDivides.pf
+++ b/lib/IntDivides.pf
@@ -353,3 +353,20 @@ proof
     by replace symmetric unfold in ul
   apply (conjunct 1 of int_divides_iff_abs[pos(lcm(abs(a), abs(b))), m]) to ul2
 end
+
+// Commutativity of `gcd` on `Int`, lifted from `uint_gcd_commutative`
+// through the `abs`-based definition.
+theorem int_gcd_commutative: all a:Int, b:Int. gcd(a, b) = gcd(b, a)
+proof
+  arbitrary a:Int, b:Int
+  expand gcd
+  replace uint_gcd_commutative[abs(a), abs(b)].
+end
+
+// Commutativity of `lcm` on `Int`, lifted from `uint_lcm_commutative`.
+theorem int_lcm_commutative: all a:Int, b:Int. lcm(a, b) = lcm(b, a)
+proof
+  arbitrary a:Int, b:Int
+  expand lcm
+  replace uint_lcm_commutative[abs(a), abs(b)].
+end

--- a/lib/UIntDiv.pf
+++ b/lib/UIntDiv.pf
@@ -1261,3 +1261,83 @@ proof
     }
   }
 end
+
+// `gcd(a, 0) = a`: definitional, since the `b = 0` guard selects `a`.
+theorem uint_gcd_zero_right: all a:UInt. gcd(a, 0) = a
+proof
+  arbitrary a:UInt
+  expand gcd.
+end
+
+// Commutativity of `gcd`. Proved through the universal property rather
+// than the (asymmetric) Euclidean recursion: each of `gcd(a,b)` and
+// `gcd(b,a)` divides the other by `uint_gcd_greatest`, so they are
+// equal by `uint_divides_antisymmetric`.
+theorem uint_gcd_commutative: all a:UInt, b:UInt. gcd(a, b) = gcd(b, a)
+proof
+  arbitrary a:UInt, b:UInt
+  have ab_a: divides(gcd(a, b), a) by uint_gcd_divides_left[a, b]
+  have ab_b: divides(gcd(a, b), b) by uint_gcd_divides_right[a, b]
+  have ba_a: divides(gcd(b, a), a) by uint_gcd_divides_right[b, a]
+  have ba_b: divides(gcd(b, a), b) by uint_gcd_divides_left[b, a]
+  have d1: divides(gcd(a, b), gcd(b, a))
+    by apply uint_gcd_greatest[gcd(a, b), b, a] to ab_b, ab_a
+  have d2: divides(gcd(b, a), gcd(a, b))
+    by apply uint_gcd_greatest[gcd(b, a), a, b] to ba_a, ba_b
+  apply uint_divides_antisymmetric[gcd(a, b), gcd(b, a)] to d1, d2
+end
+
+// `gcd(0, b) = b`, via commutativity and `uint_gcd_zero_right`.
+theorem uint_gcd_zero_left: all b:UInt. gcd(0, b) = b
+proof
+  arbitrary b:UInt
+  replace uint_gcd_commutative[0, b]
+  uint_gcd_zero_right[b]
+end
+
+// `gcd(a, a) = a`, again through the universal property.
+theorem uint_gcd_self: all a:UInt. gcd(a, a) = a
+proof
+  arbitrary a:UInt
+  have a_a: divides(a, a) by uint_divides_refl[a]
+  have d1: divides(a, gcd(a, a))
+    by apply uint_gcd_greatest[a, a, a] to a_a, a_a
+  have d2: divides(gcd(a, a), a) by uint_gcd_divides_left[a, a]
+  apply uint_divides_antisymmetric[gcd(a, a), a] to d2, d1
+end
+
+// Commutativity of `lcm`. An algebraic consequence of the product-form
+// definition: `a*b = b*a` and `gcd(a,b) = gcd(b,a)`.
+theorem uint_lcm_commutative: all a:UInt, b:UInt. lcm(a, b) = lcm(b, a)
+proof
+  arbitrary a:UInt, b:UInt
+  cases uint_zero_or_positive[a]
+  case a_z {
+    replace a_z.
+  }
+  case a_pos {
+    cases uint_zero_or_positive[b]
+    case b_z {
+      replace b_z.
+    }
+    case b_pos {
+      have a_ne: not (a = 0) by apply uint_pos_not_zero to a_pos
+      have b_ne: not (b = 0) by apply uint_pos_not_zero to b_pos
+      have cond_ab: not (a = 0 or b = 0) by {
+        assume c
+        cases c
+        case l { apply a_ne to l }
+        case r { apply b_ne to r }
+      }
+      have cond_ba: not (b = 0 or a = 0) by {
+        assume c
+        cases c
+        case l { apply b_ne to l }
+        case r { apply a_ne to r }
+      }
+      expand lcm
+      replace (apply eq_false to cond_ab) | (apply eq_false to cond_ba)
+      replace uint_mult_commute[a, b] | uint_gcd_commutative[a, b].
+    }
+  }
+end


### PR DESCRIPTION
## What

Adds the remaining gcd/lcm **convenience laws** for the `UInt`/`Int` division
theory tracked by #720. The core div/mod/divides/gcd/lcm story (rounding
convention, `%`/`mod`, `int_div_mod` + bounds, `divides` closure/antisymmetry,
gcd/lcm divisibility, `gcd_greatest`) already landed via #939, #1013, and #1027;
this fills out the "rich `UIntDiv.pf`-style theorem set" with the standard
commutativity/identity laws that were still missing.

New theorems:

**`lib/UIntDiv.pf`**
- `uint_gcd_zero_right : gcd(a, 0) = a`
- `uint_gcd_zero_left  : gcd(0, b) = b`
- `uint_gcd_self       : gcd(a, a) = a`
- `uint_gcd_commutative: gcd(a, b) = gcd(b, a)`
- `uint_lcm_commutative: lcm(a, b) = lcm(b, a)`

**`lib/IntDivides.pf`**
- `int_gcd_commutative : gcd(a, b) = gcd(b, a)`
- `int_lcm_commutative : lcm(a, b) = lcm(b, a)`

## How

- `gcd` commutativity and `gcd_self` are proved via the **universal property**
  (`uint_gcd_greatest` + `uint_divides_antisymmetric`), not the asymmetric
  Euclidean recursion: each side divides the other, so they are equal by
  antisymmetry of `divides`.
- `gcd_zero_right` is definitional; `gcd_zero_left` follows by commutativity.
- `lcm` commutativity is an algebraic consequence of the product-form
  definition `(a*b)/gcd(a,b)`, using `uint_mult_commute` and
  `uint_gcd_commutative` (with a case split on the zero operands).
- The `Int` versions lift from the `UInt` ones through the `abs`-based
  `Int` definitions of `gcd`/`lcm`.

## Testing

- `python3 deduce.py lib/UIntDiv.pf lib/IntDivides.pf` valid under both
  `--recursive-descent` and `--lalr`.
- `python3 test-deduce.py --lib` — all lib tests pass (both parsers).
- `python3 test-deduce.py --equiv` — the only failure is the **pre-existing**
  #1054 (stale `SHOULD_ERROR_PARSER_EQUIV_SKIP` entry
  `empty_switch_no_annotation.pf` on `main`), which is unrelated to this
  `.pf`-only change.

## Scope note

This does not close #720: the issue also lists optional Bezout-style theorems as
follow-up, and the lcm universal property (`lcm_least`) is in flight in #1057.
So this is `Refs #720`, not a closing keyword.

Refs #720

Resume this session on ginger: `~/deduce-runner/resume.sh 2ffae112-4b32-494a-885e-2b6732a17685 routine/20260717-210202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
