### PR TITLE
Dedup extract_and/extract_or into terms.py list_of_and/list_of_or (refs #813)

### DIFF
--- a/abstract_syntax/rewrite.py
+++ b/abstract_syntax/rewrite.py
@@ -4,8 +4,7 @@ Scope: the primitives that locate ``Mark`` nodes inside a formula, swap
 them out for a replacement, and drive the formula-matching used by
 ``rewrite`` proofs. Includes ``count_marks``/``find_mark``/``MarkException``,
 the overloaded ``replace_mark`` family, ``remove_mark``, the equation
-``rewrite_aux``/``try_rewrite``/``formula_match`` engine, conjunction and
-disjunction flatteners (``extract_and``/``extract_or``), ``auto_rewrites``,
+``rewrite_aux``/``try_rewrite``/``formula_match`` engine, ``auto_rewrites``,
 and the small module-level state (``default_mark_LHS`` toggle,
 ``num_rewrites`` counter, ``call_arity``/``call_head_name`` helpers used
 to drive the matcher).
@@ -270,21 +269,6 @@ def build_equations_proof(loc: Meta, eqs: list[tuple[Term, Term, Proof]]) -> Pro
             result = PTransitive(loc, eq_proof, result)
     assert result is not None  # the equations grammar yields >= 1 step
     return result
-
-def extract_and(frm: Formula) -> list[Formula]:
-    match frm:
-      case And(_, _, args):
-        return args
-      case _:
-       return [frm]
-
-def extract_or(frm: Formula) -> list[Formula]:
-    match frm:
-      case Or(_, _, args):
-        return args
-      case _:
-       return [frm]
-
 
 num_rewrites = 0
 rewrite_debug: bool = False

--- a/parser.py
+++ b/parser.py
@@ -20,7 +20,7 @@ from abstract_syntax import (
     SimplifyGoal, Some, SomeElim, SomeIntro, Statement, Suffices, Switch,
     SwitchCase, SwitchProof, SwitchProofCase, TAnnote, TLet, TermInst,
     Theorem, Trace, TypeAlias, TypeInst, TypeType, Union, Var,
-    ViewDecl, build_equations_proof, extract_and, extract_or,
+    ViewDecl, build_equations_proof, list_of_and, list_of_or,
     extract_tuple, listToNodeList, mkIntLit,
     mkLitNat, mkUIntLit, remove_mark,
 )
@@ -274,16 +274,16 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
     elif e.data == 'iff_formula':
         left = parse_tree_to_ast(e.children[0], e)
         right = parse_tree_to_ast(e.children[1], e)
-        return And(e.meta, None, extract_and(IfThen(e.meta, None, left.copy(), right.copy())) 
-                               + extract_and(IfThen(e.meta, None, right.copy(), left.copy())))
+        return And(e.meta, None, list_of_and(IfThen(e.meta, None, left.copy(), right.copy()))
+                               + list_of_and(IfThen(e.meta, None, right.copy(), left.copy())))
     elif e.data == 'and_formula':
        left = parse_tree_to_ast(e.children[0], e)
        right = parse_tree_to_ast(e.children[1], e)
-       return And(e.meta, None, extract_and(left) + extract_and(right))
+       return And(e.meta, None, list_of_and(left) + list_of_and(right))
     elif e.data == 'or_formula':
        left = parse_tree_to_ast(e.children[0], e)
        right = parse_tree_to_ast(e.children[1], e)
-       return Or(e.meta, None, extract_or(left) + extract_or(right))
+       return Or(e.meta, None, list_of_or(left) + list_of_or(right))
     elif e.data == 'logical_not':
        subject = parse_tree_to_ast(e.children[0], e)
        return IfThen(e.meta, None, subject, Bool(e.meta, None, False))

--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -27,7 +27,7 @@ from abstract_syntax import (
     Statement, Suffices, Switch, SwitchCase, SwitchProof, SwitchProofCase,
     TAnnote, TLet, Term, TermInst,
     Theorem, Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, ViewDecl,
-    build_equations_proof, extract_and, extract_or, extract_tuple,
+    build_equations_proof, list_of_and, list_of_or, extract_tuple,
     listToNodeList, mkIntLit, mkLitNat, mkUIntLit, remove_mark,
 )
 from lark import Lark, Token, exceptions
@@ -704,10 +704,10 @@ def parse_term_logic() -> Term:
     right = parse_term_sep()
     if opr == 'AND':
       term = And(meta_from_tokens(token, previous_token()), None,
-                 extract_and(term) + extract_and(right))
+                 list_of_and(term) + list_of_and(right))
     else:
       term = Or(meta_from_tokens(token, previous_token()), None,
-                extract_or(term) + extract_or(right))
+                list_of_or(term) + list_of_or(right))
   return term
 
 def parse_term_iff() -> Term:
