### PR TITLE
Render UInt zero value as 0 instead of bzero (closes #1062)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -325,6 +325,13 @@ class PatternCons(Pattern):
     return PatternCons(self.location, self.constructor, params)
 
   def __str__(self) -> str:
+      # A pattern's constructor must print as a constructor, never as the
+      # decimal value-sugar `ResolvedVar.__str__` gives UInt zero: `case 0`
+      # would reparse as the `Nat` `zero` pattern, not the `Binary` `bzero`
+      # constructor (unlike `empty`->`[]`, which does reparse as the nil
+      # pattern).
+      if isBZero(self.constructor):
+        return 'bzero'
       if len(self.parameters) > 0:
         ctor = applied_head_str(self.constructor) or str(self.constructor)
         return ctor \

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
         getSuc,
         getZero,
         intToNat,
+        isBZero,
         isDeduceInt,
         isLitNat,
         isLitUInt,
@@ -703,6 +704,11 @@ class ResolvedVar(VarRef):
   def __str__(self) -> str:
     if base_name(self.name) == 'empty' and not get_unique_names() and not get_verbose():
       return '[]'
+    elif isBZero(self) and not get_verbose():
+      # UInt zero is the value `bzero`; render it as the decimal literal `0`,
+      # matching the `Call.__str__` UInt branch that already prints nonzero
+      # binary values (inc_dub/dub_inc trees) back as decimals.
+      return '0'
     elif get_unique_names():
       return name2str(self.name) + '{' + self.name + '}'
     elif is_var_operator(self):

--- a/test/unit/test_uint_display.py
+++ b/test/unit/test_uint_display.py
@@ -43,3 +43,12 @@ def test_uint_zero_prints_decimal_under_unique_names() -> None:
     # decimals; zero must be consistent with them.
     set_unique_names(True)
     assert str(ast.intToUInt(Meta(), 0)) == "0"
+
+
+def test_bzero_pattern_constructor_stays_bzero() -> None:
+    # The value-sugar must not leak into pattern/constructor position:
+    # `case 0` would reparse as the Nat `zero` pattern, not the Binary
+    # `bzero` constructor. A resolved `bzero` pattern constructor (as the
+    # induction/predicate machinery builds) must print as `bzero`.
+    pat = ast.PatternCons(Meta(), ast.ResolvedVar(Meta(), None, "bzero"), [])
+    assert str(pat) == "bzero"

--- a/test/unit/test_uint_display.py
+++ b/test/unit/test_uint_display.py
@@ -1,0 +1,45 @@
+"""Unit tests for UInt value display (issue #1062).
+
+A ``UInt`` value that reduces to zero is the bare nullary constructor
+``bzero`` (a ``ResolvedVar``), while every nonzero value is a ``Call``
+(``inc_dub``/``dub_inc`` tree). Both must print as decimals in the
+default display mode; only ``--verbose`` shows the raw binary form.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from lark.tree import Meta
+
+import abstract_syntax as ast
+from flags import set_unique_names, set_verbose
+
+
+@pytest.fixture(autouse=True)
+def _reset_display_flags() -> Iterator[None]:
+    set_unique_names(False)
+    set_verbose(False)
+    yield
+    set_unique_names(False)
+    set_verbose(False)
+
+
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 255, 1000])
+def test_uint_value_prints_as_decimal(n: int) -> None:
+    # Regression: zero used to print as ``bzero`` because the bare
+    # constructor never reaches the ``Call.__str__`` UInt branch.
+    assert str(ast.intToUInt(Meta(), n)) == str(n)
+
+
+def test_uint_zero_stays_raw_under_verbose() -> None:
+    set_verbose(True)
+    assert str(ast.intToUInt(Meta(), 0)) == "bzero"
+
+
+def test_uint_zero_prints_decimal_under_unique_names() -> None:
+    # Nonzero UInt values already ignore --unique-names and print as
+    # decimals; zero must be consistent with them.
+    set_unique_names(True)
+    assert str(ast.intToUInt(Meta(), 0)) == "0"


### PR DESCRIPTION
## What

A `UInt` value that reduces to zero displayed as the internal binary
constructor name `bzero` instead of the decimal literal `0`, in both `print`
output and error/goal messages:

```
$ cat bzero.pf
import UInt
print 0
print 1
assert 3 % 3 = 1
$ python3 deduce.py bzero.pf     # before
bzero
1
bzero.pf:4.1-4.17: assertion failed:
	bzero ≠ 1
```

Every *nonzero* `UInt` value already printed as a decimal, so zero was the odd
one out and leaked an internal name to users.

## Why

`UInt` values use the compact binary representation (`bzero` / `inc_dub` /
`dub_inc`). A nonzero value is a `Call` (`inc_dub(...)` / `dub_inc(...)`), so
`Call.__str__` (`abstract_syntax/terms.py`) hits its `isUInt(self) and not
get_verbose()` branch and prints `str(uintToInt(self))`. But `UInt` zero is the
bare nullary constructor `bzero`, a `ResolvedVar`, which never reaches
`Call.__str__`; `ResolvedVar.__str__` had no `bzero`→`0` case (only the
list-nil `empty`→`[]` sugar), so it fell through to `name2str` and printed
`bzero`.

## Change

- Give `ResolvedVar.__str__` a `bzero`→`"0"` case, gated on the same
  `not get_verbose()` condition the `Call` UInt branch uses. All `UInt` values
  now display as decimals in the default and `--unique-names` modes and stay
  raw only under `--verbose` (which is the mode that intentionally shows binary
  internals).
- Add `test/unit/test_uint_display.py` locking in the display of `0`, nonzero
  values, the `--verbose` raw form, and the `--unique-names` case. (This ran as
  `make tests-unit`; verified it fails on the two zero cases without the fix.)

After:

```
$ python3 deduce.py bzero.pf
0
1
bzero.pf:4.1-4.17: assertion failed:
	0 ≠ 1
```

## Testing

- `python3 -m ruff check .` — clean
- `python3 -m mypy .` — clean (54 files)
- `python3 -m pytest test/unit/` — 566 passed
- `python3 test-deduce.py` — all passed (lib + should-validate ×2 parsers +
  should-error + should-warn + parser equivalence)

## Scope note

This is a defect in the display of the already-live binary *value*
representation and is independent of the larger #1025 literal-*parsing*
migration; it closes the `bzero` gap in the pretty-print path that #1025's
scope notes call out. `Refs #1025`.

Closes #1062
Refs #1025

Resume this session on ginger: `~/deduce-runner/resume.sh 8f7c8bb8-4fc8-4133-a78a-df5c1df8dcb7 routine/20260718-010202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
