### PR TITLE
Accept interleaved proof instantiation h[x]<T> under RD (refs #473)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -1021,26 +1021,33 @@ def parse_proof_med() -> Proof:
     start_token = current_token()
     proof = parse_proof_hi()
 
-    while (not end_of_file()) and current_token().type == 'LESSTHAN':
-      while_parsing= 'while trying to parse type arguments for instantiation of an "all" formula:\n\t'\
-              + 'proof ::= proof "<" type_list ">"'
-      advance()
-      try:
-        type_list = parse_type_list()
-        consume_token('MORETHAN', 'a closing ">"')
+    # Term (`[...]`) and type (`<...>`) instantiations chain in any order,
+    # matching the left-recursive LALR rules `atomic_proof "[" term_list "]"`
+    # and `atomic_proof "<" type_list ">"`. A single dispatching loop lets
+    # `h[x]<Nat>` and `h<Nat>[x]` both parse; two separate loops would reject
+    # a `<...>` that follows a `[...]`.
+    while not end_of_file():
+      if current_token().type == 'LESSTHAN':
+        while_parsing= 'while trying to parse type arguments for instantiation of an "all" formula:\n\t'\
+                + 'proof ::= proof "<" type_list ">"'
+        advance()
+        try:
+          type_list = parse_type_list()
+          consume_token('MORETHAN', 'a closing ">"')
+          meta = meta_from_tokens(start_token, previous_token())
+          for j, ty in enumerate(type_list):
+            proof = AllElimTypes(meta, proof, ty, (j, len(type_list)))
+        except ParseError as e:
+          raise e.extend(meta_from_tokens(start_token, current_token()), while_parsing)
+      elif current_token().type == 'LSQB':
+        advance()
+        term_list = parse_nonempty_term_list()
+        consume_token('RSQB', 'a closing "]"', advice="Perhaps you forgot a comma?")
         meta = meta_from_tokens(start_token, previous_token())
-        for j, ty in enumerate(type_list):
-          proof = AllElimTypes(meta, proof, ty, (j, len(type_list)))
-      except ParseError as e:
-        raise e.extend(meta_from_tokens(start_token, current_token()), while_parsing)
-
-    while (not end_of_file()) and current_token().type == 'LSQB':
-      advance()
-      term_list = parse_nonempty_term_list()
-      consume_token('RSQB', 'a closing "]"', advice="Perhaps you forgot a comma?")
-      meta = meta_from_tokens(start_token, previous_token())
-      for j, term in enumerate(term_list):
-        proof = AllElim(meta, proof, term, (j, len(term_list)))
+        for j, term in enumerate(term_list):
+          proof = AllElim(meta, proof, term, (j, len(term_list)))
+      else:
+        break
 
     return proof
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -546,6 +546,12 @@ PARSER_ROUND_TRIP_FILES = (
     # empty union did not reparse under LALR. Fixed by admitting the empty
     # production in `constructor_list`. Refs #473.
     "./test/should-validate/empty_union.pf",
+    # Chained proof instantiation `h[x]<Nat>` (term then type). RD used to
+    # consume all `<...>` type instantiations before any `[...]` term
+    # instantiations in two separate loops, so a `<...>` following a `[...]`
+    # was rejected -- diverging from the interleaving LALR `atomic_proof`
+    # rules. A single dispatching loop now accepts both orders. Refs #473.
+    "./test/should-validate/proof_instantiation_order_rd_lalr.pf",
 )
 
 

--- a/test/should-validate/proof_instantiation_order_rd_lalr.pf
+++ b/test/should-validate/proof_instantiation_order_rd_lalr.pf
@@ -1,0 +1,40 @@
+// Regression coverage for RD/LALR agreement on chained proof
+// instantiation (#473).
+//
+// The LALR grammar builds term (`[...]`) and type (`<...>`) instantiations
+// with two left-recursive `atomic_proof` rules, so they may interleave in
+// any order. The recursive-descent parser used to consume all `<...>`
+// instantiations first and then all `[...]` instantiations, in two separate
+// loops -- which accepted `h<Nat>[x]` but rejected `h[x]<Nat>`, a parse
+// divergence from LALR. A single dispatching loop now mirrors the grammar.
+
+theorem generic_over_type_then_value:
+  all x:bool. <T> x = x
+proof
+  arbitrary x:bool
+  arbitrary T:type
+  conclude x = x by .
+end
+
+theorem generic_over_value_then_type:
+  all T:type. all x:bool. x = x
+proof
+  arbitrary T:type
+  arbitrary x:bool
+  conclude x = x by .
+end
+
+// `[value]<type>` -- term instantiation followed by type instantiation.
+// This is the ordering RD used to reject.
+theorem use_term_then_type: all x:bool. x = x
+proof
+  arbitrary x:bool
+  conclude x = x by generic_over_type_then_value[x]<bool>
+end
+
+// `<type>[value]` -- type instantiation followed by term instantiation.
+theorem use_type_then_term: all x:bool. x = x
+proof
+  arbitrary x:bool
+  conclude x = x by generic_over_value_then_type<bool>[x]
+end


### PR DESCRIPTION
## Summary

Fixes an RD/LALR parser divergence on **chained proof instantiation**, surfaced
while sweeping grammar forms absent from the curated `--equiv` corpus (the
parser-equivalence portion of #473).

An RD-vs-LALR snippet sweep found:

```
theorem foo: true proof h[x]<Nat> end
```

- recursive-descent (the default parser): **rejected** — `expected keyword "end"
  after proof of theorem, not <`
- LALR: **accepted** — `(h[x])<Nat>` (`AllElimTypes(AllElim(h, x), Nat)`)

The two parsers disagreed on whether a type instantiation (`<...>`) may follow a
term instantiation (`[...]`).

## Root cause

`rec_desc_parser.py:parse_proof_med` chained instantiations with **two separate
sequential loops** — first consuming every `<type_list>` instantiation, then
every `[term_list]` instantiation:

```python
while ... current_token().type == 'LESSTHAN':   # all <...> first
    ...
while ... current_token().type == 'LSQB':        # then all [...]
    ...
```

That accepted `h<Nat>[x]`, `h<Nat><Bool>`, `h[x][y]`, but rejected `h[x]<Nat>`,
because a `<...>` appearing *after* a `[...]` fell outside both loops.

The LALR grammar builds both with left-recursive `atomic_proof` rules that
interleave in any order:

```
?atomic_proof: ...
    | atomic_proof "[" term_list "]"   -> all_elim
    | atomic_proof "<" type_list ">"   -> all_elim_types
```

## Fix

Replace the two loops with a single dispatching loop that handles `<...>` or
`[...]` in whatever order they appear, mirroring the grammar. The AST for the
already-accepted orders is unchanged (`h<Nat>[x]` still builds
`AllElim(AllElimTypes(h, Nat), x)`); only the previously-rejected interleavings
now parse, and they build the same AST LALR does.

## Test coverage

New `test/should-validate/proof_instantiation_order_rd_lalr.pf` (added to the
`--equiv` `PARSER_ROUND_TRIP_FILES` corpus) proves two `bool`-only theorems whose
proofs use both orderings:

- `generic_over_type_then_value[x]<bool>` — `[value]<type>`, the order RD rejected.
- `generic_over_value_then_type<bool>[x]` — `<type>[value]`.

Both type-check and round-trip identically under RD and LALR.

## Verification

- `python3 test-deduce.py --equiv` — parser-equivalence corpus green.
- `python3 test-deduce.py --passable` / `--errors` / `--parser` — all green (both parsers).
- `python3 deduce.py --recursive-descent` and `--lalr` on the new fixture — valid.
- ruff/mypy not run (not installed in this container); the change is a
  control-flow merge of two loops plus a `.pf` fixture.

## Scope

This advances only the parser-equivalence portion of the umbrella issue #473
(dual-parser equivalence + Reference.md grammar sync), which has remaining work,
so this uses `Refs`, not a closing keyword.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh b5011009-9f75-41ec-9eb8-3c4fc7f9aa45 routine/20260718-050202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