@@ -1408,9 +1408,9 @@ def parse_equation_side_logic() -> Term:
     right = parse_term_compare()
     loc = meta_from_tokens(token, previous_token())
     if opr == 'AND':
-      term = And(loc, None, extract_and(term) + extract_and(right))
+      term = And(loc, None, list_of_and(term) + list_of_and(right))
     else:
-      term = Or(loc, None, extract_or(term) + extract_or(right))
+      term = Or(loc, None, list_of_or(term) + list_of_or(right))
   return term
 
 def parse_equation_side() -> Term:

--- a/test/unit/test_issue_587_annotations.py
+++ b/test/unit/test_issue_587_annotations.py
@@ -52,8 +52,8 @@ def test_issue_587_env_method_parameters_are_annotated() -> None:
 def test_issue_587_helper_parameters_are_annotated() -> None:
     functions: list[tuple[Callable[..., Any], set[str]]] = [
         (ast.set_default_mark_LHS, {"b"}),
-        (ast.extract_and, {"frm"}),
-        (ast.extract_or, {"frm"}),
+        (ast.list_of_and, {"arg"}),
+        (ast.list_of_or, {"arg"}),
         (ast.check_post_typecheck_invariants, {"ast_list"}),
         (ast.make_switch_for, {"meta", "defs", "subject", "cases"}),
     ]


### PR DESCRIPTION
## What

`abstract_syntax/rewrite.py` defined `extract_and`/`extract_or`, which were
byte-for-byte duplicates of `list_of_and`/`list_of_or` in
`abstract_syntax/terms.py` (both just peel an `And`/`Or` node into its `args`,
returning `[frm]` for anything else). This removes the `rewrite.py` copies and
points the two callers — `parser.py` and `rec_desc_parser.py` — at the
`terms.py` pair.

`terms.py` is the natural home: `list_of_and`/`list_of_or` already live there
next to the `And`/`Or` dataclasses and the `flatten_and`/`flatten_or` helpers
that use them, and `literals.py` already imports `list_of_and` from there.

## Changes

- Delete `extract_and`/`extract_or` from `abstract_syntax/rewrite.py` and drop
  their mention from the module docstring. The facade (`abstract_syntax/__init__.py`)
  builds `__all__` from module globals, so these names are no longer exported.
- Update `parser.py` and `rec_desc_parser.py` imports and call sites to use
  `list_of_and`/`list_of_or`.
- Update `test/unit/test_issue_587_annotations.py`, which pinned the parameter
  annotations of `extract_and`/`extract_or`, to check `list_of_and`/`list_of_or`
  (parameter `arg`).

Net: 13 insertions, 29 deletions.

## Testing

Static tools (`ruff`/`mypy`/`pytest`) are not installed in this container, so
they will be exercised by CI. Locally:

- `python3 test-deduce.py --equiv` — passed (grammar + should-error corpus and
  pretty-print round trip, both parsers).
- `python3 test-deduce.py --passable --errors --warns` — passed.
- `python3 test-deduce.py --lib` — passed.
- Verified via `inspect` that `abstract_syntax.list_of_and`/`list_of_or` are
  exported with an annotated `arg` parameter and that `extract_and`/`extract_or`
  are gone from the facade.

Refs #813

Resume this session on ginger: `~/deduce-runner/resume.sh b072f4af-eee5-41eb-bf78-91a43cac8c8b routine/20260728-100201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
