### PR TITLE
Dedup: share header type-params `<...>` rendering across decl printers (refs #813)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -1212,8 +1212,7 @@ class RecFun(Declaration):
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
     header = complete_name(self.name) \
-        + ('<' + ','.join([name2str(t) for t in self.type_params]) + '>' \
-           if len(self.type_params) > 0 else '') \
+        + angle_type_params(self.type_params) \
       + '(' + ','.join([str(ty) for ty in self.params]) + ')' \
       + ' -> ' + str(self.returns)
     ret = self.visibility_prefix() + 'recursive ' + header + '{\n' \
@@ -1233,6 +1232,14 @@ class RecFun(Declaration):
 
   def substitute(self, sub: object) -> Self:
     return self
+
+def angle_type_params(type_params: Sequence[str]) -> str:
+    """`<t1,t2,...>` (rendered via `name2str`) for a non-empty type-parameter
+    list, else the empty string -- the header form shared by the RecFun /
+    GenRecFun / ViewRecFun / ViewDecl pretty-printers."""
+    if len(type_params) == 0:
+        return ''
+    return '<' + ','.join([name2str(t) for t in type_params]) + '>'
 
 def pretty_print_function_header(
     name: str,
@@ -1327,8 +1334,7 @@ class GenRecFun(Declaration):
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
     pad = indent * ' '
     header = complete_name(self.name) \
-        + ('<' + ','.join([name2str(t) for t in self.type_params]) + '>' \
-           if len(self.type_params) > 0 else '') \
+        + angle_type_params(self.type_params) \
       + '(' + ', '.join([base_name(x) + ':' + str(t) if t else x for (x,t) in self.vars])\
       + ') -> ' + str(self.returns) \
       + '\n' + pad + '  measure ' + str(self.measure) \
@@ -1422,8 +1428,7 @@ class ViewRecFun(Declaration):
 
   def pretty_print(self, indent: int) -> str:
     header = complete_name(self.name) \
-        + ('<' + ','.join([name2str(t) for t in self.type_params]) + '>' \
-           if len(self.type_params) > 0 else '') \
+        + angle_type_params(self.type_params) \
       + '(' + ', '.join([base_name(x) + ':' + str(t) if t else x for (x,t) in self.vars])\
       + ') -> ' + str(self.returns)
     ret = self.visibility_prefix() + 'viewrec ' + header \
@@ -1486,8 +1491,7 @@ class ViewDecl(Declaration):
 
   def pretty_print(self, indent: int) -> str:
     header = complete_name(self.name) \
-      + ('<' + ','.join([name2str(t) for t in self.type_params]) + '>' \
-         if len(self.type_params) > 0 else '')
+      + angle_type_params(self.type_params)
     # The view's own declaration names its underlying source type
     # (e.g. `source Binary`); suppress the source→view-name alias so
     # that line doesn't self-referentially print as `source UInt`.


### PR DESCRIPTION
## Summary

Small duplication-reduction slice for the #813 umbrella.

`RecFun`, `GenRecFun`, `ViewRecFun`, and `ViewDecl` each inlined a
byte-identical two-line expression to render the optional
`<t1,t2,...>` type-parameter suffix in their `pretty_print` headers:

```python
('<' + ','.join([name2str(t) for t in self.type_params]) + '>'
 if len(self.type_params) > 0 else '')
```

This PR extracts that into a shared `angle_type_params` helper in
`abstract_syntax/declarations.py` and points all four call sites at it.

## Why this is safe

Pure refactor — the four sites were textually identical (same `name2str`
render, same `,` separator, same `len(...) > 0` guard), so the extracted
helper reproduces each one exactly. It is deliberately scoped to the
`name2str`/`,` form only; the `base_name`- and raw-rendered type-param
lists elsewhere in the module render differently and are intentionally
left alone.

## Verification

- `python3 test-deduce.py --equiv` — pass (round-trip exercises the
  `recfun` / `viewrec` / `recursive` declaration printers via
  `recfun_roundtrip.pf`, `uint_viewrec.pf`, `fib.pf`, and the `lib/`
  modules).
- `python3 test-deduce.py --passable` — pass (both parsers).
- Spot-checked that `replicate<T>(...)`, `fib` (no params), and
  `count_down` (no params) headers render identically to before.

(`ruff`/`mypy` require `python3.13`, which is absent in this container; the
change is a helper extraction with no new type surface.)

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh 577f6331-0541-4b22-8dd1-d41e0eedad7b routine/20260724-050201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
