### PR TITLE
Guard Switch/TermInst __eq__ on child-list length (closes #1096)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1530,7 +1530,8 @@ class Switch(Term):
     if not isinstance(other, Switch):
       return False
     eq_subject = self.subject == other.subject
-    eq_cases = all([c1 == c2 for (c1,c2) in zip(self.cases, other.cases)])
+    eq_cases = len(self.cases) == len(other.cases) \
+      and all([c1 == c2 for (c1,c2) in zip(self.cases, other.cases)])
     return eq_subject and eq_cases
 
 @dataclass
@@ -1544,6 +1545,7 @@ class TermInst(Term):
       return self.subject == other
     elif isinstance(other, TermInst):
       return self.subject == other.subject \
+        and len(self.type_args) == len(other.type_args) \
         and all([t1 == t2 for (t1,t2) in zip(self.type_args, other.type_args)])
     else:
       return self.subject == other

--- a/test/unit/test_ast_invariants.py
+++ b/test/unit/test_ast_invariants.py
@@ -840,6 +840,67 @@ def test_structural_eq_nodes_are_unhashable(cls: type) -> None:
         hash(copied)
 
 
+# ---------------------------------------------------------------------------
+# Length-guard regression (issues #1087, #1096)
+# ---------------------------------------------------------------------------
+#
+# Container-shaped nodes compare their child lists elementwise. Without a
+# length guard the pairwise ``zip`` stops at the shorter list, so a node whose
+# children are a *prefix* of another's compares equal -- a structural-equality
+# hole; #1096 covers ``Switch``/``TermInst`` (``Array`` is guarded separately
+# in #1089). These build a node and the same node with one extra trailing child
+# and assert inequality in both directions, mirroring the ``And``/``Or``/
+# ``Call`` nodes that already guard on ``len``.
+
+
+def _grow_Switch(node: ast.Switch) -> ast.Switch:
+    return ast.Switch(node.location, node.typeof, node.subject,
+                      node.cases + [_spec_SwitchCase()])
+
+
+def _grow_TermInst(node: ast.TermInst) -> ast.TermInst:
+    return ast.TermInst(node.location, node.typeof, node.subject,
+                        node.type_args + [ast.BoolType(_meta())], node.inferred)
+
+
+def _grow_And(node: ast.And) -> ast.And:
+    return ast.And(node.location, node.typeof, node.args + [_var("z")])
+
+
+def _grow_Or(node: ast.Or) -> ast.Or:
+    return ast.Or(node.location, node.typeof, node.args + [_var("z")])
+
+
+def _grow_Call(node: ast.Call) -> ast.Call:
+    return ast.Call(node.location, node.typeof, node.rator, node.args + [_var("z")])
+
+
+_LENGTH_GUARD_CASES = [
+    (_spec_Switch, _grow_Switch),
+    (_spec_TermInst, _grow_TermInst),
+    (_spec_And, _grow_And),
+    (_spec_Or, _grow_Or),
+    (_spec_Call, _grow_Call),
+]
+
+
+@pytest.mark.parametrize(
+    "make,grow",
+    _LENGTH_GUARD_CASES,
+    ids=[make().__class__.__name__ for make, _ in _LENGTH_GUARD_CASES],
+)
+def test_prefix_child_list_not_equal(
+    make: Callable[[], ast.AST], grow: Callable[[ast.AST], ast.AST]
+) -> None:
+    """A node whose children are a prefix of another's is not equal to it."""
+    short = make()
+    long = grow(make())
+    assert not (short == long), f"{type(short).__name__}: prefix compared equal"
+    assert not (long == short), (
+        f"{type(short).__name__}: prefix compared equal (reversed)"
+    )
+
+
 def test_specimen_coverage_report(capsys: pytest.CaptureFixture[str]) -> None:
     """Informational: report concrete AST classes without a specimen.
 


### PR DESCRIPTION
## What

`Switch.__eq__` and `TermInst.__eq__` in `abstract_syntax/terms.py` zipped their
child lists (cases / type-args) **without a length guard**, so a node whose
children are a *prefix* of another's compared equal — the trailing children of
the longer node were never examined. This is the same structural-equality hole
the sibling `And` / `Or` / `Call` nodes already guard against.

## Fix

Add a `len(...) == len(...)` guard to both `__eq__` bodies before the pairwise
comparison. Verified against the object-level repro from the issue:

```python
Switch(m,None,v,[('a',1)]) == Switch(m,None,v,[('a',1),('b',2)])          # was True, now False
TermInst(m,None,v,[IntType(m)],False) == TermInst(m,None,v,[IntType(m),IntType(m)],False)  # was True, now False
```

Genuine equalities still hold, and the `len` guard is cheap (short-circuits
before the `all(...)`).

## Test

Added a data-driven regression to `test/unit/test_ast_invariants.py`
(`test_prefix_child_list_not_equal`) covering `Switch`/`TermInst` (the fix) plus
`And`/`Or`/`Call` as already-guarded controls. `Array` is guarded separately in
#1089, so it is intentionally not in this test's case list.

Full `python3 test-deduce.py` passes (RD + LALR, all categories). Note per repo
convention pytest is not CI-gated; the unit test was validated by replicating
its logic against the built AST nodes.

## Scope

This closes the `Switch`/`TermInst` portion tracked in #1096. The sibling
`Array` hole (#1087) is handled independently by #1089/#1088. Refs #813, #1087.

Closes #1096

Resume this session on ginger: `~/deduce-runner/resume.sh ff0fa9dd-5def-4908-800d-3730d7f07f9b routine/20260724-100202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
