### PR TITLE
Reference.md: add machine-checked Power (^) grammar entry (refs #473)

### DIFF
--- a/gh_pages/doc/Reference.md
+++ b/gh_pages/doc/Reference.md
@@ -109,6 +109,7 @@ forms are parser/AST only today and most require
 - [Pattern](#pattern)
 - [Parameter List](#parameter-list)
 - [Period (Proof of True)](#period-proof-of-true)
+- [Power](#power)
 - [Private (Visibility)](#private-visibility)
 - [Public (Visibility)](#public-visibility)
 - [Proof](#proof)
@@ -2045,6 +2046,24 @@ atomic_proof ::= "."
 
 A period is a proof of the formula `true` in Deduce.
 
+
+## Power
+
+```deduce-grammar
+exponent_term ::= exponent_term "^" atomic_term
+```
+
+The exponentiation operator `x ^ y` computes `x` raised to the power
+`y`. It binds more tightly than the multiplicative operators, so
+`2 * 3 ^ 2` is `2 * (3 ^ 2)`. Exponentiation on unsigned integers is
+defined in `UInt.pf`; the one for integers is defined in `Int.pf`.
+
+Example:
+
+```{.deduce^#power_example}
+assert 2 ^ 3 = 8
+assert 2 ^ 0 = 1
+```
 
 ## Private (Visibility)
 

--- a/gh_pages/scripts/reference_grammar.py
+++ b/gh_pages/scripts/reference_grammar.py
@@ -46,6 +46,7 @@ SUBSET_RULES = {
     "conclusion",
     "comparison_term",
     "equality_term",
+    "exponent_term",
     "iff_term",
     "logical_term",
     "multiplicative_term",


### PR DESCRIPTION
## Summary

Adds a machine-checked grammar entry for the exponentiation operator `^`
to `gh_pages/doc/Reference.md`, closing a small gap in the #473 item
"migrate remaining Reference.md grammar fragments to strict
`deduce-grammar` blocks."

Before this PR, `^` (`exponent_term`, `pow`) appeared in the
operator-precedence table but had no dedicated reference entry, and
`exponent_term` was the only precedence-level term rule not covered by a
strict `deduce-grammar` block. Every other arithmetic/logical precedence
rule (`additive_term`, `multiplicative_term`, `comparison_term`,
`equality_term`, `logical_term`, `iff_term`, …) already has both.

## Changes

- **`gh_pages/doc/Reference.md`**: new `## Power` section with a checked
  `deduce-grammar` block
  (`exponent_term ::= exponent_term "^" atomic_term`), a note on its
  precedence relative to the multiplicative operators, and an executable
  `#power_example` block (`assert 2 ^ 3 = 8` / `assert 2 ^ 0 = 1`). Added
  the corresponding table-of-contents entry.
- **`gh_pages/scripts/reference_grammar.py`**: added `exponent_term` to
  `SUBSET_RULES` so the entry can document a single syntax form, matching
  how the other precedence-level term rules are handled (they too have a
  passthrough alternative that the reference does not repeat).

## Testing

- `python3 gh_pages/scripts/reference_grammar.py` — passes (now checks
  178 grammar rules + 48 precedence entries against `Deduce.lark`).
- `python3 test-deduce.py --site` — passes (the `#power_example` block
  generates and checks under both parsers).
- `python3 test-deduce.py --equiv` — passes.

Note: `ruff`/`mypy` are not installed in this container, so the static
gate was not run locally; the `reference_grammar.py` change is a
single-string set addition and `py_compile` is clean.

Refs #473 (this is one fragment-migration slice; the umbrella has other
outstanding items, so no closing keyword).

Resume this session on ginger: `~/deduce-runner/resume.sh 2112a9b1-b020-4ef6-956b-2d186423b6d7 routine/20260724-160202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
