### PR TITLE
Drop dead `in scope: str(env)` suffix from undefined-variable errors (closes #1082)

### DIFF
--- a/checker_types.py
+++ b/checker_types.py
@@ -860,8 +860,7 @@ def type_synth_term(
       try:
         ty = env.get_type_of_term_var(term)
         if ty == None:
-          raise Exception('while type checking, undefined variable ' + str(term) \
-                + '\nin scope:\n' + 'str(env)')
+          raise Exception('while type checking, undefined variable ' + str(term))
       except Exception as e:
         user_error(loc, str(e))
       match ty:
@@ -1169,8 +1168,7 @@ def type_check_term(
       if get_verbose():
           print('var_typ = ' + str(var_typ))
       if var_typ == None:
-        user_error(loc, 'variable ' + str(term) + ' is not defined' \
-              + '\nin scope:\n' + 'str(env)')
+        user_error(loc, 'variable ' + str(term) + ' is not defined')
       match (var_typ, typ):
         case (OverloadType(loc2, overloads), _):
           for (x, ty) in overloads:

--- a/test/should-error/undefined_operator_no_str_env.pf
+++ b/test/should-error/undefined_operator_no_str_env.pf
@@ -1,0 +1,6 @@
+// Referencing an undefined operator must report a clean
+// "undefined variable" error. Regression guard for the bug where the
+// OverloadedVar branch of type_synth_term appended the literal text
+// `str(env)` (a quoted string, not the call) as a bogus "in scope:"
+// dump. See issue #1082.
+define d = operator ≠

--- a/test/should-error/undefined_operator_no_str_env.pf.err
+++ b/test/should-error/undefined_operator_no_str_env.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/undefined_operator_no_str_env.pf:6.12-6.20: while type checking, undefined variable ≠


### PR DESCRIPTION
## What

The two `OverloadedVar` branches in `checker_types.py` (lines 863 and
1172) built their "undefined variable" error with
`... + '\nin scope:\n' + 'str(env)'` — where `'str(env)'` is a **quoted
string literal**, not the call `str(env)`. As a result the error ended
with a line containing the five literal characters `str(env)`:

```
$ printf 'define d = operator ≠\n' > /tmp/x.pf
$ python3 deduce.py --no-stdlib /tmp/x.pf
/tmp/x.pf:1.12-1.20: while type checking, undefined variable ≠
in scope:
str(env)
```

## Fix

Drop the dead `in scope:` suffix at both sites, so the error now reads
just:

```
/tmp/x.pf:1.12-1.20: while type checking, undefined variable ≠
```

This matches the sibling `ResolvedVar` branch (`checker_types.py:884`),
which already emits the same message with no `in scope:` suffix. As the
issue notes, a real `str(env)` dump would be enormous under the full
prelude and is not worth restoring — dropping the suffix is the smaller,
consistent choice.

## Test

Adds regression fixture
`test/should-error/undefined_operator_no_str_env.pf` (exercises the
`type_synth_term` `OverloadedVar` undefined path). The should-error
corpus is folded into `test-deduce.py --equiv`, so the fixture is
checked under both parsers.

`python3 test-deduce.py --errors` and `python3 test-deduce.py --equiv`
pass locally. ruff/mypy are not installed in this container; CI covers
them. The source change is the removal of two dead string concatenations.

## Note for reviewers

#1081's open PR (#1083) adds a different should-error fixture
(`operator_not_equal_synonym.pf`) whose `.err` was generated **before**
this fix and captures the literal `str(env)` output. If #1083 merges
first, that fixture's `.err` will need regeneration
(`python3 test-deduce.py --generate-error
./test/should-error/operator_not_equal_synonym.pf`) once this lands.
This PR's own fixture is unaffected.

Closes #1082

Resume this session on ginger: `~/deduce-runner/resume.sh 00d380bc-03fe-4443-804e-bf5474bb32da routine/20260718-160201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
