### PR TITLE
Dedup check_type bare type-var-ref tail into a shared helper (refs #813)

### DIFF
--- a/checker_types.py
+++ b/checker_types.py
@@ -731,6 +731,30 @@ def _type_alias_arity_error(loc: Meta, name: str, expected: int, got: int) -> No
         f"Expected type alias '{base_name(name)}' to have "
         f"{expected} type arguments, not {got}")
 
+def _resolve_type_var_ref(loc: Meta, typ: TypeExpr, resolved: TypeExpr,
+                          env: Env, arity_required: bool) -> TypeExpr:
+  """The shared tail of ``check_type`` for a bare type-variable reference.
+
+  ``typ`` is an already-defined ``OverloadedVar``/``ResolvedVar`` head and
+  ``resolved`` is the reference to return once it is confirmed to name a
+  plain union (the single-candidate promotion for an ``OverloadedVar``, or
+  ``typ`` itself for a ``ResolvedVar``). A bijective-view or type-alias head
+  is expanded instead; otherwise the union's zero-arity use is validated."""
+  view_info = _instantiate_view_type(loc, typ, env)
+  if view_info is not None:
+    _, source_ty, _ = view_info
+    return source_ty
+  alias = _lookup_type_alias(loc, typ, env)
+  if alias is not None:
+    if len(alias.type_params) != 0:
+      if arity_required:
+        _type_alias_arity_error(loc, alias.name, len(alias.type_params), 0)
+      return resolved
+    return alias.body
+  if arity_required:
+    _check_union_arity(typ, 0, env)
+  return resolved
+
 # Validate that ``typ`` is well-formed in ``env`` and return the type
 # with every single-candidate ``OverloadedVar`` narrowed to
 # ``ResolvedVar``. The returned type may share structure with ``typ``
@@ -750,38 +774,13 @@ def check_type(typ: TypeExpr, env: Env, arity_required: bool = True) -> TypeExpr
         user_error(loc, 'undefined type variable ' + str(typ))
       if len(rs) > 1:
         user_error(loc, 'type names may not be overloaded ' + str(typ))
-      view_info = _instantiate_view_type(loc, typ, env)
-      if view_info is not None:
-        _, source_ty, _ = view_info
-        return source_ty
-      alias = _lookup_type_alias(loc, typ, env)
-      if alias is not None:
-        if len(alias.type_params) != 0:
-          if arity_required:
-            _type_alias_arity_error(loc, alias.name, len(alias.type_params), 0)
-          return ResolvedVar(loc, tyof, rs[0])
-        return alias.body
-      if arity_required:
-        _check_union_arity(typ, 0, env)
       # len(rs) == 1: this is a non-overloaded type reference. Promote.
-      return ResolvedVar(loc, tyof, rs[0])
-    case ResolvedVar(loc, tyof, _):
+      return _resolve_type_var_ref(loc, typ, ResolvedVar(loc, tyof, rs[0]),
+                                   env, arity_required)
+    case ResolvedVar(loc, _, _):
       if not env.type_var_is_defined(typ):
         user_error(loc, 'undefined type variable ' + str(typ))
-      view_info = _instantiate_view_type(loc, typ, env)
-      if view_info is not None:
-        _, source_ty, _ = view_info
-        return source_ty
-      alias = _lookup_type_alias(loc, typ, env)
-      if alias is not None:
-        if len(alias.type_params) != 0:
-          if arity_required:
-            _type_alias_arity_error(loc, alias.name, len(alias.type_params), 0)
-          return typ
-        return alias.body
-      if arity_required:
-        _check_union_arity(typ, 0, env)
-      return typ
+      return _resolve_type_var_ref(loc, typ, typ, env, arity_required)
     case IntType(loc) | BoolType(loc) | TypeType(loc):
       return typ
     case FunctionType(loc, typarams, param_types, return_type):


### PR DESCRIPTION
## What

Dedup a slice of the #813 duplication umbrella in `checker_types.py`.

The `OverloadedVar` and `ResolvedVar` cases of `check_type` shared an
identical tail:

- expand a bijective-view head (`_instantiate_view_type`) and return its
  source type, else
- expand a type-alias head (`_lookup_type_alias`): enforce arity and return
  the promoted reference for a parameterized alias, or return `alias.body`
  for a zero-arity alias, else
- validate the union's zero-arity use (`_check_union_arity`) and return the
  promoted reference.

The two copies differed only in (a) the extra `len(rs) > 1` overload-count
guard the `OverloadedVar` case runs first, and (b) the reference returned
when the head is a plain union — `ResolvedVar(loc, tyof, rs[0])` (the
single-candidate promotion) for `OverloadedVar` versus `typ` itself for
`ResolvedVar`.

This extracts the shared tail into `_resolve_type_var_ref(loc, typ,
resolved, env, arity_required)`, which takes that promoted reference as
`resolved`. The `undefined type variable` check and the overload-count
guard stay in their respective `case` arms so the existing error ordering
is preserved exactly. Net −13 lines, no behavior change.

## Testing

- `python3 test-deduce.py --passable` (both parsers) — pass
- `python3 test-deduce.py --errors --warns --lib` — pass
- `python3 deduce.py --quiet lib/List.pf` smoke — valid

(ruff/mypy aren't installed in this container; CI's static leg will run
them. The change is straightforward Python matching the surrounding
2-space style and line lengths.)

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh 1ed65fd9-9555-4dcc-9a2d-f61e8e090571 routine/20260807-200202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
