### PR TITLE
lib: prove gcd*lcm product identity for UInt and Int (refs #720)

### DIFF
--- a/lib/IntDivides.pf
+++ b/lib/IntDivides.pf
@@ -370,3 +370,18 @@ proof
   expand lcm
   replace uint_lcm_commutative[abs(a), abs(b)].
 end
+
+// The product of the gcd and lcm recovers the (absolute) product of the
+// arguments: `gcd(a, b) * lcm(a, b) = pos(abs(a * b))`. Both `gcd` and
+// `lcm` are nonnegative on `Int` (defined via `pos`/`abs`), so the product
+// equals `|a * b|`; it lifts the `UInt` identity `uint_gcd_lcm_product`
+// through `mult_pos_pos` and `int_abs_mult`.
+theorem int_gcd_lcm_product: all a:Int, b:Int.
+  gcd(a, b) * lcm(a, b) = pos(abs(a * b))
+proof
+  arbitrary a:Int, b:Int
+  expand gcd | lcm
+  replace mult_pos_pos[gcd(abs(a), abs(b)), lcm(abs(a), abs(b))]
+  replace uint_gcd_lcm_product[abs(a), abs(b)]
+  replace int_abs_mult[a, b].
+end

--- a/lib/UIntDiv.pf
+++ b/lib/UIntDiv.pf
@@ -1341,3 +1341,44 @@ proof
     }
   }
 end
+
+// The product of the gcd and lcm recovers the product of the arguments:
+// `gcd(a, b) * lcm(a, b) = a * b`. In the interesting case
+// `lcm(a, b) = (a * b) / gcd(a, b)`; since `gcd(a, b)` divides `a` (hence
+// `a * b`), the quotient is exact, so multiplying it back by `gcd(a, b)`
+// recovers `a * b`.
+theorem uint_gcd_lcm_product: all a:UInt, b:UInt. gcd(a, b) * lcm(a, b) = a * b
+proof
+  arbitrary a:UInt, b:UInt
+  cases uint_zero_or_positive[a]
+  case a_z {
+    replace a_z.
+  }
+  case a_pos {
+    cases uint_zero_or_positive[b]
+    case b_z {
+      replace b_z.
+    }
+    case b_pos {
+      have g_pos: 0 < gcd(a, b) by apply uint_gcd_pos[a, b] to a_pos
+      have g_div_a: divides(gcd(a, b), a) by uint_gcd_divides_left[a, b]
+      obtain k where gk_a: gcd(a, b) * k = a from expand divides in g_div_a
+      have a_ne: not (a = 0) by apply uint_pos_not_zero to a_pos
+      have b_ne: not (b = 0) by apply uint_pos_not_zero to b_pos
+      have cond_false: not (a = 0 or b = 0) by {
+        assume c
+        cases c
+        case l { apply a_ne to l }
+        case r { apply b_ne to r }
+      }
+      have prod_eq: a * b = gcd(a, b) * (k * b) by {
+        have s1: a * b = (gcd(a, b) * k) * b by replace gk_a.
+        replace s1.
+      }
+      expand lcm
+      replace (apply eq_false to cond_false)
+      replace prod_eq
+      replace (apply uint_mult_div_left_inverse[k * b, gcd(a, b)] to g_pos).
+    }
+  }
+end


### PR DESCRIPTION
## What

Adds the **gcd·lcm product identity** to the `UInt`/`Int` division theory
tracked by #720 — a core "rich theorem set" law that was still missing:

- **`uint_gcd_lcm_product`** (`lib/UIntDiv.pf`): `gcd(a, b) * lcm(a, b) = a * b`
- **`int_gcd_lcm_product`** (`lib/IntDivides.pf`): `gcd(a, b) * lcm(a, b) = pos(abs(a * b))`

The gcd side already had `gcd_divides_*` and `gcd_greatest`, and the lcm
side had `divides_lcm_left`/`divides_lcm_right`; this ties the two together
with the standard identity relating their product to the product of the
arguments.

## How

- **UInt.** Case-split on the zero operands (both sides collapse to `0`). In
  the interesting case `lcm(a, b) = (a * b) / gcd(a, b)`; since `gcd(a, b)`
  divides `a` — writing `gcd(a, b) * k = a`, so `a * b = gcd(a, b) * (k * b)`
  — the quotient is exact, and `uint_mult_div_left_inverse` (with
  `gcd(a, b) > 0` from `uint_gcd_pos`) cancels the division back to `a * b`.
- **Int.** `gcd`/`lcm` are nonnegative on `Int` (defined via `pos`/`abs`), so
  their product equals `|a * b|`. The proof lifts the `UInt` identity through
  `mult_pos_pos` (`pos(x) * pos(y) = pos(x * y)`) and `int_abs_mult`
  (`abs(x * y) = abs(x) * abs(y)`).

This uses only lemmas already on `main`, so it is independent of the
in-flight #1057 (`lcm_least`) and #1058 (commutativity / zero / self laws)
and should rebase cleanly against whichever of those merges first.

## Testing

- `python3 deduce.py lib/UIntDiv.pf` and `lib/IntDivides.pf` — valid, no warnings.
- `python3 test-deduce.py --lib` — all lib files pass under **both** parsers (RD + LALR).
- `python3 gh_pages/scripts/keywords.py` and `reference_grammar.py` — clean.

## Relation to #720

Refs #720. This adds one more coherent law to the div/mod/gcd/lcm theorem
set; other convenience laws and any Bezout-style follow-up remain, so the
umbrella stays open.

Resume this session on ginger: `~/deduce-runner/resume.sh b44563de-0836-43ae-b7b8-f3ce0a8a4fd1 routine/20260718-000202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
