### PR TITLE
Type-check imperative proc bodies: locals, assignments, returns (closes #1113)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -22,11 +22,13 @@ from abstract_syntax import (
     All, And, Array, ArrayGet, Assert, Associative, Auto, Bool,
     Call, Conditional, Constructor, Declaration, Define, Env, Export,
     Formula, FunCase, FunctionType, GenRecFun, Generic, GenericUnknownInst,
-    Hole, IfThen, Import, Inductive, Lambda, MakeArray, Module, ObjectDecl,
+    Hole, IfThen, ImpAlloc, ImpAssign, ImpCallExpr, ImpIf, ImpReturn, ImpStmt,
+    ImpVar, Import, Inductive, Lambda, LValueVar, MakeArray, Module,
+    MutableArrayType, ObjectDecl,
     ObjectField, ObserverDecl, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
     PatternBool, PatternCons, Postulate, Predicate, Print, ProcDecl, ProcParam,
     ProcSpec, RecFun, ResolvedVar, ResourceDecl, Rule, Some,
-    Statement, Switch, SwitchCase, TAnnote, TLet, Term, TermInst, Theorem,
+    Statement, Switch, SwitchCase, TAnnote, TermBinding, TLet, Term, TermInst, Theorem,
     Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, VarRef, VerboseLevel,
     ViewDecl, ViewRecFun, alpha_equiv, base_name, callable_name,
     check_post_typecheck_invariants, find_file, full_reduce, mkEqual,
@@ -139,6 +141,121 @@ def check_proc_signature(decl: ProcDecl, env: Env) -> tuple[Statement, Env]:
   new_env = env.declare_proc(loc, decl.name, decl.type_params, checked_params,
                              checked_return, checked_specs, decl.visibility)
   return checked_decl, new_env
+
+# Phase 2d (issue #1113): imperative statement forms whose *typing* is not yet
+# modeled by the verifier. Procedure calls, allocations, mutable-array reads
+# and writes, field writes, and `assert`/`assume`/loop obligations are all
+# later slices (#1116-#1122); a body that uses any of them is left untouched
+# here (and keeps emitting the Phase 1m "not verified" warning) rather than
+# risk a spurious type error. Straight-line bodies over ordinary local `var`,
+# assignment, `return`, and `if` are type-checked in full.
+def _imp_stmt_unmodeled(s: ImpStmt) -> bool:
+  match s:
+    case ImpVar(_, _, rhs, _) | ImpAssign(_, _, rhs):
+      if isinstance(rhs, (ImpCallExpr, ImpAlloc)):
+        return True
+      if isinstance(s, ImpAssign) and not isinstance(s.lhs, LValueVar):
+        return True
+      return False
+    case ImpIf(_, _, then_body, else_body):
+      return _block_unmodeled(then_body) \
+          or (else_body is not None and _block_unmodeled(else_body))
+    case ImpReturn():
+      return False
+    case _:
+      # `while`, `assert`, `assume`, and `call` statements.
+      return True
+
+def _block_unmodeled(stmts: list[ImpStmt]) -> bool:
+  return any(_imp_stmt_unmodeled(s) for s in stmts)
+
+def _proc_body_unmodeled(decl: ProcDecl) -> bool:
+  # Mutable-array parameters make even a `var y := a[i]` read untypeable until
+  # #1117 lands, so any proc that takes one is deferred wholesale.
+  if any(isinstance(p.typ, MutableArrayType) for p in decl.params):
+    return True
+  return _block_unmodeled(decl.body)
+
+def _block_always_returns(stmts: list[ImpStmt]) -> bool:
+  # Conservatively decide whether a straight-line block must execute a
+  # `return`. Only `true` when we are certain, so a body that can fall off the
+  # end is never mistaken for one that returns (the missing-return diagnostic
+  # stays sound; richer path analysis is a later slice).
+  if not stmts:
+    return False
+  match stmts[-1]:
+    case ImpReturn():
+      return True
+    case ImpIf(_, _, then_body, else_body):
+      return else_body is not None \
+          and _block_always_returns(then_body) \
+          and _block_always_returns(else_body)
+    case _:
+      return False
+
+def _type_check_imp_stmt(s: ImpStmt, env: Env,
+                         return_type: Optional[Type]) -> Env:
+  # Returns the environment as seen by the *following* statement in the same
+  # block: a `var` extends it with the new local; everything else leaves it
+  # unchanged. `Env` is functional, so nested `if` blocks type-check against a
+  # value derived from `env` without leaking their locals back out.
+  match s:
+    case ImpVar(loc, name, type_annot, rhs, _):
+      if type_annot is not None:
+        var_ty = check_type(type_annot, env)
+        type_check_term(cast(Term, rhs), var_ty, env, None, [])
+      else:
+        var_ty = type_synth_term(cast(Term, rhs), env, None, []).typeof
+      return env.declare_term_var(loc, name, var_ty, local=True)
+    case ImpAssign(loc, lhs, rhs):
+      target = cast(LValueVar, lhs)
+      binding = env.dict.get(target.name)
+      if not isinstance(binding, TermBinding):
+        user_error(loc, 'assignment to undefined variable: '
+                   + base_name(target.name))
+      if not binding.local:
+        user_error(loc, 'cannot assign to ' + base_name(target.name)
+                   + ' because it is not a local variable')
+      type_check_term(cast(Term, rhs), binding.typ, env, None, [])
+      return env
+    case ImpIf(loc, cond, then_body, else_body):
+      type_check_formula(cond, env)
+      _type_check_imp_block(then_body, env, return_type)
+      if else_body is not None:
+        _type_check_imp_block(else_body, env, return_type)
+      return env
+    case ImpReturn(loc, value):
+      if return_type is None:
+        user_error(loc, 'this procedure has no return type, so it may not '
+                   + 'return a value')
+      else:
+        type_check_term(value, return_type, env, None, [])
+      return env
+    case _:
+      return env
+
+def _type_check_imp_block(stmts: list[ImpStmt], env: Env,
+                          return_type: Optional[Type]) -> None:
+  for s in stmts:
+    env = _type_check_imp_stmt(s, env, return_type)
+
+def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
+  # Phase 2d (issue #1113): type-check a procedure's straight-line body --
+  # annotated and inferred local `var` declarations, assignments to local
+  # variables, and `return` -- with lexical block scope. Bodies that use
+  # constructs not yet modeled (see `_proc_body_unmodeled`) are deferred to
+  # later slices. No specifications are proved here.
+  if _proc_body_unmodeled(decl):
+    return
+  loc = decl.location
+  type_env = env.declare_type_vars(loc, decl.type_params)
+  param_pairs = [(p.name, p.typ) for p in decl.params]
+  body_env = type_env.declare_term_vars(loc, param_pairs, local=True)
+  _type_check_imp_block(decl.body, body_env, decl.return_type)
+  if decl.return_type is not None and not _block_always_returns(decl.body):
+    user_error(loc, "procedure '" + base_name(decl.name)
+               + "' declares return type " + str(decl.return_type)
+               + ' but may finish without returning a value')
 
 def process_declaration_visibility(decl: Declaration, env: Env,
                                    module_chain: list[str],
@@ -933,7 +1050,14 @@ def type_check_stmt(stmt: Statement, env: Env,
     case ViewDecl():
       return stmt
 
-    case ObjectDecl() | ProcDecl() | ObserverDecl() | ResourceDecl():
+    case ProcDecl():
+      # Phase 2d (issue #1113): type-check the procedure's straight-line body.
+      # Specs are checked in `check_proc_signature` (Phase 2b); proving them is
+      # a later slice, so the Phase 1m "not verified" warning still fires.
+      type_check_proc_body(stmt, env)
+      return stmt
+
+    case ObjectDecl() | ObserverDecl() | ResourceDecl():
       # Phase 1 imperative declarations (issue #854): recognized for module
       # boundaries and tooling, but their bodies and specs are not verified
       # here -- pass them through unchanged.

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -150,13 +150,15 @@ def check_proc_signature(decl: ProcDecl, env: Env) -> tuple[Statement, Env]:
 # risk a spurious type error. Straight-line bodies over ordinary local `var`,
 # assignment, `return`, and `if` are type-checked in full.
 def _imp_stmt_unmodeled(s: ImpStmt) -> bool:
+  # Field access (`s.rhs`/`s.lhs`) rather than positional matching: `ImpVar`
+  # and `ImpAssign` hold their right-hand side at different positions, so a
+  # shared positional pattern would silently read the wrong field.
   match s:
-    case ImpVar(_, _, rhs, _) | ImpAssign(_, _, rhs):
-      if isinstance(rhs, (ImpCallExpr, ImpAlloc)):
-        return True
-      if isinstance(s, ImpAssign) and not isinstance(s.lhs, LValueVar):
-        return True
-      return False
+    case ImpVar():
+      return isinstance(s.rhs, (ImpCallExpr, ImpAlloc))
+    case ImpAssign():
+      return isinstance(s.rhs, (ImpCallExpr, ImpAlloc)) \
+          or not isinstance(s.lhs, LValueVar)
     case ImpIf(_, _, then_body, else_body):
       return _block_unmodeled(then_body) \
           or (else_body is not None and _block_unmodeled(else_body))
@@ -176,14 +178,8 @@ def _proc_body_unmodeled(decl: ProcDecl) -> bool:
     return True
   return _block_unmodeled(decl.body)
 
-def _block_always_returns(stmts: list[ImpStmt]) -> bool:
-  # Conservatively decide whether a straight-line block must execute a
-  # `return`. Only `true` when we are certain, so a body that can fall off the
-  # end is never mistaken for one that returns (the missing-return diagnostic
-  # stays sound; richer path analysis is a later slice).
-  if not stmts:
-    return False
-  match stmts[-1]:
+def _stmt_always_returns(s: ImpStmt) -> bool:
+  match s:
     case ImpReturn():
       return True
     case ImpIf(_, _, then_body, else_body):
@@ -192,6 +188,14 @@ def _block_always_returns(stmts: list[ImpStmt]) -> bool:
           and _block_always_returns(else_body)
     case _:
       return False
+
+def _block_always_returns(stmts: list[ImpStmt]) -> bool:
+  # Conservatively decide whether a block must execute a `return`. Only `true`
+  # when we are certain, so a body that can fall off the end is never mistaken
+  # for one that returns (the missing-return diagnostic stays sound; richer
+  # path analysis is a later slice). Any statement that always returns makes
+  # the whole block always return -- everything after it is unreachable.
+  return any(_stmt_always_returns(s) for s in stmts)
 
 def _type_check_imp_stmt(s: ImpStmt, env: Env,
                          return_type: Optional[Type]) -> Env:

--- a/test/imperative/should-error/proc_body_assign_nonlocal.pf
+++ b/test/imperative/should-error/proc_body_assign_nonlocal.pf
@@ -1,0 +1,8 @@
+// Phase 2d (issue #1113): assignment to a global name (not a block-local
+// variable) is rejected.
+define g = true
+
+proc demo(flag: bool)
+{
+  g := flag
+}

--- a/test/imperative/should-error/proc_body_assign_nonlocal.pf.err
+++ b/test/imperative/should-error/proc_body_assign_nonlocal.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_body_assign_nonlocal.pf:7.3-7.12: cannot assign to g because it is not a local variable

--- a/test/imperative/should-error/proc_body_assign_type.pf
+++ b/test/imperative/should-error/proc_body_assign_type.pf
@@ -1,0 +1,13 @@
+// Phase 2d (issue #1113): assignment to a local variable checks that the
+// right-hand side has the same type as the variable. Here `c` is inferred as
+// `Color`, so assigning a `bool` is rejected.
+union Color {
+  red
+  green
+}
+
+proc demo(flag: bool)
+{
+  var c := red
+  c := flag
+}

--- a/test/imperative/should-error/proc_body_assign_type.pf.err
+++ b/test/imperative/should-error/proc_body_assign_type.pf.err
@@ -1,0 +1,2 @@
+./test/imperative/should-error/proc_body_assign_type.pf:12.8-12.12: expected a term of type Color
+but got term flag of type bool

--- a/test/imperative/should-error/proc_body_assign_unknown.pf
+++ b/test/imperative/should-error/proc_body_assign_unknown.pf
@@ -1,0 +1,6 @@
+// Phase 2d (issue #1113): assignment to a name that is not a local variable
+// is rejected. Here `missing` was never declared.
+proc demo(flag: bool)
+{
+  missing := flag
+}

--- a/test/imperative/should-error/proc_body_assign_unknown.pf.err
+++ b/test/imperative/should-error/proc_body_assign_unknown.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_body_assign_unknown.pf:5.3-5.18: assignment to undefined variable: missing

--- a/test/imperative/should-error/proc_body_local_leak.pf
+++ b/test/imperative/should-error/proc_body_local_leak.pf
@@ -1,0 +1,9 @@
+// Phase 2d (issue #1113): a local declared inside a nested `if` block does not
+// leak into the enclosing block, so referencing it afterwards is an error.
+proc demo(flag: bool) -> bool
+{
+  if flag {
+    var inner := flag
+  }
+  return inner
+}

--- a/test/imperative/should-error/proc_body_local_leak.pf.err
+++ b/test/imperative/should-error/proc_body_local_leak.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_body_local_leak.pf:8.10-8.15: undefined variable: inner

--- a/test/imperative/should-error/proc_body_missing_return.pf
+++ b/test/imperative/should-error/proc_body_missing_return.pf
@@ -1,0 +1,6 @@
+// Phase 2d (issue #1113): a procedure that declares a result type but whose
+// straight-line body can finish without a `return` is rejected conservatively.
+proc demo(flag: bool) -> bool
+{
+  var b := flag
+}

--- a/test/imperative/should-error/proc_body_missing_return.pf.err
+++ b/test/imperative/should-error/proc_body_missing_return.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_body_missing_return.pf:3.1-6.2: procedure 'demo' declares return type bool but may finish without returning a value

--- a/test/imperative/should-error/proc_body_return_in_void.pf
+++ b/test/imperative/should-error/proc_body_return_in_void.pf
@@ -1,0 +1,6 @@
+// Phase 2d (issue #1113): a procedure with no declared result type may not
+// `return` a value.
+proc demo(flag: bool)
+{
+  return flag
+}

--- a/test/imperative/should-error/proc_body_return_in_void.pf.err
+++ b/test/imperative/should-error/proc_body_return_in_void.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_body_return_in_void.pf:5.3-5.9: this procedure has no return type, so it may not return a value

--- a/test/imperative/should-error/proc_body_return_in_void.pf.err.lalr
+++ b/test/imperative/should-error/proc_body_return_in_void.pf.err.lalr
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_body_return_in_void.pf:5.3-5.14: this procedure has no return type, so it may not return a value

--- a/test/imperative/should-error/proc_body_return_mismatch.pf
+++ b/test/imperative/should-error/proc_body_return_mismatch.pf
@@ -1,0 +1,12 @@
+// Phase 2d (issue #1113): a `return` whose value does not match the declared
+// result type is rejected.
+union Color {
+  red
+  green
+}
+
+proc demo(flag: bool) -> bool
+{
+  var c := green
+  return c
+}

--- a/test/imperative/should-error/proc_body_return_mismatch.pf.err
+++ b/test/imperative/should-error/proc_body_return_mismatch.pf.err
@@ -1,0 +1,2 @@
+./test/imperative/should-error/proc_body_return_mismatch.pf:11.10-11.11: expected a term of type bool
+but got term c of type Color

--- a/test/imperative/should-error/proc_body_wrong_init.pf
+++ b/test/imperative/should-error/proc_body_wrong_init.pf
@@ -1,0 +1,11 @@
+// Phase 2d (issue #1113): an annotated local `var` whose initializer has a
+// different type is rejected with a focused diagnostic.
+union Color {
+  red
+  green
+}
+
+proc demo(flag: bool)
+{
+  var bad : Color := flag
+}

--- a/test/imperative/should-error/proc_body_wrong_init.pf.err
+++ b/test/imperative/should-error/proc_body_wrong_init.pf.err
@@ -1,0 +1,2 @@
+./test/imperative/should-error/proc_body_wrong_init.pf:10.22-10.26: expected a term of type Color
+but got term flag of type bool

--- a/test/imperative/should-validate/proc_body_defer_alloc.pf
+++ b/test/imperative/should-validate/proc_body_defer_alloc.pf
@@ -1,0 +1,11 @@
+// Phase 2d (issue #1113): a body whose only not-yet-modeled construct is an
+// allocation (or call) right-hand side in a `var` is deferred wholesale --
+// accepted with the Phase 1m "not verified" warning rather than type-checked.
+// Regression for a pattern-arity bug (PR #1145 review) where the deferral
+// gate read the wrong `ImpVar` field and let `var a := new C(..)` fall
+// through to the term checker as a hard error.
+proc make(x: bool) -> bool
+{
+  var a := new Cell(x)
+  return x
+}

--- a/test/imperative/should-validate/proc_body_defer_alloc.pf.warn
+++ b/test/imperative/should-validate/proc_body_defer_alloc.pf.warn
@@ -1,0 +1,1 @@
+./test/imperative/should-validate/proc_body_defer_alloc.pf:7.1-11.2: warning: proc 'make' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/proc_body_if_returns.pf
+++ b/test/imperative/should-validate/proc_body_if_returns.pf
@@ -1,0 +1,17 @@
+// Phase 2d (issue #1113): a body that returns on every branch of a terminal
+// `if`/`else` needs no trailing `return`; the conservative missing-return
+// check must recognize the guaranteed return rather than flag it (PR #1145
+// review).
+union Color {
+  red
+  green
+}
+
+proc pick(flag: bool) -> Color
+{
+  if flag {
+    return red
+  } else {
+    return green
+  }
+}

--- a/test/imperative/should-validate/proc_body_if_returns.pf
+++ b/test/imperative/should-validate/proc_body_if_returns.pf
@@ -1,7 +1,9 @@
-// Phase 2d (issue #1113): a body that returns on every branch of a terminal
-// `if`/`else` needs no trailing `return`; the conservative missing-return
-// check must recognize the guaranteed return rather than flag it (PR #1145
-// review).
+// Phase 2d (issue #1113): a body that returns on every branch of an
+// `if`/`else` cannot fall through, so a trailing (unreachable) statement must
+// not trigger the missing-return diagnostic. Regression for a missing-return
+// bug (PR #1145 review) where only the *last* statement was inspected: the
+// guaranteed return here is not the last statement, so the earlier version
+// wrongly reported that `pick` could finish without returning.
 union Color {
   red
   green
@@ -14,4 +16,5 @@ proc pick(flag: bool) -> Color
   } else {
     return green
   }
+  var unreached := red
 }

--- a/test/imperative/should-validate/proc_body_if_returns.pf.warn
+++ b/test/imperative/should-validate/proc_body_if_returns.pf.warn
@@ -1,1 +1,1 @@
-./test/imperative/should-validate/proc_body_if_returns.pf:10.1-17.2: warning: proc 'pick' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)
+./test/imperative/should-validate/proc_body_if_returns.pf:12.1-20.2: warning: proc 'pick' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/proc_body_if_returns.pf.warn
+++ b/test/imperative/should-validate/proc_body_if_returns.pf.warn
@@ -1,0 +1,1 @@
+./test/imperative/should-validate/proc_body_if_returns.pf:10.1-17.2: warning: proc 'pick' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/proc_body_locals.pf
+++ b/test/imperative/should-validate/proc_body_locals.pf
@@ -1,0 +1,26 @@
+// Phase 2d (issue #1113): straight-line procedure bodies are now type-checked
+// -- annotated and inferred local `var` declarations, assignment to a local
+// variable, nested `if`-block scope, and a `return` matching the declared
+// result type. The body stays otherwise unverified, so the Phase 1m
+// "accepted but not verified" warning (issue #1108) still fires; the
+// `.pf.warn` sibling pins it under both parsers.
+union Color {
+  red
+  green
+}
+
+proc classify(flag: bool) -> Color
+  ensures flag or not flag
+{
+  var a : bool := flag       // annotated local
+  var b := a                 // inferred local, bool
+  var c := red               // inferred local, Color
+  b := flag                  // assignment to a local variable
+  if b {
+    var picked := green      // block-local, does not leak out of the `if`
+    c := picked
+  } else {
+    c := red
+  }
+  return c
+}

--- a/test/imperative/should-validate/proc_body_locals.pf.warn
+++ b/test/imperative/should-validate/proc_body_locals.pf.warn
@@ -1,0 +1,1 @@
+./test/imperative/should-validate/proc_body_locals.pf:12.1-26.2: warning: proc 'classify' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)


