### PR TITLE
Dedup AST __eq__ into eq_fields/eq_arg_list; fix Array length soundness hole (closes #1087, refs #813)

### DIFF
--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -165,6 +165,28 @@ def _ast_map(value: object, f: Callable[[AST], AST]) -> object:
   return value
 
 
+def eq_fields(self: AST, other: object, *fields: str) -> bool:
+  """Structural `__eq__` for a leaf AST dataclass that compares a fixed set
+  of fields (never `location`). `other` must be an instance of exactly
+  `self`'s class; with no `fields` this degenerates to the isinstance-only
+  check used by nullary nodes. Kept as a module-level helper — deleting a
+  class's `__eq__` would let `@dataclass` regenerate one that also compares
+  `location`."""
+  if not isinstance(other, type(self)):
+    return False
+  return all(getattr(self, f) == getattr(other, f) for f in fields)
+
+
+def eq_arg_list(self: AST, other: object, attr: str = 'args') -> bool:
+  """Structural `__eq__` for a leaf AST dataclass whose payload is a single
+  list of children, compared pairwise under a length guard."""
+  if not isinstance(other, type(self)):
+    return False
+  a = getattr(self, attr)
+  b = getattr(other, attr)
+  return len(a) == len(b) and all(x == y for x, y in zip(a, b))
+
+
 @dataclass
 class Type(AST):
 

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -79,7 +79,7 @@ class IntType(Type):
     return 'int'
 
   def __eq__(self, other: object) -> bool:
-    return isinstance(other, IntType)
+    return eq_fields(self, other)
 
   def free_vars(self) -> Set[str]:
     return set()
@@ -91,7 +91,7 @@ class BoolType(Type):
     return 'bool'
 
   def __eq__(self, other: object) -> bool:
-    return isinstance(other, BoolType)
+    return eq_fields(self, other)
 
   def free_vars(self) -> Set[str]:
     return set()
@@ -103,7 +103,7 @@ class TypeType(Type):
     return 'type'
 
   def __eq__(self, other: object) -> bool:
-    return isinstance(other, TypeType)
+    return eq_fields(self, other)
 
   def free_vars(self) -> Set[str]:
     return set()
@@ -194,11 +194,7 @@ class ArrayType(Type):
     return '[' + str(self.elt_type) + ']'
 
   def __eq__(self, other: object) -> bool:
-    match other:
-      case ArrayType(_, elt_type):
-        return self.elt_type == elt_type
-      case _:
-        return False
+    return eq_fields(self, other, 'elt_type')
 
   def free_vars(self) -> Set[str]:
     return self.elt_type.free_vars()
@@ -211,11 +207,7 @@ class MutableArrayType(Type):
     return '[' + str(self.elt_type) + ']!'
 
   def __eq__(self, other: object) -> bool:
-    match other:
-      case MutableArrayType(_, elt_type):
-        return self.elt_type == elt_type
-      case _:
-        return False
+    return eq_fields(self, other, 'elt_type')
 
   def free_vars(self) -> Set[str]:
     return self.elt_type.free_vars()
@@ -1573,11 +1565,7 @@ class Array(Term):
   elements: List[Term]
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, Array):
-      return all([elt == other_elt for (elt, other_elt) in zip(self.elements,
-                                                               other.elements)])
-    else:
-      return False
+    return eq_arg_list(self, other, 'elements')
 
   def __str__(self) -> str:
     return 'array(' + ', '.join([str(elt) for elt in self.elements]) + ')'
@@ -1587,10 +1575,7 @@ class MakeArray(Term):
   subject: Term
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, MakeArray):
-      return self.subject == other.subject
-    else:
-      return False
+    return eq_fields(self, other, 'subject')
 
   def __str__(self) -> str:
     return 'array(' + str(self.subject) + ')'
@@ -1609,11 +1594,7 @@ class ArrayGet(Term):
   position: Term
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, ArrayGet):
-      return self.subject == other.subject \
-        and self.position == other.position
-    else:
-      return False
+    return eq_fields(self, other, 'subject', 'position')
 
   def __str__(self) -> str:
     return str(self.subject) + '[' + str(self.position) + ']'
@@ -1791,12 +1772,8 @@ class And(Formula):
                                for arg in ret_args]) + ')'
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, And):
-      return False
-    if len(self.args) != len(other.args):
-      return False
-    return all([arg1 == arg2 for arg1,arg2 in zip(self.args, other.args)])
-  
+    return eq_arg_list(self, other)
+
   def reduce(self, env: Env) -> Formula:
     #new_args = [arg.reduce(env) for arg in self.args]
     new_args = flatten_and([arg.reduce(env) for arg in self.args])
