### PR TITLE
Drop LALR-only `%<type>` term production so both parsers reject it (closes #1077)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -172,8 +172,7 @@ identifier: IDENT              -> identifier
     | "#" term "#"                                 -> mark
     | "if" term "then" term "else" term            -> conditional
     | "if" term "then" term                        -> if_then_formula
-    | "%" type
-    
+
 ?term_list:                                        -> empty
     | ne_term_list
 ?ne_term_list: term                                -> single

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -1050,21 +1050,32 @@ KEYWORD_NAME_REJECTION_CASES = (
     "define d = all if:bool. true",     # all-bound variable
 )
 
+# The LALR grammar once had an `atomic_term: "%" type` production that leaked a
+# bare Type node into a term position (crashing later in `type_synth_term`),
+# which RD never accepted (issue #1077). One `%<type>` per type shape guards
+# against reintroducing that LALR-only divergence.
+PERCENT_TYPE_REJECTION_CASES = (
+    "define d = %bool",                 # atomic type
+    "define d = %[bool]",               # array type
+    "define d = %U<bool>",              # instantiated type
+)
 
-def _check_keyword_name_rejection() -> list[tuple[str, str, str]]:
-    """Both parsers must reject reserved keywords in name/binding positions."""
+
+def _expect_both_parsers_reject(
+    cases: tuple[str, ...], marker: str, why: str,
+) -> list[tuple[str, str, str]]:
+    """Every case must fail to parse under both parsers."""
     failures: list[tuple[str, str, str]] = []
-    for src in KEYWORD_NAME_REJECTION_CASES:
+    for src in cases:
         for recursive_descent in (True, False):
             label = "recursive-descent" if recursive_descent else "lalr"
             try:
                 _parse_text_for_equivalence(
-                    "<keyword-name-rejection>", src,
-                    recursive_descent=recursive_descent,
+                    marker, src, recursive_descent=recursive_descent,
                 )
                 failures.append((src, "parser-equivalence",
-                                 f"{label} accepted a reserved keyword as an "
-                                 f"identifier; both parsers must reject"))
+                                 f"{label} accepted input both parsers must "
+                                 f"reject: {why}"))
             except Exception:
                 pass
     return failures
@@ -1148,6 +1159,20 @@ def _check_ascii_operator_synonyms() -> list[tuple[str, str, str]]:
     return failures
 
 
+def _check_keyword_name_rejection() -> list[tuple[str, str, str]]:
+    """Both parsers must reject reserved keywords in name/binding positions."""
+    return _expect_both_parsers_reject(
+        KEYWORD_NAME_REJECTION_CASES, "<keyword-name-rejection>",
+        "reserved keyword used as an identifier")
+
+
+def _check_percent_type_rejection() -> list[tuple[str, str, str]]:
+    """Both parsers must reject `%<type>` in term position (issue #1077)."""
+    return _expect_both_parsers_reject(
+        PERCENT_TYPE_REJECTION_CASES, "<percent-type-rejection>",
+        "`%<type>` is not a term")
+
+
 def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     """Compare RD and LALR ASTs for parseable syntax.
 
@@ -1190,6 +1215,7 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
         failures.extend(_check_keyword_name_rejection())
         failures.extend(_check_operator_grouping_equivalence())
         failures.extend(_check_ascii_operator_synonyms())
+        failures.extend(_check_percent_type_rejection())
         stale = (PARSER_EQUIV_EXPECTED_DIVERGENCES
                  - seen_divergences - set(all_files))
         for path in sorted(stale):


### PR DESCRIPTION
## Summary

Removes the LALR-only `atomic_term: "%" type` production from `Deduce.lark` so
the recursive-descent and LALR parsers agree, and adds a regression guard.

The production had no transformer alias, so `%<type>` parsed straight to a bare
`Type` AST node in a term position:

```sh
printf 'define d = %%bool\n' > /tmp/pct.pf

python3 deduce.py --recursive-descent --no-stdlib /tmp/pct.pf
#   ParseError: ... (RD rejects at parse time)

python3 deduce.py --lalr --no-stdlib /tmp/pct.pf
#   /tmp/pct.pf:1.13-1.17: type_synth_term called on type bool  (internal crash)
```

`%[bool]` / `%U<bool>` behave the same (any type is accepted). The construct is
undocumented and unused anywhere in `lib/`, `test/`, `examples/`, or
`gh_pages/`, and it cannot be type-checked or pretty-printed, so both parsers
should reject it. This is the conservative, minimal fix; if a type-as-term
feature is wanted later it needs a real `Term` wrapper node with
transformer/uniquify/type-check/pretty-print support in both parsers, and is
recoverable from git.

The divergence slipped through CI because `--equiv` is a curated corpus and no
checked-in file exercises `%<type>`. It was found via a local full-construct
RD/LALR snippet sweep.

## Changes

- `Deduce.lark`: delete the `| "%" type` alternative from `atomic_term`. The
  modulo operator (`multiplicative_term "%" exponent_term`) is unaffected — it
  is the only remaining use of `%`.
- `test-deduce.py`: add `PERCENT_TYPE_REJECTION_CASES` and
  `_check_percent_type_rejection`, wired into the `--equiv` global-invariant
  block, so re-adding the production fails CI. Factored the shared loop with the
  existing keyword-name rejection check into `_expect_both_parsers_reject`.

## Testing

- `python3 test-deduce.py --equiv` — pass (new rejection check included)
- `python3 test-deduce.py --passable --errors --warns` — pass
- `python3 test-deduce.py --parser` — pass
- `python3 test-deduce.py --equiv-full` — pass (525 files)
- `python3 gh_pages/scripts/keywords.py` and `reference_grammar.py` — pass
  (`Reference.md` only quotes the modulo `%` production, so no doc change needed)

ruff/mypy were not runnable in this container (not installed); they remain for CI.

## Issue

Closes #1077. Refs #473 (dual-parser equivalence umbrella; other divergences
remain, so not closed here).

Resume this session on ginger: `~/deduce-runner/resume.sh a9f165a5-5c7d-4952-a7a6-927bf118e182 routine/20260718-120202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
