### PR TITLE
Dedup Env binding inserts and rewrite mark-handling (refs #813)

### DIFF
--- a/abstract_syntax/env.py
+++ b/abstract_syntax/env.py
@@ -156,10 +156,13 @@ class Env:
                        for (k,v) in reversed(self.dict.items()) \
                        if isinstance(v,TermBinding) and v.local])
   
-  def declare_type(self, loc: Meta, name: str, vis: str = 'public') -> Env:
+  def _with_binding(self, name: str, binding: object) -> Env:
     new_env = Env(self.dict)
-    new_env.dict[name] = TypeBinding(loc, module=self.get_current_module(), visibility=vis)
+    new_env.dict[name] = binding
     return new_env
+
+  def declare_type(self, loc: Meta, name: str, vis: str = 'public') -> Env:
+    return self._with_binding(name, TypeBinding(loc, module=self.get_current_module(), visibility=vis))
 
   def declare_type_vars(self, loc: Meta, type_vars: Sequence[str]) -> Env:
     new_env = self
@@ -171,9 +174,7 @@ class Env:
                   visibility: str = 'public') -> Env:
     if defn == None:
       internal_error(loc, 'None not allowed in define_type')
-    new_env = Env(self.dict)
-    new_env.dict[name] = TypeBinding(loc, defn, module=self.get_current_module(), visibility=visibility)
-    return new_env
+    return self._with_binding(name, TypeBinding(loc, defn, module=self.get_current_module(), visibility=visibility))
 
   def declare_view(self, loc: Meta, view: ViewDecl,
                    visibility: str = 'public') -> Env:
@@ -190,12 +191,10 @@ class Env:
   def declare_proc(self, loc: Meta, name: str, type_params: List[str],
                    params: List[ProcParam], return_type: Optional[Type],
                    specs: List[ProcSpec], visibility: str = 'public') -> Env:
-    new_env = Env(self.dict)
-    new_env.dict[name] = ProcBinding(loc, type_params, params, return_type,
-                                     specs,
-                                     module=self.get_current_module(),
-                                     visibility=visibility)
-    return new_env
+    return self._with_binding(name, ProcBinding(loc, type_params, params, return_type,
+                                                specs,
+                                                module=self.get_current_module(),
+                                                visibility=visibility))
 
   def get_proc(self, name: str | VarRef) -> Optional[ProcBinding]:
     if isinstance(name, VarRef):
@@ -207,11 +206,9 @@ class Env:
                        local: bool = False, visibility: str = 'public') -> Env:
     if typ == None:
       internal_error(loc, 'None not allowed as type of variable in declare_term_var')
-    new_env = Env(self.dict)
-    new_env.dict[name] = TermBinding(loc, typ, local=local,
-                                     module=self.get_current_module(),
-                                     visibility=visibility)
-    return new_env
+    return self._with_binding(name, TermBinding(loc, typ, local=local,
+                                                module=self.get_current_module(),
+                                                visibility=visibility))
 
   def declare_assoc(self, loc: Meta, opname: str, typarams: List[str],
                     typ: Type) -> Env:
@@ -308,11 +305,9 @@ class Env:
                       visibility: str = 'public') -> Env:
     if val == None:
       internal_error(loc, 'None not allowed as value in define_term_var')
-    new_env = Env(self.dict)
-    new_env.dict[name] = TermBinding(loc, cast(Type, typ), cast(Term, val),
-                                     module=self.get_current_module(),
-                                     visibility=visibility)
-    return new_env
+    return self._with_binding(name, TermBinding(loc, cast(Type, typ), cast(Term, val),
+                                                module=self.get_current_module(),
+                                                visibility=visibility))
 
   def define_term_vars(self, loc: Meta,
                        xv_pairs: Iterable[tuple[str, Term]]) -> Env:
@@ -322,20 +317,14 @@ class Env:
     return new_env
   
   def declare_proof_var(self, loc: Meta, name: str, frm: Formula) -> Env:
-    new_env = Env(self.dict)
-    new_env.dict[name] = ProofBinding(loc, frm, False, module=self.get_current_module())
-    return new_env
+    return self._with_binding(name, ProofBinding(loc, frm, False, module=self.get_current_module()))
 
   def declare_local_proof_var(self, loc: Meta, name: str,
                               frm: Formula) -> Env:
