### PR TITLE
Respect private visibility on postulates when exporting (closes #1065)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -562,7 +562,8 @@ class Postulate(Declaration):
                      visibility=self.visibility)
 
   def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
-    export_env[base_name(self.name)] = [self.name]
+    if self.visibility != 'private' or importing_module == get_current_module():
+      export_env[base_name(self.name)] = [self.name]
 
 @dataclass
 class Theorem(Declaration):

--- a/abstract_syntax/theorems.py
+++ b/abstract_syntax/theorems.py
@@ -57,7 +57,8 @@ def collect_public(s: Statement, to_print: list[TheoremFilePrinting]) -> None:
       if not s.isLemma:
         to_print.append(s)
     elif isinstance(s, Postulate):
-      to_print.append(s)
+      if s.visibility != 'private':
+        to_print.append(s)
     elif isinstance(s, Auto):
       if not _auto_target_is_private(s.name):
         to_print.append(s)

--- a/test/should-error/import_postulate.pf
+++ b/test/should-error/import_postulate.pf
@@ -1,0 +1,6 @@
+import Private
+
+theorem T: true
+proof
+  cant_import_postulate
+end

--- a/test/should-error/import_postulate.pf.err
+++ b/test/should-error/import_postulate.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/import_postulate.pf:5.3-5.24: undefined proof variable cant_import_postulate

--- a/test/test-imports/Private.pf
+++ b/test/test-imports/Private.pf
@@ -7,3 +7,5 @@ lemma cant_import_lemma: true
 proof
   .
 end
+
+private postulate cant_import_postulate: true


### PR DESCRIPTION
## Summary

`private postulate` was silently exported to importing modules. `Postulate.collect_exports` ignored visibility entirely, so a postulate declared `private` in one module was usable from another — unlike every other name-exporting declaration (`Union`, `Define`, `RecFun`, …) and the analogous module-private `lemma`. In the issue's repro this even let an importer "prove" `true = false` from another module's private axiom.

## Fix

Add the standard private-visibility guard to `Postulate.collect_exports`, matching `ProcDecl`/`Define`/`Theorem`:

```python
def collect_exports(self, export_env, importing_module):
    if self.visibility != 'private' or importing_module == get_current_module():
      export_env[base_name(self.name)] = [self.name]
```

A `private postulate` is now hidden from importers (importer gets the ordinary `undefined proof variable` error), while remaining usable within its own module. Public postulates are unaffected.

## Verification

Repro from the issue now errors instead of validating:

```
/tmp/pt/useit.pf:2.41-2.52: undefined proof variable secret_fact
```

Confirmed all three cases:
- private postulate from another module → hidden (error) ✓
- public postulate from another module → visible (valid) ✓
- private postulate within the same module → visible (valid) ✓

## Tests

- Added `private postulate cant_import_postulate` to `test/test-imports/Private.pf` (alongside the existing private `lemma`/`union`).
- New `test/should-error/import_postulate.pf` + `.err` fixture mirroring `import_lemma.pf`, asserting the private postulate is not importable.
- Full `python3 test-deduce.py` (both parsers, should-validate/error/warn, parser equivalence) passes.

Closes #1065

Resume this session on ginger: `~/deduce-runner/resume.sh 3dc6eb8b-b61e-45bd-84cc-46a3f96bbc86 routine/20260718-040202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
