### PR TITLE
Parse `new Obj<T..>(args)` allocation in imperative RHS positions (closes #1107)

### DIFF
--- a/Deduce.lark
+++ b/Deduce.lark
@@ -147,7 +147,7 @@ identifier: IDENT              -> identifier
     | ".0."                                        -> emptyset_literal
     | "emp"                                        -> emp_resource
     | "not" atomic_term                                -> logical_not
-    | "new" IDENT type_params_opt "(" term_list ")"    -> rejected_new_object
+    | "new" IDENT new_type_args "(" term_list ")"      -> rejected_new_object
     | "new"                                            -> rejected_new_term
     | identifier                                   -> term_var
     | "@" atomic_term "<" type_list ">"                -> term_inst
@@ -360,6 +360,12 @@ identifier: IDENT              -> identifier
 
 ?type_params_opt:                                -> empty
    | "<" identifier_list ">"
+
+// Optional type arguments of a `new Obj<T..>(args)` allocation (imperative
+// layer, #854 Phase 1l). Unlike `type_params_opt` these are types, not binding
+// identifiers, so a compound argument such as `new Node<List<T>>(...)` parses.
+?new_type_args:                                  -> empty
+   | "<" type_list ">"
 
 ?constructor: IDENT                                   -> constructor_id
     | IDENT "(" type_list ")"                    -> constructor_apply

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -222,10 +222,27 @@ class ImpCallExpr(AST):
     return result
 
 @dataclass
+class ImpAlloc(AST):
+  # A `new Obj<T..>(args)` allocation used as the right-hand side of a
+  # `var`/assignment inside a `proc` body (Phase 1l, issue #1107). Parsed as
+  # inert syntax: no object allocation, `Ref<T>` checking, field visibility,
+  # or constructor arity checking (those are Phase 3). The pure-term `new`
+  # stays rejected -- allocation is only reachable directly after `:=`.
+  object_name: str
+  type_args: List[Type]
+  args: List[Term]
+
+  def __str__(self) -> str:
+    result = 'new ' + base_name(self.object_name)
+    if self.type_args:
+      result += '<' + ', '.join(str(t) for t in self.type_args) + '>'
+    return result + '(' + ', '.join(str(a) for a in self.args) + ')'
+
+@dataclass
 class ImpVar(ImpStmt):
   name: str
   type_annot: Optional[Type]
-  rhs: Term | ImpCallExpr
+  rhs: Term | ImpCallExpr | ImpAlloc
   ghost: bool = False
 
   def __str__(self) -> str:
@@ -236,7 +253,7 @@ class ImpVar(ImpStmt):
 @dataclass
 class ImpAssign(ImpStmt):
   lhs: LValueVar | LValueIndex | LValueField
-  rhs: Term | ImpCallExpr
+  rhs: Term | ImpCallExpr | ImpAlloc
 
   def __str__(self) -> str:
     return str(self.lhs) + ' := ' + str(self.rhs)
@@ -349,14 +366,20 @@ def _uniquify_lvalue(lv: LValueVar | LValueIndex | LValueField,
     return LValueField(lv.location, _resolve_local(lv.subject, env), lv.field)
   return LValueVar(lv.location, _resolve_local(lv.name, env))
 
-def _uniquify_imp_rhs(rhs: Term | ImpCallExpr, env: UniquifyEnv,
-                      ctx: UniquifyContext) -> Term | ImpCallExpr:
-  # A `var`/assignment right-hand side is either an ordinary term or a
-  # `call f(..) as h` expression. For the call form, resolve the call
-  # term's subparts but leave the label as-is (see the proof-clause note
-  # in `ProcDecl.uniquify`).
+def _uniquify_imp_rhs(rhs: Term | ImpCallExpr | ImpAlloc, env: UniquifyEnv,
+                      ctx: UniquifyContext) -> Term | ImpCallExpr | ImpAlloc:
+  # A `var`/assignment right-hand side is an ordinary term, a `call f(..) as h`
+  # expression, or a `new Obj<T..>(args)` allocation. For the call form,
+  # resolve the call term's subparts but leave the label as-is (see the
+  # proof-clause note in `ProcDecl.uniquify`). For the allocation form,
+  # resolve the type and term arguments but leave the object name as-is
+  # (object resolution is a later verifier phase).
   if isinstance(rhs, ImpCallExpr):
     return ImpCallExpr(rhs.location, rhs.call.uniquify(env, ctx), rhs.label)
+  if isinstance(rhs, ImpAlloc):
+    return ImpAlloc(rhs.location, rhs.object_name,
+                    [t.uniquify(env, ctx) for t in rhs.type_args],
+                    [a.uniquify(env, ctx) for a in rhs.args])
   return rhs.uniquify(env, ctx)
 
 def _uniquify_imp_proof(proof: Optional[Proof], env: UniquifyEnv,

--- a/parser.py
+++ b/parser.py
@@ -6,7 +6,7 @@ from abstract_syntax import (
     FunctionType,
     FrameEmpty, FrameFootprint, FrameTerm, GenRecFun, Generic,
     Hole, IfThen, ImpIntro, Import,
-    ImpAssert, ImpAssign, ImpAssume, ImpCall, ImpCallExpr, ImpIf, ImpReturn,
+    ImpAlloc, ImpAssert, ImpAssign, ImpAssume, ImpCall, ImpCallExpr, ImpIf, ImpReturn,
     ImpVar, ImpWhile, LValueField, LValueIndex, LValueVar,
     IndCase, Induction, Inductive, IntType, Lambda, MakeArray,
     Mark, Module, ModusPonens, MutableArrayType, ObjectDecl, ObjectField,
@@ -236,6 +236,20 @@ def set_visibility(statement: Any, visibility: str) -> None:
     else:
         statement.visibility = 'public'
 
+def _imp_rhs_to_ast(e: ParseNode, parent: ParseParent) -> Any:
+    # A `var`/assignment right-hand side. `new Obj<T..>(args)` parses via the
+    # shared atomic-term `rejected_new_object` shape (which raises for pure
+    # terms); in this imperative position it is instead a first-class
+    # allocation expression. Everything else -- ordinary terms and the `call`
+    # forms -- goes through the general transformer.
+    if not isinstance(e, Token) and e.data == 'rejected_new_object':
+        setattr(e.meta, 'filename', get_filename())
+        _require_experimental_imperative(e.meta)
+        return ImpAlloc(e.meta, _token_text(e, 0),
+                        parse_tree_to_list(e.children[1], e),
+                        parse_tree_to_list(e.children[2], e))
+    return parse_tree_to_ast(e, parent)
+
 # Any: the lark-tree -> AST dispatch boundary. This is dispatched on the
 # grammar rule name and so is polymorphic over every node kind the grammar
 # can produce (Term/Formula/Proof/Type/Pattern/Statement, plus bare str
@@ -245,7 +259,7 @@ def set_visibility(statement: Any, visibility: str) -> None:
 def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
     if isinstance(e, Token):
         return e
-    
+
     setattr(e.meta, 'filename', get_filename())
 
     if e.data == 'nothing':
@@ -458,26 +472,26 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
     elif e.data == 'imp_var':
         _require_experimental_imperative(e.meta)
         return ImpVar(e.meta, parse_tree_to_ast(e.children[0], e), None,
-                      parse_tree_to_ast(e.children[1], e), False)
+                      _imp_rhs_to_ast(e.children[1], e), False)
     elif e.data == 'imp_var_annot':
         _require_experimental_imperative(e.meta)
         return ImpVar(e.meta, parse_tree_to_ast(e.children[0], e),
                       parse_tree_to_ast(e.children[1], e),
-                      parse_tree_to_ast(e.children[2], e), False)
+                      _imp_rhs_to_ast(e.children[2], e), False)
     elif e.data == 'imp_ghost_var':
         _require_experimental_imperative(e.meta)
         return ImpVar(e.meta, parse_tree_to_ast(e.children[0], e), None,
-                      parse_tree_to_ast(e.children[1], e), True)
+                      _imp_rhs_to_ast(e.children[1], e), True)
     elif e.data == 'imp_ghost_var_annot':
         _require_experimental_imperative(e.meta)
         return ImpVar(e.meta, parse_tree_to_ast(e.children[0], e),
                       parse_tree_to_ast(e.children[1], e),
-                      parse_tree_to_ast(e.children[2], e), True)
+                      _imp_rhs_to_ast(e.children[2], e), True)
     elif e.data == 'imp_assign':
         _require_experimental_imperative(e.meta)
         return ImpAssign(e.meta,
                          parse_tree_to_ast(e.children[0], e),
-                         parse_tree_to_ast(e.children[1], e))
+                         _imp_rhs_to_ast(e.children[1], e))
     elif e.data == 'imp_if':
         _require_experimental_imperative(e.meta)
         return ImpIf(e.meta,

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -11,7 +11,7 @@ from abstract_syntax import (
     Define, Emp, EvaluateFact, EvaluateGoal, Export, FieldAccess, FrameEmpty,
     FrameFootprint, FrameTerm, FunCase, FunctionType,
     GenRecFun, Generic, Hole, IfThen, ImpIntro, Import,
-    ImpAssert, ImpAssign, ImpAssume, ImpCall, ImpCallExpr, ImpIf, ImpReturn,
+    ImpAlloc, ImpAssert, ImpAssign, ImpAssume, ImpCall, ImpCallExpr, ImpIf, ImpReturn,
     ImpStmt, ImpVar, ImpWhile, LValueField, LValueIndex, LValueVar,
     IndCase, Induction, Inductive, Lambda, MakeArray, Mark,
     Module, ModusPonens, MutableArrayType, ObjectDecl, ObjectField,
@@ -1889,9 +1889,11 @@ def parse_imp_lvalue() -> LValueVar | LValueIndex | LValueField:
     return LValueField(meta_from_tokens(start, previous_token()), name, field)
   return LValueVar(meta_from_tokens(start, previous_token()), name)
 
-def parse_imp_rhs() -> Term | ImpCallExpr:
-  # A `var`/assignment right-hand side is either a `call f(..)` expression
-  # (optionally labelled with `as h`) or an ordinary term.
+def parse_imp_rhs() -> Term | ImpCallExpr | ImpAlloc:
+  # A `var`/assignment right-hand side is a `call f(..)` expression (optionally
+  # labelled with `as h`), a `new Obj<T..>(args)` allocation, or an ordinary
+  # term. `new` is reachable here only in this imperative position; used as a
+  # pure term it is rejected in `parse_atom`.
   if current_token().value == 'call':
     start = current_token()
     advance()
@@ -1901,7 +1903,31 @@ def parse_imp_rhs() -> Term | ImpCallExpr:
       advance()
       label = parse_identifier()
     return ImpCallExpr(meta_from_tokens(start, previous_token()), call, label)
+  if current_token().type == 'NEW':
+    return parse_imp_alloc()
   return parse_term()
+
+def parse_imp_alloc() -> ImpAlloc:
+  # `new Obj<T..>(args)` -- inert allocation syntax (see `ImpAlloc`). The object
+  # name must be a bare IDENT to match the LALR grammar; `parse_identifier`'s
+  # `operator <op>` / `__` spellings are deliberately not accepted here (they
+  # would diverge from LALR and print to a form that no longer reparses).
+  start = current_token()
+  advance()  # consume "new"
+  name_token = current_token()
+  consume_token('IDENT', 'an object name', context='after "new"')
+  name = cast(str, name_token.value)
+  type_args: list[Type] = []
+  if not end_of_file() and current_token().type == 'LESSTHAN':
+    advance()
+    type_args = parse_type_list()
+    consume_token('MORETHAN', 'closing ">"',
+                  context='after allocation type arguments')
+  consume_token('LPAR', '"("', context='before allocation arguments')
+  args = parse_term_list('RPAR')
+  consume_token('RPAR', 'closing ")"', context='after allocation arguments')
+  return ImpAlloc(meta_from_tokens(start, previous_token()), name,
+                  type_args, args)
 
 def parse_imp_var(ghost: bool) -> ImpVar:
   start = current_token()

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -189,6 +189,9 @@ proc body_forms<T>(a: [T]!, i: T, n: T, ghost g: T) -> T
   var y := a[i]
   ghost var z : T := g
   ghost var w := g
+  var alloc0 := new Cell(n)
+  var alloc1 : T := new Box<T>(x, n)
+  alloc0 := new Cell(y)
   x := n
   a[i] := a[n]
   a.header := x
@@ -246,6 +249,9 @@ EXPERIMENTAL_IMPERATIVE_FILES = frozenset({
     "./test/should-warn/proc_declarations.pf",
     "./test/should-warn/observer_declarations.pf",
     "./test/should-warn/imperative_false_proc.pf",
+    "./test/should-warn/imperative_allocation.pf",
+    "./test/should-error/imperative_new_pure_term.pf",
+    "./test/should-error/imperative_new_operator_name.pf",
     "./test/should-validate/imperative_import.pf",
     "./test/should-error/resource_declarations.pf",
     "./test/should-error/imperative_import_unknown.pf",
@@ -291,6 +297,8 @@ SHOULD_ERROR_PARSER_EQUIV_SKIP = frozenset({
     "./test/should-error/fn_missing_arrow.pf",
     "./test/should-error/fun_params_trailing_comma.pf",
     "./test/should-error/function_case_missing_equal.pf",
+    "./test/should-error/imperative_new_operator_name.pf",
+    "./test/should-error/imperative_new_pure_term.pf",
     "./test/should-error/lambda_empty_params.pf",
     "./test/should-error/literal_too_large.pf",
     "./test/should-error/missing-colon-in-have.pf",
@@ -501,6 +509,11 @@ PARSER_ROUND_TRIP_FILES = (
     # not verified). Both parsers must agree on the AST and the pretty-printer
     # must preserve the header and repeated specification clauses.
     "./test/should-warn/proc_declarations.pf",
+    # `new Obj<T..>(args)` allocation right-hand sides inside a `proc` body
+    # (Phase 1l, #1107). The `ImpAlloc` node is parsed as inert syntax; both
+    # parsers must agree on the AST and the pretty-printer must round-trip the
+    # object name, optional `<type args>`, and constructor argument list.
+    "./test/should-warn/imperative_allocation.pf",
     # Imperative observer declarations. Both parsers must agree on the AST and
     # the pretty-printer must preserve repeated `reads` clauses and the optional
     # body.

--- a/test/should-error/imperative_new_operator_name.pf
+++ b/test/should-error/imperative_new_operator_name.pf
@@ -1,0 +1,10 @@
+// The object name in a `new Obj(args)` allocation must be a bare identifier
+// (Phase 1l, issue #1107). The recursive-descent parser must NOT accept the
+// `operator <op>` spelling that `parse_identifier` allows elsewhere, since the
+// LALR grammar requires an IDENT and the `operator +` form would print to
+// `new +(...)`, which neither parser can reparse.
+proc make() -> bool
+{
+  var a := new operator +(x)
+  return true
+}

--- a/test/should-error/imperative_new_operator_name.pf.err
+++ b/test/should-error/imperative_new_operator_name.pf.err
@@ -1,0 +1,6 @@
+
+
+  var a := new operator +(x)
+               ^^^^^^^^
+./test/should-error/imperative_new_operator_name.pf:8.16-8.24: expected an object name after "new", not
+	operator

--- a/test/should-error/imperative_new_pure_term.pf
+++ b/test/should-error/imperative_new_pure_term.pf
@@ -1,0 +1,4 @@
+// `new` allocation is only accepted directly after `:=` inside a `proc` body
+// (Phase 1l, issue #1107). Used in an ordinary pure term it must still be
+// rejected with the focused diagnostic, even with --experimental-imperative on.
+define x = new Node()

--- a/test/should-error/imperative_new_pure_term.pf.err
+++ b/test/should-error/imperative_new_pure_term.pf.err
@@ -1,0 +1,8 @@
+./test/should-error/imperative_new_pure_term.pf:4.1-4.11: while parsing
+	proof_stmt ::= "define" identifier "=" term
+
+
+define x = new Node()
+           ^^^
+
+./test/should-error/imperative_new_pure_term.pf:4.12-4.15: `new` allocation syntax is only available in imperative statement right-hand sides

--- a/test/should-warn/imperative_allocation.pf
+++ b/test/should-warn/imperative_allocation.pf
@@ -1,0 +1,16 @@
+// Allocation right-hand sides `new Obj<T..>(args)` inside a `proc` body
+// (Phase 1l, issue #1107). Parsed as inert imperative syntax: the object name
+// is not resolved and no fields, arity, or `Ref<T>` semantics are checked yet
+// (Phase 3). This file validates because proc bodies are not verified in
+// Phase 1; it exercises allocation as a `var` RHS (with and without type
+// arguments), a `ghost var` RHS, and an assignment RHS.
+proc allocations<T>(x: T, ghost g: T) -> T
+  requires x = x
+{
+  var a := new Cell(x)
+  var b : T := new Box<T>(x, g)
+  ghost var c := new Ghost<T>(g)
+  var d := new Empty()
+  a := new Cell(g)
+  return x
+}

--- a/test/should-warn/imperative_allocation.pf.warn
+++ b/test/should-warn/imperative_allocation.pf.warn
@@ -1,0 +1,1 @@
+./test/should-warn/imperative_allocation.pf:7.1-16.2: warning: proc 'allocations' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)


### PR DESCRIPTION
## Summary

Phase 1l of the imperative layer (#854): parse `new Obj<T..>(args)` allocation
expressions as inert imperative AST, accepted **only** as a `var`/assignment
right-hand side inside a `proc` body, while continuing to reject `new` in
ordinary pure Deduce terms.

Closes #1107.

## What changed

- **AST** (`abstract_syntax/declarations.py`): new `ImpAlloc` node holding the
  object name, type arguments (`List[Type]`), constructor arguments
  (`List[Term]`), and source location. `ImpVar`/`ImpAssign` RHS unions widened
  to `Term | ImpCallExpr | ImpAlloc`.
- **Grammar** (`Deduce.lark`): the shared `rejected_new_object` production now
  takes real type arguments via a new `new_type_args` rule (`< type_list >`)
  instead of the identifier-only `type_params_opt`, so a compound argument like
  `new Node<List<T>>(...)` parses.
- **LALR** (`parser.py`): a `_imp_rhs_to_ast` helper intercepts the shared
  `rejected_new_object` parse tree in the five imperative RHS positions and
  builds an `ImpAlloc`. Reusing the existing atomic-term shape means no new
  grammar production and therefore no LALR reduce/reduce conflict; pure-term
  `new` still hits the transformer's focused-diagnostic path.
- **RD** (`rec_desc_parser.py`): `parse_imp_rhs` dispatches on the `NEW` token to
  a new `parse_imp_alloc`. Used as a pure term, `new` is still rejected in
  `parse_atom` with the existing message.
- **Uniquify**: `_uniquify_imp_rhs` resolves the type and term arguments; the
  object name is left inert (object resolution / field checking / arity / `Ref<T>`
  are Phase 3).
- **Pretty-print**: `ImpAlloc.__str__` emits `new Obj<T..>(args)` and round-trips
  stably under both parsers.

## Tests

- New positive fixture `test/should-validate/imperative_allocation.pf`, enrolled
  in `EXPERIMENTAL_IMPERATIVE_FILES` and `PARSER_ROUND_TRIP_FILES` (so it is
  checked, RD/LALR equivalence-compared, and pretty-print round-tripped).
- New negative fixture `test/should-error/imperative_new_pure_term.pf` (+ `.err`),
  in the experimental set and in `SHOULD_ERROR_PARSER_EQUIV_SKIP` since both
  parsers reject it.
- `IMPERATIVE_SYNTAX_SOURCE` in `test-deduce.py` gained allocation lines, so the
  in-harness experimental parser test covers RD/LALR AST equality, round-trip,
  and validation.
- Verified locally: `ruff`, `mypy`, `keywords.py`, `reference_grammar.py`, the
  full default `test-deduce.py`, `--equiv`, `--cli`, and both-parser CLI smoke
  checks all pass. Confirmed uniquify resolves the type arg (`T` → `T.sN_M`) and
  term args while leaving the object name unresolved.

## Acceptance checklist (#1107)

- [x] `var n := new Node<T>(x, next)` parses under both parsers with `--experimental-imperative`
- [x] Assignment RHS allocation parses (`a := new Cell(g)`)
- [x] RD and LALR canonical ASTs match
- [x] Pretty-print then reparse preserves the allocation AST
- [x] Pure-term `new` remains rejected with the existing focused diagnostic
- [x] Positive round-trip and negative pure-term fixtures added

## Notes for a resuming human

Nothing outstanding. One pre-existing (not introduced here) RD/LALR divergence
worth knowing: with `--experimental-imperative` **off**, RD demotes `new` to a
plain identifier (per the keyword-contextuality behavior of #1032), so pure-term
`new` yields a generic "expected a statement" parse error under RD versus the
focused message under LALR. With the flag on, both parsers give the focused
message. This is out of scope for #1107 (which targets the flag-on path) and
belongs to the keyword-contextuality umbrella (#1032/#1135).

Resume this session on ginger: `~/deduce-runner/resume.sh 8d4325bf-56d0-4a17-ac06-76300a8b2267 routine/20260727-170202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
