### PR TITLE
Fix Array.__eq__ length hole: guard on element count (closes #1087)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1573,11 +1573,12 @@ class Array(Term):
   elements: List[Term]
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, Array):
-      return all([elt == other_elt for (elt, other_elt) in zip(self.elements,
-                                                               other.elements)])
-    else:
+    if not isinstance(other, Array):
       return False
+    if len(self.elements) != len(other.elements):
+      return False
+    return all([elt == other_elt for (elt, other_elt) in zip(self.elements,
+                                                             other.elements)])
 
   def __str__(self) -> str:
     return 'array(' + ', '.join([str(elt) for elt in self.elements]) + ')'

--- a/test/should-error/array_len_eq.pf
+++ b/test/should-error/array_len_eq.pf
@@ -1,0 +1,8 @@
+// A shorter array must not compare equal to a longer one (soundness, issue #1087).
+import UInt
+import List
+
+theorem array_len_bug: array([1]) = array([1, 2])
+proof
+  evaluate
+end

--- a/test/should-error/array_len_eq.pf.err
+++ b/test/should-error/array_len_eq.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/array_len_eq.pf:7.3-7.11: the goal did not evaluate to `true`, but instead:
+	array(1) = array(1, 2)


### PR DESCRIPTION
## Summary

`Array.__eq__` (`abstract_syntax/terms.py`) zipped the two element lists
**without a length guard**, so a shorter array compared equal to any array that
had it as a prefix. `zip` stops at the shorter list, so the trailing elements of
the longer array were never examined. This was a soundness bug: it let Deduce
prove false equalities such as `array([1]) = array([1, 2])`.

The fix adds a `len(...)` check up front, mirroring the sibling `And.__eq__` /
`Or.__eq__` / `Call.__eq__` bodies which already guard on length.

## Before

```
theorem array_len_bug: array([1]) = array([1, 2])
proof
  evaluate
end
```
```
$ python3 deduce.py array_len_bug.pf
array_len_bug.pf is valid        # false theorem accepted
```

## After

The equality no longer reduces to `true`; `evaluate` leaves the residual
`array(1) = array(1, 2)` and the proof correctly fails. True equalities
(`array([1,2]) = array([1,2])`, empty arrays) still validate.

## Changes

- `abstract_syntax/terms.py`: length guard in `Array.__eq__`.
- `test/should-error/array_len_eq.pf` (+ `.err`): regression that the false
  equality is rejected.

## Testing

- `python3 test-deduce.py --lib --passable` — pass
- `python3 test-deduce.py --errors --warns` — pass (new fixture included)
- `python3 test-deduce.py --equiv` — pass

(ruff/mypy are not installed in this container; left to CI.)

Closes #1087. Refs #813 (spotted while surveying near-identical `__eq__` bodies
for the code-duplication umbrella).

Resume this session on ginger: `~/deduce-runner/resume.sh c90ab20b-1694-464c-8ae9-7870b3f6cad2 routine/20260724-030202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
