### PR TITLE
Dedup: extract full_reduce helper for the force-full-reduce idiom (refs #813)

### DIFF
--- a/abstract_syntax/rewrite.py
+++ b/abstract_syntax/rewrite.py
@@ -488,15 +488,7 @@ def try_rewrite(
   return cast(Term, rule.rhs.substitute(matching).reduce(env))
 
 def premise_holds(premise: Formula, env: Env) -> bool:
-    old_reduce_all = get_reduce_all()
-    old_eval_all = get_eval_all()
-    try:
-      set_reduce_all(True)
-      set_eval_all(True)
-      normalized = premise.reduce(env)
-    finally:
-      set_eval_all(old_eval_all)
-      set_reduce_all(old_reduce_all)
+    normalized = full_reduce(premise, env)
     rewritten = auto_rewrites(normalized, env, include_conditionals=False)
     return is_true(cast(Formula, rewritten))
 

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -892,6 +892,19 @@ def set_eval_all(b: bool) -> None:
   global eval_all
   eval_all = b
 
+def full_reduce(term: Term, env: Env) -> Term:
+  """Reduce `term` with reduce_all and eval_all forced on, restoring the
+  previous flag settings afterward."""
+  old_reduce_all = get_reduce_all()
+  old_eval_all = get_eval_all()
+  try:
+    set_reduce_all(True)
+    set_eval_all(True)
+    return term.reduce(env)
+  finally:
+    set_eval_all(old_eval_all)
+    set_reduce_all(old_reduce_all)
+
 # Definitions that were reduced.
 reduced_defs: set[str] = set()
 

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -29,8 +29,8 @@ from abstract_syntax import (
     Statement, Switch, SwitchCase, TAnnote, TLet, Term, TermInst, Theorem,
     Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, VarRef, VerboseLevel,
     ViewDecl, ViewRecFun, alpha_equiv, base_name, callable_name,
-    check_post_typecheck_invariants, find_file, mkEqual, print_theorems,
-    set_eval_all, set_reduce_all, type_match, type_names,
+    check_post_typecheck_invariants, find_file, full_reduce, mkEqual,
+    print_theorems, type_match, type_names,
 )
 from checker_cache import (
     _collect_defined_names, _collect_referenced_names, _hash_ast,
@@ -1251,22 +1251,14 @@ def check_proofs(stmt: Statement, env: Env) -> None:
       pass
   
     case Print(loc, trm):
-      set_reduce_all(True)
-      set_eval_all(True)
-      result = trm.reduce(env)
-      set_eval_all(False)
-      set_reduce_all(False)
+      result = full_reduce(trm, env)
       print(str(result))
       
     case Assert(loc, frm):
       match frm:
         case Call(_, _, rator, [lhs, rhs]) if isinstance(rator, VarRef) and rator.get_name() == '=':
-          set_reduce_all(True)
-          set_eval_all(True)
-          L = lhs.reduce(env)
-          R = rhs.reduce(env)
-          set_eval_all(False)
-          set_reduce_all(False)
+          L = full_reduce(lhs, env)
+          R = full_reduce(rhs, env)
           if L == R:
             pass
           else:
@@ -1275,23 +1267,15 @@ def check_proofs(stmt: Statement, env: Env) -> None:
         case IfThen(_, _,
                     Call(_, _, rator, [lhs, rhs]),
                     Bool(_, _, False)) if isinstance(rator, VarRef) and rator.get_name() == '=':
-          set_reduce_all(True)
-          set_eval_all(True)
-          L = lhs.reduce(env)
-          R = rhs.reduce(env)
-          set_eval_all(False)
-          set_reduce_all(False)
+          L = full_reduce(lhs, env)
+          R = full_reduce(rhs, env)
           if L != R:
             pass
           else:
               user_error(loc, 'assertion failed:\n' +
                     '\t' + str(L) + ' = ' + str(R) + '\n')
         case _:
-          set_reduce_all(True)
-          set_eval_all(True)
-          result = frm.reduce(env)
-          set_eval_all(False)
-          set_reduce_all(False)
+          result = full_reduce(frm, env)
           match result:
             case Bool(_, _, True):
               pass


### PR DESCRIPTION
## Summary

A small, behavior-preserving dedup slice for the code-duplication umbrella.

The "force-full-reduce" idiom

```python
set_reduce_all(True)
set_eval_all(True)
result = term.reduce(env)
set_eval_all(False)
set_reduce_all(False)
```

was copy-pasted **four times** in `checker_pipeline.py` (the `Print`,
`Assert`-equal, `Assert`-not-equal, and `Assert`-bool statement arms) and once,
in a hand-rolled save/restore form, in `premise_holds` (`abstract_syntax/rewrite.py`).

This PR folds all five occurrences into a single helper next to the flag
setters in `abstract_syntax/terms.py`:

```python
def full_reduce(term: Term, env: Env) -> Term:
  """Reduce `term` with reduce_all and eval_all forced on, restoring the
  previous flag settings afterward."""
  old_reduce_all = get_reduce_all()
  old_eval_all = get_eval_all()
  try:
    set_reduce_all(True)
    set_eval_all(True)
    return term.reduce(env)
  finally:
    set_eval_all(old_eval_all)
    set_reduce_all(old_reduce_all)
```

The helper restores the *previous* flag values via `try/finally`. At the four
`checker_pipeline.py` sites the flags are always `False` beforehand (top-level
statement checking), so restoring-to-previous is behavior-identical to the old
restore-to-`False`; and this generality lets the same helper subsume the
existing `try/finally` block in `premise_holds`.

Net: −33 / +22 lines across three files.

## Testing

All green under both parsers (RD + LALR):

- `python3 test-deduce.py --passable`
- `python3 test-deduce.py --lib`
- `python3 test-deduce.py --errors --warns --equiv`

## Scope

Pure refactor. Disjoint from the recently-merged #813 slices
(declarations.py, proofs.py, terms.py `__eq__`, checker_logic.py).

Refs #813

## Resuming this session

Resume this session on ginger: `~/deduce-runner/resume.sh f7a92169-1028-4f8d-8871-bdeb6639dcb0 routine/20260724-200201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
