### PR TITLE
Type-check and register procedure signatures and contracts (closes #1111)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -494,6 +494,10 @@ class ProcDecl(Declaration):
   specs: List[ProcSpec]
   body: List[ImpStmt] = field(default_factory=list)
   proof_block: List[ProcProofEntry] = field(default_factory=list)
+  # The uniquified name bound to `result` inside postconditions. Filled in by
+  # `uniquify` for procedures with a return type (None otherwise), so the
+  # signature type-checker knows which name to give the declared return type.
+  result_name: Optional[str] = None
 
   def __str__(self) -> str:
     return self.pretty_print(0)
@@ -538,7 +542,12 @@ class ProcDecl(Declaration):
       overwrite(proc_env, old, new, self.location)
 
     new_params = []
+    seen_params: set[str] = set()
     for param in self.params:
+      if base_name(param.name) in seen_params:
+        user_error(param.location,
+                   "duplicate proc parameter name: " + base_name(param.name))
+      seen_params.add(base_name(param.name))
       new_typ = param.typ.uniquify(proc_env, uniq_ctx)
       new_param_name = generate_name(param.name, uniq_ctx)
       overwrite(proc_env, param.name, new_param_name, param.location)
@@ -550,9 +559,10 @@ class ProcDecl(Declaration):
         if self.return_type is not None
         else None
     )
+    new_result_name = None
     if new_return_type is not None:
-      overwrite(proc_env, 'result', generate_name('result', uniq_ctx),
-                self.location)
+      new_result_name = generate_name('result', uniq_ctx)
+      overwrite(proc_env, 'result', new_result_name, self.location)
     new_specs = [spec.uniquify(proc_env, uniq_ctx) for spec in self.specs]
     # Parser/AST only: uniquify resolves the body's term subparts (so no
     # pre-uniquify `Var` nodes leak past this pass) and alpha-renames local
@@ -575,7 +585,7 @@ class ProcDecl(Declaration):
     ]
     return ProcDecl(self.location, new_name, new_type_params, new_params,
                     new_return_type, new_specs, new_body, new_proof_block,
-                    visibility=self.visibility)
+                    new_result_name, visibility=self.visibility)
 
 @dataclass
 class Postulate(Declaration):

--- a/abstract_syntax/env.py
+++ b/abstract_syntax/env.py
@@ -75,6 +75,25 @@ class ViewBinding(Binding):
   def __str__(self) -> str:
     return str(self.view)
 
+@dataclass
+class ProcBinding(Binding):
+  # A procedure's checked signature: its type parameters, ordinary and ghost
+  # parameters, optional return type, and ordered spec clauses. The body is
+  # deliberately absent -- callers only need the contract to resolve and
+  # instantiate a `call` (a later verifier phase, #854), and imports expose
+  # the signature without the body.
+  type_params: List[str]
+  params: List[ProcParam]
+  return_type: Optional[Type]
+  specs: List[ProcSpec]
+
+  def __str__(self) -> str:
+    header = 'proc ' + type_params_str(self.type_params) \
+      + '(' + ', '.join(str(p) for p in self.params) + ')'
+    if self.return_type is not None:
+      header += ' -> ' + str(self.return_type)
+    return header
+
 
 def type_params_str(type_params: Sequence[str]) -> str:
   if len(type_params) > 0:
@@ -168,6 +187,22 @@ class Env:
       register_view_source_alias(src_head, view.name)
     return new_env
   
+  def declare_proc(self, loc: Meta, name: str, type_params: List[str],
+                   params: List[ProcParam], return_type: Optional[Type],
+                   specs: List[ProcSpec], visibility: str = 'public') -> Env:
+    new_env = Env(self.dict)
+    new_env.dict[name] = ProcBinding(loc, type_params, params, return_type,
+                                     specs,
+                                     module=self.get_current_module(),
+                                     visibility=visibility)
+    return new_env
+
+  def get_proc(self, name: str | VarRef) -> Optional[ProcBinding]:
+    if isinstance(name, VarRef):
+      name = name.get_name()
+    binding = self.dict.get(name)
+    return binding if isinstance(binding, ProcBinding) else None
+
   def declare_term_var(self, loc: Meta, name: str, typ: Type,
                        local: bool = False, visibility: str = 'public') -> Env:
     if typ == None:
