### PR TITLE
Dedup: drop no-op pretty_print overrides + share RecFun/GenRecFun __eq__ (refs #813)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1183,6 +1183,23 @@ class FunCase(AST):
     return FunCase(self.location, new_rator, new_pat, new_params, new_body)
 
 
+def funcdecl_ref_eq(decl: RecFun | GenRecFun, other: object) -> bool | None:
+  """Name-based equality of a function declaration against the reference
+  forms that can point at it. Shared by ``RecFun`` and ``GenRecFun``.
+  Returns ``None`` when ``other`` is not one of those forms, leaving the
+  same-kind comparison to the caller (which keeps ``RecFun`` and
+  ``GenRecFun`` from comparing equal to each other)."""
+  if isinstance(other, ResolvedVar):
+    return decl.name == other.name
+  elif isinstance(other, OverloadedVar):
+    return decl.name == other.resolved_names[0]
+  elif isinstance(other, Var):
+    return decl.name == other.name
+  elif isinstance(other, TermInst):
+    return decl == other.subject
+  return None
+
+
 @dataclass
 class RecFun(Declaration):
   type_params: List[str]
@@ -1245,18 +1262,10 @@ class RecFun(Declaration):
     return indent*' ' + ret
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, ResolvedVar):
-      return self.name == other.name
-    elif isinstance(other, OverloadedVar):
-      return self.name == other.resolved_names[0]
-    elif isinstance(other, Var):
-      return self.name == other.name
-    elif isinstance(other, TermInst):
-      return self == other.subject
-    elif isinstance(other, RecFun):
-      return self.name == other.name
-    else:
-      return False
+    res = funcdecl_ref_eq(self, other)
+    if res is not None:
+      return res
+    return isinstance(other, RecFun) and self.name == other.name
 
   def reduce(self, env: object) -> Self:
     return self
@@ -1382,19 +1391,11 @@ class GenRecFun(Declaration):
 
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, ResolvedVar):
-      return self.name == other.name
-    elif isinstance(other, OverloadedVar):
-      return self.name == other.resolved_names[0]
-    elif isinstance(other, Var):
-      return self.name == other.name
-    elif isinstance(other, TermInst):
-      return self == other.subject
-    elif isinstance(other, GenRecFun):
-      return self.name == other.name
-    else:
-      return False
-  
+    res = funcdecl_ref_eq(self, other)
+    if res is not None:
+      return res
+    return isinstance(other, GenRecFun) and self.name == other.name
+
   def reduce(self, env: object) -> Self:
     return self
 

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -135,9 +135,6 @@ class PTLetNew(Proof):
 class PRecall(Proof):
   facts: List[Formula]
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
       return 'recall ' + ', '.join([str(f) for f in self.facts])
 
@@ -342,9 +339,6 @@ class AllElimTypes(Proof):
   #  s : The variable's index in the list, starting from the first var
   pos: Tuple[int, int]
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
     s, e = self.pos
     if s == 0:
@@ -365,9 +359,6 @@ class AllElim(Proof):
   #  e : The number of vars in the list
   #  s : The variable's index in the list, starting from the first var
   pos: Tuple[int, int]
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
     s, e = self.pos
@@ -435,9 +426,6 @@ class SomeElim(Proof):
 class PTuple(Proof):
   args: List[Proof]
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
     return ', '.join(_proof_list_item_str(arg) for arg in self.args)
 
@@ -453,17 +441,11 @@ class PAndElim(Proof):
   which: int
   subject: Proof
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
     return 'conjunct ' + str(self.which) + ' of ' + str(self.subject)
 
 @dataclass
 class PTrue(Proof):
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
     return '.'
@@ -471,26 +453,17 @@ class PTrue(Proof):
 @dataclass
 class PReflexive(Proof):
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
     return 'reflexive'
 
 @dataclass
 class PHole(Proof):
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
       return '?'
 
 @dataclass
 class PSorry(Proof):
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
       return 'sorry'
