### PR TITLE
Remove dead `:` handlers left after #1060 folded annotations into logical_term (refs #473)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -660,7 +660,6 @@ def parse_term_logic() -> Term:
     else:
       term = Or(meta_from_tokens(token, previous_token()), None,
                 extract_or(term) + extract_or(right))
-
   return term
 
 def parse_term_iff() -> Term:
@@ -673,29 +672,13 @@ def parse_term_iff() -> Term:
     left_right = IfThen(loc, None, term.copy(), right.copy())
     right_left = IfThen(loc, None, right.copy(), term.copy())
     term = And(loc, None, [left_right, right_left])
-
-  if (not end_of_file()) and current_token().type == 'COLON':
-    advance()
-    typ = parse_type()
-    term = TAnnote(meta_from_tokens(token, previous_token()), None,
-                   term, typ)
-
   return term
 
 def parse_term() -> Term:
   if end_of_file():
       raise ParseError(meta_from_tokens(previous_token(),previous_token()),
             'expected a term, not end of file')
-
-  token = current_token()
-  term = parse_term_iff()
-
-  if not end_of_file() and current_token().type == 'COLON':
-    advance()
-    typ = parse_type()
-    term = TAnnote(meta_from_tokens(token, previous_token()), None,
-                   term, typ)
-  return term
+  return parse_term_iff()
 
 def parse_define_term() -> Term:
   while_parsing = 'while parsing\n' \

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -557,6 +557,12 @@ PARSER_ROUND_TRIP_FILES = (
     # was rejected -- diverging from the interleaving LALR `atomic_proof`
     # rules. A single dispatching loop now accepts both orders. Refs #473.
     "./test/should-validate/proof_instantiation_order_rd_lalr.pf",
+    # RD handled the `:` type annotation only as a trailing step after the
+    # `and`/`or` chain (and redundantly above `iff`), so a stacked annotation
+    # such as `P : bool : bool` was split, with the second colon leaking up a
+    # precedence level. `:` now folds into the same left-associative
+    # `logical_term` loop as `and`/`or`, matching LALR. Refs #473.
+    "./test/should-validate/annotation_precedence_rd_lalr.pf",
 )
 
 

--- a/test/should-validate/annotation_precedence_rd_lalr.pf
+++ b/test/should-validate/annotation_precedence_rd_lalr.pf
@@ -1,0 +1,31 @@
+// Regression coverage for RD/LALR type-annotation grouping (#473).
+//
+// The `:` type annotation sits at the left-associative `logical_term` level
+// in Deduce.lark (`logical_term ":" type`), the same level as `and`/`or`,
+// read left to right. RD used to handle `:` only as a trailing step after the
+// whole logical chain (and again, redundantly, above `iff`), so two forms
+// parsed differently from LALR:
+//
+//   * `P : bool and Q` failed to parse at all under RD -- the annotation
+//     ended the term and left `and Q` stranded -- whereas LALR reads it as
+//     `(P : bool) and Q`.
+//   * a stacked annotation such as `P : bool : bool` was split, with the
+//     second colon leaking up a precedence level, instead of grouping as
+//     `(P : bool) : bool` at this level.
+//
+// RD now folds `:` into the same left-associative `logical_term` loop as
+// `and`/`or`, so both forms agree with LALR. These theorems state them without
+// disambiguating parentheses, so the file lives in the `--equiv` corpus to
+// keep RD and LALR pinned to the same AST.
+
+theorem annote_left_of_and: all P:bool, Q:bool. (P : bool and Q) = (P and Q)
+proof
+  arbitrary P:bool, Q:bool
+  switch P { case true { . } case false { . } }
+end
+
+theorem annote_stacked_colon: all P:bool. (P : bool : bool) = P
+proof
+  arbitrary P:bool
+  switch P { case true { . } case false { . } }
+end


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1060, part of the dual-parser equivalence work in #473.

**Context / how the scope changed.** This PR originally folded the `:` type
annotation into `parse_term_logic`'s `and`/`or` loop so RD would match
Deduce.lark's left-recursive `logical_term` level. In the interim, #1060
merged and did exactly that fold (with the correct tighter `parse_term_sep()`
right operand — see the Codex review note below). After rebasing onto current
`main`, the core fold is already there, so this PR reduces to the remaining
loose ends.

## What this PR now does

1. **Removes two dead code paths.** Because #1060's loop consumes every `:`
   annotation — including stacked colons like `P : bool : bool` — at the
   `logical_term` level, `parse_term_logic` always returns with a non-`COLON`
   lookahead. That makes the trailing `COLON` handlers in `parse_term_iff` and
   `parse_term` unreachable. Remove them (−18 lines).

2. **Adds regression coverage.** New fixture
   `test/should-validate/annotation_precedence_rd_lalr.pf`, registered in the
   `--equiv` (`PARSER_ROUND_TRIP_FILES`) corpus, pins `P : bool and Q` and the
   stacked `P : bool : bool` to the same AST under both parsers. The
   stacked-colon case is not covered by #1060's fixture.

## Re: the Codex review (RHS must be the tighter level)

Correct, and already resolved on `main`: #1060's `parse_term_logic` uses
`right = parse_term_sep()`, so mixed chains like `P : bool and Q or R` group
left-to-right (`((P:bool) and Q) or R`) in agreement with LALR. This rebased
branch inherits that; the previously-flagged `right = parse_term_logic()` is
gone.

## Testing

- `python3 test-deduce.py` (full suite, both parsers) — all pass.
- `python3 test-deduce.py --equiv` and `--equiv-full` (525-file round trip,
  both parsers) — all pass, confirming removing the two handlers changes no
  observable parse.
- `ruff check .` and `mypy .` — clean.

Resume this session on ginger: `~/deduce-runner/resume.sh 105e4776-af7f-4cdd-abbf-3aee90a2a69c routine/20260718-080201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)