### PR TITLE
RD: reject `operator <non-operator>` to match LALR (refs #473)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -54,6 +54,13 @@ compare_operators = {'<', '>', '≤', '<=', '≥', '>=', '⊆', '(=', '∈', 'in
 equal_operators = {'=', '≠', '/='}
 iff_operators = {'iff', "<=>", "⇔"}
 
+# The operator symbols nameable via the `operator` keyword. Matches the
+# `operator`-prefixed alternatives of the LALR grammar's `identifier` rule
+# (Deduce.lark); note `iff`/`⇔`/`<=>` are deliberately excluded, as they are
+# connectives with no `operator` form in either parser.
+operator_names = (expt_operators | mult_operators | add_operators
+                  | compare_operators | equal_operators)
+
 to_unicode = {'.o.': '∘', '|': '∪', '&': '∩', '.+.': '⨄', '.-.': '∸',
               '<=': '≤', '>=': '≥', '/=': '≠',
               '~~': '≈', '<~': '≲', '~-': '⊝',
@@ -182,7 +189,11 @@ def parse_identifier() -> str:
     return '__'
   elif current_token().value == 'operator':
     advance()
-    rator = cast(str, current_token().value)
+    rator_token = current_token()
+    rator = cast(str, rator_token.value)
+    if rator not in operator_names:
+      raise ParseError(meta_from_tokens(rator_token, rator_token),
+            'expected an operator after "operator", not\n\t' + quote(rator))
     advance()
     return to_unicode.get(rator, rator)
   else:

--- a/test/parse/operator_not_an_operator.pf
+++ b/test/parse/operator_not_an_operator.pf
@@ -1,0 +1,6 @@
+// The `operator` keyword may only name an actual operator symbol. The
+// recursive-descent parser used to grab whatever token followed `operator`
+// unconditionally, so `operator **` (and `operator .0.`, `operator |->`,
+// `operator )`, ...) parsed to a bogus `Var`, while the LALR parser rejected
+// them -- a parser divergence. RD now rejects non-operators too. See #473.
+define d = operator **

--- a/test/parse/operator_not_an_operator.pf.err
+++ b/test/parse/operator_not_an_operator.pf.err
@@ -1,0 +1,9 @@
+./test/parse/operator_not_an_operator.pf:6.1-6.20: while parsing
+	proof_stmt ::= "define" identifier "=" term
+
+
+define d = operator **
+           ^^^^^^^^^^^
+
+./test/parse/operator_not_an_operator.pf:6.12-6.23: expected a term, not
+	"**"


### PR DESCRIPTION
## Summary

Fixes an RD/LALR parser divergence surfaced by a fresh `operator <op>` snippet
sweep (umbrella #473): the recursive-descent parser handled the `operator`
keyword by grabbing **whatever token followed it, unconditionally**, so
`operator **`, `operator .0.`, `operator |->`, `operator ─`, `operator iff`,
even `operator )` parsed to a bogus `Var`, while the LALR grammar's `identifier`
rule (`Deduce.lark`) only accepts an enumerated operator set. That let RD accept
programs LALR rejects.

```
define d = operator **   // RD: Var('**')   LALR: ParseError
define d = operator .0.   // RD: Var('∅')    LALR: ParseError
define d = operator )     // RD: Var(')')    LALR: ParseError
```

## Root cause

`parse_identifier`'s `operator` branch was:

```python
elif current_token().value == 'operator':
    advance()
    rator = cast(str, current_token().value)
    advance()
    return to_unicode.get(rator, rator)
```

No validation — any token became the operator name.

## Changes

- Add an `operator_names` set in `rec_desc_parser.py`, defined as the union of
  the existing infix category sets (`expt`/`mult`/`add`/`compare`/`equal`). This
  union is **exactly** the set of `operator`-prefixed alternatives in the LALR
  `identifier` rule (verified by hand and by a diff of both sets — no
  discrepancy in either direction). `iff`/`⇔`/`<=>` are deliberately excluded,
  matching the grammar (they are connectives with no `operator` form in either
  parser).
- `parse_identifier` now rejects `operator X` when `X ∉ operator_names`, with a
  clear `expected an operator after "operator"` message (surfaces directly in
  declaration-name contexts; term contexts wrap it as the usual "expected a
  term").
- Add `test/parse/operator_not_an_operator.pf` (+ `.err`) as an RD parser-error
  regression fixture.

For all 36 valid operators RD and LALR already produce identical identifiers
(`&`→`∩`, `<=`→`≤`, `/=`→`≠`, …); only the previously over-accepted
non-operators change behavior — now rejected under both parsers.

## Testing

- `python3 test-deduce.py` — full harness (lib + should-validate × 2 parsers +
  should-error + should-warn + parser equivalence + round trip): **all green**.
- `python3 test-deduce.py --parser` — `test/parse` fixtures green.
- `python3 test-deduce.py --equiv` — parser equivalence green.
- A local `operator <token>` sweep over the full operator table: the 4
  acceptance divergences (`.0.`, `─`, `**`, `|->`) are resolved; the only
  remaining sweep items are the `operator ≠` **pretty-print round-trip** issue,
  which is out of scope here and already handled by open PR #1086.

ruff/mypy were not installed in the run container; CI will exercise the static
gate. The change adds one module-level `frozenset`-style union and a guard — no
new imports or typing surface.

Refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 0ae8fc62-7dba-4200-8d64-9340ce8a39ec routine/20260724-090202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