@@ -338,6 +373,10 @@ class Env:
         return TypeType(cast(Meta, None))
       elif isinstance(binding, ViewBinding):
         raise Exception('expected a term or type variable, not view ' + base_name(name))
+      elif isinstance(binding, ProcBinding):
+        raise Exception("'" + base_name(name) + "' is a procedure and cannot"
+                        + ' be used as an ordinary term; procedures are'
+                        + ' invoked with a `call` statement inside a proc')
       else:
         raise Exception('expected a term or type variable, not ' + base_name(name))
     else:

--- a/abstract_syntax/env.py
+++ b/abstract_syntax/env.py
@@ -421,7 +421,15 @@ class Env:
     
   def type_var_is_defined(self, tyname: VarRef) -> bool:
     if isinstance(tyname, VarRef):
-      return tyname.get_name() in self.dict.keys()
+      name = tyname.get_name()
+      # A procedure name lives in the env (so `call` can resolve it) but is
+      # not a type. Exclude it here so a proc used in a type position gets a
+      # clean `check_type` "undefined type variable" diagnostic instead of
+      # silently type-checking or hitting the bare-Exception fallback in
+      # `_def_of_type_var` (which would escape the error sink and abort LSP
+      # checking).
+      return name in self.dict.keys() \
+        and not isinstance(self.dict[name], ProcBinding)
     raise Exception('expected a type name, not ' + str(tyname))
 
   def term_var_is_defined(self, tvar: VarRef) -> bool:

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -24,8 +24,8 @@ from abstract_syntax import (
     Formula, FunCase, FunctionType, GenRecFun, Generic, GenericUnknownInst,
     Hole, IfThen, Import, Inductive, Lambda, MakeArray, Module, ObjectDecl,
     ObjectField, ObserverDecl, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
-    PatternBool, PatternCons, Postulate, Predicate, Print, ProcDecl, RecFun,
-    ResolvedVar, ResourceDecl, Rule, Some,
+    PatternBool, PatternCons, Postulate, Predicate, Print, ProcDecl, ProcParam,
+    ProcSpec, RecFun, ResolvedVar, ResourceDecl, Rule, Some,
     Statement, Switch, SwitchCase, TAnnote, TLet, Term, TermInst, Theorem,
     Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, VarRef, VerboseLevel,
     ViewDecl, ViewRecFun, alpha_equiv, base_name, callable_name,
@@ -71,12 +71,84 @@ ViewInfo = tuple[ViewDecl, Type, Type]
 PatternCoverage = dict[str, bool]
 ParamTypes = list[tuple[str, Type]]
 
+def check_proc_signature(decl: ProcDecl, env: Env) -> tuple[Statement, Env]:
+  # Phase 2b (issue #1111): type-check a procedure's signature -- its type
+  # parameters, ordinary and ghost parameter types, optional return type, and
+  # `requires`/`ensures`/`reads`/`modifies`/`decreases` spec clauses -- and
+  # register the checked signature in `Env` so later `call` resolution finds
+  # it. The body and proof slots are left to later slices. Duplicate proc
+  # names are already rejected in `uniquify`.
+  loc = decl.location
+  type_env = env.declare_type_vars(loc, decl.type_params)
+
+  # Parameter types. Duplicate parameter names are already rejected in
+  # `uniquify` (before any binding is created), so they never reach here.
+  checked_params: list[ProcParam] = []
+  param_pairs: list[tuple[str, Type]] = []
+  for p in decl.params:
+    checked_ty = check_type(p.typ, type_env)
+    checked_params.append(ProcParam(p.location, p.name, checked_ty, p.ghost))
+    param_pairs.append((p.name, checked_ty))
+
+  # `requires`, `reads`, `modifies`, and `decreases` see the parameters.
+  param_env = type_env.declare_term_vars(loc, param_pairs)
+
+  checked_return = None
+  if decl.return_type is not None:
+    checked_return = check_type(decl.return_type, type_env)
+
+  # Postconditions additionally see `result`, bound to the return type.
+  post_env = param_env
+  if checked_return is not None and decl.result_name is not None:
+    post_env = param_env.declare_term_var(loc, decl.result_name,
+                                          checked_return, local=True)
+
+  checked_specs: list[ProcSpec] = []
+  seen_post_labels: set[str] = set()
+  for spec in decl.specs:
+    match spec.keyword:
+      case 'requires':
+        value = check_formula(cast(Term, spec.value), param_env)
+        checked_specs.append(ProcSpec(spec.location, 'requires', value))
+      case 'ensures':
+        if spec.label is not None:
+          if base_name(spec.label) in seen_post_labels:
+            user_error(spec.location,
+                       'duplicate postcondition label: '
+                       + base_name(spec.label))
+          seen_post_labels.add(base_name(spec.label))
+        value = check_formula(cast(Term, spec.value), post_env)
+        checked_specs.append(ProcSpec(spec.location, 'ensures', value,
+                                      spec.label))
+      case 'decreases':
+        value = type_synth_term(cast(Term, spec.value), param_env, None, [])
+        checked_specs.append(ProcSpec(spec.location, 'decreases', value))
+      case _:  # 'reads' | 'modifies'
+        # Frame expressions are checked structurally only: `uniquify` has
+        # already resolved their subject names, but the footprint/heap
+        # semantics needed to type a mutable-array read (`a[i]`, #1117) or a
+        # `footprint(...)` (#1126) are later slices, so the frame list passes
+        # through unchanged here.
+        checked_specs.append(ProcSpec(spec.location, spec.keyword,
+                                      spec.value))
+
+  checked_decl = ProcDecl(loc, decl.name, decl.type_params, checked_params,
+                          checked_return, checked_specs, decl.body,
+                          decl.proof_block, decl.result_name,
+                          visibility=decl.visibility)
+  new_env = env.declare_proc(loc, decl.name, decl.type_params, checked_params,
+                             checked_return, checked_specs, decl.visibility)
+  return checked_decl, new_env
+
 def process_declaration_visibility(decl: Declaration, env: Env,
                                    module_chain: list[str],
                                    downstream_needs_checking: list[bool]
                                    ) -> tuple[Statement, Env]:
   match decl:
-    case ProcDecl() | ObserverDecl() | ResourceDecl():
+    case ProcDecl():
+      return check_proc_signature(decl, env)
+
+    case ObserverDecl() | ResourceDecl():
       return decl, env
 
     case Define(loc, name, ty, body):

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -259,7 +259,13 @@ end
 
 EXPERIMENTAL_IMPERATIVE_FILES = frozenset({
     "./test/should-warn/proc_declarations.pf",
+    "./test/should-warn/proc_signatures.pf",
     "./test/should-warn/observer_declarations.pf",
+    "./test/should-error/proc_requires_not_bool.pf",
+    "./test/should-error/proc_result_without_return.pf",
+    "./test/should-error/proc_duplicate_param.pf",
+    "./test/should-error/proc_duplicate_post_label.pf",
+    "./test/should-error/proc_call_as_term.pf",
     "./test/should-warn/imperative_false_proc.pf",
     "./test/should-warn/imperative_allocation.pf",
     "./test/should-error/imperative_new_pure_term.pf",

--- a/test/imperative/should-error/proc_as_type.pf
+++ b/test/imperative/should-error/proc_as_type.pf
@@ -1,0 +1,9 @@
+// Phase 2b (issue #1111): a procedure name is registered in the environment so
+// `call` can resolve it, but it is not a type. Using a proc name in a type
+// position must be rejected with a clean "undefined type variable" diagnostic
+// (both parsers agree) rather than silently type-checking or crashing the
+// error sink via the bare-Exception fallback in `_def_of_type_var`.
+proc p() {
+}
+proc q(a: p) {
+}

--- a/test/imperative/should-error/proc_as_type.pf.err
+++ b/test/imperative/should-error/proc_as_type.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_as_type.pf:8.11-8.12: undefined type variable p

--- a/test/should-error/proc_call_as_term.pf
+++ b/test/should-error/proc_call_as_term.pf
@@ -1,0 +1,8 @@
+// Phase 2b (issue #1111): a procedure name may not be used as an ordinary
+// term. Procedures are invoked with a `call` statement inside a proc body.
+proc demo_proc(x: bool) -> bool
+  ensures result = result
+{
+  return x
+}
+define oops : bool = demo_proc(true)

--- a/test/should-error/proc_call_as_term.pf.err
+++ b/test/should-error/proc_call_as_term.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/proc_call_as_term.pf:8.22-8.31: 'demo_proc' is a procedure and cannot be used as an ordinary term; procedures are invoked with a `call` statement inside a proc

--- a/test/should-error/proc_duplicate_param.pf
+++ b/test/should-error/proc_duplicate_param.pf
@@ -1,0 +1,4 @@
+// Phase 2b (issue #1111): procedure parameter names must be distinct.
+proc demo_bad(x: bool, x: bool)
+{
+}

--- a/test/should-error/proc_duplicate_param.pf.err
+++ b/test/should-error/proc_duplicate_param.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/proc_duplicate_param.pf:2.24-2.31: duplicate proc parameter name: x

--- a/test/should-error/proc_duplicate_post_label.pf
+++ b/test/should-error/proc_duplicate_post_label.pf
@@ -1,0 +1,6 @@
+// Phase 2b (issue #1111): labelled postconditions must have distinct labels.
+proc demo_bad(x: bool)
+  ensures same: x = x
+  ensures same: x or not x
+{
+}

--- a/test/should-error/proc_duplicate_post_label.pf.err
+++ b/test/should-error/proc_duplicate_post_label.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/proc_duplicate_post_label.pf:4.3-4.27: duplicate postcondition label: same

--- a/test/should-error/proc_requires_not_bool.pf
+++ b/test/should-error/proc_requires_not_bool.pf
@@ -1,0 +1,6 @@
+// Phase 2b (issue #1111): a `requires` clause must have type bool.
+import Nat
+proc demo_bad(x: Nat)
+  requires x
+{
+}

--- a/test/should-error/proc_requires_not_bool.pf.err
+++ b/test/should-error/proc_requires_not_bool.pf.err
@@ -1,0 +1,2 @@
+./test/should-error/proc_requires_not_bool.pf:4.12-4.13: expected a term of type bool
+but got term x of type Nat

--- a/test/should-error/proc_result_without_return.pf
+++ b/test/should-error/proc_result_without_return.pf
@@ -1,0 +1,6 @@
+// Phase 2b (issue #1111): `result` is only in scope in the postconditions of
+// a procedure that declares a return type.
+proc demo_bad(x: bool)
+  ensures result
+{
+}

--- a/test/should-error/proc_result_without_return.pf.err
+++ b/test/should-error/proc_result_without_return.pf.err
@@ -1,0 +1,1 @@
+./test/should-error/proc_result_without_return.pf:4.11-4.17: undefined variable: result

--- a/test/should-warn/proc_signatures.pf
+++ b/test/should-warn/proc_signatures.pf
@@ -1,0 +1,33 @@
+// Phase 2b (issue #1111): procedure signatures and contracts are now
+// type-checked -- parameter and return types, requires/ensures (which must be
+// bool), reads/modifies frames, and decreases terms. Bodies and specs are
+// still only recognized, so each proc still emits the Phase 1m
+// "accepted but not verified" warning (issue #1108).
+import Nat
+
+// Generic signature: `result` is bound in postconditions to the return type.
+proc demo_pick<T>(x: T, y: T) -> T
+  requires x = x
+  ensures keep: result = result
+{
+  return x
+}
+
+// Non-generic signature with a ghost parameter, a mutable-array parameter,
+// frames, and a decreases term -- all checked structurally.
+proc demo_sweep(a: [Nat]!, ghost n: Nat) -> bool
+  requires n = n
+  reads a
+  modifies a
+  decreases n
+  ensures result or not result
+{
+  return true
+}
+
+// A procedure with no return type accepts requires/ensures over its params.
+proc demo_nudge(b: bool)
+  requires b = b
+  ensures b or not b
+{
+}

--- a/test/should-warn/proc_signatures.pf.warn
+++ b/test/should-warn/proc_signatures.pf.warn
@@ -1,0 +1,3 @@
+./test/should-warn/proc_signatures.pf:9.1-14.2: warning: proc 'demo_pick' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)
+./test/should-warn/proc_signatures.pf:18.1-26.2: warning: proc 'demo_sweep' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)
+./test/should-warn/proc_signatures.pf:29.1-33.2: warning: proc 'demo_nudge' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)


