### PR TITLE
Add a focused imperative-tooling regression lane (closes #1109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ python test-deduce.py --warns          # only test/should-warn (valid + diff vs 
 python test-deduce.py --equiv          # compare RD/LALR ASTs for a curated grammar corpus
 python test-deduce.py --equiv-full     # opt-in: pretty-print round-trip over EVERY accepted-syntax .pf (not in CI)
 python test-deduce.py --parser         # only test/parse (parser-error fixtures)
+python test-deduce.py --imperative     # Phase 1 imperative tooling: LSP outline + parser smoke + flag-enrollment
 python test-deduce.py --site           # generates and checks doc code from gh_pages/doc
 
 # Regenerate the expected stderr fixture for a should-error test

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -1644,41 +1644,58 @@ def _check_imperative_symbol_outline() -> list[tuple[str, str, str]]:
 
 def _check_imperative_flag_enrollment() -> list[tuple[str, str, str]]:
     """Pin that every ``EXPERIMENTAL_IMPERATIVE_FILES`` entry genuinely needs
-    ``--experimental-imperative`` (issue #1109, acceptance box 3). If the flag
-    stopped being load-bearing for a tracked fixture, the enrollment is stale
-    and should be removed; if a positive fixture stopped validating with the
-    flag, the harness would silently run it wrong. All enrolled files are
-    prelude-free, so ``prelude=()`` keeps this off the expensive bootstrap."""
+    ``--experimental-imperative`` (issue #1109, acceptance box 3).
+
+    A fixture is load-bearing only if the flag actually changes its outcome, so
+    we compare the ``(ok, error_message)`` pair for a checked-with-flag run
+    against a checked-without-flag run and require that they *differ*. Merely
+    asserting "fails without the flag" is not enough: a ``should-error`` fixture
+    such as ``imperative_proc_undefined_label.pf`` fails for its own reason with
+    or without the flag, so a no-flag failure alone is no evidence the flag is
+    required. When the two runs are identical the flag is inert and the
+    enrollment is stale. Positive fixtures (should-validate / should-warn /
+    test-imports) must additionally still succeed with the flag. All enrolled
+    files are prelude-free, so ``prelude=()`` avoids the expensive bootstrap."""
     label = "flag-enrollment"
     failures: list[tuple[str, str, str]] = []
-    for path in sorted(EXPERIMENTAL_IMPERATIVE_FILES):
-        if not os.path.exists(path):
-            failures.append((path, label, "enrolled fixture does not exist"))
-            continue
-        try:
-            set_experimental_imperative(False)
-            without_flag = check_file(path, prelude=())
-            set_experimental_imperative(True)
-            with_flag = check_file(path, prelude=())
-        finally:
+    positive_dirs = ("./test/should-validate/", "./test/should-warn/",
+                     "./test/test-imports/")
+    set_quiet_mode(True)
+    sink = io.StringIO()
+    try:
+        for path in sorted(EXPERIMENTAL_IMPERATIVE_FILES):
+            if not os.path.exists(path):
+                failures.append((
+                    path, label, "enrolled fixture does not exist"))
+                continue
+            with contextlib.redirect_stdout(sink):
+                set_experimental_imperative(False)
+                off = check_file(path, prelude=())
+                set_experimental_imperative(True)
+                on = check_file(path, prelude=())
             set_experimental_imperative(False)
 
-        if without_flag.ok:
-            failures.append((
-                path, label,
-                "checks successfully without --experimental-imperative; the "
-                "enrollment is stale (remove it from "
-                "EXPERIMENTAL_IMPERATIVE_FILES)",
-            ))
-        # Positive fixtures must validate with the flag; a regression here
-        # means a tracked fixture would be reported as a spurious failure.
-        positive_dirs = ("./test/should-validate/", "./test/test-imports/")
-        if path.startswith(positive_dirs) and not with_flag.ok:
-            failures.append((
-                path, label,
-                "positive imperative fixture no longer validates with the "
-                f"flag:\n{(with_flag.error_message or '')[:500]}",
-            ))
+            inert = (on.ok == off.ok
+                     and (on.error_message or "") == (off.error_message or ""))
+            if inert:
+                failures.append((
+                    path, label,
+                    "checks identically with and without "
+                    "--experimental-imperative, so the flag is inert here; the "
+                    "enrollment is stale (drop it from "
+                    "EXPERIMENTAL_IMPERATIVE_FILES)",
+                ))
+            # Positive fixtures must validate with the flag; a regression here
+            # means a tracked fixture would be reported as a spurious failure.
+            if path.startswith(positive_dirs) and not on.ok:
+                failures.append((
+                    path, label,
+                    "positive imperative fixture no longer validates with the "
+                    f"flag:\n{(on.error_message or '')[:500]}",
+                ))
+    finally:
+        set_experimental_imperative(False)
+        set_quiet_mode(False)
     return failures
 
 

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -32,6 +32,14 @@ Per-category flags (combinable):
                    divergences and parse-time-rejected fixtures are allowlisted
                    so CI catches new drift. Also round-trip representative ASTs
                    through the pretty-printer and both parsers.
+    --imperative   Phase 1 imperative tooling regression (issue #1109): the
+                   LSP symbol outline still lists proc/observer/object/resource,
+                   the experimental-imperative parser smoke test, and every
+                   ``EXPERIMENTAL_IMPERATIVE_FILES`` fixture genuinely needs
+                   ``--experimental-imperative``. Runs in-process without the
+                   memory-heavy LSP suite. Also runs under ``--cli`` (and thus
+                   the passable-1 CI shard), so CI covers it without a dedicated
+                   workflow leg.
 
 Standalone modes (mutually exclusive with the above):
     --site             Generate ``doc_*.pf`` from ``gh_pages/doc/``
@@ -254,6 +262,7 @@ EXPERIMENTAL_IMPERATIVE_FILES = frozenset({
     "./test/should-error/imperative_new_operator_name.pf",
     "./test/should-validate/imperative_import.pf",
     "./test/should-error/resource_declarations.pf",
+    "./test/should-error/imperative_proc_undefined_label.pf",
     "./test/should-error/imperative_import_unknown.pf",
     "./test/should-error/imperative_import_field.pf",
     "./test/should-error/imperative_export_private_contract.pf",
@@ -660,6 +669,7 @@ class ParsedFlags(TypedDict):
     gen_parse: bool
     workers: int
     shard: Optional[tuple[int, int]]
+    imperative: bool
 
 
 T = TypeVar("T")
@@ -1573,6 +1583,132 @@ def run_experimental_imperative_parser_test() -> list[tuple[str, str, str]]:
     return failures
 
 
+# Source that declares one of every imperative top-level kind, mirroring
+# ``test/lsp/test_symbols.py::test_list_symbols_includes_imperative_declarations``
+# so the two stay in sync. Kept in ``bool``/type territory so no prelude is
+# needed.
+IMPERATIVE_OUTLINE_SOURCE = (
+    "object Box<T> {\n"
+    "  var data : T\n"
+    "}\n"
+    "\n"
+    "proc do_nothing(x: bool)\n"
+    "  ensures x = x\n"
+    "{\n"
+    "}\n"
+    "\n"
+    "observer peek(x: bool) -> bool\n"
+    "  reads x\n"
+    "{\n"
+    "  x\n"
+    "}\n"
+    "\n"
+    "resource cell(p: bool, v: bool)\n"
+)
+
+
+def _check_imperative_symbol_outline() -> list[tuple[str, str, str]]:
+    """Pin that ``proc``/``observer``/``object``/``resource`` still surface in
+    the LSP symbol outline (issue #1109, acceptance box 1). Runs
+    ``lsp.query.list_symbols`` in-process -- it depends only on ``lark``, not on
+    the memory-heavy LSP server SDKs, so this stays in the focused CI lane."""
+    from lsp.query import SymbolKind, list_symbols
+
+    label = "lsp-outline"
+    path = "__imperative_outline__.pf"
+    set_experimental_imperative(True)
+    try:
+        syms = list_symbols(path, IMPERATIVE_OUTLINE_SOURCE)
+    except Exception as exc:  # pragma: no cover -- defensive
+        return [(path, label, f"list_symbols raised: {exc}")]
+    finally:
+        set_experimental_imperative(False)
+
+    by_name = {s.name: s.kind for s in syms}
+    expected = {
+        "Box": SymbolKind.OBJECT,
+        "do_nothing": SymbolKind.PROC,
+        "peek": SymbolKind.OBSERVER,
+        "cell": SymbolKind.RESOURCE,
+    }
+    failures: list[tuple[str, str, str]] = []
+    for name, kind in expected.items():
+        if by_name.get(name) is not kind:
+            failures.append((
+                path, label,
+                f"imperative declaration {name!r} missing from the outline "
+                f"(expected {kind}, got {by_name.get(name)})",
+            ))
+    return failures
+
+
+def _check_imperative_flag_enrollment() -> list[tuple[str, str, str]]:
+    """Pin that every ``EXPERIMENTAL_IMPERATIVE_FILES`` entry genuinely needs
+    ``--experimental-imperative`` (issue #1109, acceptance box 3). If the flag
+    stopped being load-bearing for a tracked fixture, the enrollment is stale
+    and should be removed; if a positive fixture stopped validating with the
+    flag, the harness would silently run it wrong. All enrolled files are
+    prelude-free, so ``prelude=()`` keeps this off the expensive bootstrap."""
+    label = "flag-enrollment"
+    failures: list[tuple[str, str, str]] = []
+    for path in sorted(EXPERIMENTAL_IMPERATIVE_FILES):
+        if not os.path.exists(path):
+            failures.append((path, label, "enrolled fixture does not exist"))
+            continue
+        try:
+            set_experimental_imperative(False)
+            without_flag = check_file(path, prelude=())
+            set_experimental_imperative(True)
+            with_flag = check_file(path, prelude=())
+        finally:
+            set_experimental_imperative(False)
+
+        if without_flag.ok:
+            failures.append((
+                path, label,
+                "checks successfully without --experimental-imperative; the "
+                "enrollment is stale (remove it from "
+                "EXPERIMENTAL_IMPERATIVE_FILES)",
+            ))
+        # Positive fixtures must validate with the flag; a regression here
+        # means a tracked fixture would be reported as a spurious failure.
+        positive_dirs = ("./test/should-validate/", "./test/test-imports/")
+        if path.startswith(positive_dirs) and not with_flag.ok:
+            failures.append((
+                path, label,
+                "positive imperative fixture no longer validates with the "
+                f"flag:\n{(with_flag.error_message or '')[:500]}",
+            ))
+    return failures
+
+
+def run_imperative_regression() -> list[tuple[str, str, str]]:
+    """Focused CI lane for the Phase 1 imperative tooling (issue #1109).
+
+    Bundles three fast, in-process checks so the imperative surface is
+    continuously covered without standing up the full LSP suite:
+
+      * the LSP symbol outline still lists proc/observer/object/resource;
+      * the experimental-imperative parser smoke test;
+      * every tracked imperative fixture genuinely needs the feature flag.
+
+    Runs both standalone (``--imperative``) and under ``--cli`` so the
+    passable-1 CI shard (``--passable --cli``) covers it without its own
+    workflow leg.
+    """
+    failures: list[tuple[str, str, str]] = []
+    _, fails = time_section("lsp symbol outline",
+                            _check_imperative_symbol_outline)
+    failures.extend(fails)
+    _, fails = time_section("experimental imperative parser",
+                            run_experimental_imperative_parser_test)
+    failures.extend(fails)
+    _, fails = time_section("flag enrollment",
+                            _check_imperative_flag_enrollment)
+    failures.extend(fails)
+    return failures
+
+
 def run_examples_parallel(workers: int) -> list[tuple[str, str, str]]:
     """``examples/*.pf`` × RD parser only.
 
@@ -1688,7 +1824,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         "examples": False, "regen_all": False, "regen_files": [],
         "regen_all_warns": False, "regen_warn_files": [],
         "gen_parse": False, "workers": max(1, (os.cpu_count() or 4)),
-        "shard": None,
+        "shard": None, "imperative": False,
     }
     i = 0
     while i < len(argv):
@@ -1704,6 +1840,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         elif a == "--site": flags["site"] = True
         elif a == "--parser": flags["parser"] = True
         elif a == "--examples": flags["examples"] = True
+        elif a == "--imperative": flags["imperative"] = True
         elif a == "--regenerate-errors": flags["regen_all"] = True
         elif a == "--generate-error":
             flags["regen_files"].append(argv[i + 1])
@@ -1731,7 +1868,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         or flags["errors"]
         or flags["warns"] or flags["site"] or flags["parser"]
         or flags["examples"] or flags["equiv"] or flags["equiv_full"]
-        or flags["regen_all"]
+        or flags["regen_all"] or flags["imperative"]
         or flags["regen_all_warns"] or flags["gen_parse"]
         or flags["regen_files"] or flags["regen_warn_files"]
     ):
@@ -1748,6 +1885,7 @@ def parse_args(argv: list[str]) -> ParsedFlags:
         ("errors", flags["errors"]),
         ("warns", flags["warns"]),
         ("equiv", flags["equiv"]),
+        ("imperative", flags["imperative"]),
     )
     standalone_flags = (
         ("site", flags["site"]),
@@ -1865,10 +2003,15 @@ def main(argv: list[str]) -> int:
             "deduce.py --no-stdlib theorem_true.pf", run_cli_test
         )
         total_failures.extend(fails)
-        _, fails = time_section(
-            "experimental imperative parser",
-            run_experimental_imperative_parser_test,
-        )
+
+    # Imperative tooling lane (issue #1109): LSP outline + parser smoke test +
+    # flag-enrollment pin. Rides on --cli so it is covered by the passable-1 CI
+    # shard (``--passable --cli``) without a dedicated workflow leg; ``--imperative``
+    # runs it standalone as a focused lane for local iteration.
+    if flags["cli"] or flags["imperative"]:
+        print("\n=== imperative: Phase 1 imperative tooling regression ===")
+        _, fails = time_section("imperative tooling",
+                                run_imperative_regression)
         total_failures.extend(fails)
 
     # Lib pool: clean state (no shared cache).

--- a/test/should-error/imperative_proc_undefined_label.pf
+++ b/test/should-error/imperative_proc_undefined_label.pf
@@ -1,0 +1,15 @@
+// A malformed procedure proof-block entry: the body's `assert ... by`
+// references a proof label that the trailing `proof ... end` block never
+// defines. Phase 1 (issue #968) recognizes proc declarations but does not
+// verify bodies; the label reference is still resolved, so an undefined label
+// is rejected here rather than silently accepted. Regression for issue #1109.
+proc p(n: bool)
+  ensures n = n
+{
+  assert n = n by missing_label
+}
+proof
+  other_label {
+    .
+  }
+end

--- a/test/should-error/imperative_proc_undefined_label.pf.err
+++ b/test/should-error/imperative_proc_undefined_label.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/imperative_proc_undefined_label.pf:9.19-9.32: undefined proof variable missing_label


### PR DESCRIPTION
## Summary

Phase 1 of the imperative layer (#854) shipped `proc`/`observer`/`object`/`resource`
declarations, the experimental-imperative parser, and their LSP symbol outline,
but that surface was only exercised by local-only pytest runs or buried inside
the `--cli`/passable shard. This adds a **focused, dependency-light regression
bundle** so CI catches regressions in the Phase 1 tooling directly, addressing
#1109.

`run_imperative_regression` gathers three in-process checks (no memory-heavy LSP
suite, no stdlib bootstrap):

- **LSP symbol outline** still lists `proc`/`observer`/`object`/`resource`.
  Mirrors `test/lsp/test_symbols.py::test_list_symbols_includes_imperative_declarations`
  and uses `lsp.query.list_symbols`, which depends only on `lark` (not on the
  `pygls`/`mcp` server SDKs), so it stays in the focused lane.
- **Experimental-imperative parser smoke test** (`run_experimental_imperative_parser_test`).
- **Flag-enrollment pin**: every `EXPERIMENTAL_IMPERATIVE_FILES` entry genuinely
  needs `--experimental-imperative` — it fails to check without the flag (so a
  stale enrollment turns CI red), and positive fixtures still validate with it.

It runs standalone via `python test-deduce.py --imperative` for focused local
iteration, and also rides on `--cli`, so the existing **passable-1** CI shard
(`--passable --cli`) covers it — no new workflow leg required.

Also adds a negative fixture for a malformed procedure proof-block entry:
`test/should-error/imperative_proc_undefined_label.pf`, whose body's
`assert ... by missing_label` references a label the trailing `proof ... end`
block never defines (rejected with `undefined proof variable missing_label`).

## Acceptance mapping (#1109)

- ✅ CI fails if `proc`/`observer`/`object`/`resource` disappears from the LSP
  outline — `_check_imperative_symbol_outline`.
- ✅ CI fails if the feature-flag smoke test stops running, and the owning shard
  is documented (passable-1) — `run_imperative_regression` under `--cli`.
- ✅ CI fails if a tracked imperative fixture no longer needs the flag —
  `_check_imperative_flag_enrollment`. (The inverse — a *new* imperative
  should-validate file forgotten from the enrollment set — is already caught by
  the `--passable` leg, which would run it without the flag and fail to parse.)
- ✅ Stays focused: in-process, `lark`-only, no full LSP suite, ~2.6s.

## Testing

```
python3 test-deduce.py --imperative   # passes (~2.6s)
python3 test-deduce.py --cli          # passes; now includes the imperative lane
python3 test-deduce.py --errors       # passes (new negative fixture)
python3 test-deduce.py --equiv        # passes
python3 test-deduce.py --passable --cli  # passes
```

`ruff`/`mypy` were unavailable in the container; the new code touches only
`test-deduce.py` (excluded from the mypy config) and adds no line-length or
Pyflakes violations under the repo's `pyproject.toml` ruff selection.

## Note on the dedicated CI matrix leg

The issue's scope also mentions a *dedicated* CI matrix leg. The routine token
lacks `workflow` scope and cannot push `.github/workflows/*` changes, so instead
the lane rides on the existing passable-1 shard (documented in-code). A
maintainer who wants a standalone leg can add this one entry to the
`regression` matrix in `.github/workflows/test_deduce.yml`:

```yaml
          - name: imperative
            args: --imperative
            requirements: core
```

Resume this session on ginger: `~/deduce-runner/resume.sh 9415159b-60e8-4a7b-bd12-f1bf17ddd2e1 routine/20260727-180202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
