### PR TITLE
Group RD approx-equal ≈ at comparison precedence to match LALR (refs #473)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -50,8 +50,8 @@ from parser_common import set_filename as set_filename
 expt_operators = { '^' }
 mult_operators = {'*', '/', '%', '∘', '.o.'}
 add_operators = {'+', '-', '∸', '.-.', '∪', '|', '∩', '&', '⨄', '.+.', '++', '⊝' }
-compare_operators = {'<', '>', '≤', '<=', '≥', '>=', '⊆', '(=', '∈', 'in', '≲', '<~'}
-equal_operators = {'=', '≠', '/=', '≈', '~~'}
+compare_operators = {'<', '>', '≤', '<=', '≥', '>=', '⊆', '(=', '∈', 'in', '≲', '<~', '≈', '~~'}
+equal_operators = {'=', '≠', '/='}
 iff_operators = {'iff', "<=>", "⇔"}
 
 to_unicode = {'.o.': '∘', '|': '∪', '&': '∩', '.+.': '⨄', '.-.': '∸',

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -1046,6 +1046,43 @@ def _check_keyword_name_rejection() -> list[tuple[str, str, str]]:
     return failures
 
 
+# Operator-grouping forms that both parsers must group identically (refs #473,
+# #931). These belong here rather than in a ``should-validate`` fixture because
+# the approximate operators ``≈``/``≲`` only apply to ``fn UInt -> UInt`` while
+# the comparison/equality operators apply to numbers, so a mixed expression like
+# ``a ≈ b < c`` never type-checks -- yet both parsers must still parse it to the
+# same AST. ``≈`` sits at the ``comparison_term``
+# level in ``Deduce.lark`` and the Reference.md precedence table (level 4), but
+# RD used to group it with the looser equality operators, so ``a ≈ b < c``
+# diverged (``a ≈ (b < c)`` under RD vs ``(a ≈ b) < c`` under LALR).
+OPERATOR_GROUPING_EQUIV_CASES = (
+    "define t = a ≈ b < c",
+    "define t = a = b ≈ c",
+    "define t = a ≠ b ≈ c",
+    "define t = a ≈ b ≲ c",
+    "define t = a ≲ b ≈ c",
+)
+
+
+def _check_operator_grouping_equivalence() -> list[tuple[str, str, str]]:
+    """Both parsers must group mixed operator forms identically."""
+    failures: list[tuple[str, str, str]] = []
+    for src in OPERATOR_GROUPING_EQUIV_CASES:
+        try:
+            rd = _canonical_ast(_parse_text_for_equivalence(
+                "<operator-grouping>", src, recursive_descent=True))
+            lalr = _canonical_ast(_parse_text_for_equivalence(
+                "<operator-grouping>", src, recursive_descent=False))
+        except Exception as exc:
+            failures.append((src, "parser-equivalence",
+                             f"{type(exc).__name__}: {exc}"))
+            continue
+        if not _canonical_equal(rd, lalr):
+            failures.append((src, "parser-equivalence",
+                             "RD and LALR group this form differently"))
+    return failures
+
+
 def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     """Compare RD and LALR ASTs for parseable syntax.
 
@@ -1086,6 +1123,7 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     if _SHARD is None or _SHARD[0] == 0:
         failures.extend(_check_should_error_skip_set())
         failures.extend(_check_keyword_name_rejection())
+        failures.extend(_check_operator_grouping_equivalence())
         stale = (PARSER_EQUIV_EXPECTED_DIVERGENCES
                  - seen_divergences - set(all_files))
         for path in sorted(stale):


### PR DESCRIPTION
## Summary

Fixes another RD/LALR AST divergence under #473. The recursive-descent parser
listed `≈` (approx-equal, and its ASCII form `~~`) in `equal_operators`, giving
it **equality** precedence — looser than the other comparison operators. But
`Deduce.lark` (`comparison_term "≈" additive_term -> approx_equal`) and the
Reference.md operator-precedence table (level 4) place `≈` at the
`comparison_term` level, alongside `≲`. So an unparenthesized mix of `≈` with a
comparison or equality operator parsed to a different AST under each parser:

| source | RD (before) | LALR |
|---|---|---|
| `a ≈ b < c` | `a ≈ (b < c)` | `(a ≈ b) < c` |
| `a = b ≈ c` | `(a = b) ≈ c` | `a = (b ≈ c)` |

This is a continuation of #1038 (which fixed comparison/equality associativity
and the `not` prefix level) — it left `≈` at the wrong precedence *level*
entirely.

## Why it's safe

The divergence is **latent** in accepted programs: `≈`/`≲` only apply to
`fn UInt -> UInt` (they are defined in `lib/BigO.pf`), while the
comparison/equality operators apply to numbers, so a mixed expression like
`a ≈ b < c` never type-checks. `BigO.pf` (the only `≈`/`≲` user) uses `≈` solely
between function expressions with no adjacent comparison at the same level, so no
accepted program changes meaning. Full harness (`python3 test-deduce.py`) passes.

## The fix

- `rec_desc_parser.py`: move `≈`/`~~` from `equal_operators` into
  `compare_operators`.
- `test-deduce.py`: because a mixed `≈`/comparison form can't be expressed as a
  type-checking `should-validate` fixture, coverage is an inline
  `OPERATOR_GROUPING_EQUIV_CASES` parse-equivalence check, run alongside the
  existing keyword-rejection invariant in `run_parser_equivalence`.

## How it was found

A full operator-mixing snippet sweep comparing RD vs LALR canonical ASTs across
every same-precedence and cross-precedence operator pair. It flagged 14
`≈`-related divergences (all fixed here); the remaining sweep hits are the
`and`/`or` grouping already handled by #1060.

## Noticed in passing

Filed #1069: `~~`/`<~` are listed as ASCII synonyms for `≈`/`≲` in the RD
operator maps but neither lexer accepts `~`, so those two entries are unreachable
dead code (unlike every other working ASCII synonym). Out of scope here.

## Testing

- `python3 test-deduce.py --equiv` — passes (includes the new inline check).
- `python3 test-deduce.py` (full default harness) — all tests pass.
- `python3 deduce.py lib/BigO.pf` — valid.
- ruff/mypy not installed in this container; CI covers them. The new
  `_check_operator_grouping_equivalence` mirrors the existing
  `_check_keyword_name_rejection` signature exactly.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 7d0962fb-ef24-4d37-9796-1f17980d1ab0 routine/20260718-060202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