### PR DESCRIPTION
Closes #1111.

Phase 2b of the imperative verification layer (#854): make a `proc` a typed
callable declaration with a **checked public contract**, while leaving statement
execution and body verification to later slices.

## What changed

`checker_pipeline.check_proc_signature` now runs in the declaration phase
(`process_declaration_visibility`) for every `ProcDecl` (observer/resource still
pass through):

- **Parameter types** (ordinary and ghost) and the optional **return type** are
  checked with `check_type`, over the procedure's type parameters.
- **`requires` / `ensures`** are checked as `bool` formulas. `ensures` clauses
  additionally see `result`, bound to the declared return type.
- **`decreases`** terms are type-synthesized.
- **`reads` / `modifies` frames** are accepted structurally — their subject
  names are already resolved by `uniquify`, but the footprint/heap semantics
  needed to type a mutable-array read (`a[i]`, #1117) or a `footprint(...)`
  (#1126) are later slices, so the frame list passes through unchanged.

The checked signature is registered as a new `Env.ProcBinding` (signature only,
no body), so **imports expose procedure contracts without bodies** and later
`call` resolution can find them. A pure `fun`/`define` that references a
procedure name as an ordinary term now gets a focused
*"…is a procedure and cannot be used as an ordinary term; procedures are invoked
with a `call` statement…"* diagnostic.

**Duplicate proc parameter names** are rejected in `uniquify` (a single clean
diagnostic, avoiding the pre-existing `overwrite` shadowing warning);
**duplicate labelled postconditions** are rejected in the checker. `result` is
only in scope where a return type is declared. To recover the uniquified
`result` name inside the checker, `ProcDecl` gains a `result_name` field that
`uniquify` fills in.

Procedures are signature-checked but **not yet verified**, so each still emits
the Phase 1m "accepted but not verified" warning (#1108) — retiring that for
`ProcDecl` is a later body-verification slice.

## Fixtures

Enrolled in `EXPERIMENTAL_IMPERATIVE_FILES`:

- `test/should-warn/proc_signatures.pf` — positive: generic + non-generic
  signatures, a ghost parameter, a `[Nat]!` parameter, `reads`/`modifies`
  frames, `decreases`, and `result` typed in a postcondition.
- `test/should-error/proc_requires_not_bool.pf` — `requires` must be `bool`.
- `test/should-error/proc_result_without_return.pf` — `result` without a return
  type.
- `test/should-error/proc_duplicate_param.pf` — duplicate parameter name.
- `test/should-error/proc_duplicate_post_label.pf` — duplicate `ensures` label.
- `test/should-error/proc_call_as_term.pf` — calling a proc as an ordinary term.

Cross-module signature exposure stays covered by the existing
`test/should-validate/imperative_import.pf`; a dedicated cross-module
should-error fixture was intentionally avoided because its golden would include
the imported module's Phase 1m warning, which is stale-`.thm`-order-dependent.

## Testing

`python3 test-deduce.py` (full default suite), `--warns`, `--errors`, `--equiv`,
`--imperative`, plus `ruff` and `mypy` all pass; both parsers (`--recursive-descent`
and `--lalr`) accept the positive fixture.

## Out of scope (later slices)

No body checking, weakest preconditions, call statements, frame enforcement,
proof slots, or runtime behavior.

Resume this session on ginger: `~/deduce-runner/resume.sh e4ccaf53-3e78-4699-9474-8e1ddeedb955 routine/20260727-210202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
