### PR TITLE
Print UInt zero value as `0` instead of `bzero` (closes #1062)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -708,6 +708,8 @@ class ResolvedVar(VarRef):
   def __str__(self) -> str:
     if base_name(self.name) == 'empty' and not get_unique_names() and not get_verbose():
       return '[]'
+    elif base_name(self.name) == 'bzero' and not get_unique_names() and not get_verbose():
+      return '0'
     elif get_unique_names():
       return name2str(self.name) + '{' + self.name + '}'
     elif is_var_operator(self):

--- a/test/should-error/uint_zero_prints_decimal.pf
+++ b/test/should-error/uint_zero_prints_decimal.pf
@@ -1,0 +1,7 @@
+// Issue #1062 regression: a UInt value that reduces to zero must print as
+// the decimal `0`, not the internal binary constructor name `bzero`. The
+// failing assertion below forces the reduced zero (`3 % 3`) into the error
+// message; a `bzero` substring in the fixture would mean the leak is back.
+import UInt
+
+assert 3 % 3 = 1

--- a/test/should-error/uint_zero_prints_decimal.pf.err
+++ b/test/should-error/uint_zero_prints_decimal.pf.err
@@ -1,0 +1,3 @@
+./test/should-error/uint_zero_prints_decimal.pf:7.1-7.17: assertion failed:
+	0 ≠ 1
+


### PR DESCRIPTION
## Summary

Fixes the `UInt` zero-value display bug from #1062: a `UInt` value that reduces
to the bare nullary constructor `bzero` printed its internal name instead of the
decimal `0`, even though every nonzero `UInt` already renders as a decimal.

## Root cause

Nonzero `UInt` values are `Call`s (`inc_dub(...)` / `dub_inc(...)`), so
`Call.__str__` collapses them to a decimal via `uintToInt`. But `UInt` zero is
the bare `bzero` `ResolvedVar`, which never reaches `Call.__str__`.
`ResolvedVar.__str__` only special-cased the list-nil `empty` → `[]` and fell
through to `name2str`, leaking `bzero` into `print`, `assert`, and goal/error
output.

## Fix

Add the parallel `bzero` → `0` case in `ResolvedVar.__str__`
(`abstract_syntax/terms.py`), guarded exactly like the `empty` case
(`not get_unique_names() and not get_verbose()`).

Before:

```
bzero
...
	bzero ≠ 1
```

After:

```
0
...
	0 ≠ 1
```

## Test

Adds `test/should-error/uint_zero_prints_decimal.pf`, which asserts
`3 % 3 = 1` to force the reduced zero into the failure message; the fixture
would contain `bzero` if the leak regressed.

Ran `python3 test-deduce.py --errors --warns` and `--equiv` (RD + LALR): all
pass.

Closes #1062.

Resume this session on ginger: `~/deduce-runner/resume.sh 870fb5a7-2c46-43ab-8e74-aa9cd7deb3ae routine/20260718-020201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
