### PR TITLE
Extract shared type-parameter uniquify helper (refs #813)

### DIFF
--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -324,6 +324,27 @@ def generate_name(name: str, ctx: UniquifyContext) -> str:
   return base + '.' + ctx.scope + str(new_id)
 
 
+def uniquify_type_params(
+    env: UniquifyEnv,
+    type_params: List[str],
+    ctx: UniquifyContext,
+    loc: Meta,
+    bind: Callable[[UniquifyEnv, str, str, Meta], None],
+) -> Tuple[UniquifyEnv, List[str]]:
+  """Copy ``env`` and bind fresh names for ``type_params`` in the copy.
+
+  Shared by the ``uniquify`` methods of every type-parameterized
+  declaration and type.  Returns the extended body environment and the
+  freshly generated parameter names.  ``bind`` is ``extend`` or
+  ``overwrite`` depending on whether the caller allows overloading.
+  """
+  body_env = copy_dict(env)
+  new_type_params = [generate_name(t, ctx) for t in type_params]
+  for (old, new) in zip(type_params, new_type_params):
+    bind(body_env, old, new, loc)
+  return body_env, new_type_params
+
+
 def base_name(name: str) -> str:
   ls = name.split('.')
   return ls[0]

--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -532,10 +532,8 @@ class ProcDecl(Declaration):
     overwrite(env_map, self.name, new_name, self.location)
     env_map['no overload'][self.name] = 'proc'
 
-    proc_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      overwrite(proc_env, old, new, self.location)
+    proc_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, overwrite)
 
     new_params = []
     for param in self.params:
@@ -778,10 +776,8 @@ class Predicate(Declaration):
     env_map[rule_inv_base] = [rule_inv_unique]
     env_map['no overload'][rule_inv_base] = 'theorem'
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, extend)
 
     new_signature = self.signature.uniquify(body_env, uniq_ctx)
     new_rules = [rule.uniquify(env_map, body_env, uniq_ctx) for rule in self.rules]
@@ -839,10 +835,8 @@ class Union(Declaration):
     env_map[self.name] = [new_name]
     env_map['no overload'][self.name] = 'union'
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, extend)
 
     new_alts = [con.uniquify(env_map, body_env, uniq_ctx)
                 for con in self.alternatives]
@@ -889,10 +883,8 @@ class TypeAlias(Declaration):
     env_map[self.name] = [new_name]
     env_map['no overload'][self.name] = 'type alias'
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for old, new in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, extend)
 
     return TypeAlias(self.location, new_name, new_type_params,
                      self.body.uniquify(body_env, uniq_ctx),
@@ -949,10 +941,8 @@ class ObjectDecl(Declaration):
     env_map[self.name] = [new_name]
     env_map['no overload'][self.name] = 'object'
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for old, new in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, extend)
     new_fields = None if self.fields is None \
       else [field.uniquify(body_env, uniq_ctx) for field in self.fields]
     return ObjectDecl(self.location, new_name, new_type_params, new_fields,
@@ -996,10 +986,8 @@ class ObserverDecl(Declaration):
     overwrite(env_map, self.name, new_name, self.location)
     env_map['no overload'][self.name] = 'observer'
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      overwrite(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, overwrite)
 
     new_params = []
     for param in self.params:
@@ -1067,10 +1055,8 @@ class ResourceDecl(Declaration):
     overwrite(env_map, self.name, new_name, self.location)
     env_map['no overload'][self.name] = 'resource'
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      overwrite(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, overwrite)
 
     new_params = []
     for param in self.params:
@@ -1185,10 +1171,8 @@ class RecFun(Declaration):
     new_name = generate_name(self.name, uniq_ctx)
     extend(env_map, self.name, new_name, self.location)
 
-    body_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, extend)
 
     new_params = [ty.uniquify(body_env, uniq_ctx) for ty in self.params]
     new_returns = self.returns.uniquify(body_env, uniq_ctx)
@@ -1272,11 +1256,10 @@ class GenRecFun(Declaration):
     new_name = generate_name(self.name, uniq_ctx)
     extend(env_map, self.name, new_name, self.location)
 
-    body_env = copy_dict(env_map)
+    body_env, new_type_params = uniquify_type_params(
+        env_map, self.type_params, uniq_ctx, self.location, extend)
     terminates_env = copy_dict(env_map)
-    new_type_params = [generate_name(t, uniq_ctx) for t in self.type_params]
     for (old, new) in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
       extend(terminates_env, old, new, self.location)
 
     new_returns = self.returns.uniquify(body_env, uniq_ctx)
@@ -1362,10 +1345,8 @@ class ViewRecFun(Declaration):
     new_name = generate_name(self.name, ctx)
     extend(env, self.name, new_name, self.location)
 
