### PR TITLE
Dedup diagnostic exception construction in error.py (refs #813)

### DIFF
--- a/error.py
+++ b/error.py
@@ -136,15 +136,36 @@ class ErrorSink:
   def __len__(self) -> int:
     return len(self.errors)
 
-def user_error(location: Meta, msg: str) -> NoReturn:
+def _user_error_exc(location: Meta, msg: str) -> UserError:
+  """Build the ``UserError`` shared by the raising ``user_error`` and the
+  sink-recording ``add_diagnostic``. Attaches structured fields so
+  library/LSP/MCP callers can build ``Diagnostic`` objects without
+  regex-parsing ``str(exc)``. The CLI ignores these attributes; existing
+  ``print(str(exc))`` output is unchanged."""
   exc = UserError(error_header(location) + msg)
   exc.depth = 0
-  # Attach structured fields so library/LSP/MCP callers can build
-  # Diagnostic objects without regex-parsing str(exc). The CLI ignores
-  # these attributes; existing print(str(exc)) output is unchanged.
   exc.location = location
   exc.message_body = msg
-  raise exc
+  return exc
+
+def _incomplete_exc(location: Meta, msg: str,
+                    formula: Optional['Term'],
+                    env: Optional['Env']) -> IncompleteProof:
+  """Build the ``IncompleteProof`` shared by the raising ``incomplete_error``
+  and the sink-recording ``add_incomplete``. ``formula``/``env`` are the
+  optional structured fields for the LSP/MCP refine pipeline (the goal AST
+  and the type-checking env at the hole). The CLI ignores these; existing
+  ``print(str(exc))`` output is unchanged."""
+  exc = IncompleteProof(error_header(location) + msg)
+  exc.depth = 0
+  exc.location = location
+  exc.message_body = msg
+  exc.formula = formula
+  exc.env = env
+  return exc
+
+def user_error(location: Meta, msg: str) -> NoReturn:
+  raise _user_error_exc(location, msg)
 
 def internal_error(location: Meta, msg: str) -> NoReturn:
   raise InternalError(error_header(location) + msg)
@@ -152,16 +173,7 @@ def internal_error(location: Meta, msg: str) -> NoReturn:
 def incomplete_error(location: Meta, msg: str, *,
                      formula: Optional['Term'] = None,
                      env: Optional['Env'] = None) -> NoReturn:
-  exc = IncompleteProof(error_header(location) + msg)
-  exc.depth = 0
-  exc.location = location
-  exc.message_body = msg
-  # Optional structured fields for the LSP/MCP refine pipeline:
-  # the goal AST and the type-checking env at the hole. The CLI
-  # ignores these; print(str(exc)) output is unchanged.
-  exc.formula = formula
-  exc.env = env
-  raise exc
+  raise _incomplete_exc(location, msg, formula, env)
 
 @dataclass
 class WarningRecord:
@@ -329,11 +341,7 @@ def add_diagnostic(location: Meta, msg: str) -> None:
   global _active_sink
   if _active_sink is None or _speculative_depth > 0:
     user_error(location, msg)
-  exc = UserError(error_header(location) + msg)
-  exc.depth = 0
-  exc.location = location
-  exc.message_body = msg
-  _active_sink.add(exc)
+  _active_sink.add(_user_error_exc(location, msg))
 
 def add_incomplete(location: Meta, msg: str,
                    formula: Optional['Term'] = None,
@@ -350,16 +358,7 @@ def add_incomplete(location: Meta, msg: str,
   global _active_sink
   if _active_sink is None:
     incomplete_error(location, msg, formula=formula, env=env)
-  exc = IncompleteProof(error_header(location) + msg)
-  exc.depth = 0
-  exc.location = location
-  exc.message_body = msg
-  # Optional structured fields for the LSP/MCP refine pipeline:
-  # the goal AST and the type-checking env at the hole. The CLI
-  # ignores these; print(str(exc)) output is unchanged.
-  exc.formula = formula
-  exc.env = env
-  _active_sink.add(exc)
+  _active_sink.add(_incomplete_exc(location, msg, formula, env))
 
   
 class StaticError(Diagnostic):


### PR DESCRIPTION
## Summary

A slice of the code-duplication umbrella (#813), in the uncontended `error.py`.

Each diagnostic had a raising variant and a sink-recording variant that built
the exception with a **byte-for-byte identical** sequence — construct with
`error_header(location) + msg`, set `depth = 0`, stash `location` /
`message_body`, and (for incomplete proofs) stash the `formula` / `env`
structured fields. The two paths must stay in sync: a new stashed field has to
be added in both the `raise` site and the sink site, and the identical
explanatory comment was copied verbatim.

This PR extracts two typed builders next to the other error helpers:

- **`_user_error_exc(location, msg) -> UserError`** — shared by `user_error`
  (raises) and `add_diagnostic` (records into the active `ErrorSink`).
- **`_incomplete_exc(location, msg, formula, env) -> IncompleteProof`** —
  shared by `incomplete_error` (raises) and `add_incomplete` (records).

Each builder returns the **concrete** exception type, so mypy still sees the
`UserError.depth` / `IncompleteProof.formula` / `IncompleteProof.env` fields and
the assignments type-check without `attr-defined` errors. The callers reduce to
`raise _..._exc(...)` or `_active_sink.add(_..._exc(...))`.

Pure refactor: `str(exc)` output and every stashed attribute are identical to
before. Net −1 line, but the real win is collapsing a must-stay-in-sync hazard
into one place each.

## Testing

All run locally on this branch:

- `python3 test-deduce.py --errors --warns --passable` — should-error /
  should-warn / should-validate (both parsers for validate). Green — error and
  warning text is unchanged.
- `python3 test-deduce.py --imperative` — exercises `add_incomplete` via the
  imperative-obligation discharge path.
- `python3 test-deduce.py --equiv` — grammar + should-error corpus +
  pretty-print round trip.

`ruff`/`mypy` are not installed in this container; CI's static-checks leg covers
them. The two builders return concrete `UserError` / `IncompleteProof`, so the
post-construction field assignments remain type-clean by construction.

## Issue

Refs #813 (code-duplication umbrella; this is one slice, the umbrella stays open).

## Noticed in passing

While reading the recursive-descent parser's precedence-climbing functions I
found an unrelated RD/LALR location divergence for `^`/`*`/`/`/`%` and filed it
as #1152 (with a minimal repro). Not touched here.

Resume this session on ginger: `~/deduce-runner/resume.sh d4d8c5ab-8830-4158-8559-c8bab9560807 routine/20260728-060202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
