### PR TITLE
Dedup proc/observer/resource declaration formatting helpers (refs #813)

### DIFF
--- a/abstract_syntax/declarations.py
+++ b/abstract_syntax/declarations.py
@@ -486,6 +486,46 @@ class ProcProofEntry(AST):
   def __str__(self) -> str:
     return self.pretty_print(0)
 
+
+def _decl_signature_header(visibility_prefix: str, keyword: str, name: str,
+                           type_params: List[str],
+                           params: List[ProcParam]) -> str:
+  """Format the shared ``<vis> keyword name<T..>(params)`` head of a
+  procedure/observer/resource declaration. Callers append whatever follows
+  (return type, specs, reads clauses, or body)."""
+  if get_verbose():
+    shown_name = name
+    typarams = type_params
+  else:
+    shown_name = base_name(name)
+    typarams = [base_name(t) for t in type_params]
+  header = visibility_prefix + keyword + ' ' + shown_name
+  if typarams:
+    header += '<' + ','.join(typarams) + '>'
+  header += '(' + ', '.join(str(p) for p in params) + ')'
+  return header
+
+
+def _uniquify_decl_params(params: List[ProcParam], body_env: UniquifyEnv,
+                          uniq_ctx: UniquifyContext) -> List[ProcParam]:
+  """Alpha-rename a procedure/observer/resource parameter list into
+  ``body_env``, returning the freshly-named parameters."""
+  new_params: List[ProcParam] = []
+  for param in params:
+    new_typ = param.typ.uniquify(body_env, uniq_ctx)
+    new_param_name = generate_name(param.name, uniq_ctx)
+    overwrite(body_env, param.name, new_param_name, param.location)
+    new_params.append(ProcParam(param.location, new_param_name,
+                                new_typ, param.ghost))
+  return new_params
+
+
+def _indent_multiline(text: str, indent: int) -> str:
+  """Indent every line of ``text`` by ``indent`` spaces, trimming trailing
+  whitespace and terminating with a single newline."""
+  return indent * ' ' + text.replace('\n', '\n' + indent * ' ').rstrip() + '\n'
+
+
 @dataclass
 class ProcDecl(Declaration):
   type_params: List[str]
@@ -503,17 +543,10 @@ class ProcDecl(Declaration):
     return self.pretty_print(0)
 
   def pretty_print(self, indent: int) -> str:
-    if get_verbose():
-      shown_name = self.name
-      typarams = self.type_params
-    else:
-      shown_name = base_name(self.name)
-      typarams = [base_name(t) for t in self.type_params]
     pad = indent * ' '
-    header = pad + self.visibility_prefix() + 'proc ' + shown_name
-    if typarams:
-      header += '<' + ','.join(typarams) + '>'
-    header += '(' + ', '.join(str(p) for p in self.params) + ')'
+    header = pad + _decl_signature_header(self.visibility_prefix(), 'proc',
+                                          self.name, self.type_params,
+                                          self.params)
     if self.return_type is not None:
       header += ' -> ' + str(self.return_type)
     if self.specs:
@@ -999,13 +1032,7 @@ class ObserverDecl(Declaration):
     body_env, new_type_params = uniquify_type_params(
         env_map, self.type_params, uniq_ctx, self.location, overwrite)
 
-    new_params = []
-    for param in self.params:
-      new_typ = param.typ.uniquify(body_env, uniq_ctx)
-      new_param_name = generate_name(param.name, uniq_ctx)
-      overwrite(body_env, param.name, new_param_name, param.location)
-      new_params.append(ProcParam(param.location, new_param_name,
-                                  new_typ, param.ghost))
+    new_params = _uniquify_decl_params(self.params, body_env, uniq_ctx)
 
     new_return_type = self.return_type.uniquify(body_env, uniq_ctx)
     new_reads = [
@@ -1019,16 +1046,8 @@ class ObserverDecl(Declaration):
                         new_body, visibility=self.visibility)
 
   def __str__(self) -> str:
-    if get_verbose():
-      shown_name = self.name
-      typarams = self.type_params
-    else:
-      shown_name = base_name(self.name)
-      typarams = [base_name(t) for t in self.type_params]
-    header = self.visibility_prefix() + 'observer ' + shown_name
-    if typarams:
-      header += '<' + ','.join(typarams) + '>'
-    header += '(' + ', '.join(str(p) for p in self.params) + ')'
+    header = _decl_signature_header(self.visibility_prefix(), 'observer',
+                                    self.name, self.type_params, self.params)
     header += ' -> ' + str(self.return_type)
     lines = [header]
     for clause in self.reads:
@@ -1039,8 +1058,7 @@ class ObserverDecl(Declaration):
     return s
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
-    return indent * ' ' \
-      + str(self).replace('\n', '\n' + indent * ' ').rstrip() + '\n'
+    return _indent_multiline(str(self), indent)
 
 
 @dataclass
@@ -1068,13 +1086,7 @@ class ResourceDecl(Declaration):
     body_env, new_type_params = uniquify_type_params(
         env_map, self.type_params, uniq_ctx, self.location, overwrite)
 
-    new_params = []
-    for param in self.params:
-      new_typ = param.typ.uniquify(body_env, uniq_ctx)
-      new_param_name = generate_name(param.name, uniq_ctx)
-      overwrite(body_env, param.name, new_param_name, param.location)
-      new_params.append(ProcParam(param.location, new_param_name,
-                                  new_typ, param.ghost))
+    new_params = _uniquify_decl_params(self.params, body_env, uniq_ctx)
 
     new_body = (self.body.uniquify(body_env, uniq_ctx)
                 if self.body is not None else None)
@@ -1082,23 +1094,14 @@ class ResourceDecl(Declaration):
                         new_params, new_body, visibility=self.visibility)
 
   def __str__(self) -> str:
-    if get_verbose():
-      shown_name = self.name
-      typarams = self.type_params
-    else:
-      shown_name = base_name(self.name)
-      typarams = [base_name(t) for t in self.type_params]
-    header = self.visibility_prefix() + 'resource ' + shown_name
-    if typarams:
-      header += '<' + ','.join(typarams) + '>'
-    header += '(' + ', '.join(str(p) for p in self.params) + ')'
+    header = _decl_signature_header(self.visibility_prefix(), 'resource',
+                                    self.name, self.type_params, self.params)
     if self.body is not None:
       header += ' {\n  ' + str(self.body) + '\n}'
     return header
 
   def pretty_print(self, indent: int, afterNewline: bool = False) -> str:
-    return indent * ' ' \
-      + str(self).replace('\n', '\n' + indent * ' ').rstrip() + '\n'
+    return _indent_multiline(str(self), indent)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Extracts three shared module-level helpers in `abstract_syntax/declarations.py`
that were duplicated across the imperative declaration classes `ProcDecl`,
`ObserverDecl`, and `ResourceDecl`:

- **`_decl_signature_header`** — the `<vis> keyword name<T..>(params)` head
  built (verbose/non-verbose) by all three declarations' `__str__` /
  `pretty_print`. This was a 3-way copy of the same ~10-line block.
- **`_uniquify_decl_params`** — the parameter alpha-renaming loop shared
  verbatim by `ObserverDecl.uniquify` and `ResourceDecl.uniquify`.
- **`_indent_multiline`** — the `indent + str(self).replace(...)` pretty-print
  body shared by `ObserverDecl.pretty_print` and `ResourceDecl.pretty_print`.

This is a pure refactor: pretty-printer output and `uniquify` behavior are
unchanged. The helpers also give the later imperative-verification phases
(#854) a single place to evolve this formatting.

`ProcDecl.uniquify` keeps its own parameter loop because it additionally
enforces duplicate-parameter-name detection; only the two identical loops were
folded.

## Verification

All run locally on this branch (both parsers where applicable):

- `python3 test-deduce.py --equiv` — grammar + should-error corpus + pretty-print round trip
- `python3 test-deduce.py --equiv-full` — pretty-print → reparse round trip over all 544 accepted-syntax files
- `python3 test-deduce.py --imperative` — imperative tooling + should-error lane
- `python3 test-deduce.py --warns` and `--errors`
- Verbose print path (`deduce.py --experimental-imperative --verbose`) on the
  observer/resource fixtures to exercise the `get_verbose()` branch of the
  shared header helper.

## Issue

Refs #813 (code-duplication umbrella; this is one slice, the umbrella stays open).

Resume this session on ginger: `~/deduce-runner/resume.sh c2b64551-1397-48d8-a401-4ad3768a4ac0 routine/20260728-050202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