-    new_env = Env(self.dict)
-    new_env.dict[name] = ProofBinding(loc, frm, True, module=self.get_current_module())
-    return new_env
+    return self._with_binding(name, ProofBinding(loc, frm, True, module=self.get_current_module()))
 
   def declare_module(self, module: str) -> Env:
-    new_env = Env(self.dict)
-    new_env.dict['__current_module__'] = module
-    return new_env
+    return self._with_binding('__current_module__', module)
   
   def declare_tracing(self, function_name: str) -> Env:
     new_env = Env(self.dict)

--- a/checker_logic.py
+++ b/checker_logic.py
@@ -274,20 +274,13 @@ def pattern_to_term(pat: Pattern) -> Term:
 def rewrite(loc: Meta, formula: Formula, equation: Formula | AutoRewriteRule,
             env: Env) -> Formula:
     num_marks = count_marks(formula)
+    subject = _single_marked_subject(loc, formula, num_marks, 'replace', 'replace')
+    ret = rewrite_aux(loc, subject, equation, env)
     if num_marks == 0:
-        ret = rewrite_aux(loc, formula, equation, env)
         print_verbose(lambda: '\trewrote ' + str(formula) + '\n\t    ==> ' + str(ret) \
                       + '\n\tusing ' + str(equation))
         return ret
-    elif num_marks == 1:
-        try:
-            find_mark(formula)
-            internal_error(loc, 'in replace, find_mark failed on formula:\n\t' + str(formula))
-        except MarkException as ex:
-            new_subject = rewrite_aux(loc, ex.subject, equation, env)
-            return replace_mark(formula, new_subject)
-    else:
-        internal_error(loc, 'in replace, formula contains more than one mark:\n\t' + str(formula))
+    return replace_mark(formula, ret)
 
 def facts_to_str(env: Mapping[str, object]) -> str:
   result = ''


### PR DESCRIPTION
## Dedup: `Env` binding inserts and `rewrite` mark-handling

Refs #813. Two self-contained, behavior-preserving dedup slices in files not
touched by the other open #813 PRs.

### `abstract_syntax/env.py` — `Env._with_binding`

Eight `Env` declare/define methods repeated the identical three-line skeleton
that only differed in the `Binding` subtype constructed:

```python
new_env = Env(self.dict)
new_env.dict[name] = <SomeBinding>(...)
return new_env
```

Extracted a private `Env._with_binding(name, binding)` helper (typed `object`
so it also serves `declare_module`, which stores the module string). The eight
callers — `declare_type`, `define_type`, `declare_proc`, `declare_term_var`,
`define_term_var`, `declare_proof_var`, `declare_local_proof_var`,
`declare_module` — now each `return self._with_binding(...)`. `self.dict` is
still cloned per call, so the immutable-`Env` semantics are unchanged. The
methods that do extra per-binding work (`declare_view`, `declare_assoc`,
`declare_auto_rewrite`, `declare_inductive`, the batch `*_vars` folders) are
left as-is.

### `checker_logic.py` — reuse `_single_marked_subject` in `rewrite`

`rewrite` hand-rolled the same "0 marks → whole formula / 1 mark → marked
subject / >1 → internal error" `find_mark`/`MarkException` branching that
`_single_marked_subject` already centralizes (and that `expand_definitions`
and `apply_rewrites` already call). `rewrite` now delegates to that helper and
keeps the verbose-print only on the no-mark path, matching the
`apply_rewrites` idiom. The internal-error text is byte-for-byte identical
(`find_mark_where`/`multi_mark_where` are both `'replace'`).

### Net effect

`22 insertions, 40 deletions` → **-18 lines**, no behavior change.

### Testing

- `python3 test-deduce.py` — all lanes green (lib, should-validate ×2 parsers,
  should-error, should-warn, prelude, parser equivalence, round-trip).
- ruff/mypy not installed in this container; changes are type-safe by
  construction (`_with_binding` param typed `object` against
  `dict[str, object]`; `rewrite` reuses an already-typed helper). CI runs the
  static checks.

### Notes for a human picking this up

- Purely mechanical dedup under the #813 umbrella; nothing else remains for
  these two slices. Coordination comment posted on #813 naming the exact
  functions so parallel dedup runs avoid them.

Resume this session on ginger: `~/deduce-runner/resume.sh de5d3c84-eabb-401f-9d78-69a7e8af0c56 routine/20260807-210202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
