### PR TITLE
Dedup: extract shared _all_elim_str helper for AllElim/AllElimTypes (refs #813)

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -325,6 +325,26 @@ def _postfix_base_str(p: Proof) -> str:
   return '(' + str(p) + ')'
 
 
+def _all_elim_str(univ: Proof, arg: object, pos: Tuple[int, int],
+                  open_b: str, close_b: str) -> str:
+  """Printed form of one argument in an ``AllElim`` / ``AllElimTypes`` chain.
+  ``pos`` is ``(index, count)``: the first argument (index 0) prints the
+  postfix base and the opening bracket, and the last argument appends the
+  closing bracket. ``open_b`` / ``close_b`` are ``[``/``]`` for terms and
+  ``<``/``>`` for types.
+  """
+  s, e = pos
+  if s == 0:
+    res = _postfix_base_str(univ) + f"{open_b}{arg}"
+  else:
+    res = str(univ) + f", {arg}"
+
+  if s + 1 == e:
+    res += close_b
+
+  return res
+
+
 @dataclass
 class AllElimTypes(Proof):
   univ: Proof
@@ -335,16 +355,7 @@ class AllElimTypes(Proof):
   pos: Tuple[int, int]
 
   def __str__(self) -> str:
-    s, e = self.pos
-    if s == 0:
-      res = _postfix_base_str(self.univ) + f"<{self.arg}"
-    else:
-      res = str(self.univ) + f", {self.arg}"
-
-    if s + 1 == e:
-      res += ">"
-
-    return res
+    return _all_elim_str(self.univ, self.arg, self.pos, "<", ">")
 
 @dataclass
 class AllElim(Proof):
@@ -356,16 +367,7 @@ class AllElim(Proof):
   pos: Tuple[int, int]
 
   def __str__(self) -> str:
-    s, e = self.pos
-    if s == 0:
-      res = _postfix_base_str(self.univ) + f"[{self.arg}"
-    else:
-      res = str(self.univ) + f", {self.arg}"
-
-    if s + 1 == e:
-      res += "]"
-
-    return res
+    return _all_elim_str(self.univ, self.arg, self.pos, "[", "]")
 
 @dataclass
 class SomeIntro(Proof):


### PR DESCRIPTION
## Summary

Small duplication-reduction slice for the #813 umbrella.

`AllElim.__str__` and `AllElimTypes.__str__` in `abstract_syntax/proofs.py`
were byte-for-byte identical except for the two bracket glyphs — `[`/`]` for
term arguments vs `<`/`>` for type arguments. Both already delegated their
base-proof rendering to the module-level `_postfix_base_str`.

This PR folds the shared control flow into a new module-level helper next to
`_postfix_base_str`:

```python
def _all_elim_str(univ, arg, pos, open_b, close_b) -> str: ...
```

so each `__str__` becomes a one-line call:

- `AllElimTypes.__str__` → `_all_elim_str(self.univ, self.arg, self.pos, "<", ">")`
- `AllElim.__str__`      → `_all_elim_str(self.univ, self.arg, self.pos, "[", "]")`

No behavior change: the emitted string is identical for both cases.

## Tests

Ran locally (green):

- `python3 test-deduce.py --equiv` — RD/LALR AST equivalence **and** the
  pretty-print round-trip corpus, which exercises `AllElim`/`AllElimTypes`
  printing directly.
- `python3 test-deduce.py --passable` — should-validate under both parsers.

`ruff` and `mypy` are not installed in this container; CI's static-checks leg
covers them. The change is a pure refactor with no signature changes to public
APIs.

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh 208dc587-9660-431b-b3f2-a9d904333886 routine/20260728-010202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
