### PR TITLE
lib: Int truncated mod-by-zero and divisor-sign laws (refs #720)

### DIFF
--- a/lib/IntMod.pf
+++ b/lib/IntMod.pf
@@ -272,6 +272,30 @@ proof
   }
 end
 
+// Under truncated division the remainder ignores the divisor's sign, since
+// it only depends on the divisor through `abs`.
+theorem int_mod_neg_divisor: all n:Int, m:Int. n % (- m) = n % m
+proof
+  arbitrary n:Int, m:Int
+  expand operator%
+  replace abs_neg.
+end
+
+// Truncated modulo by zero returns the dividend (following `UInt`), so that
+// the division identity `(n / m) * m + (n % m) = n` still holds at m = +0.
+theorem int_mod_zero: all n:Int. n % +0 = n
+proof
+  arbitrary n:Int
+  have umz: all x:UInt. x % 0 = x by {
+    arbitrary x:UInt
+    expand operator%.
+  }
+  switch n {
+    case pos(au) { replace umz. }
+    case negsuc(au) { replace umz | neg_pos. }
+  }
+end
+
 // Zero divided by anything is zero.
 theorem int_zero_div: all m:Int. +0 / m = +0
 proof


### PR DESCRIPTION
## Summary

Adds two truncated-division convenience laws to `lib/IntMod.pf`, filling gaps in
the `Int` div/mod story for #720. Both live in the currently-uncontended
`IntMod.pf` (the open gcd/lcm PRs #1057/#1058/#1061 touch `IntDivides.pf` and
`UIntDiv.pf`).

- **`int_mod_zero: n % +0 = n`** — the missing complement to the existing
  `int_div_zero: n / +0 = +0`. With both, the division identity
  `(n / m) * m + (n % m) = n` continues to hold at `m = +0`
  (`+0 * (n / +0) + (n % +0) = +0 + n = n`).
- **`int_mod_neg_divisor: n % (- m) = n % m`** — under the truncated convention
  the remainder ignores the divisor's sign, because `%` depends on the divisor
  only through `abs` (`n % m = sign(n) * (abs(n) % abs(m))`).

Both are directly listed under the issue's "`mod_small`, `mod_self`, `mod_one`,
`div_one`, `div_zero` policy, and sign / `abs` interaction" candidate.

## Testing

- `python3 deduce.py lib/IntMod.pf` → valid
- `python3 test-deduce.py --lib` → all pass (both parsers)
- `python3 gh_pages/scripts/keywords.py` and `reference_grammar.py` → pass

## Scope note

`#720` remains open after this PR — Bezout-style identities and the remaining
sign/`abs` interaction laws (e.g. `(-n) % m = -(n % m)`) are not covered here,
so this uses `Refs`, not `Closes`.

Refs #720

Resume this session on ginger: `~/deduce-runner/resume.sh 6d772972-77b8-49e4-bf89-1f15799daa8f routine/20260718-110202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