### PR DESCRIPTION
## Summary

Phase 2d of the imperative verification layer (#854): type-check straight-line
procedure bodies without yet proving specifications.

`type_check_proc_body` runs in `type_check_stmt` for `ProcDecl` and checks:

- **annotated and inferred local `var` declarations** — an annotation is
  checked against the initializer; an unannotated `var` synthesizes its type
  from the initializer;
- **assignment to local variables** — the target must be a block-local
  `var`/parameter; assigning to an unknown name or a global is rejected with a
  focused diagnostic;
- **`return e`** — checked against the declared result type; a value `return`
  in a procedure with no result type is rejected;
- **nested `if`-block lexical scope** — block-locals do not leak into the
  enclosing block (`Env` is functional, so nested blocks type-check against a
  copy);
- **conservative missing-return** — a straight-line body that declares a
  result type but can fall off the end is rejected; the check is sound (only
  fires when it is certain the body can complete without returning).

### Out of scope (deferred to later slices)

Constructs not yet modeled by the verifier — procedure calls, allocations,
mutable-array reads/writes, field writes, `assert`/`assume`, and loops
(#1116–#1122) — are deferred **wholesale**: a body using any of them is left
untouched and keeps emitting the Phase 1m "accepted but not verified" warning
(#1108) rather than risk a spurious type error. A mutable-array (`[T]!`)
parameter defers the whole body, since `a[i]` reads are not typeable until
#1117. No specifications are proved here.

## Tests

New fixtures under `test/imperative`, run under both parsers by the
`--imperative` lane (which also rides `--passable --cli` in CI):

- `should-validate/proc_body_locals.pf` — positive path (annotated + inferred
  locals, assignment, nested-`if` scope, matching `return`).
- `should-error/` negatives: wrong initializer type, return-type mismatch,
  value return in a void proc, assignment to an unknown name, assignment to a
  global (non-local), missing return, and a nested-block local that does not
  leak.

`return_in_void` has a `.pf.err.lalr` sibling for the known RD/LALR return
location-span divergence.

Ran locally: `test-deduce.py --imperative --warns --errors --passable --equiv
--lib`, `ruff check .`, `mypy .`, and the token/grammar checks — all green.

## Bug filed in passing

- #1144 — spurious `already defined` warning on legitimate nested `var`
  shadowing (pre-existing uniquify behavior surfaced while scoping this slice).

Closes #1113. Refs #854.

Resume this session on ginger: `~/deduce-runner/resume.sh 62f47fd3-d10e-4e38-8096-6f4732a69f79 routine/20260727-230202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
