### PR TITLE
Fold should-warn and prelude fixtures into the --equiv parser-equivalence corpus (refs #473)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -637,11 +637,10 @@ PARSER_EQUIV_FILES = PARSER_ROUND_TRIP_FILES + (
     "./lib/Nat.pf",
     "./lib/UInt.pf",
     "./lib/Int.pf",
-    # Warning fixtures add syntax that is not always present in validating
-    # examples. The ``test/should-error`` corpus is folded in wholesale by
-    # ``should_error_equiv_files`` below (everything both parsers accept at
-    # parse time), so individual should-error paths are not listed here.
-    "./test/should-warn/replace_auto_handled_922.pf",
+    # The ``test/should-error``, ``test/should-warn``, and ``test/prelude``
+    # corpora are folded in wholesale by ``should_error_equiv_files``,
+    # ``should_warn_equiv_files``, and ``prelude_equiv_files`` below, so their
+    # individual paths are not listed here.
 )
 
 
@@ -658,6 +657,30 @@ def should_error_equiv_files() -> tuple[str, ...]:
     """
     return tuple(p for p in list_pf(ERROR_DIR)
                  if p not in SHOULD_ERROR_PARSER_EQUIV_SKIP)
+
+
+def should_warn_equiv_files() -> tuple[str, ...]:
+    """Every ``test/should-warn`` fixture, folded into the equivalence corpus.
+
+    These files must check successfully, so both parsers accept them at parse
+    time by construction -- no parse-error skip baseline is needed (unlike
+    ``should_error_equiv_files``). They cover imperative proc/observer/
+    allocation surface syntax that the curated round-trip corpus does not, and
+    the directory grows as the imperative layer lands, so folding it in
+    wholesale keeps that syntax under drift detection automatically.
+    """
+    return tuple(list_pf(WARN_DIR))
+
+
+def prelude_equiv_files() -> tuple[str, ...]:
+    """Every ``test/prelude`` fixture, folded into the equivalence corpus.
+
+    These exercise import surface syntax (plain ``import``, ``import ... using
+    ...``, ``import ... hiding ...``) that the rest of the corpus barely
+    touches; like the should-warn fixtures they all parse cleanly under both
+    parsers, so no skip baseline is required.
+    """
+    return tuple(list_pf(PRELUDE_DIR))
 
 
 class ParsedFlags(TypedDict):
@@ -1248,6 +1271,8 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     all_files = tuple(dict.fromkeys(
         PARSER_EQUIV_FILES
         + should_error_equiv_files()
+        + should_warn_equiv_files()
+        + prelude_equiv_files()
         + tuple(sorted(PARSER_EQUIV_EXPECTED_DIVERGENCES))
     ))
     files = shard(list(all_files))


### PR DESCRIPTION
## Summary

Extends the `test-deduce.py --equiv` parser-equivalence corpus to fold in
**every** `test/should-warn` and `test/prelude` fixture wholesale, mirroring how
`test/should-error` is already included via `should_error_equiv_files()`.

This is a slice of the #473 umbrella — specifically goal **A.1**, "Extend
equivalence checking as appropriate beyond the current `lib/` and
`test/should-validate/` coverage."

## Why these directories

Both directories consist of files that **must check successfully**, so both
parsers accept them at parse time by construction — unlike `should-error`, they
need no parse-error skip baseline. They add real surface-syntax drift coverage
the curated round-trip corpus barely touches:

- **`test/prelude/`** — import surface syntax: plain `import`, `import M using
  ... | operator≲`, `import M hiding ...` (issue #365 companions).
- **`test/should-warn/`** — imperative `proc`/`observer`/allocation declaration
  syntax that lands with the Phase 2 imperative work (#854).

Because the imperative layer keeps adding `should-warn` fixtures, folding the
directories in wholesale keeps that syntax under RD-vs-LALR drift detection
automatically as it grows, rather than requiring a manual corpus edit per file.

## Validation

- All 20 folded-in files (6 should-warn + 14 prelude) already produce identical
  canonical RD and LALR ASTs — confirmed by a standalone check before wiring
  them in, and by the full suite after.
- `python3 test-deduce.py --equiv` passes with the extended corpus.
- The single explicit `should-warn` entry previously listed in
  `PARSER_EQUIV_FILES` (`replace_auto_handled_922.pf`) is now covered by the
  wholesale fold and was removed to avoid duplication; `PARSER_ROUND_TRIP_FILES`
  is untouched, so the parse-preserving round-trip phase is unaffected.

## Scope

Partial contribution to the #473 umbrella (further items — additional
Reference.md grammar migration and round-trip expansion — remain), so this uses
`Refs`, not a closing keyword.

Refs #473

Resume this session on ginger: `~/deduce-runner/resume.sh 6c368791-e074-4527-a8aa-2352da321dee routine/20260728-110202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
