### PR TITLE
Enforce ghost-variable noninterference in procedure bodies (closes #1114)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -197,19 +197,49 @@ def _block_always_returns(stmts: list[ImpStmt]) -> bool:
   # the whole block always return -- everything after it is unreachable.
   return any(_stmt_always_returns(s) for s in stmts)
 
-def _type_check_imp_stmt(s: ImpStmt, env: Env,
-                         return_type: Optional[Type]) -> Env:
+# Phase 2e (issue #1114): ghost-variable noninterference. `ghost` parameters
+# and `ghost var` locals are proof-only, so Phase 6 can erase them without
+# changing runtime behavior. `imp_ghost_dependencies` is the core dependency
+# predicate -- the ghost names a term references -- and a runtime context
+# (runtime local initializer, runtime assignment, branch condition, return
+# value) whose result is nonempty would let proof-only data flow into runtime
+# behavior, which is rejected. Runtime data flowing *into* a ghost binding is
+# fine, so ghost contexts are never checked.
+def imp_ghost_dependencies(node: object, ghost_names: set[str]) -> set[str]:
+  return _referenced_names(node) & ghost_names
+
+def _reject_ghost_flow(loc: Meta, node: object, ghost_names: set[str],
+                       context: str) -> None:
+  refs = imp_ghost_dependencies(node, ghost_names)
+  if refs:
+    named = ', '.join(sorted(base_name(g) for g in refs))
+    noun = 'ghost variables ' if len(refs) > 1 else 'ghost variable '
+    user_error(loc, context + ' may not depend on ' + noun + named
+               + ' because ghost data is proof-only and cannot influence '
+               + 'runtime behavior')
+
+def _type_check_imp_stmt(s: ImpStmt, env: Env, return_type: Optional[Type],
+                         ghost_names: set[str]) -> Env:
   # Returns the environment as seen by the *following* statement in the same
   # block: a `var` extends it with the new local; everything else leaves it
   # unchanged. `Env` is functional, so nested `if` blocks type-check against a
   # value derived from `env` without leaking their locals back out.
+  # `ghost_names` is threaded in the same spirit: a `ghost var` extends it in
+  # place, and nested `if` blocks receive a copy so a ghost local declared in
+  # a branch does not leak out.
   match s:
-    case ImpVar(loc, name, type_annot, rhs, _):
+    case ImpVar(loc, name, type_annot, rhs, ghost):
       if type_annot is not None:
         var_ty = check_type(type_annot, env)
         type_check_term(cast(Term, rhs), var_ty, env, None, [])
       else:
         var_ty = type_synth_term(cast(Term, rhs), env, None, []).typeof
+      if ghost:
+        ghost_names.add(name)
+      else:
+        _reject_ghost_flow(loc, rhs, ghost_names,
+                           "the initializer of runtime variable '"
+                           + base_name(name) + "'")
       return env.declare_term_var(loc, name, var_ty, local=True)
     case ImpAssign(loc, lhs, rhs):
       target = cast(LValueVar, lhs)
@@ -221,12 +251,17 @@ def _type_check_imp_stmt(s: ImpStmt, env: Env,
         user_error(loc, 'cannot assign to ' + base_name(target.name)
                    + ' because it is not a local variable')
       type_check_term(cast(Term, rhs), binding.typ, env, None, [])
+      if target.name not in ghost_names:
+        _reject_ghost_flow(loc, rhs, ghost_names,
+                           "assignment to runtime variable '"
+                           + base_name(target.name) + "'")
       return env
     case ImpIf(loc, cond, then_body, else_body):
       type_check_formula(cond, env)
-      _type_check_imp_block(then_body, env, return_type)
+      _reject_ghost_flow(loc, cond, ghost_names, 'a branch condition')
+      _type_check_imp_block(then_body, env, return_type, set(ghost_names))
       if else_body is not None:
-        _type_check_imp_block(else_body, env, return_type)
+        _type_check_imp_block(else_body, env, return_type, set(ghost_names))
       return env
     case ImpReturn(loc, value):
       if return_type is None:
@@ -234,14 +269,16 @@ def _type_check_imp_stmt(s: ImpStmt, env: Env,
                    + 'return a value')
       else:
         type_check_term(value, return_type, env, None, [])
+        _reject_ghost_flow(loc, value, ghost_names, 'a return value')
       return env
     case _:
       return env
 
 def _type_check_imp_block(stmts: list[ImpStmt], env: Env,
-                          return_type: Optional[Type]) -> None:
+                          return_type: Optional[Type],
+                          ghost_names: set[str]) -> None:
   for s in stmts:
-    env = _type_check_imp_stmt(s, env, return_type)
+    env = _type_check_imp_stmt(s, env, return_type, ghost_names)
 
 def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
   # Phase 2d (issue #1113): type-check a procedure's straight-line body --
@@ -255,7 +292,9 @@ def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
   type_env = env.declare_type_vars(loc, decl.type_params)
   param_pairs = [(p.name, p.typ) for p in decl.params]
   body_env = type_env.declare_term_vars(loc, param_pairs, local=True)
-  _type_check_imp_block(decl.body, body_env, decl.return_type)
+  # Ghost parameters seed the ghost-noninterference tracking (issue #1114).
+  ghost_names = {p.name for p in decl.params if p.ghost}
+  _type_check_imp_block(decl.body, body_env, decl.return_type, ghost_names)
   if decl.return_type is not None and not _block_always_returns(decl.body):
     user_error(loc, "procedure '" + base_name(decl.name)
                + "' declares return type " + str(decl.return_type)

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -23,7 +23,8 @@ from abstract_syntax import (
     Call, Conditional, Constructor, Declaration, Define, Env, Export,
     Formula, FunCase, FunctionType, GenRecFun, Generic, GenericUnknownInst,
     Hole, IfThen, ImpAlloc, ImpAssign, ImpCallExpr, ImpIf, ImpReturn, ImpStmt,
-    ImpVar, Import, Inductive, Lambda, LValueVar, MakeArray, Module,
+    ImpVar, ImpWhile, Import, Inductive, Lambda, LValueField, LValueIndex,
+    LValueVar, MakeArray, Module,
     MutableArrayType, ObjectDecl,
     ObjectField, ObserverDecl, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
     PatternBool, PatternCons, Postulate, Predicate, Print, ProcDecl, ProcParam,
@@ -197,14 +198,72 @@ def _block_always_returns(stmts: list[ImpStmt]) -> bool:
   # the whole block always return -- everything after it is unreachable.
   return any(_stmt_always_returns(s) for s in stmts)
 
+def _type_check_imp_stmt(s: ImpStmt, env: Env,
+                         return_type: Optional[Type]) -> Env:
+  # Returns the environment as seen by the *following* statement in the same
+  # block: a `var` extends it with the new local; everything else leaves it
+  # unchanged. `Env` is functional, so nested `if` blocks type-check against a
+  # value derived from `env` without leaking their locals back out.
+  match s:
+    case ImpVar(loc, name, type_annot, rhs, _):
+      if type_annot is not None:
+        var_ty = check_type(type_annot, env)
+        type_check_term(cast(Term, rhs), var_ty, env, None, [])
+      else:
+        var_ty = type_synth_term(cast(Term, rhs), env, None, []).typeof
+      return env.declare_term_var(loc, name, var_ty, local=True)
+    case ImpAssign(loc, lhs, rhs):
+      target = cast(LValueVar, lhs)
+      binding = env.dict.get(target.name)
+      if not isinstance(binding, TermBinding):
+        user_error(loc, 'assignment to undefined variable: '
+                   + base_name(target.name))
+      if not binding.local:
+        user_error(loc, 'cannot assign to ' + base_name(target.name)
+                   + ' because it is not a local variable')
+      type_check_term(cast(Term, rhs), binding.typ, env, None, [])
+      return env
+    case ImpIf(loc, cond, then_body, else_body):
+      type_check_formula(cond, env)
+      _type_check_imp_block(then_body, env, return_type)
+      if else_body is not None:
+        _type_check_imp_block(else_body, env, return_type)
+      return env
+    case ImpReturn(loc, value):
+      if return_type is None:
+        user_error(loc, 'this procedure has no return type, so it may not '
+                   + 'return a value')
+      else:
+        type_check_term(value, return_type, env, None, [])
+      return env
+    case _:
+      return env
+
+def _type_check_imp_block(stmts: list[ImpStmt], env: Env,
+                          return_type: Optional[Type]) -> None:
+  for s in stmts:
+    env = _type_check_imp_stmt(s, env, return_type)
+
 # Phase 2e (issue #1114): ghost-variable noninterference. `ghost` parameters
 # and `ghost var` locals are proof-only, so Phase 6 can erase them without
-# changing runtime behavior. `imp_ghost_dependencies` is the core dependency
-# predicate -- the ghost names a term references -- and a runtime context
-# (runtime local initializer, runtime assignment, branch condition, return
-# value) whose result is nonempty would let proof-only data flow into runtime
-# behavior, which is rejected. Runtime data flowing *into* a ghost binding is
-# fine, so ghost contexts are never checked.
+# changing runtime behavior -- which is sound only if ghost data never
+# influences runtime behavior. `imp_ghost_dependencies` is the core dependency
+# predicate: the ghost names a term references. A runtime context whose result
+# is nonempty would let proof-only data flow into runtime behavior and is
+# rejected. Runtime data flowing *into* a ghost binding (and ghost bindings
+# referencing each other) stays valid, so ghost contexts are never checked.
+#
+# This pass is purely syntactic -- it depends on uniquified names, not on
+# types -- so unlike `type_check_proc_body` it runs on EVERY proc body,
+# including ones deferred by `_proc_body_unmodeled`; otherwise the guarantee
+# could be bypassed just by adding an unmodeled construct (e.g. a mutable-array
+# parameter would defer the whole body and let a `return g` slip through).
+# Contexts that need infrastructure not yet built are deliberately skipped: a
+# `call`'s argument positions cannot be classified runtime-vs-ghost until call
+# resolution knows which callee parameters are ghost (#1124/#1125), and a
+# `call`/`new` right-hand side likewise, so those are left to their own slices.
+# Proof-only contexts (`assert`/`assume`, loop invariants, decreases) may
+# freely mention ghost data and are never checked.
 def imp_ghost_dependencies(node: object, ghost_names: set[str]) -> set[str]:
   return _referenced_names(node) & ghost_names
 
@@ -218,67 +277,64 @@ def _reject_ghost_flow(loc: Meta, node: object, ghost_names: set[str],
                + ' because ghost data is proof-only and cannot influence '
                + 'runtime behavior')
 
-def _type_check_imp_stmt(s: ImpStmt, env: Env, return_type: Optional[Type],
-                         ghost_names: set[str]) -> Env:
-  # Returns the environment as seen by the *following* statement in the same
-  # block: a `var` extends it with the new local; everything else leaves it
-  # unchanged. `Env` is functional, so nested `if` blocks type-check against a
-  # value derived from `env` without leaking their locals back out.
-  # `ghost_names` is threaded in the same spirit: a `ghost var` extends it in
-  # place, and nested `if` blocks receive a copy so a ghost local declared in
-  # a branch does not leak out.
+def _lvalue_is_ghost(lhs: LValueVar | LValueIndex | LValueField,
+                     ghost_names: set[str]) -> bool:
+  # A write target is ghost exactly when the variable/array/object it names is
+  # a ghost binding (mutable arrays are runtime today, so an indexed/field
+  # write is normally a runtime context). Attribute access, not positional
+  # matching: each `LValue*` dataclass leads with `location`, and the naming
+  # field lives at a different position in each, so a positional pattern would
+  # silently bind the wrong field.
+  match lhs:
+    case LValueVar():
+      return lhs.name in ghost_names
+    case LValueIndex():
+      return lhs.array in ghost_names
+    case _:
+      return cast(LValueField, lhs).subject in ghost_names
+
+def _ghost_check_stmt(s: ImpStmt, ghost_names: set[str]) -> None:
+  # `ghost_names` grows in place as ghost locals come into scope; nested blocks
+  # get a copy (see `_ghost_check_block`) so a branch/loop-local ghost
+  # declaration does not leak out.
   match s:
-    case ImpVar(loc, name, type_annot, rhs, ghost):
-      if type_annot is not None:
-        var_ty = check_type(type_annot, env)
-        type_check_term(cast(Term, rhs), var_ty, env, None, [])
-      else:
-        var_ty = type_synth_term(cast(Term, rhs), env, None, []).typeof
+    case ImpVar(loc, name, _, rhs, ghost):
       if ghost:
         ghost_names.add(name)
-      else:
+      elif not isinstance(rhs, (ImpCallExpr, ImpAlloc)):
         _reject_ghost_flow(loc, rhs, ghost_names,
                            "the initializer of runtime variable '"
                            + base_name(name) + "'")
-      return env.declare_term_var(loc, name, var_ty, local=True)
     case ImpAssign(loc, lhs, rhs):
-      target = cast(LValueVar, lhs)
-      binding = env.dict.get(target.name)
-      if not isinstance(binding, TermBinding):
-        user_error(loc, 'assignment to undefined variable: '
-                   + base_name(target.name))
-      if not binding.local:
-        user_error(loc, 'cannot assign to ' + base_name(target.name)
-                   + ' because it is not a local variable')
-      type_check_term(cast(Term, rhs), binding.typ, env, None, [])
-      if target.name not in ghost_names:
+      if not _lvalue_is_ghost(lhs, ghost_names) \
+         and not isinstance(rhs, (ImpCallExpr, ImpAlloc)):
+        if isinstance(lhs, LValueIndex):
+          _reject_ghost_flow(loc, lhs.index, ghost_names,
+                             'an array index of a runtime assignment')
         _reject_ghost_flow(loc, rhs, ghost_names,
-                           "assignment to runtime variable '"
-                           + base_name(target.name) + "'")
-      return env
+                           "a runtime assignment to '" + str(lhs) + "'")
     case ImpIf(loc, cond, then_body, else_body):
-      type_check_formula(cond, env)
       _reject_ghost_flow(loc, cond, ghost_names, 'a branch condition')
-      _type_check_imp_block(then_body, env, return_type, set(ghost_names))
+      _ghost_check_block(then_body, ghost_names)
       if else_body is not None:
-        _type_check_imp_block(else_body, env, return_type, set(ghost_names))
-      return env
+        _ghost_check_block(else_body, ghost_names)
+    case ImpWhile(loc, cond, _, _, _, body, _, _, _):
+      _reject_ghost_flow(loc, cond, ghost_names, 'a loop condition')
+      _ghost_check_block(body, ghost_names)
     case ImpReturn(loc, value):
-      if return_type is None:
-        user_error(loc, 'this procedure has no return type, so it may not '
-                   + 'return a value')
-      else:
-        type_check_term(value, return_type, env, None, [])
-        _reject_ghost_flow(loc, value, ghost_names, 'a return value')
-      return env
+      _reject_ghost_flow(loc, value, ghost_names, 'a return value')
     case _:
-      return env
+      # `assert`/`assume` are proof-only; `call` argument classification is a
+      # later slice (see the pass note above).
+      pass
 
-def _type_check_imp_block(stmts: list[ImpStmt], env: Env,
-                          return_type: Optional[Type],
-                          ghost_names: set[str]) -> None:
+def _ghost_check_block(stmts: list[ImpStmt], ghost_names: set[str]) -> None:
+  ghost_names = set(ghost_names)
   for s in stmts:
-    env = _type_check_imp_stmt(s, env, return_type, ghost_names)
+    _ghost_check_stmt(s, ghost_names)
+
+def check_ghost_noninterference(decl: ProcDecl) -> None:
+  _ghost_check_block(decl.body, {p.name for p in decl.params if p.ghost})
 
 def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
   # Phase 2d (issue #1113): type-check a procedure's straight-line body --
@@ -292,9 +348,7 @@ def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
   type_env = env.declare_type_vars(loc, decl.type_params)
   param_pairs = [(p.name, p.typ) for p in decl.params]
   body_env = type_env.declare_term_vars(loc, param_pairs, local=True)
-  # Ghost parameters seed the ghost-noninterference tracking (issue #1114).
-  ghost_names = {p.name for p in decl.params if p.ghost}
-  _type_check_imp_block(decl.body, body_env, decl.return_type, ghost_names)
+  _type_check_imp_block(decl.body, body_env, decl.return_type)
   if decl.return_type is not None and not _block_always_returns(decl.body):
     user_error(loc, "procedure '" + base_name(decl.name)
                + "' declares return type " + str(decl.return_type)
@@ -1097,6 +1151,9 @@ def type_check_stmt(stmt: Statement, env: Env,
       # Phase 2d (issue #1113): type-check the procedure's straight-line body.
       # Specs are checked in `check_proc_signature` (Phase 2b); proving them is
       # a later slice, so the Phase 1m "not verified" warning still fires.
+      # Phase 2e (issue #1114): the syntactic ghost-noninterference check runs
+      # regardless of whether the body is type-modeled (see its note).
+      check_ghost_noninterference(stmt)
       type_check_proc_body(stmt, env)
       return stmt
 

--- a/test/imperative/should-error/ghost_flow_assign.pf
+++ b/test/imperative/should-error/ghost_flow_assign.pf
@@ -1,0 +1,8 @@
+// Phase 2e (issue #1114): an assignment to a runtime local may not depend on
+// ghost data.
+proc demo(x: bool, ghost g: bool) -> bool
+{
+  var r := x
+  r := g
+  return r
+}

--- a/test/imperative/should-error/ghost_flow_assign.pf.err
+++ b/test/imperative/should-error/ghost_flow_assign.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_assign.pf:6.3-6.9: assignment to runtime variable 'r' may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_assign.pf.err
+++ b/test/imperative/should-error/ghost_flow_assign.pf.err
@@ -1,1 +1,1 @@
-./test/imperative/should-error/ghost_flow_assign.pf:6.3-6.9: assignment to runtime variable 'r' may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior
+./test/imperative/should-error/ghost_flow_assign.pf:6.3-6.9: a runtime assignment to 'r' may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_branch.pf
+++ b/test/imperative/should-error/ghost_flow_branch.pf
@@ -1,0 +1,9 @@
+// Phase 2e (issue #1114): a branch condition is runtime control flow and may
+// not depend on ghost data.
+proc demo(x: bool, ghost g: bool) -> bool
+{
+  if g {
+    return x
+  }
+  return x
+}

--- a/test/imperative/should-error/ghost_flow_branch.pf.err
+++ b/test/imperative/should-error/ghost_flow_branch.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_branch.pf:5.3-7.4: a branch condition may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_deferred_body.pf
+++ b/test/imperative/should-error/ghost_flow_deferred_body.pf
@@ -1,0 +1,9 @@
+// Phase 2e (issue #1114): the ghost-noninterference check is syntactic and
+// runs even when the body is otherwise deferred for type-checking. Here a
+// mutable-array parameter defers the body (no `a[i]` typing until #1117), but
+// the runtime `return g` must still be rejected -- the guarantee cannot be
+// bypassed by adding an unmodeled construct.
+proc leak(a: [bool]!, ghost g: bool) -> bool
+{
+  return g
+}

--- a/test/imperative/should-error/ghost_flow_deferred_body.pf.err
+++ b/test/imperative/should-error/ghost_flow_deferred_body.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_deferred_body.pf:8.3-8.9: a return value may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_deferred_body.pf.err.lalr
+++ b/test/imperative/should-error/ghost_flow_deferred_body.pf.err.lalr
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_deferred_body.pf:8.3-8.11: a return value may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_init.pf
+++ b/test/imperative/should-error/ghost_flow_init.pf
@@ -1,0 +1,7 @@
+// Phase 2e (issue #1114): a runtime local's initializer may not depend on
+// ghost data -- proof-only values cannot influence runtime behavior.
+proc demo(x: bool, ghost g: bool) -> bool
+{
+  var bad := g
+  return x
+}

--- a/test/imperative/should-error/ghost_flow_init.pf.err
+++ b/test/imperative/should-error/ghost_flow_init.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_init.pf:5.3-5.15: the initializer of runtime variable 'bad' may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_return.pf
+++ b/test/imperative/should-error/ghost_flow_return.pf
@@ -1,0 +1,6 @@
+// Phase 2e (issue #1114): a return value is runtime data and may not depend on
+// ghost data.
+proc demo(x: bool, ghost g: bool) -> bool
+{
+  return g
+}

--- a/test/imperative/should-error/ghost_flow_return.pf.err
+++ b/test/imperative/should-error/ghost_flow_return.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_return.pf:5.3-5.9: a return value may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-error/ghost_flow_return.pf.err.lalr
+++ b/test/imperative/should-error/ghost_flow_return.pf.err.lalr
@@ -1,0 +1,1 @@
+./test/imperative/should-error/ghost_flow_return.pf:5.3-5.11: a return value may not depend on ghost variable g because ghost data is proof-only and cannot influence runtime behavior

--- a/test/imperative/should-validate/ghost_deferred_body.pf
+++ b/test/imperative/should-validate/ghost_deferred_body.pf
@@ -1,0 +1,11 @@
+// Phase 2e (issue #1114): a body deferred from type-checking (mutable-array
+// parameter, allocation, and `call` are all still unmodeled) is still allowed
+// to move runtime data into ghost bindings and to read ghost data in a ghost
+// context. Only ghost-to-runtime flows are rejected, so this body validates
+// (still emitting the Phase 1m "accepted but not verified" warning).
+proc keep(a: [bool]!, x: bool, ghost g: bool)
+{
+  ghost var seen := g        // ghost <- ghost, ok
+  seen := x                  // runtime flows into a ghost local, ok
+  var slot := new Cell(x)    // deferred allocation, ghost check skips it
+}

--- a/test/imperative/should-validate/ghost_deferred_body.pf.warn
+++ b/test/imperative/should-validate/ghost_deferred_body.pf.warn
@@ -1,0 +1,1 @@
+./test/imperative/should-validate/ghost_deferred_body.pf:6.1-11.2: warning: proc 'keep' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/ghost_noninterference.pf
+++ b/test/imperative/should-validate/ghost_noninterference.pf
@@ -1,0 +1,22 @@
+// Phase 2e (issue #1114): ghost-variable noninterference. `ghost` parameters
+// and `ghost var` locals are proof-only. Runtime data may freely flow *into*
+// ghost bindings, and ghost bindings may reference each other, so every flow
+// below is accepted. (Ghost-to-runtime flows are rejected -- see the
+// `ghost_flow_*` fixtures under should-error.) The body stays otherwise
+// unverified, so the Phase 1m "accepted but not verified" warning still fires.
+proc mix(x: bool, ghost g: bool) -> bool
+  ensures g or not g
+{
+  ghost var gv := g          // ghost <- ghost, ok
+  ghost var gr := x          // ghost <- runtime, ok (runtime flows into ghost)
+  var r := x                 // runtime <- runtime, ok
+  gv := x                    // runtime assigned into a ghost local, ok
+  gr := gv                   // ghost <- ghost, ok
+  if x {                     // runtime branch condition, ok
+    r := x
+  } else {
+    ghost var branchghost := g   // ghost use inside a branch, ok
+    gr := branchghost
+  }
+  return r                   // runtime return value over runtime data, ok
+}

--- a/test/imperative/should-validate/ghost_noninterference.pf.warn
+++ b/test/imperative/should-validate/ghost_noninterference.pf.warn
@@ -1,0 +1,1 @@
+./test/imperative/should-validate/ghost_noninterference.pf:7.1-22.2: warning: proc 'mix' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/should-warn/proc_declarations.pf
+++ b/test/should-warn/proc_declarations.pf
@@ -17,7 +17,7 @@ public proc identity<T>(x: T, ghost witness: T) -> T
   ensures x = x
 {
   var a : T := x
-  var b := witness
+  var b := x
   ghost var c : T := x
   ghost var d := witness
   a := b

--- a/test/unit/test_imperative_ghost.py
+++ b/test/unit/test_imperative_ghost.py
@@ -1,0 +1,71 @@
+"""Unit tests for the ghost-variable dependency predicate (issue #1114).
+
+`imp_ghost_dependencies(term, ghost_names)` is the core of ghost-variable
+noninterference: it returns the ghost names a term references. A runtime
+context (runtime local initializer, runtime assignment, branch condition,
+return value) whose result is nonempty would let proof-only data influence
+runtime behavior and is rejected by the checker. These tests exercise the
+predicate directly, in isolation from the pipeline.
+"""
+
+import pytest
+from lark.tree import Meta
+
+from abstract_syntax import And, Bool, BoolType, Or, Var
+from checker_pipeline import imp_ghost_dependencies
+
+
+def _meta() -> Meta:
+  m = Meta()
+  m.empty = False
+  m.filename = 'test.pf'
+  m.line = 1
+  m.column = 1
+  m.start_pos = 0
+  m.end_line = 1
+  m.end_column = 2
+  m.end_pos = 1
+  return m
+
+
+def _var(name: str) -> Var:
+  return Var(_meta(), None, name)
+
+
+def _bool(value: bool) -> Bool:
+  return Bool(_meta(), BoolType(_meta()), value)
+
+
+def _and(*args: object) -> And:
+  return And(_meta(), None, list(args))
+
+
+def _or(*args: object) -> Or:
+  return Or(_meta(), None, list(args))
+
+
+GHOST = {'g', 'h'}
+
+# (description, term, expected ghost dependencies)
+_CASES = [
+  ('bare ghost var', _var('g'), {'g'}),
+  ('bare runtime var', _var('x'), set()),
+  ('constant', _bool(True), set()),
+  ('nested ghost under conjunction', _and(_var('x'), _var('g')), {'g'}),
+  ('two ghosts referenced', _and(_var('g'), _var('h')), {'g', 'h'}),
+  ('deeply nested ghost', _or(_var('x'), _and(_var('y'), _var('h'))), {'h'}),
+  ('only runtime data', _and(_var('x'), _var('y')), set()),
+  ('ghost mentioned twice', _or(_var('g'), _var('g')), {'g'}),
+]
+
+
+@pytest.mark.parametrize('desc,term,expected',
+                         _CASES, ids=[c[0] for c in _CASES])
+def test_ghost_dependency_predicate(desc: str, term: object,
+                                    expected: set[str]) -> None:
+  assert imp_ghost_dependencies(term, GHOST) == expected
+
+
+def test_empty_ghost_set_never_depends() -> None:
+  # With no ghost bindings in scope, nothing can depend on ghost data.
+  assert imp_ghost_dependencies(_and(_var('g'), _var('h')), set()) == set()


### PR DESCRIPTION
Closes #1114.

## Phase 2e: enforce ghost-variable noninterference in procedure bodies

`ghost` parameters and `ghost var` locals are proof-only, so a later compilation
phase (Phase 6) can erase them without changing runtime behavior. That erasure
is only sound if ghost data never influences runtime behavior. This PR adds that
check.

### What it does

`check_ghost_noninterference` is a standalone, purely syntactic pass (name
dependency, no types) that walks a procedure body tracking the in-scope ghost
binding names (uniquified). Ghost parameters seed the set; a `ghost var` extends
it; nested `if`/`while` blocks receive a copy so a ghost local declared in a
branch or loop does not leak out.

A runtime context is rejected when it depends on any ghost binding:

- a runtime local's initializer (`var r := g`),
- a runtime assignment — including the index and value of a runtime array/field
  write (`a[i] := g`, `x.f := g`),
- a branch or loop condition (`if g { … }`, `while g { … }`), and
- a return value (`return g`).

Flows in the other direction stay valid — runtime data may flow *into* a ghost
binding, and ghost bindings may reference each other — so ghost contexts are
never checked. Proof-only contexts (`assert`/`assume`, loop invariants,
`decreases`) may freely mention ghost data.

Because the pass is syntactic and does not depend on type-checking, it runs on
**every** proc body, including ones deferred by `_proc_body_unmodeled` (e.g. a
proc with a mutable-array parameter). Otherwise the guarantee could be bypassed
just by adding an unmodeled construct — see the review note below.

The core dependency predicate is factored out as
`imp_ghost_dependencies(term, ghost_names)` (the ghost names a term references,
via the existing `_referenced_names` walk).

The diagnostic names the offending ghost binding(s) and the runtime context they
would influence, e.g.:

```
the initializer of runtime variable 'bad' may not depend on ghost variable g
because ghost data is proof-only and cannot influence runtime behavior
```

### Addressing the Codex review

Codex (P2) flagged that the check was gated behind `_proc_body_unmodeled`, so
`proc p(a: [bool]!, ghost g: bool) -> bool { return g }` was accepted — a
deferred construct bypassed the whole guarantee. Fixed by decoupling the check
from `type_check_proc_body` into the always-run `check_ghost_noninterference`
pass. `ghost_flow_deferred_body.pf` pins exactly that regression. Runtime-vs-ghost
classification of `call`/`new` argument positions is left to call resolution
(#1124/#1125) — that is the only phase that knows which callee parameters are
ghost — so those RHS forms stay deferred.

### Tests

- `test/unit/test_imperative_ghost.py` — table-driven unit tests for the
  dependency predicate.
- `test/imperative/should-error/ghost_flow_{init,assign,branch,return,deferred_body}.pf`
  — one rejected runtime context each, plus the deferred-body regression.
- `test/imperative/should-validate/{ghost_noninterference,ghost_deferred_body}.pf`
  — accepted flows (runtime→ghost, ghost→ghost, ghost use in a branch, and a
  deferred body with legitimate runtime→ghost flow), still emitting the Phase 1m
  "accepted but not verified" warning.
- `test/should-warn/proc_declarations.pf` had a `var b := witness` ghost→runtime
  leak in its Phase 1 plumbing body; the runtime local now reads runtime data.

### Checks run locally

`python3 test-deduce.py --imperative --warns --errors --equiv` pass; `ruff
check .`, `mypy .`, and the new pytest module are green.

### Out of scope

No code generation or physical erasure (Phase 6). No specifications are proved
here — the Phase 1m "not verified" warning still fires. `call`/`new` argument
noninterference is deferred to the call-resolution slices (#1124/#1125).

Resume this session on ginger: `~/deduce-runner/resume.sh 67eb08bb-d0fc-4f7a-91a2-abb8e393415c routine/20260807-160202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)