### PR TITLE
Pretty-print `operator ≠` with its keyword so the term round-trips (refs #931)

### DIFF
--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -64,6 +64,12 @@ infix_precedence = {'+': 6, '-': 6, '∸': 6, '⊝': 6, '*': 7, '/': 7, '%': 7,
                     '++': 6, '⨄': 6, '∈':1, '∪':6, '∩':6, '⊆': 1, '⇔': 2,
                     '∘': 7, '^' : 8}
 prefix_precedence = {'-': 9, 'not': 4}
+# Operator symbols addressable as a term via the `operator` keyword but with
+# no infix/prefix precedence entry because they are pure sugar: `≠` desugars
+# to `not (x = y)`, so no Call/term node is ever headed by it. Pretty-printing
+# still needs the `operator` prefix to reparse a bare `Var('≠')` (the AST that
+# `operator ≠` produces); without it the printed `≠` fails to reparse.
+sugar_operators = {'≠'}
 recursion_depth = 0
 
 def name2str(s: str) -> str:

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -913,15 +913,15 @@ def add_reduced_def(df: str) -> None:
   reduced_defs.add(df)
 
 def complete_name(name: str) -> str:
-    if base_name(name) in infix_precedence.keys() \
-       or base_name(name) in prefix_precedence.keys():
+    if is_operator_name(name):
         return 'operator ' + base_name(name)
     else:
         return name2str(name)
     
 def is_operator_name(name: str) -> bool:
     return base_name(name) in infix_precedence.keys() \
-        or base_name(name) in prefix_precedence.keys()
+        or base_name(name) in prefix_precedence.keys() \
+        or base_name(name) in sugar_operators
     
     
 def is_var_operator(trm: Term) -> bool:

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -570,6 +570,13 @@ PARSER_ROUND_TRIP_FILES = (
     # precedence level. `:` now folds into the same left-associative
     # `logical_term` loop as `and`/`or`, matching LALR. Refs #473.
     "./test/should-validate/annotation_precedence_rd_lalr.pf",
+    # `operator ≠` (and its ASCII synonym `operator /=`) produce a bare
+    # `Var('≠')`, but `≠` has no infix/prefix precedence entry (it is sugar
+    # for `not (x = y)`), so `is_operator_name` reported False and the term
+    # pretty-printed to a bare `≠` that no longer reparses. `≠` is now
+    # recognized as an operator name, so the `operator` prefix is preserved.
+    # Refs #931, #473.
+    "./test/should-error/operator_not_equal_synonym.pf",
 )
 
 

--- a/test/should-error/operator_not_equal_synonym.pf.err
+++ b/test/should-error/operator_not_equal_synonym.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/operator_not_equal_synonym.pf:7.12-7.20: while type checking, undefined variable ≠
+./test/should-error/operator_not_equal_synonym.pf:7.12-7.20: while type checking, undefined variable operator ≠

--- a/test/should-error/undefined_operator_no_str_env.pf.err
+++ b/test/should-error/undefined_operator_no_str_env.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/undefined_operator_no_str_env.pf:6.12-6.20: while type checking, undefined variable ≠
+./test/should-error/undefined_operator_no_str_env.pf:6.12-6.20: while type checking, undefined variable operator ≠


### PR DESCRIPTION
## Summary

Fixes a pretty-printer round-trip defect surfaced by a fresh full-corpus `--equiv-full` audit (issue #931): `operator ≠` — and its ASCII synonym `operator /=` — pretty-printed to a bare `≠`, which no longer reparses as a term.

`operator ≠` parses to a bare `Var('≠')`, but `≠` has no infix/prefix precedence entry, because it is pure sugar (`x ≠ y` desugars to `not (x = y)`, so no `Call`/term node is ever headed by it). As a result `is_operator_name('≠')` reported `False`, `Var.__str__` dropped the `operator` keyword, and the printed bare `≠` failed to reparse.

## Changes

- Add a small `sugar_operators = {'≠'}` set in `abstract_syntax/core.py` for operator symbols addressable via the `operator` keyword but with no precedence entry.
- `is_operator_name` now also consults `sugar_operators`, so `Var('≠')` prints as `operator ≠` and round-trips.
- Fold `complete_name` onto `is_operator_name` so the two stay in sync (they had identical duplicated conditions).
- Regenerate the two should-error fixtures whose undefined-variable message now reads `operator ≠` — consistent with how every other operator symbol already renders through the same `is_var_operator` path, and still names `≠` (so the `/=`→`≠` normalization regression guard is preserved: both fixtures now emit identical text).
- Add `test/should-error/operator_not_equal_synonym.pf` to the curated `PARSER_ROUND_TRIP_FILES` set so CI `--equiv` guards this shape.

## Testing

- `python3 test-deduce.py --equiv-full` — 533 accepted-syntax files round-trip (was 8 failures on the two `operator ≠` fixtures).
- `python3 test-deduce.py` — full harness, both parsers, all green.
- `python3 -m ruff check .` and `python3 -m mypy .` — clean.

Refs #931, #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 0bf03d63-78c9-43d4-ba93-bed890a5ff5d routine/20260724-000202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
