### PR TITLE
Extract single-name uniquify binder helper (refs #813)

### DIFF
--- a/abstract_syntax/core.py
+++ b/abstract_syntax/core.py
@@ -55,7 +55,7 @@ from math import ceil
 import os
 
 if TYPE_CHECKING:
-    from .declarations import GenRecFun, RecFun
+    from .declarations import GenRecFun, RecFun, overwrite
     from .env import Env
 
 infix_precedence = {'+': 6, '-': 6, '∸': 6, '⊝': 6, '*': 7, '/': 7, '%': 7,
@@ -343,6 +343,25 @@ def uniquify_type_params(
   for (old, new) in zip(type_params, new_type_params):
     bind(body_env, old, new, loc)
   return body_env, new_type_params
+
+
+def uniquify_binder(
+    env: UniquifyEnv,
+    name: str,
+    ctx: UniquifyContext,
+    loc: Meta,
+) -> Tuple[UniquifyEnv, str]:
+  """Copy ``env`` and bind a single fresh name for ``name`` in the copy.
+
+  Shared by the ``uniquify`` methods of single-name shadowing binders
+  (``PLet``, ``PTLetNew``, ``ImpIntro``, ``TLet``).  Returns the extended
+  body environment and the freshly generated name.  These binders always
+  shadow rather than overload, so the binding uses ``overwrite``.
+  """
+  body_env = copy_dict(env)
+  new_name = generate_name(name, ctx)
+  overwrite(body_env, name, new_name, loc)
+  return body_env, new_name
 
 
 def base_name(name: str) -> str:

--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -97,9 +97,7 @@ class PLet(Proof):
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> PLet:
     new_proved = self.proved.uniquify(env, ctx)
     new_because = self.because.uniquify(env, ctx)
-    body_env = {x:y for (x,y) in env.items()}
-    new_label = generate_name(self.label, ctx)
-    overwrite(body_env, self.label, new_label, self.location)
+    body_env, new_label = uniquify_binder(env, self.label, ctx, self.location)
     new_body = self.body.uniquify(body_env, ctx)
     return PLet(self.location, new_label, new_proved, new_because, new_body)
 
@@ -119,9 +117,7 @@ class PTLetNew(Proof):
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> PTLetNew:
     new_rhs = self.rhs.uniquify(env, ctx)
-    body_env = {x:y for (x,y) in env.items()}
-    new_var = generate_name(self.var, ctx)
-    overwrite(body_env, self.var, new_var, self.location)
+    body_env, new_var = uniquify_binder(env, self.var, ctx, self.location)
     new_body = self.body.uniquify(body_env, ctx)
     return PTLetNew(self.location, new_var, new_rhs, new_body)
 
@@ -259,9 +255,7 @@ class ImpIntro(Proof):
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> ImpIntro:
     new_premise = self.premise.uniquify(env, ctx) if self.premise else None
-    body_env = copy_dict(env)
-    new_label = generate_name(self.label, ctx)
-    overwrite(body_env, self.label, new_label, self.location)
+    body_env, new_label = uniquify_binder(env, self.label, ctx, self.location)
     new_body = self.body.uniquify(body_env, ctx)
     return ImpIntro(self.location, new_label, new_premise, new_body)
 

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1688,9 +1688,7 @@ class TLet(Term):
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> TLet:
     new_rhs = self.rhs.uniquify(env, ctx)
-    body_env = {x:y for (x,y) in env.items()}
-    new_var = generate_name(self.var, ctx)
-    overwrite(body_env, self.var, new_var, self.location)
+    body_env, new_var = uniquify_binder(env, self.var, ctx, self.location)
     new_body = self.body.uniquify(body_env, ctx)
     return TLet(self.location, self.typeof, new_var, new_rhs, new_body)
 


### PR DESCRIPTION
## Summary

Extracts the single-name shadowing-binder `uniquify` idiom into a shared
`uniquify_binder(env, name, ctx, loc)` helper in `abstract_syntax/core.py`,
alongside the existing `uniquify_type_params`.

The idiom — copy the environment, generate one fresh name, `overwrite` it into
the copy, then recurse into the body against that copy — was repeated verbatim
in four `uniquify` methods:

- `PLet` (`abstract_syntax/proofs.py`)
- `PTLetNew` (`abstract_syntax/proofs.py`)
- `ImpIntro` (`abstract_syntax/proofs.py`)
- `TLet` (`abstract_syntax/terms.py`)

Each now reduces to a single `body_env, new_name = uniquify_binder(...)` call.
These binders always *shadow* (never overload), so the helper always uses
`overwrite` — unlike `uniquify_type_params`, which takes the `bind` function
explicitly because its callers vary. `SomeElim` was deliberately left alone: it
accumulates several bindings (witnesses + label) into one shared `body_env`, so
it does not fit the single-fresh-env-per-binder shape.

`overwrite` is added to the `TYPE_CHECKING` import block in `core.py` so mypy
resolves it statically; at runtime it is already injected into `core`'s globals
by the package facade.

## Testing

- `python3 -m ruff check abstract_syntax/` — clean
- `python3 -m mypy abstract_syntax/core.py abstract_syntax/proofs.py abstract_syntax/terms.py` — clean
- `python3 test-deduce.py` — all tests passed (both parsers, incl. pretty-print round trip)

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh 8716119c-2afe-4bda-8e14-b659aed50ef4 routine/20260728-020202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
