### PR TITLE
Anchor RD ^/*//% Call location at left operand (closes #1152)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -574,31 +574,31 @@ def parse_make_array() -> Term:
 
 
 def parse_term_expt() -> Term:
+  token = current_token()
   term = parse_make_array()
 
   while (not end_of_file()) and current_token().value in expt_operators:
-    start_token = current_token()
     rator = Var(meta_from_tokens(current_token(), current_token()),
                 None, to_unicode.get(current_token().value,
                                      current_token().value))
     advance()
     right = parse_make_array()
-    term = Call(meta_from_tokens(start_token, previous_token()), None,
+    term = Call(meta_from_tokens(token, previous_token()), None,
                 rator, [term,right])
 
   return term
 
 def parse_term_mult() -> Term:
+  token = current_token()
   term = parse_term_expt()
 
   while (not end_of_file()) and current_token().value in mult_operators:
-    start_token = current_token()
     rator = Var(meta_from_tokens(current_token(), current_token()),
                 None, to_unicode.get(current_token().value,
                                      current_token().value))
     advance()
     right = parse_term_expt()
-    term = Call(meta_from_tokens(start_token, previous_token()), None,
+    term = Call(meta_from_tokens(token, previous_token()), None,
                 rator, [term,right])
 
   return term

--- a/test/should-error/nat_literal_hint_overload.pf.err
+++ b/test/should-error/nat_literal_hint_overload.pf.err
@@ -1,4 +1,4 @@
-./test/should-error/nat_literal_hint_overload.pf:5.16-5.19: could not find a match for function call:
+./test/should-error/nat_literal_hint_overload.pf:5.14-5.19: could not find a match for function call:
 	2 * n
 argument types: UInt, Nat
 overloads:


### PR DESCRIPTION
## Summary

In the recursive-descent parser, `parse_term_expt` and `parse_term_mult`
anchored the resulting `Call` node's location at the **operator token**
(`^`, `*`, `/`, `%`) instead of the start of the **left operand**. This
diverged both from the LALR parser and from the recursive-descent parser's
own `parse_term_add` / `parse_term_compare` / `parse_term_equal` levels,
producing a wrong error caret/location for those expressions.

The fix captures the start token *before* parsing the left operand, exactly
as the additive/comparison/equality levels already do.

## Verification

```
$ printf 'define x = 3 * true\n' > /tmp/loc_mult.pf
$ python3 deduce.py --recursive-descent /tmp/loc_mult.pf   # now 1.12-1.20 (was 1.14-1.20)
$ python3 deduce.py --lalr             /tmp/loc_mult.pf   # 1.12-1.20
```

RD now anchors at the left operand for all of `^ * / %`, matching LALR.

The `nat_literal_hint_overload` should-error fixture recorded the buggy
location (`5.16`); it now correctly reads `5.14`, which also serves as the
regression test. `python3 test-deduce.py --errors` and `--equiv` pass.

## Notes

`test-deduce.py --equiv` does not catch location bugs (its canonical-AST
comparison ignores source locations), which is why this went unnoticed; the
should-error fixture diff is what locks it in.

Closes #1152. Refs #473 (dual-parser equivalence).

Resume this session on ginger: `~/deduce-runner/resume.sh e723dfb9-5feb-4a26-b4da-6ae0832d19f7 routine/20260728-070201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
