### PR TITLE
Add rule-induction/inversion, view, and export round-trip fixtures (refs #931)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -577,6 +577,23 @@ PARSER_ROUND_TRIP_FILES = (
     # recognized as an operator name, so the `operator` prefix is preserved.
     # Refs #931, #473.
     "./test/should-error/operator_not_equal_synonym.pf",
+    # `rule induction <pred>` / `rule inversion <pred>` proofs (`RuleInduction`,
+    # `RuleInductionCase`, `RuleInversion` AST nodes). No prior round-trip fixture
+    # exercised these tactics, so a pretty-printer regression on the `rule
+    # induction`/`rule inversion` header or its `case <rule> { ... }` list would
+    # have passed CI silently. Refs #931, #473.
+    "./test/should-validate/predicate_rule_induction_sugar.pf",
+    "./test/should-validate/predicate_rule_inversion.pf",
+    # A `view` declaration (`ViewDecl` node) with its `source`/`target`/`into`/
+    # `out`/`roundtrip`/`inverse` clauses, plus a `recursive f(<view>) -> ...`
+    # function keyed on the view. No prior round-trip fixture covered `view`, so
+    # the pretty-printer's reproduction of the clause block was unverified.
+    # Refs #931, #473.
+    "./test/should-validate/view_inverse_decl.pf",
+    # A bare `export <name>` re-export statement (`Export` node). Only stdlib
+    # modules exercised it before, none of them in the round-trip corpus, so the
+    # pretty-printer's `export IDENT` form was unverified. Refs #931, #473.
+    "./test/should-validate/export_decl.pf",
 )
 
 

--- a/test/should-validate/export_decl.pf
+++ b/test/should-validate/export_decl.pf
@@ -1,0 +1,9 @@
+// `export <name>` (the `Export` statement) re-exports a name so that a module
+// importing this one sees it without a qualified path. Round-trip coverage for
+// the pretty-printer's reproduction of the bare `export IDENT` form. Refs #931.
+
+import UInt
+
+define answer : UInt = 42
+
+export answer


### PR DESCRIPTION
## Summary

Closes a concrete coverage blind spot in the curated `--equiv` round-trip
corpus (`PARSER_ROUND_TRIP_FILES` in `test-deduce.py`), the check that
pretty-prints each AST, re-parses the generated source with **both** parsers,
and asserts the canonical AST is unchanged.

An AST-node-class coverage sweep over every accepted-syntax `.pf` file showed
that the round-trip corpus exercised **none** of these node classes:

- `RuleInduction`, `RuleInductionCase` — `rule induction <pred>` proofs
- `RuleInversion` — `rule inversion <pred>` proofs
- `ViewDecl` — `view { source/target/into/out/roundtrip/inverse }` declarations
- `Export` — bare `export <name>` re-export statements

Because these constructs had no round-trip fixture, a pretty-printer regression
on any of them (e.g. dropping a `view` clause, mangling the `case <rule> { ... }`
list, or losing the `export` keyword) would have passed CI silently.

## Changes

- **`test-deduce.py`**: added four fixtures to `PARSER_ROUND_TRIP_FILES`, each
  with a comment naming the AST node(s) it newly covers:
  - `test/should-validate/predicate_rule_induction_sugar.pf` (existing)
  - `test/should-validate/predicate_rule_inversion.pf` (existing)
  - `test/should-validate/view_inverse_decl.pf` (existing)
  - `test/should-validate/export_decl.pf` (new, minimal `import UInt` + `define` + `export`)
- **`test/should-validate/export_decl.pf`**: new minimal fixture — the only
  `export` occurrences in `test/should-validate/` were in comments, and the
  statement was otherwise exercised only by stdlib modules not in the round-trip
  corpus.

After this PR, the round-trip node-class coverage gap over all accepted-syntax
files (`lib/` + `test/should-validate/`) is **zero**.

## Testing

- `python3 test-deduce.py --equiv` — passes (round-trip + RD/LALR AST equivalence).
- `python3 test-deduce.py --passable` — passes (new `export_decl.pf` validates
  under both parsers).
- `python3 deduce.py test/should-validate/export_decl.pf` and `--lalr` — both valid.
- The coverage sweep that motivated this now reports 0 missing node classes.

Note: `ruff`/`mypy` are not installed in this container, so the static gate was
not run locally; the `test-deduce.py` change is append-only tuple entries and
`py_compile` is clean.

## Scope

`Refs #931` (and `#473`): this is one round-trip coverage increment on a standing
umbrella, not a full resolution — future constructs added to the grammar should
continue getting representative round-trip fixtures.

Resume this session on ginger: `~/deduce-runner/resume.sh 15d281bd-bec6-4d99-ab53-cb4884ddbfee routine/20260724-190202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
