### PR TITLE
Dedup: fold identical reduce/substitute no-ops into Declaration base (refs #813)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -77,6 +77,17 @@ class Declaration(Statement):
       return
     export_env[base_name(self.name)] = [self.name]
 
+  def reduce(self, env: object) -> Self:
+    # A declaration is not a reducible term: reducing or substituting into
+    # one yields the declaration unchanged. (The recursive `AST` default is
+    # only meaningful for terms; declarations that live in the runtime
+    # environment as values -- `RecFun`, `GenRecFun`, `ViewRecFun` -- rely
+    # on this.)
+    return self
+
+  def substitute(self, sub: object) -> Self:
+    return self
+
 ################ Statements ######################################
 
 ## Updates the environment with a name, creating overloads
@@ -700,12 +711,6 @@ class Predicate(Declaration):
   # `None` on a Predicate that hasn't been processed yet.
   translated_ast: Optional[List["Statement"]] = None
 
-  def reduce(self, env: object) -> Self:
-    return self
-
-  def substitute(self, sub: object) -> Self:
-    return self
-
   def uniquify(self, env: object, ctx: object) -> Predicate:
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
@@ -794,9 +799,6 @@ class Union(Declaration):
   alternatives: List[Constructor]
   param_polarities: Optional[List[str]] = None
 
-  def reduce(self, env: object) -> Self:
-    return self
-  
   def uniquify(self, env: object, ctx: object) -> Union:
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
@@ -823,10 +825,7 @@ class Union(Declaration):
     if not self.visibility == 'opaque' or (importing_module == get_current_module()):
       for con in self.alternatives:
         extend(export_env, base_name(con.name), con.name, self.location)
-    
-  def substitute(self, sub: object) -> Self:
-    return self
-      
+
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
       header = self.visibility_prefix() + 'union ' + base_name(self.name) \
           + ('<' + ','.join([base_name(t) for t in self.type_params]) + '>' if len(self.type_params) > 0 \
@@ -850,9 +849,6 @@ class TypeAlias(Declaration):
   type_params: List[str]
   body: Type
 
-  def reduce(self, env: object) -> Self:
-    return self
-
   def uniquify(self, env: object, ctx: object) -> TypeAlias:
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
@@ -870,9 +866,6 @@ class TypeAlias(Declaration):
     return TypeAlias(self.location, new_name, new_type_params,
                      self.body.uniquify(body_env, uniq_ctx),
                      visibility=self.visibility)
-
-  def substitute(self, sub: object) -> Self:
-    return self
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
     header = self.visibility_prefix() + 'type ' + base_name(self.name) \
@@ -916,9 +909,6 @@ class ObjectDecl(Declaration):
   type_params: List[str]
   fields: Optional[List[ObjectField]] = None
 
-  def reduce(self, env: object) -> Self:
-    return self
-
   def uniquify(self, env: object, ctx: object) -> ObjectDecl:
     env_map = cast(UniquifyEnv, env)
     uniq_ctx = cast(UniquifyContext, ctx)
@@ -936,9 +926,6 @@ class ObjectDecl(Declaration):
       else [field.uniquify(body_env, uniq_ctx) for field in self.fields]
     return ObjectDecl(self.location, new_name, new_type_params, new_fields,
                       visibility=self.visibility)
-
-  def substitute(self, sub: object) -> Self:
-    return self
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
     header = self.visibility_prefix() + 'object ' + base_name(self.name) \
@@ -966,12 +953,6 @@ class ObserverDecl(Declaration):
   return_type: Type
   reads: List[List[FrameExpr]]
   body: Optional[Term] = None
-
-  def reduce(self, env: object) -> Self:
-    return self
-
-  def substitute(self, sub: object) -> Self:
-    return self
 
   def uniquify(self, env: object, ctx: object) -> ObserverDecl:
     env_map = cast(UniquifyEnv, env)
@@ -1043,12 +1024,6 @@ class ResourceDecl(Declaration):
   type_params: List[str]
   params: List[ProcParam]
   body: Optional[Term] = None
-
-  def reduce(self, env: object) -> Self:
-    return self
-
-  def substitute(self, sub: object) -> Self:
-    return self
 
   def uniquify(self, env: object, ctx: object) -> ResourceDecl:
     env_map = cast(UniquifyEnv, env)
@@ -1228,12 +1203,6 @@ class RecFun(Declaration):
       return res
     return isinstance(other, RecFun) and self.name == other.name
 
-  def reduce(self, env: object) -> Self:
-    return self
-
-  def substitute(self, sub: object) -> Self:
-    return self
-
 def pretty_print_function_header(
     name: str,
     type_params: Sequence[str],
@@ -1352,12 +1321,6 @@ class GenRecFun(Declaration):
     if res is not None:
       return res
     return isinstance(other, GenRecFun) and self.name == other.name
-
-  def reduce(self, env: object) -> Self:
-    return self
-
-  def substitute(self, sub: object) -> Self:
-    return self
 
 @dataclass
 class ViewRecFun(Declaration):


### PR DESCRIPTION
## What

A slice of the #813 duplication-reduction umbrella.

Eight overloadable/type declarations in `abstract_syntax/declarations.py` —
`Predicate`, `Union`, `TypeAlias`, `ObjectDecl`, `ObserverDecl`,
`ResourceDecl`, `RecFun`, `GenRecFun` — each carried a verbatim pair of
no-op overrides:

```python
def reduce(self, env: object) -> Self:
    return self

def substitute(self, sub: object) -> Self:
    return self
```

These exist because the recursive `AST.reduce` / `AST.substitute` default
(walk children via `_map_children`) is only meaningful for *terms*; a
declaration is not a reducible term, so reducing or substituting into one
should yield it unchanged. This PR folds that behavior into a single default
on the `Declaration` base class and deletes the eight repeated pairs.

Net −37 lines (12 insertions, 49 deletions), and the default is now correct
for **every** declaration kind rather than only the eight that happened to
patch it locally. This also removes a latent inconsistency: `ViewRecFun` is
stored in the runtime environment as a value (like `RecFun`/`GenRecFun`) but
previously inherited the recursive default instead of `return self`; it now
matches its siblings.

## Why it's safe

Declarations placed into the runtime environment as reducible values are
`RecFun`, `GenRecFun`, and `ViewRecFun` (see `collect_env` in
`checker_pipeline.py`); all three now consistently return `self`. Other
declarations (`Define`, `Import`, `Postulate`, `Theorem`, etc.) store their
payload terms directly rather than being reduced/substituted as whole
statements, so the default never fires on a path that relied on recursion.

## Testing

- `python3 test-deduce.py` — all tests pass (lib, should-validate ×2 parsers,
  should-error, should-warn, parser equivalence).
- `python3 deduce.py --lalr lib/UInt.pf` — valid (view-heavy stdlib module).
- `python3 deduce.py test/should-validate/uint_viewrec.pf` — valid
  (exercises the `ViewRecFun` reduce path).

(`ruff`/`mypy` are not installed in this container, so the static gate will be
exercised by CI. The base overrides reuse the exact signatures the deleted
ones had, so mypy behavior is unchanged.)

Refs #813

Resume this session on ginger: `~/deduce-runner/resume.sh a4f231a0-696b-4225-a14d-59ec67c61f65 routine/20260724-170202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
