### PR TITLE
Dedup: fold identical collect_exports overrides into Declaration (refs #813)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -30,7 +30,7 @@ Does NOT go here:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from .core import *
 from .terms import *
@@ -69,13 +69,21 @@ class Declaration(Statement):
     return self.visibility == 'private' \
         and importing_module != get_current_module()
 
+  # Function-like declarations (`Define`, `RecFun`, ...) permit several
+  # definitions sharing a base name, so they accumulate overloads via
+  # `extend`; other declarations just overwrite their single name.
+  _exports_overload: ClassVar[bool] = False
+
   def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
     # Default: export this declaration's single name. Subclasses that
-    # export additional names (constructors, rules), accumulate overloads
-    # via `extend`, or use a different visibility rule override this.
+    # export additional names (constructors, rules) or use a different
+    # visibility rule override this.
     if self._skip_export(importing_module):
       return
-    export_env[base_name(self.name)] = [self.name]
+    if self._exports_overload:
+      extend(export_env, base_name(self.name), self.name, self.location)
+    else:
+      export_env[base_name(self.name)] = [self.name]
 
 ################ Statements ######################################
 
@@ -1192,10 +1200,7 @@ class RecFun(Declaration):
                   new_params, new_returns, new_cases,
                   visibility=self.visibility)
       
-  def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
-    if self._skip_export(importing_module):
-      return
-    extend(export_env, base_name(self.name), self.name, self.location)
+  _exports_overload = True
 
   def __str__(self) -> str:
     if get_verbose():
@@ -1304,10 +1309,7 @@ class GenRecFun(Declaration):
                      new_measure_ty, new_body, new_terminates,
                      self.trusted_terminates, visibility=self.visibility)
     
-  def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
-    if self._skip_export(importing_module):
-      return
-    extend(export_env, base_name(self.name), self.name, self.location)
+  _exports_overload = True
 
   def __str__(self) -> str:
     if get_verbose():
@@ -1412,10 +1414,7 @@ class ViewRecFun(Declaration):
                       new_view_subject, new_cases,
                       visibility=self.visibility)
 
-  def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
-    if self._skip_export(importing_module):
-      return
-    extend(export_env, base_name(self.name), self.name, self.location)
+  _exports_overload = True
 
   def __str__(self) -> str:
     return self.name if get_unique_names() else base_name(self.name)
@@ -1476,10 +1475,7 @@ class ViewDecl(Declaration):
                     new_source, new_target, new_into, new_out,
                     new_roundtrip, new_inverse, visibility=self.visibility)
 
-  def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
-    if self._skip_export(importing_module):
-      return
-    extend(export_env, base_name(self.name), self.name, self.location)
+  _exports_overload = True
 
   def __str__(self) -> str:
     return self.name if get_unique_names() else base_name(self.name)
@@ -1552,10 +1548,7 @@ class Define(Declaration):
     return Define(self.location, new_name, new_typ, new_body,
                   visibility=self.visibility)
 
-  def collect_exports(self, export_env: UniquifyEnv, importing_module: str) -> None:
-    if self._skip_export(importing_module):
-      return
-    extend(export_env, base_name(self.name), self.name, self.location)
+  _exports_overload = True
 
 uniquified_modules: "dict[str, List[Statement]]" = {}
 


### PR DESCRIPTION
## What

A slice of the #813 duplication-reduction umbrella.

The five overloadable, function-like declarations in
`abstract_syntax/declarations.py` — `Define`, `RecFun`, `GenRecFun`,
`ViewRecFun`, `ViewDecl` — each carried a verbatim copy of the same
`collect_exports` override:

```python
def collect_exports(self, export_env, importing_module) -> None:
    if self._skip_export(importing_module):
        return
    extend(export_env, base_name(self.name), self.name, self.location)
```

The only way this differs from `Declaration.collect_exports` is that it
accumulates overloads with `extend(...)` instead of overwriting the single
name. This PR folds that one difference into the base method behind a
class-level `_exports_overload` opt-in flag (default `False`), and the five
classes now just set `_exports_overload = True` instead of repeating the body.

Net −7 lines, and adding a new overloadable declaration kind is now a
one-line flag rather than another copy of the method.

## Testing

- `python3 test-deduce.py --lib` — passes (exercises imports/exports across
  the whole stdlib with both parsers)
- `python3 test-deduce.py --passable` — passes
- `python3 test-deduce.py --equiv` — passes
- `python3 test-deduce.py --errors` — passes (covers private/opaque export
  visibility errors)
- `python3 test-deduce.py --warns` — passes

(`ruff`/`mypy` are not installed in this container, so the static gate will be
exercised by CI.)

Refs #813

Resume this session on ginger: `~/deduce-runner/resume.sh bf762bd7-2198-4a8b-85c3-42b074f24c49 routine/20260724-150202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