@@ -1838,12 +1815,8 @@ class Or(Formula):
                               for arg in self.args]) + ')'
   
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, Or):
-      return False
-    if len(self.args) != len(other.args):
-      return False
-    return all([arg1 == arg2 for arg1,arg2 in zip(self.args, other.args)])
-  
+    return eq_arg_list(self, other)
+
   def reduce(self, env: Env) -> Formula:
     new_args = flatten_or([arg.reduce(env) for arg in self.args])
     newer_args = []
@@ -1886,9 +1859,7 @@ class IfThen(Formula):
           + ' then ' + str(self.conclusion) + ')'
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, IfThen):
-      return False
-    return self.premise == other.premise and self.conclusion == other.conclusion
+    return eq_fields(self, other, 'premise', 'conclusion')
   
   def reduce(self, env: Env) -> Formula:
     prem = self.premise.reduce(env)
@@ -1946,7 +1917,7 @@ class Emp(Formula):
   # The empty-heap resource assertion, written `emp`.
 
   def __eq__(self, other: object) -> bool:
-    return isinstance(other, Emp)
+    return eq_fields(self, other)
 
   def __str__(self) -> str:
     return 'emp'
@@ -1958,9 +1929,7 @@ class PointsTo(Formula):
   value: Term
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, PointsTo):
-      return False
-    return self.address == other.address and self.value == other.value
+    return eq_fields(self, other, 'address', 'value')
 
   def __str__(self) -> str:
     return '(' + str(self.address) + ' |-> ' + str(self.value) + ')'
@@ -1973,9 +1942,7 @@ class SepConj(Formula):
   right: Formula
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, SepConj):
-      return False
-    return self.left == other.left and self.right == other.right
+    return eq_fields(self, other, 'left', 'right')
 
   def __str__(self) -> str:
     return '(' + str(self.left) + ' ** ' + str(self.right) + ')'

--- a/test/should-error/array_eq_length.pf
+++ b/test/should-error/array_eq_length.pf
@@ -1,0 +1,10 @@
+import UInt
+import List
+
+// Regression for #1087: Array equality must respect length. Previously
+// `Array.__eq__` zipped elements without a length guard, so an array that is
+// a prefix of another compared equal and this false theorem checked as valid.
+theorem array_eq_length: array([1]) = array([1, 2])
+proof
+  evaluate
+end

--- a/test/should-error/array_eq_length.pf.err
+++ b/test/should-error/array_eq_length.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/array_eq_length.pf:9.3-9.11: the goal did not evaluate to `true`, but instead:
+	array(1) = array(1, 2)


### PR DESCRIPTION
## What

Another duplication-reduction slice for the code-dedup umbrella #813, plus a
soundness fix that fell out of it.

Collapses the near-identical structural `__eq__` bodies across the leaf AST
dataclasses in `abstract_syntax/terms.py` into two shared module-level helpers
in `abstract_syntax/core.py`, following the existing `funcdecl_ref_eq`
precedent:

- **`eq_fields(self, other, *fields)`** — isinstance guard + per-field `==`.
  With no `fields` it degenerates to the isinstance-only check used by the
  nullary nodes (`IntType`, `BoolType`, `TypeType`, `Emp`), and it also covers
  the single/two-field comparisons (`ArrayType`, `MutableArrayType`,
  `MakeArray`, `ArrayGet`, `IfThen`, `PointsTo`, `SepConj`).
- **`eq_arg_list(self, other, attr='args')`** — isinstance guard + a
  length-checked pairwise comparison of one list field (`And`, `Or`, `Array`).

The helpers stay module-level rather than base methods on purpose: these are
plain `@dataclass` classes, so deleting a class's `__eq__` would let the
dataclass machinery regenerate one that also compares `location`. Keeping a
thin delegating `__eq__` in each class body preserves the exact behavior.

Net: 11 `__eq__` bodies in `terms.py` collapse onto two helpers (−49/+38 lines).

## Soundness fix (Closes #1087)

`Array.__eq__` previously zipped its element lists **without a length guard**,
so an array that is a prefix of another compared equal — letting Deduce prove
false equalities:

```
theorem array_len_bug: array([1]) = array([1, 2])
proof
  evaluate
end
```

checked as valid. Folding `Array` onto the length-checked `eq_arg_list` closes
that hole. Added `test/should-error/array_eq_length.pf` as a regression guard.

## Testing

- `python3 test-deduce.py` — all categories pass (should-validate ×2 parsers,
  should-error, should-warn, parser RD/LALR equivalence, pretty-print round
  trip).
- `python3 -m ruff check .` and `python3 -m mypy .` — clean.

Resume this session on ginger: `~/deduce-runner/resume.sh e6fc818b-6a10-4c59-a465-1ca0667f4fb1 routine/20260724-020201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
