### PR TITLE
lib: add int_div_self (n/n = +1 for nonzero Int) to Int div/mod laws (refs #720)

### DIFF
--- a/lib/IntMod.pf
+++ b/lib/IntMod.pf
@@ -262,6 +262,33 @@ proof
   }
 end
 
+// A nonzero integer divides evenly into itself: the self-quotient is one.
+// (The division-side mirror of `int_mod_self`.)
+theorem int_div_self: all n:Int. if n ≠ +0 then n / n = +1
+proof
+  arbitrary n:Int
+  assume neq: n ≠ +0
+  switch n {
+    case pos(au) assume eq: n = pos(au) {
+      have neq2: pos(au) ≠ +0 by replace eq in neq
+      have au_pos: 0 < au by {
+        cases uint_zero_or_positive[au]
+        case au_z: au = 0 {
+          conclude false by replace au_z in neq2
+        }
+        case au_p { au_p }
+      }
+      show pos(au) / pos(au) = +1
+      replace (apply uint_div_cancel[au] to au_pos).
+    }
+    case negsuc(au) assume eq: n = negsuc(au) {
+      show negsuc(au) / negsuc(au) = +1
+      have p: 0 < 1 + au by .
+      replace (apply uint_div_cancel[1 + au] to p).
+    }
+  }
+end
+
 // Truncated division by zero yields zero (following `UInt`).
 theorem int_div_zero: all n:Int. n / +0 = +0
 proof


### PR DESCRIPTION
## Summary

Adds `int_div_self` to the `Int` division/modulo convenience laws in
`lib/IntMod.pf`:

```
theorem int_div_self: all n:Int. if n ≠ +0 then n / n = +1
```

This fills a small but real asymmetry in the Int div/mod story from #720.
`int_mod_self` (`n % n = +0`) already existed, but its quotient-side mirror
`int_div_self` did not, even though the sibling pairs `int_mod_one`/`int_div_one`
and `int_zero_mod`/`int_zero_div` are both present. The issue explicitly lists
`div_self`/`mod_self`-style convenience laws in scope.

## Proof

Cases on the sign of `n` (`pos`/`negsuc`), reducing each to the underlying
unsigned quotient and discharging it with the existing
`uint_div_cancel: all y:UInt. if 0 < y then y / y = 1`:

- `pos(au)`: from `pos(au) ≠ +0` derive `0 < au` (via `uint_zero_or_positive`),
  then `pos(au)/pos(au) = pos(au/au) = pos(1) = +1`.
- `negsuc(au)`: `1 + au` is always positive, so
  `negsuc(au)/negsuc(au) = pos((1+au)/(1+au)) = pos(1) = +1`.

The `div_pos_pos`/`div_negsuc_negsuc` structural specs are auto rules, so the
proof only needs the `uint_div_cancel` step in each case.

## Verification

- `python3 deduce.py lib/IntMod.pf` — valid (recursive-descent).
- `python3 deduce.py --lalr lib/IntMod.pf` — valid (LALR).
- `python3 test-deduce.py --lib` — all 41 lib modules pass under both parsers.

The change is pure `.pf`; no Python touched, so ruff/mypy are unaffected.

## Scope

This advances the Int div/mod/gcd/lcm work in #720 but does not complete the
whole issue (Bezout-style follow-up and further sign/abs interaction laws
remain, and are being worked in parallel PRs), so this uses `Refs`, not a
closing keyword.

Refs #720.

Resume this session on ginger: `~/deduce-runner/resume.sh 21d0daec-376b-4513-94a9-a3de0892bf7d routine/20260718-130202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
