### PR TITLE
Dedup: share the alpha-renaming binder __eq__ body (refs #813)

### DIFF
--- a/abstract_syntax/ops.py
+++ b/abstract_syntax/ops.py
@@ -390,6 +390,17 @@ def alpha_equiv(t1: object, t2: object) -> bool:
   return _alpha_equiv(t1, t2, {}, {})
 
 
+def binder_eq(self: object, other: object, cls: type,
+              alpha: Callable[..., bool]) -> bool:
+  """Shared ``__eq__`` body for the alpha-renaming binder nodes
+  (``FunctionType`` / ``Lambda`` / ``All`` / ``Some`` / ``TLet``): reject a
+  mismatched operand type, then defer to the node's alpha-equivalence walk
+  with empty rename environments. These deliberately bypass the
+  ``_alpha_equiv`` empty-env fast path, which calls ``==`` and would recurse
+  straight back into these methods."""
+  return isinstance(other, cls) and alpha(self, other, {}, {})
+
+
 def _alpha_equiv(t1: object, t2: object,
                  env1: dict[str, object], env2: dict[str, object]) -> bool:
   # TermInst / TAnnote are transparent for equality -- existing

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
         _alpha_equiv_binders,
         _alpha_equiv_function_type,
         _alpha_equiv_tlet,
+        binder_eq,
         callable_name,
         explicit_term_inst,
         flatten_assoc_list,
@@ -153,9 +154,7 @@ class FunctionType(Type):
       + ' -> ' + str(self.return_type) + ')'
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, FunctionType):
-      return False
-    return _alpha_equiv_function_type(self, other, {}, {})
+    return binder_eq(self, other, FunctionType, _alpha_equiv_function_type)
 
   def free_vars(self) -> Set[str]:
     fvs = [pt.free_vars() for pt in self.param_types] \
@@ -777,9 +776,7 @@ class Lambda(Term):
         + indent*' ' + '}'
 
   def __eq__(self, other: object) -> bool:
-      if not isinstance(other, Lambda):
-        return False
-      return _alpha_equiv_binders(self, other, {}, {})
+    return binder_eq(self, other, Lambda, _alpha_equiv_binders)
 
   def reduce(self, env: Env) -> Lambda:
     if get_eval_all():
@@ -1695,9 +1692,7 @@ class TLet(Term):
     return TLet(self.location, self.typeof, new_var, new_rhs, new_body)
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, TLet):
-      return False
-    return _alpha_equiv_tlet(self, other, {}, {})
+    return binder_eq(self, other, TLet, _alpha_equiv_tlet)
 
 @dataclass
 class Hole(Term):
@@ -2010,9 +2005,7 @@ class All(Formula):
                    new_body)
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, All):
-      return False
-    return _alpha_equiv_all(self, other, {}, {})
+    return binder_eq(self, other, All, _alpha_equiv_all)
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> All:
     body_env = {x:y for (x,y) in env.items()}
@@ -2060,7 +2053,5 @@ class Some(Formula):
     return Some(self.location, self.typeof, new_vars, new_body)
 
   def __eq__(self, other: object) -> bool:
-    if not isinstance(other, Some):
-      return False
-    return _alpha_equiv_binders(self, other, {}, {})
+    return binder_eq(self, other, Some, _alpha_equiv_binders)
   


### PR DESCRIPTION
## What

Deduplicate the alpha-renaming binder `__eq__` methods. `FunctionType`,
`Lambda`, `All`, `Some`, and `TLet` (all in `abstract_syntax/terms.py`) each
carried the same three-line body:

```python
def __eq__(self, other):
    if not isinstance(other, <Cls>):
        return False
    return <_alpha_equiv_helper>(self, other, {}, {})
```

The only things that vary are the operand class and the per-node
alpha-equivalence helper. This PR extracts the shared body into
`abstract_syntax/ops.binder_eq(self, other, cls, alpha)` so the five methods
become one-liners, and the subtle "these deliberately bypass the
`_alpha_equiv` empty-env fast path, which calls `==` and would recurse back
here" rationale is documented in exactly one place instead of being implicit
in five.

## Why this is safe

`binder_eq(self, other, Cls, alpha)` is exactly
`isinstance(other, Cls) and alpha(self, other, {}, {})`, which short-circuits
to `False` on a type mismatch just like the original guard. No semantic
change.

## Verification

Local (this container has no ruff/mypy/pytest; those run in CI):

- `python3 test-deduce.py --passable` — pass
- `python3 test-deduce.py --lib` — pass
- `python3 test-deduce.py --equiv` — pass (grammar + should-error corpus +
  round-trip; canonical-AST comparison exercises these `__eq__` methods)
- `python3 test-deduce.py --errors --warns` — pass
- Direct alpha-equivalence spot check: `all x. x=x == all y. y=y` (True),
  vs `all y. y=zero` (False), analogous cases for `some`/`fun`/term-let, and
  `All != Lambda` / `All != 5` (False) all behave as before.

## Scope / coordination

Touches only `abstract_syntax/terms.py` and `abstract_syntax/ops.py`, disjoint
from the other in-flight #813 slices (#1153 error.py, #1151 declarations.py,
#1147 proofs.py, #1148 uniquify binder, #1149 checker view-law).

Refs #813 (this is one slice of the standing dedup umbrella, which stays open).

Resume this session on ginger: `~/deduce-runner/resume.sh 2a46bc68-a6b2-4e22-82b2-a48cd10d0ef8 routine/20260728-080201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