@@ -499,18 +472,12 @@ class PSorry(Proof):
 class PHelpUse(Proof):
   proof : Proof
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
       return 'help ' + str(self.proof)
 
 @dataclass
 class PSymmetric(Proof):
   body: Proof
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
     return 'symmetric ' + str(self.body)
@@ -519,9 +486,6 @@ class PSymmetric(Proof):
 class PTransitive(Proof):
   first: Proof
   second: Proof
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
     return 'transitive ' + str(self.first) + ' ' + str(self.second)
@@ -794,18 +758,12 @@ class SwitchProof(Proof):
 @dataclass
 class EvaluateGoal(Proof):
 
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
-
   def __str__(self) -> str:
     return 'evaluate'
 
 @dataclass
 class EvaluateFact(Proof):
   subject: Proof
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
     return 'evaluate in ' + str(self.subject)
@@ -889,9 +847,6 @@ class SimplifyGoal(Proof):
 class SimplifyFact(Proof):
   subject: Proof
   givens: List[Proof]
-
-  def pretty_print(self, indent: int) -> str:
-      return str(self)
 
   def __str__(self) -> str:
     head = 'simplify'


### PR DESCRIPTION
## Summary

Two distinct, low-risk duplication removals under the **#813** ("Reduce code
duplication across files") umbrella. Both are self-contained within one module
each and independent of the other open #813 slices (#1075 VarRef method bodies,
#1066 `collect_exports`, #1055 edit-distance hint).

### 1. `abstract_syntax/proofs.py` — drop 15 no-op `pretty_print` overrides

The base class already defines the default (`abstract_syntax/core.py`):

```python
def pretty_print(self, indent: int) -> str:
    return str(self)
```

Fifteen `Proof` subclasses re-declared `pretty_print(self, indent)` with the
**byte-for-byte identical** body `return str(self)`, so each override was a pure
no-op shadowing the inherited method. The affected classes — `PRecall`,
`AllElimTypes`, `AllElim`, `PTuple`, `PAndElim`, `PTrue`, `PReflexive`, `PHole`,
`PSorry`, `PHelpUse`, `PSymmetric`, `PTransitive`, `EvaluateGoal`,
`EvaluateFact`, `SimplifyFact` — all inherit `Proof` **directly** (verified), so
deleting the overrides lets them fall through to the identical base method. No
behavior change.

### 2. `abstract_syntax/declarations.py` — share `RecFun`/`GenRecFun` `__eq__`

`RecFun.__eq__` and `GenRecFun.__eq__` were identical except for the single
same-kind branch. The four shared reference-form branches (`ResolvedVar`,
`OverloadedVar`, `Var`, `TermInst`) are now single-sourced in a module-level
`funcdecl_ref_eq(decl, other)` helper that returns `None` when `other` is not a
reference form. Each `__eq__` keeps its own same-kind branch:

```python
def __eq__(self, other: object) -> bool:
    res = funcdecl_ref_eq(self, other)
    if res is not None:
      return res
    return isinstance(other, RecFun) and self.name == other.name
```

Keeping the same-kind check per-method preserves the invariant that `RecFun`
and `GenRecFun` never compare equal to each other, and keeps mypy narrowing
clean.

Net **−44 lines** (26 insertions, 70 deletions).

## Verification

- `python3 test-deduce.py` — all categories green (lib + should-validate ×2
  parsers + should-error + should-warn + prelude + parser equivalence +
  pretty-print round-trip), 113s. The round-trip category exercises the
  now-inherited `pretty_print`; the should-validate/lib evaluation traces
  exercise `__eq__`.
- `python3 test-deduce.py --equiv` — RD/LALR parity + round-trip green.
- `ast.parse` sanity-checks both edited files.
- ruff/mypy could not run in this container (no `python3.13`); relying on CI
  static checks. The moved logic is type-preserving: `funcdecl_ref_eq` returns
  `bool | None` and the `isinstance(other, RecFun)` guard narrows cleanly.

Refs #813

Resume this session on ginger: `~/deduce-runner/resume.sh 5ef88df0-ee86-4744-ae41-4b876aa94cb2 routine/20260718-170202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
