### PR TITLE
RD: include visibility modifier in declaration location (closes #1135)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -217,6 +217,19 @@ def meta_from_tokens(start_token: Token, end_token: Token) -> Meta:
     meta.end_pos = require_token_position(end_token.end_pos, "end_pos")
     return meta
 
+def with_visibility_location(stmt: Statement, vis_token: Optional[Token]) -> Statement:
+    # When a visibility keyword (public/private/opaque) precedes a declaration,
+    # the parse_* helpers anchor the declaration's location at the declaration
+    # keyword, dropping the modifier. Extend the span back to the modifier so it
+    # matches the LALR parser, whose rule meta already covers the whole
+    # declaration. See issue #1135.
+    if vis_token is not None:
+        loc = stmt.location
+        loc.line = require_token_position(vis_token.line, "line")
+        loc.column = require_token_position(vis_token.column, "column")
+        loc.start_pos = require_token_position(vis_token.start_pos, "start_pos")
+    return stmt
+
 @contextmanager
 def parse_region(while_parsing: str) -> Iterator[Token]:
   """Wrap a parse of one construct, adding `while_parsing` context to errors.
@@ -2080,54 +2093,56 @@ def parse_statement() -> Statement:
   token = current_token()
 
   if token.type in accessiblity_keywords:
+    vis_token: Optional[Token] = token
     visibility = token.value
     advance()
   else:
+    vis_token = None
     visibility = 'default'
 
   token = current_token()
 
   if token.type == 'DEFINE':
-    return parse_define(visibility)
+    return with_visibility_location(parse_define(visibility), vis_token)
 
   elif token.type == 'FUN':
-    return parse_function(visibility)
+    return with_visibility_location(parse_function(visibility), vis_token)
 
   elif token.type == 'RECURSIVE':
-    return parse_recursive_function(visibility)
+    return with_visibility_location(parse_recursive_function(visibility), vis_token)
 
   elif token.value == 'proc':
-    return parse_proc_decl(visibility)
+    return with_visibility_location(parse_proc_decl(visibility), vis_token)
 
   elif token.type == 'UNION':
-    return parse_union(visibility)
+    return with_visibility_location(parse_union(visibility), vis_token)
 
   elif token.type == 'TYPE':
-    return parse_type_alias(visibility)
+    return with_visibility_location(parse_type_alias(visibility), vis_token)
 
   elif token.type == 'OBJECT':
-    return parse_object(visibility)
+    return with_visibility_location(parse_object(visibility), vis_token)
 
   elif token.type == 'OBSERVER':
-    return parse_observer_decl(visibility)
+    return with_visibility_location(parse_observer_decl(visibility), vis_token)
 
   elif token.type == 'RESOURCE':
-    return parse_resource_decl(visibility)
+    return with_visibility_location(parse_resource_decl(visibility), vis_token)
 
   elif token.type == 'PREDICATE':
-    return parse_predicate(visibility, 'predicate')
+    return with_visibility_location(parse_predicate(visibility, 'predicate'), vis_token)
 
   elif token.type == 'RELATION':
-    return parse_predicate(visibility, 'relation')
+    return with_visibility_location(parse_predicate(visibility, 'relation'), vis_token)
 
   elif token.type == 'RECFUN':
-    return parse_gen_rec_function(visibility)
+    return with_visibility_location(parse_gen_rec_function(visibility), vis_token)
 
   elif token.type == 'VIEW':
-    return parse_view_decl(visibility)
+    return with_visibility_location(parse_view_decl(visibility), vis_token)
 
   elif token.type == 'PROC':
-    return parse_proc_decl(visibility)
+    return with_visibility_location(parse_proc_decl(visibility), vis_token)
 
   elif token.type == 'ASSERT':
     while_parsing = 'while parsing assert\n' \
@@ -2142,7 +2157,7 @@ def parse_statement() -> Statement:
       raise ParseError(meta_from_tokens(token, previous_token()), "Unexpected error while parsing:\n\t" \
         + str(e))
   elif token.type == 'THEOREM' or token.type == 'LEMMA' or token.type == 'POSTULATE':
-    return parse_theorem(visibility)
+    return with_visibility_location(parse_theorem(visibility), vis_token)
 
   elif token.type == 'EXPORT':
     while_parsing = 'while parsing import\n' \
@@ -2176,9 +2191,11 @@ def parse_statement() -> Statement:
             using = names
           else:
             hiding = names
-        return Import(meta_from_tokens(token, previous_token()),
-                      name, using=using, hiding=hiding,
-                      visibility=visibility)
+        return with_visibility_location(
+                      Import(meta_from_tokens(token, previous_token()),
+                             name, using=using, hiding=hiding,
+                             visibility=visibility),
+                      vis_token)
     except ParseError as e:
       raise e.extend(meta_from_tokens(token, previous_token()), while_parsing)
     except Exception as e:

--- a/test/should-error/imperative_export_private_contract.pf.err
+++ b/test/should-error/imperative_export_private_contract.pf.err
@@ -1,1 +1,1 @@
-./test/should-error/imperative_export_private_contract.pf:9.8-13.2: exported proc 'op' mentions the private name 'rep' in its contract; a public contract may only mention names visible to importing modules.
+./test/should-error/imperative_export_private_contract.pf:9.1-13.2: exported proc 'op' mentions the private name 'rep' in its contract; a public contract may only mention names visible to importing modules.


### PR DESCRIPTION
## Summary

Fixes the RD/LALR disagreement on the `.location` start column for
visibility-prefixed declarations (issue #1135).

The recursive-descent parser anchored a declaration's `.location` at the
declaration **keyword**, discarding any preceding `public`/`private`/`opaque`
modifier. LALR's rule meta already covers the whole declaration (modifier
included), so `decl.location` was parser-dependent for any visibility-prefixed
declaration — e.g. `public define x = 5` gave RD column 8 vs LALR column 1.

This was latent because `--equiv` ignores `location` and the `--warns`/`--errors`
harnesses are RD-only, but any feature that surfaces `decl.location`
(diagnostics, LSP ranges, the Phase 1m "accepted but not verified" warning that
surfaced it) would diverge between parsers.

Confirmed not imperative-specific: it reproduces for ordinary declarations
(`define`, `theorem`, `union`, `import`, …), not just `proc`/`observer`/`resource`.

## Fix

- `rec_desc_parser.py`: capture the visibility token in `parse_statement` and,
  via a new `with_visibility_location` helper, extend the parsed declaration's
  location start back to that token. When there is no modifier the wrapper is a
  no-op, so declarations without visibility are unchanged.
- Regenerated the one affected fixture,
  `test/should-error/imperative_export_private_contract.pf.err`, whose span
  moved `9.8 -> 9.1` — the error now covers the whole `public proc` declaration.

## Verification

- Cross-parser location parity confirmed for `define`/`theorem`/`union`/`import`
  (with and without `public`/`private`/`opaque`) and the imperative `public proc`
  case from the issue (both now `1.1-4.2`).
- `python3 test-deduce.py --equiv --errors --warns --passable --parser` all pass.
- `ruff check` and `mypy` clean on `rec_desc_parser.py`.

Closes #1135

Resume this session on ginger: `~/deduce-runner/resume.sh 2fa35574-b3cf-482c-91c9-838fa32e4fd0 routine/20260727-160201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
