### PR TITLE
Cover Import.hiding and generic ViewDecl in the round-trip corpus (refs #931)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -627,6 +627,18 @@ PARSER_ROUND_TRIP_FILES = (
     # modules exercised it before, none of them in the round-trip corpus, so the
     # pretty-printer's `export IDENT` form was unverified. Refs #931, #473.
     "./test/should-validate/export_decl.pf",
+    # `import M hiding <name> | <name>` (`Import.hiding` non-empty). The existing
+    # import fixtures only exercise the `using` form and the bare `import`; a
+    # field-level coverage sweep showed `Import.hiding` was never non-empty in
+    # the corpus, so a regression in `Import._filter_clause_str`'s `hiding`
+    # branch would have passed CI silently. Refs #931, #473.
+    "./test/should-validate/import_hiding.pf",
+    # A generic `view T<...> { ... }` declaration (`ViewDecl.type_params`
+    # non-empty). The `view_inverse_decl.pf` fixture covers a monomorphic view,
+    # but the same sweep showed `ViewDecl.type_params` was never exercised, so
+    # the pretty-printer's reproduction of a view's `<T>` type-parameter list was
+    # unverified. Refs #931, #473.
+    "./test/should-validate/viewrec_join_list.pf",
 )
 
 


### PR DESCRIPTION
## Summary

Closes two field-level gaps in the curated CI parser round-trip corpus
(`PARSER_ROUND_TRIP_FILES`), the coverage set behind `test-deduce.py --equiv`.

A field-level AST-coverage sweep (for each `(node type, field)` reachable from
the corpus, is a non-trivial value ever exercised?) compared the CI corpus
against the full accepted tree (`lib/` + `test/should-validate/`). Node-type
coverage is already complete, but two `(node, field)` shapes the tree exercises
were never non-trivial in the corpus:

- **`Import.hiding`** — the `import M hiding a | b` form. The existing import
  fixtures only cover `using` and the bare `import`, so a regression in
  `Import._filter_clause_str`'s `hiding` branch would pass CI silently.
- **`ViewDecl.type_params`** — a generic `view T<...> { ... }`. The existing
  `view_inverse_decl.pf` fixture is monomorphic, leaving the pretty-printer's
  reproduction of a view's `<T>` type-parameter list unverified.

## Change

Adds the existing focused should-validate fixtures to the round-trip corpus:

- `test/should-validate/import_hiding.pf` (9 lines, `import Filter hiding …`)
- `test/should-validate/viewrec_join_list.pf` (`view JCons<T> { … }`)

Both were verified clean on every check the `--equiv` round-trip worker applies:
RD/LALR canonical-AST equality, pretty-print → reparse (both parsers), text
idempotence, and cross-parser pretty-print text agreement. No production code
changes — this is coverage only.

## Verification

- `python3 test-deduce.py --equiv` — passes with the expanded corpus.
- Re-ran the field-coverage sweep afterward: **0 remaining field gaps** between
  the corpus and the full accepted tree.

Refs #931, #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 479d5af8-6ce2-4d03-a6cf-2029bf7c76b7 routine/20260728-090202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
