### PR TITLE
Fast-path UInt literal evaluation under eval_all (closes #1050)

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -527,6 +527,57 @@ def try_fast_lit_nat_arith(loc: Meta, rator: Term, args: list[Term],
                    sname=suc_name or 'suc')
   return Call(loc, ty, _resolved_or_var(loc, None, lit_name), [inner])
 
+def _mk_uint_from_int(loc: Meta, n: int, ty: Type | None, env: Env) -> Term | None:
+  # Build the compact ``Binary`` value for ``n`` using the environment's
+  # uniquified constructor names, so the result is structurally identical
+  # to what the opaque recursive reduction would produce.
+  bz = env.base_to_unique('bzero')
+  di = env.base_to_unique('dub_inc')
+  idd = env.base_to_unique('inc_dub')
+  if bz is None or di is None or idd is None:
+    return None
+  return intToUInt(loc, n, bzero=bz, dubinc=di, incdub=idd, uint_ty=ty)
+
+def try_fast_uint_arith(loc: Meta, rator: Term, args: list[Term],
+                        ty: Type | None, env: Env) -> Term | None:
+  # Full-evaluation (``assert``/``evaluate``) fast path for UInt.  A UInt
+  # literal enters the evaluator as ``fromNat(<unary Nat of depth N>)``,
+  # whose opaque unfolding is O(N); and the recursive ``Binary`` division
+  # operator is O(N/M).  Both make ``assert`` on large literals take tens
+  # of seconds (issue #1050).  Here we compute the result with Python ints
+  # and emit the compact ``Binary`` value directly.  Returns None unless
+  # every operand is a concrete UInt literal, so symbolic terms fall
+  # through to normal reduction.  Only sound under ``eval_all``, where the
+  # ``fromNat``/``Binary``-operator shape that proof automation keys on is
+  # already being reduced away.
+  if not isinstance(rator, (Var, OverloadedVar, ResolvedVar)):
+    return None
+  op = base_name(rator.get_name())
+  if op == 'fromNat' and len(args) == 1 and isNat(args[0]):
+    return _mk_uint_from_int(loc, natToInt(args[0]), ty, env)
+  if op not in ('+', '*', '∸', '/', '%', '<', '≤'):
+    return None
+  if len(args) != 2 or not (isUInt(args[0]) and isUInt(args[1])):
+    return None
+  a = uintToInt(args[0])
+  b = uintToInt(args[1])
+  if op == '<':
+    return Bool(loc, ty, a < b)
+  if op == '≤':
+    return Bool(loc, ty, a <= b)
+  if op == '+':
+    result_int = a + b
+  elif op == '*':
+    result_int = a * b
+  elif op == '∸':
+    result_int = max(0, a - b)
+  elif op == '/':
+    # UInt division truncates and defines n / 0 = 0 (lib/UIntDiv.pf).
+    result_int = a // b if b != 0 else 0
+  else:  # '%' : n % m = n ∸ (n / m) * m, so n % 0 = n (lib/UIntDiv.pf).
+    result_int = a % b if b != 0 else a
+  return _mk_uint_from_int(loc, result_int, ty, env)
+
 def _same_numeric_literal(t1: AST, t2: AST) -> bool:
   if not isinstance(t1, Term) or not isinstance(t2, Term):
     return False

--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -527,6 +527,22 @@ def try_fast_lit_nat_arith(loc: Meta, rator: Term, args: list[Term],
                    sname=suc_name or 'suc')
   return Call(loc, ty, _resolved_or_var(loc, None, lit_name), [inner])
 
+def _uint_binary_name(env: Env) -> str | None:
+  # Unique name of the UInt library's private ``Binary`` representation
+  # type. It is ``private`` to the UInt module, so a user file cannot
+  # name it: a call whose result type is this ``Binary`` is therefore a
+  # library UInt operation, which is what lets the fast path tell the
+  # built-in UInt conversion/arithmetic apart from a same-named user
+  # overload (e.g. ``fun fromNat(n:Nat) -> Nat``).
+  return env.base_to_unique('Binary')
+
+def _is_uint_binary_type(ty: Type | VarRef | None, env: Env) -> bool:
+  # A named type such as ``Binary`` is represented as a ``VarRef`` node.
+  binary_name = _uint_binary_name(env)
+  return binary_name is not None \
+      and isinstance(ty, VarRef) \
+      and ty.get_name() == binary_name
+
 def _mk_uint_from_int(loc: Meta, n: int, ty: Type | None, env: Env) -> Term | None:
   # Build the compact ``Binary`` value for ``n`` using the environment's
   # uniquified constructor names, so the result is structurally identical
@@ -550,11 +566,22 @@ def try_fast_uint_arith(loc: Meta, rator: Term, args: list[Term],
   # through to normal reduction.  Only sound under ``eval_all``, where the
   # ``fromNat``/``Binary``-operator shape that proof automation keys on is
   # already being reduced away.
+  #
+  # To avoid hijacking a same-named user overload (issue #1050 review),
+  # value-producing operations require the call's result type to be the
+  # UInt library's private ``Binary`` -- unspoofable by user code -- so a
+  # user ``fromNat : Nat -> Nat`` (or any op not returning UInt) is left
+  # to normal reduction.  Comparisons return ``bool``, so they instead
+  # rely on both operands being genuine UInt values (built from the
+  # private UInt constructors), the same operand-type guard the Nat fast
+  # path uses.
   if not isinstance(rator, (Var, OverloadedVar, ResolvedVar)):
     return None
   op = base_name(rator.get_name())
-  if op == 'fromNat' and len(args) == 1 and isNat(args[0]):
-    return _mk_uint_from_int(loc, natToInt(args[0]), ty, env)
+  if op == 'fromNat':
+    if len(args) == 1 and isNat(args[0]) and _is_uint_binary_type(ty, env):
+      return _mk_uint_from_int(loc, natToInt(args[0]), ty, env)
+    return None
   if op not in ('+', '*', '∸', '/', '%', '<', '≤'):
     return None
   if len(args) != 2 or not (isUInt(args[0]) and isUInt(args[1])):
@@ -565,6 +592,8 @@ def try_fast_uint_arith(loc: Meta, rator: Term, args: list[Term],
     return Bool(loc, ty, a < b)
   if op == '≤':
     return Bool(loc, ty, a <= b)
+  if not _is_uint_binary_type(ty, env):
+    return None
   if op == '+':
     result_int = a + b
   elif op == '*':

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         nodeListToList,
         nodeListToString,
         try_fast_lit_nat_arith,
+        try_fast_uint_arith,
         uintToInt,
     )
     from .ops import (
@@ -1244,6 +1245,11 @@ class Call(Term):
       fast = try_fast_lit_nat_arith(self.location, self.rator, args, self.typeof)
       if fast is not None:
         return auto_rewrites(fast, env)
+    else:
+      fast_uint = try_fast_uint_arith(self.location, self.rator, args,
+                                      self.typeof, env)
+      if fast_uint is not None:
+        return fast_uint
     ret: Term | None = None
     match fun:
       case Var(loc, _, '=') | OverloadedVar(loc, _, ['=']) | ResolvedVar(loc, _, '='):

--- a/test/should-validate/large_numeric_literals.pf
+++ b/test/should-validate/large_numeric_literals.pf
@@ -4,14 +4,28 @@ import UInt
 // Large-but-supported numeric literals must *type-check* near MAX_LITERAL
 // (4000) without blowing the recursion limit -- the regression from #1021.
 //
-// Type-checking a large literal is cheap; it is runtime *evaluation* of UInt
-// arithmetic on such values that is pathologically slow under the unary
-// literal representation (see #1050, and the binary-literal work in #1025),
-// and it was making this one file dominate CI (~100s/parser). So we keep the
-// type-check coverage for both Nat and UInt large literals and arithmetic
-// expressions, and evaluate only on the cheap Nat path.
+// Runtime *evaluation* of UInt arithmetic on such values used to be
+// pathologically slow under the unary literal representation (~100s/parser
+// for this file, see #1050): a UInt literal enters the evaluator as
+// `fromNat(<unary Nat of depth N>)`, whose opaque unfolding is O(N). The
+// `eval_all` fast path (`try_fast_uint_arith`) now computes `fromNat`,
+// arithmetic, and comparison on concrete literal operands with Python ints,
+// so these asserts are cheap again.
 define _big_uint : UInt = 4000
 define _sum_uint : UInt = 1500 + 1500
 define _lt_uint  : bool = 3000 < 4000
 define _big_nat  : Nat  = ℕ4000
 assert ℕ3000 = ℕ3000
+
+// UInt runtime-evaluation coverage restored now that large literals evaluate
+// in O(log N) (#1050): equality, ordering, and each arithmetic operator on
+// values near MAX_LITERAL.
+assert 4000 = 4000
+assert not (4000 = 3999)
+assert 3000 < 4000
+assert 3000 ≤ 3000
+assert not (4000 < 3000)
+assert 2000 + 2000 = 4000
+assert 4000 ∸ 1500 = 2500
+assert 4000 / 7 = 571
+assert 4000 % 7 = 3

--- a/test/should-validate/uint_fast_path_overload.pf
+++ b/test/should-validate/uint_fast_path_overload.pf
@@ -1,0 +1,20 @@
+import Nat
+import UInt
+
+// Regression test for the #1050 UInt evaluation fast path
+// (`try_fast_uint_arith`): it must not hijack a same-named *user* overload.
+//
+// `fromNat` is exported by UInt as `Nat -> UInt`. A user file may define
+// its own `fromNat : Nat -> Nat`. The fast path matches operators by base
+// name, so it must additionally require the call's result type to be the
+// UInt library's private `Binary` before replacing semantics -- otherwise
+// this user `fromNat`, resolved by the type checker at expected type Nat,
+// would be evaluated as the built-in UInt conversion and yield a UInt
+// value instead of the intended Nat.
+fun fromNat(n : Nat) { n + ℕ1 }
+
+// Resolved to the user function via the expected type; must reduce with
+// the user body (5 + 1 = 6), NOT the UInt conversion. Before the
+// result-type guard this asserted `5 ≠ 6` (LHS collapsed to UInt 5).
+define user_r : Nat = fromNat(ℕ5)
+assert user_r = ℕ6


### PR DESCRIPTION
## Summary

Closes #1050.

Runtime evaluation of `UInt` arithmetic/comparison on large literals was
pathologically slow. A `UInt` literal enters the evaluator as
`fromNat(<unary Nat of depth N>)`, whose `opaque` unfolding is O(N), and the
recursive `Binary` division operator is O(N/M). Under `assert`/`evaluate`
(which set `eval_all`) these unfold through the full tree-rewriter, so
`assert 4000 = 4000` took ~37s and the `large_numeric_literals.pf` regression
test cost ~107s **per parser** — effectively the entire CI bottleneck tracked
in #1049.

## Approach

Rather than block on the full binary-literal migration (#1025, which changes the
literal *AST shape* and would break `UInt` proof automation globally), this adds
an evaluation fast path that keeps the shape and only changes reduction speed —
directly analogous to the existing Nat `try_fast_lit_nat_arith`.

`try_fast_uint_arith` (in `abstract_syntax/literals.py`, called from
`Call.reduce`) recognizes concrete `UInt` literal operands and computes the
result with Python ints, emitting the compact `Binary` value directly:

- `fromNat(<concrete Nat>)` → the compact `Binary` value in O(log N) (this is
  the dominant win; once operands are compact, `=`/`<`/`+` are already O(log N)).
- `+`, `*`, `∸`, `/`, `%`, `<`, `≤` on two concrete `UInt` literals.
- `=` is left to the generic structural-equality path (operands are already
  compact after `fromNat` is fast).

It fires **only under `eval_all`** (`assert`/`evaluate`), where the
`fromNat(lit(...))`/`Binary`-operator shape is being reduced away regardless, so
the result is structurally identical to what the slow opaque unfolding produces
and symbolic proofs are untouched. It returns `None` unless every operand is a
concrete `UInt` literal, so symbolic terms fall through to normal reduction.
`n / 0 = 0` and `n % 0 = n` match `lib/UIntDiv.pf`.

**Not hijacking user overloads** (per the Codex review): matching by base name
alone would evaluate a same-named user overload (e.g. `fun fromNat(n:Nat) -> Nat`)
as the built-in UInt conversion. Value-producing operations therefore also
require the call's result type to be the UInt library's `private` `Binary`
representation — unspoofable by user code — so a user `fromNat` returning `Nat`
(or any op not returning UInt) is left to normal reduction. Comparisons return
`bool`, so they keep the operand-type guard (both operands must be genuine UInt
values). Covered by `test/should-validate/uint_fast_path_overload.pf`, which
fails on the pre-fix logic.

## Results

| expression | before | after |
|------------|--------|-------|
| `assert 4000 = 4000` | ~37s | <0.1s |
| `assert 3000 < 4000` | ~30s | <0.1s |
| `assert 2000 + 2000 = 4000` | ~29s | <0.1s |
| `large_numeric_literals.pf` (whole file) | ~107s/parser | ~14s/parser |

The trimmed UInt runtime-eval coverage is restored in
`test/should-validate/large_numeric_literals.pf` (equality, ordering, and each
arithmetic operator near `MAX_LITERAL`), now that it is cheap.

## Testing

- `python3 test-deduce.py` (full default harness: lib + should-validate ×2
  parsers + should-error + should-warn + parser equivalence + round-trip) — all
  pass.
- `python3 -m ruff check .` and `python3 -m mypy .` — clean.
- Correctness spot-checks against hand-computed values for `=`, `<`, `≤`, `+`,
  `∸`, `/`, `%`, including saturating monus, div/mod by zero, and negative
  (must-fail) assertions.

Resume this session on ginger: `~/deduce-runner/resume.sh 97a39018-ccaf-4e38-b5e2-d5b566d0f928 routine/20260717-220201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)