### PR TITLE
Sync imperative docs to reflect implemented Phase 1 (closes #1106)

### DIFF
--- a/docs/imperative-verification-plan.md
+++ b/docs/imperative-verification-plan.md
@@ -17,9 +17,12 @@ To keep the status precise, this plan distinguishes four levels of support:
 
 Phase 1 delivers *parsed* plus the declaration-level slice of *type-checked*:
 `proc`, `observer`, `object`, and `resource` declarations are recognized,
-threaded through imports/exports and the exported-contract visibility check
-(`checker_pipeline.check_exported_contract_visibility`), and surfaced as LSP
-symbols. Their bodies and specifications are **not** verified — the checker
+threaded through imports/exports, and surfaced as LSP symbols. Public `proc`
+and `observer` contracts additionally go through the exported-contract
+visibility check (`checker_pipeline.check_exported_contract_visibility`), which
+rejects a contract that mentions a private name; `object` and `resource`
+declarations do not yet have an analogous check. Their bodies and
+specifications are **not** verified — the checker
 passes them through unchanged, so a file full of `proc`s reports `is valid`
 without any correctness guarantee. Nothing below the declaration surface is
 verified or executable yet. The verifier, runtime, and everything Phases 2–6

--- a/docs/imperative-verification-plan.md
+++ b/docs/imperative-verification-plan.md
@@ -2,8 +2,28 @@
 
 Tracking issue: #854.
 
-**Status:** design draft. Nothing in this document is implemented yet. The
-examples are proposed surface syntax and future acceptance tests.
+**Status:** Phase 1 (parser/AST + declaration plumbing) is implemented on
+`main`; Phases 2–6 are still a design draft.
+
+To keep the status precise, this plan distinguishes four levels of support:
+
+- **parsed** — the concrete syntax is accepted by both parsers (behind
+  `--experimental-imperative`) and the pretty-printer round-trips it;
+- **type-checked** — declarations are woven into the type environment,
+  imports/exports, module-boundary visibility checks, and LSP symbols;
+- **verified** — verification goals (bounds, frames, invariants,
+  postconditions) are computed and discharged;
+- **executable** — the procedure compiles and runs.
+
+Phase 1 delivers *parsed* plus the declaration-level slice of *type-checked*:
+`proc`, `observer`, `object`, and `resource` declarations are recognized,
+threaded through imports/exports and the exported-contract visibility check
+(`checker_pipeline.check_exported_contract_visibility`), and surfaced as LSP
+symbols. Their bodies and specifications are **not** verified — the checker
+passes them through unchanged, so a file full of `proc`s reports `is valid`
+without any correctness guarantee. Nothing below the declaration surface is
+verified or executable yet. The verifier, runtime, and everything Phases 2–6
+describe below are still proposed surface syntax and future acceptance tests.
 
 ## Goal
 
@@ -991,28 +1011,54 @@ terms.
 
 ## Implementation phases
 
-### Phase 1: Imperative AST and parser, no verifier
+### Phase 1: Imperative AST and parser, no verifier — implemented
+
+This phase has landed on `main` (sub-issues #960–#969, #473; tracked by #854).
 
 - Add AST nodes for `Proc`, imperative statements, spec clauses, frame
   expressions, observer declarations, object declarations, and resource
-  declarations.
-- Parser accepts the proposed syntax under a feature flag, for example
-  `--experimental-imperative`.
-- Type checker rejects procedure calls from pure terms.
+  declarations. **Done** (`imperative_syntax.py`, `abstract_syntax/`).
+- Parser accepts the proposed syntax under the `--experimental-imperative`
+  feature flag. **Done** in both parsers (`parser.py`, `rec_desc_parser.py`,
+  `parser_common.py`); the pretty-printer round-trips every form.
 - Pretty-printer and symbol outline include procedures, observers, objects, and
-  resources.
-- Import filters accept the new top-level declaration names.
+  resources. **Done** — LSP symbols cover all four declaration kinds.
+- Import filters accept the new top-level declaration names, and the
+  exported-contract visibility check
+  (`checker_pipeline.check_exported_contract_visibility`) rejects a public
+  `proc`/`observer` whose contract mentions a private name. **Done**.
+- The imperative surface is documented in
+  [gh_pages/doc/ImperativeReference.md](../gh_pages/doc/ImperativeReference.md).
 
-Acceptance:
+Note: declaration bodies and specifications are accepted but **not** verified —
+`type_check_stmt` passes `proc`/`observer`/`object`/`resource` through
+unchanged. There is no check that a pure `fun` cannot write mutable state,
+because mutable-state semantics do not exist yet; that guarantee arrives with
+the Phase 2 verifier.
 
-- parser fixtures for each new syntactic form;
-- type checker confirms pure `fun` cannot write mutable state;
+Remaining Phase 1 finishing work (open):
+
+- **#1107** (Phase 1l): parse `new`/allocation expressions, restricted to
+  imperative statement right-hand sides.
+- **#1108** (Phase 1m): warn when imperative declarations are accepted without
+  verification, so `is valid` does not read as "verified".
+- **#1109** (Phase 1n): run imperative parser and LSP-symbol regressions in CI.
+- **#1106** (Phase 1k): this documentation sync.
+
+Original acceptance targets:
+
+- parser fixtures for each new syntactic form; **done**
 - LSP symbols include `proc`, `observer`, `object`, and `resource`
-  declarations;
-- `import M using p` can import an exported procedure `p`;
-- a public procedure whose contract mentions a private name is rejected.
+  declarations; **done**
+- `import M using p` can import an exported procedure `p`; **done**
+- a public procedure whose contract mentions a private name is rejected. **done**
+- type checker confirms pure `fun` cannot write mutable state — deferred to
+  Phase 2, since there is no mutable-state semantics to write against yet.
 
 ### Phase 2: Mutable arrays and local variables
+
+This phase is broken into sub-issues #1110–#1133 (Phase 2a–2x), tracked by
+#854. It is not yet implemented.
 
 - Add `[T]!` handles and operations: length, read, write, allocation from
   a list.

--- a/gh_pages/doc/ImperativeReference.md
+++ b/gh_pages/doc/ImperativeReference.md
@@ -9,11 +9,12 @@ and tracked by [issue #854](https://github.com/jsiek/deduce/issues/854).
 entries below are recognized by both parsers and the pretty-printer
 round-trips them. `proc`, `observer`, `object`, and `resource`
 declarations are currently *accepted* — they are threaded through
-imports/exports, the exported-contract visibility check, and LSP
-symbols — but their bodies and specifications are **not verified**. The
-imperative verifier itself does not exist yet, so a file containing
-these declarations reports `is valid` without any correctness
-guarantee. Verification lands in later phases.
+imports/exports and LSP symbols, and public `proc`/`observer` contracts
+additionally go through the exported-contract visibility check — but
+their bodies and specifications are **not verified**. The imperative
+verifier itself does not exist yet, so a file containing these
+declarations reports `is valid` without any correctness guarantee.
+Verification lands in later phases.
 
 Most of the surface lives behind the `--experimental-imperative`
 flag. The exceptions are noted per-section.

--- a/gh_pages/doc/ImperativeReference.md
+++ b/gh_pages/doc/ImperativeReference.md
@@ -5,11 +5,15 @@ design is described in
 [docs/imperative-verification-plan.md](../../docs/imperative-verification-plan.md)
 and tracked by [issue #854](https://github.com/jsiek/deduce/issues/854).
 
-**Status:** Phase 1 (parser/AST only). The grammar entries below are
-recognized by both parsers and the pretty-printer round-trips them. The
-imperative verifier itself does not exist yet — the checker rejects
-every `proc`, `observer`, and `resource` declaration until later phases
-land.
+**Status:** Phase 1 (parser/AST + declaration plumbing). The grammar
+entries below are recognized by both parsers and the pretty-printer
+round-trips them. `proc`, `observer`, `object`, and `resource`
+declarations are currently *accepted* — they are threaded through
+imports/exports, the exported-contract visibility check, and LSP
+symbols — but their bodies and specifications are **not verified**. The
+imperative verifier itself does not exist yet, so a file containing
+these declarations reports `is valid` without any correctness
+guarantee. Verification lands in later phases.
 
 Most of the surface lives behind the `--experimental-imperative`
 flag. The exceptions are noted per-section.
@@ -108,8 +112,10 @@ observer sorted(a: [UInt]!) -> bool
 }
 ```
 
-Observer declarations require `--experimental-imperative`. The checker
-rejects them until the imperative verifier exists.
+Observer declarations require `--experimental-imperative`. They are
+accepted but not verified: the observer body is parsed and the
+declaration participates in module visibility and LSP symbols, but no
+proof semantics are attached until the imperative verifier exists.
 
 ## Procedure (Statement)
 
@@ -153,10 +159,12 @@ proc swap(a: [UInt]!, i: UInt, j: UInt)
 }
 ```
 
-Procedure declarations require `--experimental-imperative`. The checker
-rejects every procedure until the imperative verifier exists, so a
-procedure body is parsed but not yet type-checked or verified. Frame
-clauses use the [Frame Expression](#frame-expression) grammar.
+Procedure declarations require `--experimental-imperative`. They are
+accepted but not verified: a procedure body is parsed and the
+declaration participates in module visibility and LSP symbols, but its
+body and contract are not yet type-checked or verified against the
+verification goals until the imperative verifier exists. Frame clauses
+use the [Frame Expression](#frame-expression) grammar.
 
 ## Procedure Body (Statement Block)
 
@@ -263,8 +271,11 @@ resource list_seg(p: Node, q: Node)
 }
 ```
 
-Resource declarations require `--experimental-imperative`. The checker
-rejects them until the imperative verifier exists.
+Resource declarations require `--experimental-imperative`. They are
+accepted but not verified: the resource body is parsed and the
+declaration participates in module visibility and LSP symbols, but the
+separation-logic connectives it contains have no proof rules until the
+resource tier of the verifier exists.
 
 ## Resource Formulas
 


### PR DESCRIPTION
Closes #1106.

## Problem

The imperative-verification tracking docs were out of date now that Phase 1
(parser/AST + declaration plumbing) has landed on `main`:

- `docs/imperative-verification-plan.md` opened with *"Nothing in this document
  is implemented yet."*
- `gh_pages/doc/ImperativeReference.md` claimed *"the checker rejects every
  `proc`, `observer`, and `resource` declaration until later phases land."*

Both are false. `type_check_stmt` passes `ObjectDecl`/`ProcDecl`/`ObserverDecl`/
`ResourceDecl` through unchanged, and `check_exported_contract_visibility`
already enforces the module-boundary rule. A file full of `proc`s reports
`is valid` today (verified locally with `--experimental-imperative`) — the
declarations are *accepted but not verified*, not rejected.

## Changes

- **`docs/imperative-verification-plan.md`**
  - Rewrote the status block: Phase 1 is implemented; Phases 2–6 remain a
    design draft. Added an explicit **parsed / type-checked / verified /
    executable** distinction so "accepted" is never read as "verified".
  - Marked Phase 1 done in the phase list, linked the closed sub-issues
    (#960–#969, #473), and recorded the remaining Phase 1 finishing work:
    #1107 (allocation parsing), #1108 (unverified-declaration warning),
    #1109 (CI regressions), #1106 (this docs sync).
  - Linked the Phase 2 sub-issues (#1110–#1133) at the Phase 2 heading.
- **`gh_pages/doc/ImperativeReference.md`**
  - Fixed the status block and the per-section "checker rejects …" claims for
    observers, procedures, and resources to "accepted but not verified".
- **Tracking issue #854**: checked the Phase 1 box and linked the sub-issues.
- Grammar blocks were left unchanged (the grammar itself is correct).

## Acceptance (from #1106)

- [x] No documentation says that nothing from the plan is implemented.
- [x] No documentation says the checker rejects all imperative declarations.
- [x] The distinction between parsed, type-checked, verified, and executable is explicit.
- [x] `python gh_pages/scripts/reference_grammar.py` passes.
- [x] `python test-deduce.py --site` passes (`markdown` pip module required).

No parser, verifier, runtime, or compiler behavior changes.

Resume this session on ginger: `~/deduce-runner/resume.sh dc4def27-75da-4968-885d-fc1a9b9aed35 routine/20260727-140202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
