### PR TITLE
Guard RD if/then `else` lookahead against EOF to match LALR (closes #1073)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -269,7 +269,12 @@ def parse_term_hi() -> Term:
             + '\tformula ::= "if" formula "then" formula')
     conc = parse_term()
 
-    if current_token().type == 'ELSE':
+    # An `if ... then ...` with no `else` is the implication form
+    # (`if_then_formula`), which is a valid term. Guard the `else` lookahead so
+    # a bare implication at end of input does not trip `current_token()`'s
+    # end-of-file error, matching the LALR grammar which accepts
+    # `"if" term "then" term`.
+    if not end_of_file() and current_token().type == 'ELSE':
       advance()
       els = parse_term()
       return Conditional(meta_from_tokens(token, previous_token()), None,

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -527,6 +527,13 @@ PARSER_ROUND_TRIP_FILES = (
     # `object Empty` at EOF did not reparse under RD. Fixed by guarding the
     # `LESSTHAN` lookahead with `not end_of_file()`.
     "./test/should-validate/object_bodyless_eof.pf",
+    # A bare `if ... then ...` implication (no `else`) as the final term of the
+    # file hit the same EOF hazard: the `IF` branch checked for an optional
+    # `else` with `current_token()`, which raised "Expected a token, got end of
+    # file" under RD while LALR accepted the `"if" term "then" term` form.
+    # Fixed by guarding the `else` lookahead with `not end_of_file()`.
+    # Refs #1073, #473.
+    "./test/should-validate/if_then_no_else_eof.pf",
     # The experimental-imperative keyword vocabulary (`call`, `return`,
     # `while`, `emp`, `reads`, ...) is only reserved with
     # `--experimental-imperative` on. RD tokenizes with lark's

--- a/test/should-validate/if_then_no_else_eof.pf
+++ b/test/should-validate/if_then_no_else_eof.pf
@@ -1,0 +1,7 @@
+// A bare `if ... then ...` implication (no `else`), appearing as the final
+// term of the file, exercises the recursive-descent parser at end-of-file:
+// after parsing the conclusion the `IF` branch checked for an optional `else`
+// with `current_token()`, which raised "Expected a token, got end of file" at
+// EOF while LALR accepted the `"if" term "then" term` implication form.
+// Regression coverage for that parser divergence. Refs #1073, #473.
+define implication_at_eof = if true then false


### PR DESCRIPTION
## Summary

Fixes an RD/LALR parser divergence: the recursive-descent parser (the default)
crashed on a bare `if ... then ...` implication (no `else`) when it was the
final token of the input, while LALR accepts it.

```
$ printf 'define x = if true then false' | python3 deduce.py --recursive-descent /dev/stdin
... :1.25-1.30: Expected a token, got end of file
$ printf 'define x = if true then false' | python3 deduce.py --lalr /dev/stdin
... is valid   # parses if true then false = true ⇒ false = not true
```

## Root cause

In `rec_desc_parser.py`, the `IF` branch parses the conclusion and then checks
for an optional `else` with `if current_token().type == 'ELSE':`. But
`current_token()` *raises* `Expected a token, got end of file` at EOF instead
of returning, so a complete `if ... then ...` at end of input dies in the
lookahead rather than returning the `IfThen` node.

`Deduce.lark` has `"if" term "then" term -> if_then_formula` as a valid term,
so LALR accepts the form. The divergence only manifests at literal
end-of-input: `if ... then ...` followed by any further token (another
statement, or `proof`/`)` etc.) already parsed under both parsers.

## Fix

Guard the `else` lookahead with `not end_of_file()`, mirroring the earlier
object-declaration-at-EOF fix (`object_bodyless_eof.pf`), which was the exact
same `current_token()`-at-EOF hazard.

## Test coverage

Adds `test/should-validate/if_then_no_else_eof.pf` — a file ending in a bare
`if ... then ...` implication — to the curated `--equiv` corpus
(`PARSER_ROUND_TRIP_FILES`), so both parsers are pinned to the same AST and the
pretty-printer round-trips it.

## How this was found

Local in-process RD-vs-LALR snippet sweep over grammar forms absent from the
curated `--equiv` corpus (same technique that surfaced #1069/#1060).

## Verification

- `python3 test-deduce.py` — all categories pass (should-validate ×2 parsers,
  should-error, should-warn, parser equivalence).
- `python3 test-deduce.py --equiv` — passes.
- `python3 deduce.py --recursive-descent` and `--lalr` both validate the new
  fixture.

(ruff/mypy not installed in this container; CI will run them. The change adds a
single `not end_of_file()` conjunct plus comments and a test file.)

Closes #1073. Refs #473 (dual-parser equivalence umbrella).

Resume this session on ginger: `~/deduce-runner/resume.sh a3ce6eaa-7b5f-4080-8dc3-cbcb2f5b95b4 routine/20260718-090202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
