### PR TITLE
lib: bridge Int divisibility to the truncated remainder (refs #720)

### DIFF
--- a/abstract_syntax/theorems.py
+++ b/abstract_syntax/theorems.py
@@ -65,8 +65,12 @@ def collect_public(s: Statement, to_print: list[TheoremFilePrinting]) -> None:
     elif isinstance(s, Import):
       if s.name in collected_imports:
           return
-      collected_imports.add(s.name)
+      # Only a public import contributes (and dedups) the module's public
+      # theorems. A private import must not mark the module collected, or a
+      # later public re-export of the same module would be skipped and its
+      # public theorems silently dropped from the .thm summary.
       if s.ast != None and s.visibility == 'public':
+        collected_imports.add(s.name)
         for stmt in s.ast:
             collect_public(stmt, to_print)
     elif isinstance(s, Declaration) and not s.visibility == 'private':

--- a/lib/IntDivides.pf
+++ b/lib/IntDivides.pf
@@ -7,6 +7,7 @@ import IntAddSub
 import IntMult
 import IntLess
 import IntAbs
+import IntMod
 
 /*
   Integer divisibility, gcd, and lcm.
@@ -220,6 +221,45 @@ proof
   have ba: divides(abs(b), abs(a))
     by apply (conjunct 0 of int_divides_iff_abs[b, a]) to conjunct 1 of prem
   apply uint_divides_antisymmetric[abs(a), abs(b)] to ab, ba
+end
+
+// Divisibility bridges to the remainder: for a nonzero divisor, `m` divides
+// `n` exactly when the truncated remainder `n % m` vanishes. The forward
+// direction routes `abs(n % m)` through `int_abs_mod` /
+// `uint_mult_mod_left_zero`; the backward direction reconstructs `n` from the
+// division identity `int_div_mod` once the remainder is `+0`.
+theorem int_divides_iff_mod_zero: all m:Int, n:Int.
+  if not (m = +0) then (divides(m, n) ⇔ n % m = +0)
+proof
+  arbitrary m:Int, n:Int
+  assume prem: not (m = +0)
+  have mpos: 0 < abs(m) by {
+    have nz: not (abs(m) = 0) by {
+      assume az: abs(m) = 0
+      conclude false
+        by apply prem to (apply int_abs_eq_zero_implies_zero[m] to az)
+    }
+    apply uint_not_zero_pos to nz
+  }
+  have fwd: if divides(m, n) then n % m = +0 by {
+    assume dvd
+    obtain k where mk: m * k = n from expand divides in dvd
+    have absmod0: abs(n % m) = 0 by {
+      replace int_abs_mod[n, m] | symmetric mk | int_abs_mult[m, k]
+      apply uint_mult_mod_left_zero[abs(k), abs(m)] to mpos
+    }
+    apply int_abs_eq_zero_implies_zero[n % m] to absmod0
+  }
+  have bwd: if n % m = +0 then divides(m, n) by {
+    assume modz: n % m = +0
+    have dm: (n / m) * m + (n % m) = n by apply int_div_mod[n, m] to prem
+    have eq: (n / m) * m = n by replace modz in dm
+    expand divides
+    choose n / m
+    replace int_mult_commute[m, n / m]
+    eq
+  }
+  fwd, bwd
 end
 
 // Greatest common divisor on Int, defined through `UInt.gcd` on


### PR DESCRIPTION
## Summary

Adds the divisibility↔remainder bridge to `lib/IntDivides.pf`, one of the
remaining sign/`abs`-interaction laws in the `Int` div/mod/gcd story tracked by
#720:

- **`int_divides_iff_mod_zero: if not (m = +0) then (divides(m, n) ⇔ n % m = +0)`**
  — for a nonzero divisor, `m` divides `n` exactly when the truncated remainder
  `n % m` vanishes. This is the foundational bridge connecting the `divides`
  predicate (`lib/IntDivides.pf`) to the `%` operator (`lib/IntMod.pf`).

### Proof shape

- **Forward** (`divides(m, n) → n % m = +0`): from `m * k = n`, show
  `abs(n % m) = 0` by routing through `int_abs_mod`, `int_abs_mult`, and
  `uint_mult_mod_left_zero` (using `0 < abs(m)` from `m ≠ +0`), then conclude via
  `int_abs_eq_zero_implies_zero`.
- **Backward** (`n % m = +0 → divides(m, n)`): substitute the remainder into the
  `int_div_mod` identity `(n / m) * m + (n % m) = n` to get `(n / m) * m = n`, and
  choose `n / m` as the witness.

`IntDivides.pf` now imports `IntMod` (no import cycle: `IntMod` depends only on
`{UInt, Base, IntDefs, IntAddSub, IntMult, IntLess, IntAbs, IntDiv}`, none of
which depend on `IntDivides`).

## Theorem-summary generation fix (addresses Codex review)

The new private `import IntMod` inside `IntDivides.pf` exposed a latent bug in
`abstract_syntax/theorems.py`. `collect_public` added a module to
`collected_imports` even for a **private** import, so when a file publicly
re-exported a module that an earlier public import had already reached
privately, the later public import was skipped and that module's public
theorems were dropped from the generated `.thm` summary.

Concretely, `lib/Int.pf` does `public import IntDivides` (line 24) before
`public import IntMod` (line 25); the private `import IntMod` inside
`IntDivides` marked `IntMod` collected, so `Int.thm` lost the entire public `%`
/ IntMod surface.

Fix: only mark a module collected when we actually recurse into it (i.e. on a
public import). Verified across the whole `lib/` tree that the change is purely
additive (0 lines removed from any `.thm`):

- `Int.thm` regains its IntMod public surface (`%`, div/mod laws, Even/Odd).
- `Nat.thm` regains `EvenNat`/`OddNat` — a **pre-existing** instance of the same
  drop (via `NatDiv`'s private `import NatEvenOdd`, before `Nat.pf`'s
  `public import NatEvenOdd`), fixed here as a bonus.

## Testing

- `python3 deduce.py lib/IntDivides.pf` and `--lalr` → valid (both parsers)
- `python3 test-deduce.py` (full default suite: lib × 2 parsers, should-validate,
  should-error, should-warn, parser equivalence) → all pass
- `python3 gh_pages/scripts/keywords.py` and `reference_grammar.py` → pass
- Regenerated every `lib/*.thm` before/after the `theorems.py` change and
  confirmed only `Int.thm` and `Nat.thm` differ, both purely additive.

## Scope note

`#720` remains open after this PR — Bezout-style identities and other remaining
laws are not covered here, so this uses `Refs`, not `Closes`.

Refs #720.

Resume this session on ginger: `~/deduce-runner/resume.sh 600c1d6b-7d19-4b98-93db-02c9c3bd946e routine/20260718-140202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
