### PR TITLE
Suppress spurious 'already defined' warning for nested imperative var shadowing (closes #1144)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -111,12 +111,13 @@ def extend(env: UniquifyEnv, name: str, new_name: str, loc: Meta) -> None:
     env[name] = [new_name]
 
 ## Overwrites a value in the environment, with a warning
-def overwrite(env: UniquifyEnv, name: str, new_name: str, loc: Meta) -> None:
+def overwrite(env: UniquifyEnv, name: str, new_name: str, loc: Meta,
+              warn: bool = True) -> None:
   if name in env['no overload']:
     ty = env['no overload'][name]
     user_error(loc, f"Cannot overload {ty} names. {name} is already defined as a {ty}")
 
-  if base_name(name) != "_" and name in env.keys():
+  if warn and base_name(name) != "_" and name in env.keys():
     warning(loc, f"WARNING: {name} is already defined")
   env[name] = [new_name]
 
@@ -393,16 +394,20 @@ def _uniquify_imp_proof(proof: Optional[Proof], env: UniquifyEnv,
   return proof.uniquify(env, ctx) if proof is not None else None
 
 def _uniquify_imp_stmt(s: ImpStmt, env: UniquifyEnv,
-                       ctx: UniquifyContext) -> ImpStmt:
+                       ctx: UniquifyContext, declared: set[str]) -> ImpStmt:
   # `env` is the enclosing block's environment; a `var` declaration mutates
   # it so later statements in the same block see the binding. Nested blocks
-  # receive a copy so their locals do not leak outward.
+  # receive a copy so their locals do not leak outward. `declared` names the
+  # vars bound *in this block*, so redeclaring a name in the same block warns
+  # while shadowing an outer-block binding (a distinct alpha-renamed local)
+  # does not.
   if isinstance(s, ImpVar):
     new_rhs = _uniquify_imp_rhs(s.rhs, env, ctx)
     new_type = (s.type_annot.uniquify(env, ctx)
                 if s.type_annot is not None else None)
     new_name = generate_name(s.name, ctx)
-    overwrite(env, s.name, new_name, s.location)
+    overwrite(env, s.name, new_name, s.location, warn=s.name in declared)
+    declared.add(s.name)
     return ImpVar(s.location, new_name, new_type, new_rhs, s.ghost)
   if isinstance(s, ImpAssign):
     return ImpAssign(s.location, _uniquify_lvalue(s.lhs, env, ctx),
@@ -439,7 +444,10 @@ def _uniquify_imp_stmt(s: ImpStmt, env: UniquifyEnv,
 
 def _uniquify_imp_block(stmts: List[ImpStmt], env: UniquifyEnv,
                         ctx: UniquifyContext) -> List[ImpStmt]:
-  return [_uniquify_imp_stmt(s, env, ctx) for s in stmts]
+  # A fresh `declared` set per block: names bound in an enclosing block are
+  # inherited via `env` but do not count as same-block redeclarations here.
+  declared: set[str] = set()
+  return [_uniquify_imp_stmt(s, env, ctx, declared) for s in stmts]
 
 @dataclass
 class ProcParam(AST):

--- a/test/imperative/should-validate/nested_var_shadow.pf
+++ b/test/imperative/should-validate/nested_var_shadow.pf
@@ -1,0 +1,12 @@
+// Nested-block `var` shadowing must not emit a spurious "already defined"
+// warning: the inner `var a` is a distinct block-local that uniquify
+// alpha-renames, shadowing the outer `a` in a nested scope (issue #1144).
+proc demo(flag: bool)
+{
+  var a := flag
+  if flag {
+    var a := flag
+  } else {
+    var a := flag
+  }
+}

--- a/test/imperative/should-validate/nested_var_shadow.pf.warn
+++ b/test/imperative/should-validate/nested_var_shadow.pf.warn
@@ -1,0 +1,1 @@
+./test/imperative/should-validate/nested_var_shadow.pf:4.1-12.2: warning: proc 'demo' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)


### PR DESCRIPTION
## Summary

Fixes a spurious `WARNING: <name> is already defined` emitted when an
imperative `var` legitimately shadows an outer-block `var` inside a nested
block (issue #1144). Nested-block shadowing is a supported feature of the
imperative layer, and uniquify already alpha-renames the inner `var` to a
distinct name — the warning was noise.

## Root cause

`_uniquify_imp_stmt` (for `ImpVar`) called `overwrite`, which warns whenever
the name is already present in the environment. A nested block receives a
`copy_dict(env)` that still contains the *outer* binding, so `overwrite` saw
the name and warned even though this was a shadow in a new scope, not a
same-block re-declaration.

## Fix

- `overwrite` gains a `warn: bool = True` keyword so callers can suppress the
  "already defined" warning while keeping the no-overload guard and the binding
  update.
- The imperative-body uniquify walk now threads a per-block `declared: set[str]`
  set. Each block (`_uniquify_imp_block`) starts with a fresh empty set, so a
  `var` only warns when its name was *already declared in the same block*.
  Shadowing an outer-block binding is silent.

Same-block re-declaration (`var a; var a` in one block) still warns, as before.

## Testing

- Added `test/imperative/should-validate/nested_var_shadow.pf` (+ `.pf.warn`)
  covering `var a` shadowed in both `if` and `else` branches; it emits only the
  expected "accepted but not verified" proc warning.
- `python3 test-deduce.py --imperative` — passes (both parsers).
- `python3 test-deduce.py --warns --passable --errors` — all pass.

Closes #1144.
Refs #854.

## Resuming this session

Resume this session on ginger: `~/deduce-runner/resume.sh 047b2d4f-de87-4690-953c-6cd0e72a48c7 routine/20260728-000202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
