### PR TITLE
Add a source-located imperative verification-obligation API (closes #1112)

### DIFF
--- a/imperative_verifier.py
+++ b/imperative_verifier.py
@@ -1,0 +1,149 @@
+"""Source-located verification obligations for the imperative layer.
+
+Issue #854 Phase 2c (#1112). Provides ONE representation and discharge path
+for every imperative proof obligation (preconditions, postconditions,
+assertions, array bounds, frames, loop entry / preservation / exit, and
+decreases) so later verifier slices construct obligations instead of
+hand-rolling goal/given plumbing and error presentation.
+
+The representation is pure and CLI-independent: constructing an
+``ImperativeObligation`` runs no proof checking and touches no global state,
+so later slices can unit-test the formulas they generate without spinning up
+the whole pipeline. ``discharge`` is the only method that reaches into the
+checker, and it reuses the existing machinery rather than copying it:
+
+  * an attached ``by`` proof is checked with ``check_proof_of``;
+  * an unproved goal is attempted automatically -- ``reduce`` applies the
+    ambient ``auto`` rewrite rules (the same normalization ``simplify`` uses)
+    and ``check_implies`` decides whether the givens entail the goal;
+  * when nothing discharges the goal, the standard source-located
+    ``Goal:`` / ``Givens:`` incomplete-proof diagnostic is reported at the
+    annotation that created the obligation.
+
+There is NO statement-specific verification-condition generation here; that
+is the job of the later Phase 2 slices that build obligations of these kinds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional, Tuple
+
+from lark.tree import Meta
+
+import style
+from abstract_syntax import And, Bool, Env, Formula, Proof, is_true
+
+
+class ObligationKind(Enum):
+  """The provenance of an imperative proof obligation.
+
+  The value doubles as the human-readable phrase shown in diagnostics, so a
+  reader can tell a failed array-bounds check from a failed loop-invariant
+  preservation without decoding an internal enum name."""
+
+  PRECONDITION = 'precondition'
+  POSTCONDITION = 'postcondition'
+  ASSERTION = 'assertion'
+  ARRAY_BOUNDS = 'array bounds'
+  FRAME = 'frame'
+  LOOP_ENTRY = 'loop invariant on entry'
+  LOOP_PRESERVATION = 'loop invariant preservation'
+  LOOP_EXIT = 'loop exit'
+  DECREASES = 'decreases'
+
+  def __str__(self) -> str:
+    return self.value
+
+
+@dataclass
+class ImperativeObligation:
+  """One imperative proof obligation.
+
+  Attributes:
+    location: the source annotation that created the obligation (a
+      ``requires``/``ensures`` clause, an ``assert``, an array index, a
+      loop's ``invariant``/``decreases``, ...). Diagnostics point here.
+    goal: the ``Formula`` that must hold. Callers pass an already
+      type-checked formula.
+    kind: which sort of obligation this is (see ``ObligationKind``).
+    givens: the facts in scope, as ``(label, formula)`` pairs in the order
+      they were established. Discharge installs them as local proof
+      hypotheses so an attached proof can cite them by ``label`` and the
+      ``Givens:`` presentation lists them.
+    proof: the optional ``by`` proof the user attached at ``location``.
+  """
+
+  location: Meta
+  goal: Formula
+  kind: ObligationKind
+  givens: List[Tuple[str, Formula]] = field(default_factory=list)
+  proof: Optional[Proof] = None
+
+  def givens_formula(self) -> Formula:
+    """The conjunction of the given hypotheses, or ``true`` when there are
+    none -- the antecedent handed to ``check_implies`` for the automatic
+    discharge attempt."""
+    facts = [frm for (_label, frm) in self.givens]
+    if len(facts) == 0:
+      return Bool(self.location, None, True)
+    if len(facts) == 1:
+      return facts[0]
+    return And(self.location, None, facts)
+
+  def env_with_givens(self, env: Env) -> Env:
+    """``env`` extended with each given as a local proof hypothesis."""
+    proof_env = env
+    for (label, frm) in self.givens:
+      proof_env = proof_env.declare_local_proof_var(self.location, label, frm)
+    return proof_env
+
+  def discharge(self, env: Env) -> None:
+    """Verify the obligation in ``env``.
+
+    Returns normally when the goal is discharged. Otherwise reports a
+    source-located diagnostic through the usual channels (raising in a CLI
+    run, recording into the active error sink for the LSP/MCP multi-error
+    path) -- an attached-proof failure surfaces the proof checker's own
+    error; an unproved goal surfaces the ``Goal:`` / ``Givens:``
+    incomplete-proof diagnostic."""
+    proof_env = self.env_with_givens(env)
+    if self.proof is not None:
+      # Independent obligation: route any failure into the active error
+      # sink (when one is installed) exactly like a top-level theorem.
+      from checker_proofs import _try_check_proof_of
+      _try_check_proof_of(self.proof, self.goal, proof_env)
+      return
+    if self._discharged_automatically(proof_env):
+      return
+    self._report_incomplete(proof_env)
+
+  def _discharged_automatically(self, env: Env) -> bool:
+    """Attempt to discharge the goal without a user proof: normalize with the
+    ambient ``auto`` rules and ask ``check_implies`` whether the givens entail
+    the result. Returns whether the goal was proved."""
+    from checker_logic import check_implies
+    from error import UserError
+
+    reduced_goal = self.goal.reduce(env)
+    if is_true(reduced_goal):
+      return True
+    antecedent = self.givens_formula().reduce(env)
+    try:
+      check_implies(self.location, antecedent, reduced_goal)
+      return True
+    except UserError:
+      return False
+
+  def _report_incomplete(self, env: Env) -> None:
+    from checker_proofs import givens_str
+    from error import add_incomplete
+
+    add_incomplete(
+        self.location,
+        style.bold_red('incomplete proof') + '\n'
+        + 'could not prove this ' + str(self.kind) + ' obligation\n'
+        + style.orange('Goal:') + '\n\t' + str(self.goal)
+        + givens_str(env),
+        formula=self.goal, env=env)

--- a/test/unit/test_imperative_obligation.py
+++ b/test/unit/test_imperative_obligation.py
@@ -1,0 +1,146 @@
+"""Unit tests for the imperative verification-obligation API (issue #1112).
+
+These construct and discharge obligations directly, without running the CLI
+or the rest of the pipeline -- the whole point of the API is that later
+verifier slices can unit-test the formulas they generate in isolation.
+"""
+
+from lark.tree import Meta
+
+from abstract_syntax import Bool, BoolType, Env, PTrue
+from error import Diagnostic, ErrorSink, IncompleteProof, set_active_sink
+from imperative_verifier import ImperativeObligation, ObligationKind
+
+
+def _meta() -> Meta:
+  m = Meta()
+  m.empty = False
+  m.filename = 'test.pf'
+  m.line = 3
+  m.column = 5
+  m.start_pos = 0
+  m.end_line = 3
+  m.end_column = 6
+  m.end_pos = 1
+  return m
+
+
+def _env() -> Env:
+  return Env({'__current_module__': 'test'})
+
+
+def _true() -> Bool:
+  return Bool(_meta(), BoolType(_meta()), True)
+
+
+def _false() -> Bool:
+  return Bool(_meta(), BoolType(_meta()), False)
+
+
+# --- construction is pure ---------------------------------------------------
+
+def test_construction_runs_no_checking() -> None:
+  # Building an obligation must not touch the checker or global state -- a
+  # false goal is fine until someone calls discharge().
+  ob = ImperativeObligation(_meta(), _false(), ObligationKind.ASSERTION)
+  assert ob.kind is ObligationKind.ASSERTION
+  assert ob.givens == []
+  assert ob.proof is None
+
+
+def test_obligation_kinds_have_readable_phrases() -> None:
+  # The enum value doubles as the diagnostic phrase.
+  assert str(ObligationKind.ARRAY_BOUNDS) == 'array bounds'
+  assert str(ObligationKind.LOOP_PRESERVATION) == 'loop invariant preservation'
+  # Every kind is a distinct, non-empty phrase.
+  phrases = [str(k) for k in ObligationKind]
+  assert len(phrases) == len(set(phrases))
+  assert all(phrases)
+
+
+def test_givens_formula_shape() -> None:
+  loc = _meta()
+  a, b = _true(), _false()
+  # No givens -> `true` antecedent.
+  none = ImperativeObligation(loc, _true(), ObligationKind.FRAME)
+  assert isinstance(none.givens_formula(), Bool) and none.givens_formula().value
+  # One given -> that formula verbatim.
+  one = ImperativeObligation(loc, _true(), ObligationKind.FRAME,
+                             givens=[('h', a)])
+  assert one.givens_formula() is a
+  # Many givens -> conjunction, in order.
+  many = ImperativeObligation(loc, _true(), ObligationKind.FRAME,
+                              givens=[('h1', a), ('h2', b)])
+  assert many.givens_formula().args == [a, b]
+
+
+def test_env_with_givens_installs_local_hypotheses() -> None:
+  ob = ImperativeObligation(_meta(), _true(), ObligationKind.PRECONDITION,
+                            givens=[('h', _false())])
+  base = _env()
+  extended = ob.env_with_givens(base)
+  assert len(extended.local_proofs()) == 1
+  # The base env is not mutated -- Env updates are functional.
+  assert base.local_proofs() == []
+
+
+# --- discharge: automatic ---------------------------------------------------
+
+def test_trivial_true_goal_discharges() -> None:
+  ob = ImperativeObligation(_meta(), _true(), ObligationKind.ASSERTION)
+  ob.discharge(_env())  # returns normally
+
+
+def test_false_goal_reports_source_located_incomplete_proof() -> None:
+  loc = _meta()
+  ob = ImperativeObligation(loc, _false(), ObligationKind.PRECONDITION)
+  try:
+    ob.discharge(_env())
+    assert False, 'expected an IncompleteProof'
+  except IncompleteProof as e:
+    msg = str(e)
+    assert 'test.pf:3.5' in msg            # source-located at the annotation
+    assert 'precondition' in msg           # obligation kind is visible
+    assert 'Goal:' in msg
+    assert e.formula is ob.goal            # structured field for the LSP/MCP
+
+
+def test_false_given_discharges_any_goal() -> None:
+  # A contradictory hypothesis entails the goal via check_implies.
+  ob = ImperativeObligation(_meta(), _false(), ObligationKind.LOOP_EXIT,
+                            givens=[('h', _false())])
+  ob.discharge(_env())  # returns normally
+
+
+# --- discharge: attached proofs ---------------------------------------------
+
+def test_attached_correct_proof_discharges() -> None:
+  loc = _meta()
+  ob = ImperativeObligation(loc, _true(), ObligationKind.ASSERTION,
+                            proof=PTrue(loc))
+  ob.discharge(_env())  # returns normally
+
+
+def test_attached_wrong_proof_reports_diagnostic() -> None:
+  loc = _meta()
+  ob = ImperativeObligation(loc, _false(), ObligationKind.ASSERTION,
+                            proof=PTrue(loc))
+  try:
+    ob.discharge(_env())
+    assert False, 'expected a diagnostic'
+  except Diagnostic:
+    pass
+
+
+# --- discharge: error-sink routing ------------------------------------------
+
+def test_failure_records_into_active_sink_without_raising() -> None:
+  sink = ErrorSink()
+  prev = set_active_sink(sink)
+  try:
+    ImperativeObligation(_meta(), _false(),
+                         ObligationKind.FRAME).discharge(_env())
+  finally:
+    set_active_sink(prev)
+  assert len(sink) == 1
+  assert isinstance(sink.errors[0], IncompleteProof)


### PR DESCRIPTION
## Summary

Phase 2c of the imperative verification layer (#854). Adds one reusable,
source-located representation and discharge path for **every** imperative
proof obligation, so the later Phase 2 slices (#1113, bounds checks, loops,
proof slots, …) construct obligations instead of each hand-rolling
goal/given plumbing and error presentation.

New module `imperative_verifier.py`:

- **`ObligationKind`** — an enum whose value doubles as the human-readable
  phrase shown in diagnostics: `precondition`, `postcondition`, `assertion`,
  `array bounds`, `frame`, `loop invariant on entry`,
  `loop invariant preservation`, `loop exit`, `decreases`.
- **`ImperativeObligation`** — a dataclass holding the source `location`, the
  `goal` formula, the `kind`, the ordered `givens` (`(label, formula)`
  pairs), and the optional attached `proof`.

**Construction is pure and CLI-independent** — building an obligation runs no
proof checking and touches no global state, so later slices can unit-test the
formulas they generate in isolation (acceptance: "keep obligation
construction pure/testable").

**`discharge(env)` reuses the existing checker rather than copying it:**

- an attached `by` proof is checked with `check_proof_of` (routed through
  `_try_check_proof_of` so a failure records into an active error sink
  exactly like a top-level theorem);
- an unproved goal is attempted automatically — `reduce` applies the ambient
  `auto` rewrite rules (the same normalization `simplify` uses) and
  `check_implies` decides whether the givens entail the goal;
- when nothing discharges the goal, the standard source-located
  `Goal:` / `Givens:` incomplete-proof diagnostic is reported at the
  annotation that created the obligation, with the obligation kind in the
  message. Discharge honors the active error sink (LSP/MCP multi-error path)
  and raises in a CLI run, matching every other checker diagnostic.

The givens are installed as **local** proof hypotheses under caller-supplied
labels, so no generated global names are exposed to users.

## Acceptance (#1112)

- ✅ Unit tests construct and discharge a trivial obligation
  (`test/unit/test_imperative_obligation.py`).
- ✅ A false obligation produces a source-located incomplete-proof
  diagnostic (`test_false_goal_reports_source_located_incomplete_proof`).
- ✅ Existing proof-checker behavior is reused, not copied (`check_proof_of`,
  `check_implies`, `reduce`, `givens_str`, `add_incomplete`).
- ✅ Obligation kinds are visible in diagnostics
  (`could not prove this <kind> obligation`).
- ✅ No generated global names are exposed (givens use caller labels
  declared as *local* proof vars).

Out of scope (deferred to later slices, per the issue): statement-specific
VC generation, a symbolic heap, and LSP code actions. Nothing is wired into
the pipeline yet — this slice is the reusable foundation the next slices
build obligations with.

## Testing

```
python3 -m pytest test/unit/test_imperative_obligation.py   # 10 passed
python3 -m pytest test/unit                                 # 585 passed
python3 -m ruff check .                                     # all checks passed
python3 -m mypy .                                           # no issues (55 files)
python3 ./gh_pages/scripts/keywords.py                      # ok
python3 ./gh_pages/scripts/reference_grammar.py             # ok
python3 test-deduce.py --equiv                              # all tests passed
```

Note: the new unit tests live under `test/unit/`, which (like the rest of
that directory) is not gated by the current CI matrix — CI runs the
`test-deduce.py` categories plus static checks. This PR changes no
grammar/parser/AST and wires nothing into the CLI pipeline, so the existing
should-validate/should-error/equiv suites are unaffected; `ruff`/`mypy` (which
CI does run) cover `imperative_verifier.py`.

Resume this session on ginger: `~/deduce-runner/resume.sh f0b81de4-8a57-4836-a9ff-4124e1c558ee routine/20260727-190202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1112
Refs #854