-    body_env = copy_dict(env)
-    new_type_params = [generate_name(t, ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env, self.type_params, ctx, self.location, extend)
 
     new_returns = self.returns.uniquify(body_env, ctx)
     new_var_types = [t.uniquify(body_env, ctx) if t else None
@@ -1437,10 +1418,8 @@ class ViewDecl(Declaration):
     env[self.name] = [new_name]
     env['no overload'][self.name] = 'view'
 
-    body_env = copy_dict(env)
-    new_type_params = [generate_name(t, ctx) for t in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      extend(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env, self.type_params, ctx, self.location, extend)
 
     def resolve_name(name: str, kind: str) -> str:
       if name not in env.keys():
@@ -1825,10 +1804,8 @@ class Associative(Statement):
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Associative:
     new_op = self.op.uniquify(env, ctx)
-    body_env = {x:y for (x,y) in env.items()}
-    new_type_params = [generate_name(x, ctx) for x in self.type_params]
-    for (old, new) in zip(self.type_params, new_type_params):
-      overwrite(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env, self.type_params, ctx, self.location, overwrite)
     new_typeof = self.typeof.uniquify(body_env, ctx)
     return Associative(self.location, new_type_params, new_op, new_typeof)
 

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -163,10 +163,8 @@ class FunctionType(Type):
     return set().union(*fvs) - set(self.type_params)
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> FunctionType:
-    body_env = {x:y for (x,y) in env.items()}
-    new_type_params = [generate_name(t, ctx) for t in self.type_params]
-    for (old,new) in zip(self.type_params, new_type_params):
-      overwrite(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env, self.type_params, ctx, self.location, overwrite)
     new_param_types = [p.uniquify(body_env, ctx) for p in self.param_types]
     new_return_type = self.return_type.uniquify(body_env, ctx)
     return FunctionType(self.location, new_type_params,
@@ -377,10 +375,8 @@ class Generic(Term):
       return new_body == other.body
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> Generic:
-    body_env = {x:y for (x,y) in env.items()}
-    new_type_params = [generate_name(x, ctx) for x in self.type_params]
-    for (old,new) in zip(self.type_params, new_type_params):
-      overwrite(body_env, old, new, self.location)
+    body_env, new_type_params = uniquify_type_params(
+        env, self.type_params, ctx, self.location, overwrite)
     return Generic(self.location, self.typeof, new_type_params,
                    self.body.uniquify(body_env, ctx))
 


### PR DESCRIPTION
## What

Extract the repeated *type-parameter uniquify* idiom into a single shared
helper, `uniquify_type_params`, in `abstract_syntax/core.py`.

The `uniquify` methods of every type-parameterized declaration and type
repeated the same four-line block:

```python
body_env = copy_dict(env)
new_type_params = [generate_name(t, ctx) for t in self.type_params]
for (old, new) in zip(self.type_params, new_type_params):
    bind(body_env, old, new, self.location)
```

Fourteen near-identical copies existed across
`abstract_syntax/declarations.py` (Predicate, Union, TypeAlias, ObjectDecl,
ObserverDecl, ResourceDecl, RecFun, GenRecFun, ViewRecFun, ViewDecl,
Associative, ProcDecl) and `abstract_syntax/terms.py` (FunctionType, Generic),
differing only in whether they bound with `extend` or `overwrite`, and in
incidental spelling (`copy_dict(env)` vs `{x:y for (x,y) in env.items()}`,
`uniq_ctx` vs `ctx`).

## How

- New free function in `core.py` next to `copy_dict`/`generate_name`:

  ```python
  def uniquify_type_params(env, type_params, ctx, loc, bind):
      body_env = copy_dict(env)
      new_type_params = [generate_name(t, ctx) for t in type_params]
      for (old, new) in zip(type_params, new_type_params):
          bind(body_env, old, new, loc)
      return body_env, new_type_params
  ```

  `bind` is passed explicitly (`extend` or `overwrite`) so the helper needs no
  cross-module default. The `abstract_syntax` package facade injects every
  public name into each submodule's globals, so both `declarations.py` and
  `terms.py` call it bare.

- All 14 call sites now delegate to the helper. `GenRecFun` keeps its separate
  `terminates_env` bind loop but reuses the helper's returned names for
  `body_env`, so behavior is unchanged.

Net `-55 / +49` lines; behavior-preserving (`extend`/`overwrite` semantics per
site are preserved exactly).

## Testing

- `python3 test-deduce.py` — all categories green (lib, should-validate ×2
  parsers, should-error, should-warn, parser equivalence RD/LALR, pretty-print
  round trip).
- `python3 -m ruff check .` and `python3 -m mypy .` — clean (55 files).

Refs #813 (code-duplication umbrella — stays open; this is one slice).

Resume this session on ginger: `~/deduce-runner/resume.sh 96083abd-03bf-4ca5-b5eb-374a48508838 routine/20260727-220202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
