### PR TITLE
Dedup: share pattern-case uniquify between IndCase and SwitchProofCase (refs #813)

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -508,6 +508,41 @@ class PExtensionality(Proof):
   def __str__(self) -> str:
     return 'extensionality\n' + maybe_str(self.body)
 
+def uniquify_pattern_case(
+    loc: Meta,
+    pattern: Pattern,
+    labeled_hyps: list[Tuple[str, Optional[Formula]]],
+    body: Proof,
+    env_map: UniquifyEnv,
+    uniq_ctx: UniquifyContext,
+) -> Tuple[Pattern, list[Tuple[str, Optional[Formula]]], Proof]:
+  """Uniquify a `case <pattern> assume <labeled_hyps> { <body> }` block.
+
+  Renames the pattern's bindings and the hypothesis/assumption labels to
+  globally unique names, uniquifies each hypothesis formula and the body
+  against the extended environment, and returns the rebuilt
+  `(pattern, labeled_hyps, body)`. Shared by `IndCase.uniquify` (induction
+  hypotheses) and `SwitchProofCase.uniquify` (switch assumptions).
+  """
+  body_env = copy_dict(env_map)
+
+  new_params = [generate_name(x, uniq_ctx) for x in pattern.bindings()]
+  for (old, new) in zip(pattern.bindings(), new_params):
+    overwrite(body_env, old, new, loc)
+
+  new_labels = [generate_name(x, uniq_ctx) for (x, _) in labeled_hyps]
+  for ((old, _), new) in zip(labeled_hyps, new_labels):
+    overwrite(body_env, old, new, loc)
+
+  new_hyps: list[Tuple[str, Optional[Formula]]] = []
+  for ((_, f), new_label) in zip(labeled_hyps, new_labels):
+    new_f = f.uniquify(body_env, uniq_ctx) if f else None
+    new_hyps.append((new_label, new_f))
+
+  new_pat = pattern.with_bindings(new_params).uniquify(body_env, uniq_ctx)
+  new_body = body.uniquify(body_env, uniq_ctx)
+  return (new_pat, new_hyps, new_body)
+
 @dataclass
 class IndCase(AST):
   pattern: Pattern
@@ -535,27 +570,12 @@ class IndCase(AST):
       + ' {' + str(self.body) + '}'
 
   def uniquify(self, env: object, ctx: object) -> IndCase:
-    env_map = cast(UniquifyEnv, env)
-    uniq_ctx = cast(UniquifyContext, ctx)
-    body_env = copy_dict(env_map)
-    pattern = cast(PatternCons, self.pattern)
-
-    new_params = [generate_name(x, uniq_ctx) for x in pattern.parameters]
-    for (old, new) in zip(pattern.parameters, new_params):
-      overwrite(body_env, old, new, self.location)
-
-    new_hyp_labels = [generate_name(x, uniq_ctx) for (x, _) in self.induction_hypotheses]
-    for ((old, _), new) in zip(self.induction_hypotheses, new_hyp_labels):
-      overwrite(body_env, old, new, self.location)
-
-    new_hyps: list[Tuple[str, Formula]] = []
-    for ((_, f), new_label) in zip(self.induction_hypotheses, new_hyp_labels):
-      new_f = f.uniquify(body_env, uniq_ctx) if f else None
-      new_hyps.append((new_label, cast(Formula, new_f)))
-
-    new_pat = pattern.with_bindings(new_params).uniquify(body_env, uniq_ctx)
-    new_body = self.body.uniquify(body_env, uniq_ctx)
-    return IndCase(self.location, new_pat, new_hyps, new_body)
+    new_pat, new_hyps, new_body = uniquify_pattern_case(
+        self.location, self.pattern,
+        cast('list[Tuple[str, Optional[Formula]]]', self.induction_hypotheses),
+        self.body, cast(UniquifyEnv, env), cast(UniquifyContext, ctx))
+    return IndCase(self.location, new_pat,
+                   cast('list[Tuple[str, Formula]]', new_hyps), new_body)
 
 @dataclass
 class Induction(Proof):
@@ -696,26 +716,9 @@ class SwitchProofCase(AST):
         + '{' + str(self.body) + '}'
 
   def uniquify(self, env: object, ctx: object) -> SwitchProofCase:
-    env_map = cast(UniquifyEnv, env)
-    uniq_ctx = cast(UniquifyContext, ctx)
-    body_env = copy_dict(env_map)
-    pattern = self.pattern
-
-    new_params = [generate_name(x, uniq_ctx) for x in pattern.bindings()]
-    for (old, new) in zip(pattern.bindings(), new_params):
-      overwrite(body_env, old, new, self.location)
-
-    new_assumption_labels = [generate_name(x, uniq_ctx) for (x, _) in self.assumptions]
-    for ((old, _), new) in zip(self.assumptions, new_assumption_labels):
-      overwrite(body_env, old, new, self.location)
-
-    new_assumptions: list[Tuple[str, Optional[Formula]]] = []
-    for ((_, f), new_label) in zip(self.assumptions, new_assumption_labels):
-      new_f = f.uniquify(body_env, uniq_ctx) if f else None
-      new_assumptions.append((new_label, new_f))
-
-    new_pat = pattern.with_bindings(new_params).uniquify(body_env, uniq_ctx)
-    new_body = self.body.uniquify(body_env, uniq_ctx)
+    new_pat, new_assumptions, new_body = uniquify_pattern_case(
+        self.location, self.pattern, self.assumptions, self.body,
+        cast(UniquifyEnv, env), cast(UniquifyContext, ctx))
     return SwitchProofCase(self.location, new_pat,
                            new_assumptions, new_body)
 


### PR DESCRIPTION
## Summary

Duplication-reduction slice for the #813 umbrella.

`IndCase.uniquify` (induction-hypothesis cases) and
`SwitchProofCase.uniquify` (switch assumption cases) in
`abstract_syntax/proofs.py` each inlined the same block:

1. copy the uniquify env,
2. generate globally-unique names for the pattern bindings and rewrite them
   in the copied env,
3. generate globally-unique names for the labeled hypotheses/assumptions and
   rewrite them,
4. uniquify each hypothesis/assumption formula and the body against the
   extended env,
5. rebuild the case node.

This PR extracts that into a shared `uniquify_pattern_case` helper and points
both `uniquify` methods at it.

## Why this is safe

The two sites were behaviorally identical modulo surface detail:

- `IndCase` cast its pattern to `PatternCons` and read `.parameters`;
  `PatternCons.bindings()` returns `self.parameters` verbatim, so the helper's
  `pattern.bindings()` is the same list.
- `IndCase.induction_hypotheses` is `list[Tuple[str, Formula]]` while
  `SwitchProofCase.assumptions` is `list[Tuple[str, Optional[Formula]]]`. The
  helper works over the `Optional` shape (the superset); `IndCase` casts at
  the call site, preserving its stricter field type — exactly what the old
  `cast(Formula, new_f)` did.

No behavior change; pure refactor.

## Testing

- `python3 -m ruff check .` — clean
- `python3 -m mypy abstract_syntax proof_checker.py` — clean
- `python3 test-deduce.py` — all tests pass (lib + should-validate ×2 parsers +
  should-error + should-warn + parser equivalence, incl. RD/LALR AST +
  pretty-print round trip). Induction and switch proofs are exercised
  throughout the lib and should-validate corpus.

## Resume note

Resume this session on ginger: `~/deduce-runner/resume.sh f2e9082a-6c1c-4db5-8b73-9c4ac537f30b routine/20260724-070202`

Refs #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
