### PR TITLE
Guard TypeInst/Generic/SwitchCase __eq__ on child-list length (closes #1101)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -225,6 +225,7 @@ class TypeInst(Type):
     match other:
       case TypeInst(_, typ, arg_types):
         return self.typ == typ and \
+          len(self.arg_types) == len(arg_types) and \
           all([t1 == t2 for (t1, t2) in zip(self.arg_types, arg_types)])
       # case GenericUnknownInst(loc, typ):
       #   return self.typ == typ
@@ -367,6 +368,8 @@ class Generic(Term):
 
   def __eq__(self, other: object) -> bool:
       if not isinstance(other, Generic):
+          return False
+      if len(self.type_params) != len(other.type_params):
           return False
       ren = {x: ResolvedVar(self.location, None, y) \
              for (x,y) in zip(self.type_params, other.type_params) }
@@ -1467,6 +1470,8 @@ class SwitchCase(AST):
       case PatternBool(_, value1), PatternBool(_, value2):
         return value1 == value2 and self.body == other.body
       case PatternCons(_, constr1, params1), PatternCons(_, constr2, params2):
+        if len(params1) != len(params2):
+          return False
         # Use ResolvedVar in the rename so substituted-in references
         # compare equal to the (already uniquified) ResolvedVars in
         # `other.body`. Picking Var here would break post-uniquify

--- a/test/unit/test_ast_invariants.py
+++ b/test/unit/test_ast_invariants.py
@@ -35,7 +35,7 @@ deferred to subsequent PRs.
 from __future__ import annotations
 
 from dataclasses import fields as dc_fields
-from typing import Callable, Iterable
+from typing import Callable, Iterable, cast
 
 import pytest
 from lark.tree import Meta
@@ -841,21 +841,47 @@ def test_structural_eq_nodes_are_unhashable(cls: type) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Length-guard regression (issues #1087, #1096)
+# Length-guard regression (issues #1087, #1096, #1101)
 # ---------------------------------------------------------------------------
 #
 # Container-shaped nodes compare their child lists elementwise. Without a
 # length guard the pairwise ``zip`` stops at the shorter list, so a node whose
 # children are a *prefix* of another's compares equal -- a structural-equality
 # hole; #1096 covers ``Switch``/``TermInst`` (``Array`` is guarded separately
-# in #1089). These build a node and the same node with one extra trailing child
-# and assert inequality in both directions, mirroring the ``And``/``Or``/
-# ``Call`` nodes that already guard on ``len``.
+# in #1089), and #1101 covers ``TypeInst`` plus the two alpha-renaming nodes
+# ``Generic`` and ``SwitchCase`` (whose ``zip`` builds the rename map rather
+# than comparing directly, but has the same prefix hole). These build a node
+# and the same node with one extra trailing child and assert inequality in both
+# directions, mirroring the ``And``/``Or``/``Call`` nodes that already guard on
+# ``len``.
+
+
+def _spec_SwitchCaseCons() -> ast.SwitchCase:
+    return ast.SwitchCase(
+        _meta(), ast.PatternCons(_meta(), _var("C"), ["x"]), _var("z")
+    )
 
 
 def _grow_Switch(node: ast.Switch) -> ast.Switch:
     return ast.Switch(node.location, node.typeof, node.subject,
                       node.cases + [_spec_SwitchCase()])
+
+
+def _grow_TypeInst(node: ast.TypeInst) -> ast.TypeInst:
+    return ast.TypeInst(node.location, node.typ,
+                        node.arg_types + [ast.BoolType(_meta())])
+
+
+def _grow_Generic(node: ast.Generic) -> ast.Generic:
+    return ast.Generic(node.location, node.typeof,
+                       node.type_params + ["U"], node.body)
+
+
+def _grow_SwitchCaseCons(node: ast.SwitchCase) -> ast.SwitchCase:
+    pat = cast(ast.PatternCons, node.pattern)
+    grown = ast.PatternCons(pat.location, pat.constructor,
+                            pat.parameters + ["y"])
+    return ast.SwitchCase(node.location, grown, node.body)
 
 
 def _grow_TermInst(node: ast.TermInst) -> ast.TermInst:
@@ -881,6 +907,9 @@ _LENGTH_GUARD_CASES = [
     (_spec_And, _grow_And),
     (_spec_Or, _grow_Or),
     (_spec_Call, _grow_Call),
+    (_spec_TypeInst, _grow_TypeInst),
+    (_spec_Generic, _grow_Generic),
+    (_spec_SwitchCaseCons, _grow_SwitchCaseCons),
 ]
 
 


### PR DESCRIPTION
## What

Closes #1101.

Three more AST `__eq__` methods in `abstract_syntax/terms.py` zipped their
child lists **without a length guard** — the same prefix-equality hole as
`Array.__eq__` (#1087) and `Switch`/`TermInst.__eq__` (#1096). `zip` stops at
the shorter list, so a node whose children are a *prefix* of another's compared
equal and the trailing children of the longer node were never examined:

- **`TypeInst.__eq__`** compared its `arg_types` elementwise (direct hole):
  `IntType<Int>` compared equal to `IntType<Int, Bool>`.
- **`Generic.__eq__`** and the **`PatternCons` branch of `SwitchCase.__eq__`**
  `zip` to build an alpha-rename map, so a length mismatch only renamed the
  common prefix and could still report equal when the bodies matched.

The sibling connective/call nodes (`And`, `Or`, `Call`) already guard on `len`
first; these three did not.

## Fix

Add the `len(...) == len(...)` guard to all three methods (mirroring the
#1097 fix for `Switch`/`TermInst`). Equal nodes with matching arities still
compare equal — verified for all three.

## Testing

- Extended the data-driven length-guard regression in
  `test/unit/test_ast_invariants.py` with `TypeInst`, `Generic`, and a
  constructor-pattern `SwitchCase`; the 8 `test_prefix_child_list_not_equal`
  cases pass and the full file's 509 tests pass.
- `python3 test-deduce.py --lib --passable --errors` — all pass (both parsers).
- `python3 test-deduce.py --equiv` — all pass.
- `ruff check` clean on both changed files. (Pre-existing mypy notes in the
  test file are on unchanged lines and `test/` mypy is not CI-gated.)

## How this was found

Audited every `__eq__` in `abstract_syntax/*.py` for the
`zip(...)`-without-`len`-guard pattern after the #1096 fix (`git show
bb359aa`). These were the three remaining offenders; `Call` already guards
with `!=`. Repros are in #1101.

Resume this session on ginger: `~/deduce-runner/resume.sh 192c8c96-fc50-4597-af59-77402ba33e30 routine/20260724-180202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
