### PR TITLE
Phase 2g: verify if/assert/assume control flow (closes #1116)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -25,8 +25,8 @@ from abstract_syntax import (
     All, And, Array, ArrayGet, Assert, Associative, Auto, Bool,
     Call, Conditional, Constructor, Declaration, Define, Env, Export,
     Formula, FunCase, FunctionType, GenRecFun, Generic, GenericUnknownInst,
-    Hole, IfThen, ImpAlloc, ImpAssert, ImpAssign, ImpCallExpr, ImpIf,
-    ImpReturn, ImpStmt, ImpVar, ImpWhile, Import, Inductive, Lambda,
+    Hole, IfThen, ImpAlloc, ImpAssert, ImpAssign, ImpAssume, ImpCallExpr,
+    ImpIf, ImpReturn, ImpStmt, ImpVar, ImpWhile, Import, Inductive, Lambda,
     LValueField, LValueIndex, LValueVar, MakeArray, Module,
     MutableArrayType, ObjectDecl,
     ObjectField, ObserverDecl, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
@@ -166,10 +166,10 @@ def _imp_stmt_unmodeled(s: ImpStmt) -> bool:
     case ImpIf(_, _, then_body, else_body):
       return _block_unmodeled(then_body) \
           or (else_body is not None and _block_unmodeled(else_body))
-    case ImpReturn() | ImpAssert():
+    case ImpReturn() | ImpAssert() | ImpAssume():
       return False
     case _:
-      # `while`, `assume`, and `call` statements.
+      # `while` and `call` statements.
       return True
 
 def _block_unmodeled(stmts: list[ImpStmt]) -> bool:
@@ -242,6 +242,12 @@ def _type_check_imp_stmt(s: ImpStmt, env: Env,
     case ImpAssert(loc, formula, _):
       # The asserted formula must be a `bool`; the obligation that it actually
       # holds is discharged later in `verify_proc` (Phase 2f).
+      type_check_formula(formula, env)
+      return env
+    case ImpAssume(loc, formula):
+      # `assume` is proof-only: the formula must be a `bool`, and it becomes a
+      # given for the statements that follow (see `proc_obligations`). It has
+      # no runtime effect, so it never contributes to the state.
       type_check_formula(formula, env)
       return env
     case _:
@@ -362,13 +368,13 @@ def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
                + "' declares return type " + str(decl.return_type)
                + ' but may finish without returning a value')
 
-# --- Phase 2f (issue #1115): straight-line procedure verification -----------
-# A procedure is *verifiable* by this slice when its body is entirely
-# straight-line over local state: local `var` declarations, assignments to a
-# local variable, `assert`, and a final `return`, all with ordinary-term
-# right-hand sides. Branches (`if`), loops (`while`), `assume`, procedure
-# calls, allocations, and mutable-array reads/writes are later slices, so a
-# body using any of them stays deferred (and keeps the Phase 1m warning). A
+# --- Phase 2f/2g (issues #1115, #1116): procedure verification --------------
+# A procedure is *verifiable* by these slices when its body is built from local
+# state and finite branching: local `var` declarations, assignments to a local
+# variable, `assert`, `assume`, `if`/`else` (recursively verifiable), and
+# `return`, all with ordinary-term right-hand sides. Loops (`while`), procedure
+# calls, allocations, and mutable-array reads/writes are later slices, so a body
+# using any of them stays deferred (and keeps the Phase 1m warning). A
 # mutable-array parameter also defers the whole procedure (its reads are not
 # modeled until those slices land).
 def _stmt_verifiable(s: ImpStmt) -> bool:
@@ -378,10 +384,14 @@ def _stmt_verifiable(s: ImpStmt) -> bool:
     case ImpAssign():
       return isinstance(s.lhs, LValueVar) \
           and not isinstance(s.rhs, (ImpCallExpr, ImpAlloc))
-    case ImpAssert() | ImpReturn():
+    case ImpAssert() | ImpAssume() | ImpReturn():
       return True
+    case ImpIf(_, _, then_body, else_body):
+      return all(_stmt_verifiable(t) for t in then_body) \
+          and (else_body is None
+               or all(_stmt_verifiable(t) for t in else_body))
     case _:
-      # `if`, `while`, `assume`, and `call` statements.
+      # `while` and `call` statements.
       return False
 
 def _assigns_to_a_parameter(decl: ProcDecl) -> bool:
@@ -389,11 +399,20 @@ def _assigns_to_a_parameter(decl: ProcDecl) -> bool:
   # one. Without an entry-state/`old` snapshot (a later slice, #1120) a
   # postcondition mentioning a reassigned parameter is ambiguous between its
   # entry and exit value, so such a procedure is deferred rather than verified
-  # against the entry value alone. A verifiable body has no nested blocks (`if`
-  # defers), so every assignment is at the top level.
+  # against the entry value alone. `if` branches nest, so the scan recurses.
   param_names = {p.name for p in decl.params}
-  return any(isinstance(s, ImpAssign) and isinstance(s.lhs, LValueVar)
-             and s.lhs.name in param_names for s in decl.body)
+  def assigns(stmts: list[ImpStmt]) -> bool:
+    for s in stmts:
+      match s:
+        case ImpAssign() if isinstance(s.lhs, LValueVar) \
+                and s.lhs.name in param_names:
+          return True
+        case ImpIf(_, _, then_body, else_body):
+          if assigns(then_body) \
+             or (else_body is not None and assigns(else_body)):
+            return True
+    return False
+  return assigns(decl.body)
 
 def _proc_verifiable(decl: ProcDecl) -> bool:
   if any(isinstance(p.typ, MutableArrayType) for p in decl.params):
@@ -436,70 +455,99 @@ def _proc_postconditions(decl: ProcDecl,
 
 def proc_obligations(decl: ProcDecl,
                      env: Env) -> tuple[Env, list['ImperativeObligation']]:
-  # Phase 2f (issue #1115): the verification conditions of a straight-line,
-  # `_proc_verifiable` procedure, by forward symbolic execution. `state` maps
-  # each local variable to its current value as a term over the parameters, so
-  # substituting it into an assertion or returned expression yields a goal
-  # mentioning only parameters. Returns the parameter environment obligations
-  # discharge in, together with the obligations in source order. Pure w.r.t.
-  # proof checking (it only builds formulas), so it can be unit-tested in
-  # isolation from `verify_proc`, which discharges what it returns.
+  # Phase 2f/2g (issues #1115, #1116): the verification conditions of a
+  # `_proc_verifiable` procedure, by path-sensitive forward symbolic execution.
+  # `state` maps each local variable to its current value as a term over the
+  # parameters, so substituting it into an assertion, returned expression, or
+  # branch condition yields a goal or given mentioning only parameters.
+  #
+  # `if` splits the current path in two: the then-path carries the condition as
+  # a given, the else-path its negation (a missing `else` is `skip`), and both
+  # continue through the statements that follow the `if`. A `return` ends its
+  # path (discharging the postconditions with the returned value); a path that
+  # falls off the end discharges the postconditions with `result` unbound. Each
+  # path keeps its own `state`/`givens`, so a fact asserted or assumed on one
+  # branch is not visible on the other, and never before the statement itself.
+  #
+  # Obligations are emitted in path/source order, with per-path given labels
+  # derived from `len(givens)`, so the ordering is deterministic. Returns the
+  # parameter environment obligations discharge in (goals mention only
+  # parameters, so the locals are not needed) together with the obligations.
+  # Pure w.r.t. proof checking -- it only builds formulas -- so it can be
+  # unit-tested in isolation from `verify_proc`, which discharges what it
+  # returns.
   from imperative_verifier import ImperativeObligation, ObligationKind
   loc = decl.location
   type_env = env.declare_type_vars(loc, decl.type_params)
-  cur_env = type_env.declare_term_vars(
+  base_env = type_env.declare_term_vars(
       loc, [(p.name, p.typ) for p in decl.params], local=True)
-  givens = _proc_givens(decl)
-  state: Substitution = {}
   obligations: list[ImperativeObligation] = []
 
-  def symbolic(rhs: Term, typ: Type) -> Term:
-    return cast(Term, type_check_term(rhs, typ, cur_env, None, [])
-                .substitute(state))
-
-  returned = False
-  for s in decl.body:
-    match s:
-      case ImpVar(vloc, name, type_annot, rhs, _):
-        if type_annot is not None:
-          var_ty = check_type(type_annot, cur_env)
-          state[name] = symbolic(cast(Term, rhs), var_ty)
-        else:
-          checked = type_synth_term(cast(Term, rhs), cur_env, None, [])
-          var_ty = checked.typeof
-          state[name] = cast(Term, checked.substitute(state))
-        cur_env = cur_env.declare_term_var(vloc, name, var_ty, local=True)
-      case ImpAssign(_, lhs, rhs):
-        target = cast(LValueVar, lhs)
-        binding = cast(TermBinding, cur_env.dict[target.name])
-        state[target.name] = symbolic(cast(Term, rhs), binding.typ)
-      case ImpAssert(aloc, formula, proof):
-        goal = cast(Formula,
-                    type_check_formula(formula, cur_env).substitute(state))
-        obligations.append(
-            ImperativeObligation(aloc, goal, ObligationKind.ASSERTION,
-                                 givens=list(givens), proof=proof))
-        # The asserted fact is available to everything downstream.
-        givens = givens + [('assert' + str(len(givens)), goal)]
-      case ImpReturn(_, value):
-        result = symbolic(value, cast(Type, decl.return_type))
-        for (post_loc, goal) in _proc_postconditions(decl, result):
-          obligations.append(
-              ImperativeObligation(post_loc, goal,
-                                   ObligationKind.POSTCONDITION,
-                                   givens=list(givens)))
-        returned = True
-        break  # a `return` is terminal; anything after it is unreachable.
-
-  if not returned:
-    # A procedure with no return value (or that falls off the end) exits with
-    # `result` unbound; its postconditions may not mention `result`.
-    for (post_loc, goal) in _proc_postconditions(decl, None):
+  def emit_posts(result: Optional[Term],
+                 givens: list[tuple[str, Formula]]) -> None:
+    for (post_loc, goal) in _proc_postconditions(decl, result):
       obligations.append(
           ImperativeObligation(post_loc, goal, ObligationKind.POSTCONDITION,
                                givens=list(givens)))
 
-  return cur_env, obligations
+  def walk(stmts: list[ImpStmt], state: Substitution,
+           givens: list[tuple[str, Formula]], cur_env: Env) -> None:
+    def symbolic(rhs: Term, typ: Type) -> Term:
+      return cast(Term, type_check_term(rhs, typ, cur_env, None, [])
+                  .substitute(state))
+    for idx, s in enumerate(stmts):
+      match s:
+        case ImpVar(vloc, name, type_annot, rhs, _):
+          if type_annot is not None:
+            var_ty = check_type(type_annot, cur_env)
+            state[name] = symbolic(cast(Term, rhs), var_ty)
+          else:
+            checked = type_synth_term(cast(Term, rhs), cur_env, None, [])
+            var_ty = checked.typeof
+            state[name] = cast(Term, checked.substitute(state))
+          cur_env = cur_env.declare_term_var(vloc, name, var_ty, local=True)
+        case ImpAssign(_, lhs, rhs):
+          target = cast(LValueVar, lhs)
+          binding = cast(TermBinding, cur_env.dict[target.name])
+          state[target.name] = symbolic(cast(Term, rhs), binding.typ)
+        case ImpAssert(aloc, formula, proof):
+          goal = cast(Formula,
+                      type_check_formula(formula, cur_env).substitute(state))
+          obligations.append(
+              ImperativeObligation(aloc, goal, ObligationKind.ASSERTION,
+                                   givens=list(givens), proof=proof))
+          # The asserted fact is available to everything downstream.
+          givens = givens + [('assert' + str(len(givens)), goal)]
+        case ImpAssume(_, formula):
+          # `assume` has no runtime effect; it only adds a proof-only given for
+          # the statements that follow it on this path.
+          fact = cast(Formula,
+                      type_check_formula(formula, cur_env).substitute(state))
+          givens = givens + [('assume' + str(len(givens)), fact)]
+        case ImpIf(iloc, cond, then_body, else_body):
+          cond_frm = cast(Formula,
+                          type_check_formula(cond, cur_env).substitute(state))
+          neg = IfThen(iloc, None, cond_frm, Bool(iloc, None, False))
+          rest = stmts[idx + 1:]
+          # Both branches are checked against the same continuation; each gets
+          # its own copy of `state` so a branch-local write does not leak out.
+          walk(cast(list[ImpStmt], then_body) + rest, dict(state),
+               givens + [('if' + str(len(givens)), cond_frm)], cur_env)
+          else_stmts = cast(list[ImpStmt], else_body) if else_body is not None \
+              else []
+          walk(else_stmts + rest, dict(state),
+               givens + [('if' + str(len(givens)), neg)], cur_env)
+          return  # both branch paths already handled the continuation
+        case ImpReturn(_, value):
+          result = symbolic(value, cast(Type, decl.return_type))
+          emit_posts(result, givens)
+          return  # a `return` is terminal; anything after it is unreachable
+    # This path fell off the end without returning: its postconditions hold
+    # with `result` unbound (so they may not mention `result`).
+    emit_posts(None, givens)
+
+  walk(decl.body, {}, _proc_givens(decl), base_env)
+  return base_env, obligations
 
 def verify_proc(decl: ProcDecl, env: Env) -> None:
   # Phase 2f (issue #1115): verify a straight-line procedure by discharging

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -470,18 +470,24 @@ def proc_obligations(decl: ProcDecl,
   # branch is not visible on the other, and never before the statement itself.
   #
   # Obligations are emitted in path/source order, with per-path given labels
-  # derived from `len(givens)`, so the ordering is deterministic. Returns the
-  # parameter environment obligations discharge in (goals mention only
-  # parameters, so the locals are not needed) together with the obligations.
-  # Pure w.r.t. proof checking -- it only builds formulas -- so it can be
-  # unit-tested in isolation from `verify_proc`, which discharges what it
-  # returns.
+  # derived from `len(givens)`, so the ordering is deterministic. Pure w.r.t.
+  # proof checking -- it only builds formulas -- so it can be unit-tested in
+  # isolation from `verify_proc`, which discharges what it returns.
+  #
+  # Returns the environment obligations discharge in: the parameters plus every
+  # local declared anywhere in the body. Goals and givens are substituted
+  # through `state` and so mention only parameters, but an attached inline-
+  # assert proof (`assert P by <proof>`) is stored unchanged and may reference a
+  # body local in an intermediate step, so the locals must stay in scope for it
+  # to type-check. Uniquify makes every local name globally unique, so gathering
+  # them across all branch paths introduces no clashes.
   from imperative_verifier import ImperativeObligation, ObligationKind
   loc = decl.location
   type_env = env.declare_type_vars(loc, decl.type_params)
   base_env = type_env.declare_term_vars(
       loc, [(p.name, p.typ) for p in decl.params], local=True)
   obligations: list[ImperativeObligation] = []
+  local_bindings: dict[str, tuple[Meta, Type]] = {}
 
   def emit_posts(result: Optional[Term],
                  givens: list[tuple[str, Formula]]) -> None:
@@ -505,6 +511,7 @@ def proc_obligations(decl: ProcDecl,
             checked = type_synth_term(cast(Term, rhs), cur_env, None, [])
             var_ty = checked.typeof
             state[name] = cast(Term, checked.substitute(state))
+          local_bindings[name] = (vloc, var_ty)
           cur_env = cur_env.declare_term_var(vloc, name, var_ty, local=True)
         case ImpAssign(_, lhs, rhs):
           target = cast(LValueVar, lhs)
@@ -547,7 +554,11 @@ def proc_obligations(decl: ProcDecl,
     emit_posts(None, givens)
 
   walk(decl.body, {}, _proc_givens(decl), base_env)
-  return base_env, obligations
+  discharge_env = base_env
+  for (name, (vloc, var_ty)) in local_bindings.items():
+    discharge_env = discharge_env.declare_term_var(vloc, name, var_ty,
+                                                    local=True)
+  return discharge_env, obligations
 
 def verify_proc(decl: ProcDecl, env: Env) -> None:
   # Phase 2f (issue #1115): verify a straight-line procedure by discharging

--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -430,7 +430,13 @@ def _proc_verifiable(decl: ProcDecl) -> bool:
 def _proc_givens(decl: ProcDecl) -> list[tuple[str, Formula]]:
   # Entry givens: every `requires` clause, in source order. Repeated clauses
   # are conjoined by the obligation's `givens_formula`. The generated
-  # `requiresN` labels are only for the `Givens:` presentation.
+  # `requiresN` labels (like the `assertN`/`assumeN`/`ifN` labels
+  # `proc_obligations` generates) are internal: they drive auto-discharge and
+  # the `Givens:` presentation, but are deliberately not citable by name from a
+  # manual inline proof (uniquify, which resolves proof `PVar`s, runs before
+  # these are created). Binding in-scope givens for manual imperative proofs is
+  # the proof-slot/context work of Phase 2n (#1123); keeping auto-labeled facts
+  # available only to automation (not by a fabricated name) matches #1125.
   givens: list[tuple[str, Formula]] = []
   for spec in decl.specs:
     if spec.keyword == 'requires':

--- a/test/imperative/should-error/proc_assume_scope.pf
+++ b/test/imperative/should-error/proc_assume_scope.pf
@@ -1,0 +1,7 @@
+// Phase 2g (issue #1116): an assumed fact becomes a given only for the
+// statements that follow the `assume`. Here the `assert b` precedes
+// `assume b`, so nothing in scope justifies it and the assertion fails.
+proc premature(b: bool) {
+  assert b
+  assume b
+}

--- a/test/imperative/should-error/proc_assume_scope.pf.err
+++ b/test/imperative/should-error/proc_assume_scope.pf.err
@@ -1,0 +1,4 @@
+./test/imperative/should-error/proc_assume_scope.pf:5.3-5.11: incomplete proof
+could not prove this assertion obligation
+Goal:
+	b

--- a/test/imperative/should-error/proc_fact_scope.pf
+++ b/test/imperative/should-error/proc_fact_scope.pf
@@ -1,0 +1,10 @@
+// Phase 2g (issue #1116): a fact established inside a branch is available only
+// within that branch, not after the `if`. `b` is asserted (and holds) inside
+// the then-branch, but the `assert b` after the `if` must also hold on the
+// else-path -- where the only given is `not b` -- so it fails there.
+proc leaky(b: bool) {
+  if b {
+    assert b
+  }
+  assert b
+}

--- a/test/imperative/should-error/proc_fact_scope.pf.err
+++ b/test/imperative/should-error/proc_fact_scope.pf.err
@@ -1,0 +1,6 @@
+./test/imperative/should-error/proc_fact_scope.pf:9.3-9.11: incomplete proof
+could not prove this assertion obligation
+Goal:
+	b
+Givens:
+	if0: not b

--- a/test/imperative/should-error/proc_if_cond_type.pf
+++ b/test/imperative/should-error/proc_if_cond_type.pf
@@ -1,0 +1,11 @@
+// Phase 2g (issue #1116): an `if` condition must have type `bool`.
+union Color {
+  red
+  green
+}
+
+proc badcond(c: Color) {
+  if c {
+    assert true
+  }
+}

--- a/test/imperative/should-error/proc_if_cond_type.pf.err
+++ b/test/imperative/should-error/proc_if_cond_type.pf.err
@@ -1,0 +1,2 @@
+./test/imperative/should-error/proc_if_cond_type.pf:8.6-8.7: expected a term of type bool
+but got term c of type Color

--- a/test/imperative/should-error/proc_if_partial_return.pf
+++ b/test/imperative/should-error/proc_if_partial_return.pf
@@ -1,0 +1,9 @@
+// Phase 2g (issue #1116): when only some branches of an `if` return, the
+// procedure can still finish without returning a value, so a declared return
+// type is rejected conservatively (partial-return diagnosis). The then-branch
+// returns, but the missing `else` falls through.
+proc partial(b: bool) -> bool {
+  if b {
+    return true
+  }
+}

--- a/test/imperative/should-error/proc_if_partial_return.pf.err
+++ b/test/imperative/should-error/proc_if_partial_return.pf.err
@@ -1,0 +1,1 @@
+./test/imperative/should-error/proc_if_partial_return.pf:5.1-9.2: procedure 'partial' declares return type bool but may finish without returning a value

--- a/test/imperative/should-error/proc_if_postcondition.pf
+++ b/test/imperative/should-error/proc_if_postcondition.pf
@@ -1,0 +1,19 @@
+// Phase 2g (issue #1116): both branches of an `if` are verified against the
+// continuation, so a postcondition that holds on one branch but not the other
+// is rejected. The then-branch returns `pos` (satisfying `ensures result =
+// pos`), but the else-branch returns `neg`, which violates it -- the failure
+// is reported at the postcondition with the else-path given `not b` shown.
+union Sign {
+  neg
+  pos
+}
+
+proc bad(b: bool) -> Sign
+  ensures result = pos
+{
+  if b {
+    return pos
+  } else {
+    return neg
+  }
+}

--- a/test/imperative/should-error/proc_if_postcondition.pf.err
+++ b/test/imperative/should-error/proc_if_postcondition.pf.err
@@ -1,0 +1,6 @@
+./test/imperative/should-error/proc_if_postcondition.pf:12.3-12.23: incomplete proof
+could not prove this postcondition obligation
+Goal:
+	neg = pos
+Givens:
+	if0: not b

--- a/test/imperative/should-validate/ghost_noninterference.pf
+++ b/test/imperative/should-validate/ghost_noninterference.pf
@@ -2,10 +2,11 @@
 // and `ghost var` locals are proof-only. Runtime data may freely flow *into*
 // ghost bindings, and ghost bindings may reference each other, so every flow
 // below is accepted. (Ghost-to-runtime flows are rejected -- see the
-// `ghost_flow_*` fixtures under should-error.) The body stays otherwise
-// unverified, so the Phase 1m "accepted but not verified" warning still fires.
+// `ghost_flow_*` fixtures under should-error.) The straight-line/`if` body is
+// now verified (Phase 2g, issue #1116): `result` is the runtime value `x` on
+// both branches, so `ensures result = x` discharges and no warning fires.
 proc mix(x: bool, ghost g: bool) -> bool
-  ensures g or not g
+  ensures result = x
 {
   ghost var gv := g          // ghost <- ghost, ok
   ghost var gr := x          // ghost <- runtime, ok (runtime flows into ghost)

--- a/test/imperative/should-validate/ghost_noninterference.pf.warn
+++ b/test/imperative/should-validate/ghost_noninterference.pf.warn
@@ -1,1 +1,0 @@
-./test/imperative/should-validate/ghost_noninterference.pf:7.1-22.2: warning: proc 'mix' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/nested_var_shadow.pf
+++ b/test/imperative/should-validate/nested_var_shadow.pf
@@ -1,6 +1,8 @@
 // Nested-block `var` shadowing must not emit a spurious "already defined"
 // warning: the inner `var a` is a distinct block-local that uniquify
 // alpha-renames, shadowing the outer `a` in a nested scope (issue #1144).
+// `demo` has no specs, so Phase 2g (issue #1116) verifies it (both `if`
+// branches, no obligations) and it is warning-free.
 proc demo(flag: bool)
 {
   var a := flag

--- a/test/imperative/should-validate/nested_var_shadow.pf.warn
+++ b/test/imperative/should-validate/nested_var_shadow.pf.warn
@@ -1,1 +1,0 @@
-./test/imperative/should-validate/nested_var_shadow.pf:4.1-12.2: warning: proc 'demo' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/proc_assert_proof_local.pf
+++ b/test/imperative/should-validate/proc_assert_proof_local.pf
@@ -1,0 +1,22 @@
+// Phase 2g (issue #1116): an inline `assert P by <proof>` is verified with the
+// body's locals in scope, so the attached proof may reference a local in an
+// intermediate step even though the obligation goal and givens are substituted
+// down to the parameters. Here `y` is a local, and the proof's `have h: y = y`
+// step names it directly. Regression for PR #1165 review (P2): the verifier
+// briefly discharged obligations in a parameters-only environment, which
+// reported `undefined variable y` for exactly this shape. A branch-local
+// (`z`, declared inside the `if`) is likewise in scope for its branch's proof.
+proc p(x: bool) {
+  var y := x
+  assert true by {
+    have h: y = y by reflexive
+    .
+  }
+  if x {
+    var z := x
+    assert true by {
+      have h: z = z by reflexive
+      .
+    }
+  }
+}

--- a/test/imperative/should-validate/proc_body_if_returns.pf
+++ b/test/imperative/should-validate/proc_body_if_returns.pf
@@ -3,7 +3,9 @@
 // not trigger the missing-return diagnostic. Regression for a missing-return
 // bug (PR #1145 review) where only the *last* statement was inspected: the
 // guaranteed return here is not the last statement, so the earlier version
-// wrongly reported that `pick` could finish without returning.
+// wrongly reported that `pick` could finish without returning. `pick` has no
+// specs, so Phase 2g (issue #1116) verifies it with no obligations and no
+// warning.
 union Color {
   red
   green

--- a/test/imperative/should-validate/proc_body_if_returns.pf.warn
+++ b/test/imperative/should-validate/proc_body_if_returns.pf.warn
@@ -1,1 +1,0 @@
-./test/imperative/should-validate/proc_body_if_returns.pf:12.1-20.2: warning: proc 'pick' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/proc_body_locals.pf
+++ b/test/imperative/should-validate/proc_body_locals.pf
@@ -1,16 +1,17 @@
-// Phase 2d (issue #1113): straight-line procedure bodies are now type-checked
-// -- annotated and inferred local `var` declarations, assignment to a local
+// Phase 2d (issue #1113): straight-line procedure bodies are type-checked --
+// annotated and inferred local `var` declarations, assignment to a local
 // variable, nested `if`-block scope, and a `return` matching the declared
-// result type. The body stays otherwise unverified, so the Phase 1m
-// "accepted but not verified" warning (issue #1108) still fires; the
-// `.pf.warn` sibling pins it under both parsers.
+// result type. Phase 2g (issue #1116) now also verifies the `if`: `c` holds
+// `green` on the then-branch and `red` on the else-branch, so the
+// branch-covering postcondition `result = red or result = green` discharges
+// on both paths and no warning fires.
 union Color {
   red
   green
 }
 
 proc classify(flag: bool) -> Color
-  ensures flag or not flag
+  ensures result = red or result = green
 {
   var a : bool := flag       // annotated local
   var b := a                 // inferred local, bool

--- a/test/imperative/should-validate/proc_body_locals.pf.warn
+++ b/test/imperative/should-validate/proc_body_locals.pf.warn
@@ -1,1 +1,0 @@
-./test/imperative/should-validate/proc_body_locals.pf:12.1-26.2: warning: proc 'classify' is accepted but not verified -- parsing and declaration plumbing succeeded, but no verifier has run on its body or specs yet (experimental imperative layer, issue #854)

--- a/test/imperative/should-validate/proc_control_flow.pf
+++ b/test/imperative/should-validate/proc_control_flow.pf
@@ -1,0 +1,57 @@
+// Phase 2g (issue #1116): control-flow verification. An `if` splits the proof
+// into two paths -- the then-path carries the condition as a given, the
+// else-path its negation -- and both must satisfy everything that follows.
+// A missing `else` is treated as `skip`. An `assume` adds a proof-only given
+// for the statements after it. Every procedure here is fully verified, so the
+// missing `.pf.warn` sibling pins that this run is warning-free.
+union Sign {
+  neg
+  pos
+}
+
+// The postcondition depends on the branch taken: `result` is `pos` on the
+// then-path and `neg` on the else-path, and `result = pos or result = neg`
+// discharges on both.
+proc classify(b: bool) -> Sign
+  ensures result = pos or result = neg
+{
+  if b {
+    return pos
+  } else {
+    return neg
+  }
+}
+
+// The branch condition (and its negation) is available as a given inside the
+// corresponding branch, and an `else`-less `if` leaves the missing branch as
+// `skip` -- the continuation still verifies on the skipped path.
+proc guards(b: bool, c: bool) {
+  if b {
+    assert b
+  } else {
+    assert not b
+  }
+  if c {
+    assert c
+  }
+}
+
+// An `else` branch made unreachable by the entry `requires` discharges any
+// obligation (here `assert false`): the contradiction `b` and `not b` entails
+// everything.
+proc unreachable_else(b: bool)
+  requires b
+{
+  if b {
+    assert b
+  } else {
+    assert false
+  }
+}
+
+// An `assume` contributes its formula as a given to the statements that follow
+// it (and only those), letting the later `assert` discharge.
+proc assumed(b: bool) {
+  assume b
+  assert b
+}

--- a/test/unit/test_imperative_verify.py
+++ b/test/unit/test_imperative_verify.py
@@ -176,6 +176,30 @@ def test_assume_supplies_a_downstream_given() -> None:
   assert [str(f) for (_l, f) in obs[0].givens] == ['x']
 
 
+def test_locals_remain_in_the_discharge_environment() -> None:
+  # The returned discharge environment carries the body's locals, not just the
+  # parameters, so an attached inline-assert proof (`assert P by <proof>`) can
+  # reference a local even though goals and givens are substituted down to
+  # parameters. Regression for the PR #1165 review (P2).
+  decl = _proc('p', [_param('x')], None, [],
+               [ImpVar(_meta(), 'y', None, _rv('x')),
+                ImpAssert(_meta(), _rv('x'), None)])
+  env_out, _obs = proc_obligations(decl, _env())
+  assert 'x' in env_out.dict
+  assert 'y' in env_out.dict
+
+
+def test_branch_locals_reach_the_discharge_environment() -> None:
+  # A local declared inside a branch is likewise gathered into the discharge
+  # environment (uniquify keeps its name distinct, so no clash with same-named
+  # locals on other paths).
+  decl = _proc('q', [_param('x')], None, [],
+               [ImpIf(_meta(), _rv('x'),
+                      [ImpVar(_meta(), 'y', None, _rv('x'))], None)])
+  env_out, _obs = proc_obligations(decl, _env())
+  assert 'y' in env_out.dict
+
+
 def test_void_fall_through_checks_postconditions_without_a_result() -> None:
   # A procedure with no return value exits by falling off the end; its
   # postconditions must hold there and may not mention `result`.

--- a/test/unit/test_imperative_verify.py
+++ b/test/unit/test_imperative_verify.py
@@ -1,17 +1,19 @@
-"""Unit tests for straight-line procedure verification (issue #1115, Phase 2f).
+"""Unit tests for procedure verification (issues #1115 Phase 2f, #1116 Phase
+2g).
 
-`checker_pipeline.proc_obligations` performs forward symbolic execution over a
-`_proc_verifiable` procedure and returns the verification conditions it
-generates (without discharging them), so the weakest-precondition formulas can
-be pinned here without the CLI or the stdlib. `verify_proc` then discharges
-what it returns -- exercised at the end for one provable and one false goal.
+`checker_pipeline.proc_obligations` performs path-sensitive forward symbolic
+execution over a `_proc_verifiable` procedure and returns the verification
+conditions it generates (without discharging them), so the weakest-precondition
+formulas can be pinned here without the CLI or the stdlib. `verify_proc` then
+discharges what it returns -- exercised at the end for one provable and one
+false goal.
 """
 
 from lark.tree import Meta
 
 from abstract_syntax import (
-    BoolType, Env, ImpAssert, ImpAssign, ImpIf, ImpReturn, ImpVar, LValueVar,
-    MutableArrayType, ResolvedVar,
+    Bool, BoolType, Env, ImpAssert, ImpAssign, ImpAssume, ImpIf, ImpReturn,
+    ImpVar, ImpWhile, LValueVar, MutableArrayType, ResolvedVar,
 )
 from abstract_syntax.declarations import ProcDecl, ProcParam, ProcSpec
 from abstract_syntax.literals import mkEqual
@@ -125,6 +127,55 @@ def test_assert_raises_a_goal_and_then_supplies_a_fact() -> None:
   assert [str(f) for (_l, f) in obs[1].givens] == ['x = y', 'x = y']
 
 
+def test_if_generates_a_postcondition_per_branch_with_the_condition() -> None:
+  # Phase 2g (issue #1116): an `if` splits verification into two paths. Each
+  # branch's `return` discharges the postcondition on its own path, carrying
+  # the branch condition (then) or its negation (else) as a given.
+  decl = _proc('pick', [_param('x')], _bool(),
+               [ProcSpec(_meta(), 'ensures', mkEqual(_meta(), _rv('result'),
+                                                     _rv('x')))],
+               [ImpIf(_meta(), _rv('x'),
+                      [ImpReturn(_meta(), _rv('x'))],
+                      [ImpReturn(_meta(), _rv('x'))])],
+               'result')
+  _env_out, obs = proc_obligations(decl, _env())
+  assert [str(o.kind) for o in obs] == ['postcondition', 'postcondition']
+  # `result` is `x` on both paths, so each goal is `x = x`.
+  assert [str(o.goal) for o in obs] == ['x = x', 'x = x']
+  # The then-path sees the condition; the else-path sees its negation.
+  assert [str(f) for (_l, f) in obs[0].givens] == ['x']
+  assert [str(f) for (_l, f) in obs[1].givens] == ['not x']
+
+
+def test_elseless_if_skips_the_missing_branch() -> None:
+  # A missing `else` is `skip`: the continuation is still checked on the
+  # else-path, with the negated condition as a given. Here the void proc's
+  # postcondition is checked on both the then-path (given `x`) and the
+  # fall-through else-path (given `not x`).
+  decl = _proc('guard', [_param('x')], None,
+               [ProcSpec(_meta(), 'ensures', _rv('x'))],
+               [ImpIf(_meta(), _rv('x'),
+                      [ImpAssert(_meta(), _rv('x'), None)], None)])
+  _env_out, obs = proc_obligations(decl, _env())
+  # then-path: the `assert` obligation, then the postcondition; else-path: just
+  # the postcondition.
+  assert [str(o.kind) for o in obs] == \
+      ['assertion', 'postcondition', 'postcondition']
+  assert [str(f) for (_l, f) in obs[0].givens] == ['x']
+  assert [str(f) for (_l, f) in obs[-1].givens] == ['not x']
+
+
+def test_assume_supplies_a_downstream_given() -> None:
+  # Phase 2g (issue #1116): `assume P` raises no obligation but adds `P` as a
+  # given for the statements that follow it (here the later `assert`).
+  decl = _proc('assumed', [_param('x')], None, [],
+               [ImpAssume(_meta(), _rv('x')),
+                ImpAssert(_meta(), _rv('x'), None)])
+  _env_out, obs = proc_obligations(decl, _env())
+  assert [str(o.kind) for o in obs] == ['assertion']
+  assert [str(f) for (_l, f) in obs[0].givens] == ['x']
+
+
 def test_void_fall_through_checks_postconditions_without_a_result() -> None:
   # A procedure with no return value exits by falling off the end; its
   # postconditions must hold there and may not mention `result`.
@@ -144,9 +195,31 @@ def test_straight_line_body_is_verifiable() -> None:
   assert _proc_verifiable(decl)
 
 
-def test_branch_defers_verification() -> None:
+def test_branch_is_verifiable() -> None:
+  # Phase 2g (issue #1116): an `if` over otherwise-verifiable statements is now
+  # itself verifiable (was deferred in Phase 2f). A missing `else` is `skip`.
   decl = _proc('branchy', [_param('x')], None, [],
                [ImpIf(_meta(), _rv('x'), [], None)])
+  assert _proc_verifiable(decl)
+
+
+def test_branch_with_unmodeled_statement_defers() -> None:
+  # `_stmt_verifiable` recurses into branch bodies, so a still-unmodeled
+  # construct (here a `while`) nested inside a branch defers the whole proc.
+  loop = ImpWhile(_meta(), _rv('x'), [], [], None, [])
+  decl = _proc('loopy', [_param('x')], None, [],
+               [ImpIf(_meta(), _rv('x'), [loop], None)])
+  assert not _proc_verifiable(decl)
+
+
+def test_branch_assigning_to_a_parameter_defers() -> None:
+  # `_assigns_to_a_parameter` recurses into branches, so a parameter assignment
+  # nested in a branch still defers (entry/exit ambiguity, #1120).
+  decl = _proc('sneaky_branch', [_param('x')], None,
+               [ProcSpec(_meta(), 'ensures', _rv('x'))],
+               [ImpIf(_meta(), _rv('x'),
+                      [ImpAssign(_meta(), LValueVar(_meta(), 'x'),
+                                 Bool(_meta(), None, True))], None)])
   assert not _proc_verifiable(decl)
 
 


### PR DESCRIPTION
## Phase 2g: verify `if`, `assert`, and `assume` control flow (issue #1116)

Extends the straight-line procedure verifier (Phase 2f, #1115) to finite
branching and proof-only assumptions. Both dependencies (#1114, #1115) merged
earlier today, so this slice was unblocked.

### What changed

**`checker_pipeline.proc_obligations` is now path-sensitive.** An `if` splits
the current path in two — the then-path carries the condition as a given, the
else-path its negation — and both branches continue through the statements that
follow the `if`. A missing `else` is treated as `skip`. A `return` ends its
path (discharging the postconditions with the returned value substituted for
`result`); a path that falls off the end discharges the postconditions with
`result` unbound. Each path keeps its own symbolic `state` and `givens`, so a
fact asserted or assumed on one branch is **not** visible on the other branch,
nor before the statement that established it. Given labels are derived from
`len(givens)` per path, so obligation/given ordering is deterministic.

**`assume P`** is now type-checked (formula must be `bool`) and modeled by the
verifier: it contributes `P` as a proof-only given to the statements that
follow, with no runtime effect and no state contribution. Previously it was
deferred wholesale.

**Verifiability gate.** `_stmt_verifiable` now accepts `if` (recursively) and
`assume`; `_assigns_to_a_parameter` recurses into branches so a branch-nested
assignment to a parameter still defers (entry/exit ambiguity, #1120). Loops,
calls, allocations, and heap writes remain out of scope. Missing-return on a
partial branch return is already diagnosed conservatively by
`_block_always_returns`.

The obligation-discharge environment is now the parameter environment
(`base_env`) rather than the final locals-laden one: every goal and given is
substituted through `state` to mention only parameters, so the locals were
never needed.

### Fixtures (`test/imperative`, both parsers, prelude-free)

- **New positive** `should-validate/proc_control_flow.pf`: branch-dependent
  postcondition, per-branch condition as a given, `else`-less `if` as `skip`,
  an unreachable `else` discharging `assert false` by contradiction, and an
  `assume`-then-`assert`.
- **New negatives** `should-error/`: `proc_if_postcondition.pf` (postcondition
  fails on one branch, deterministic `if0: not b` given shown),
  `proc_fact_scope.pf` (a fact asserted inside a branch is not available after
  the `if`), `proc_assume_scope.pf` (an `assert` before its `assume` fails),
  `proc_if_partial_return.pf` (partial-return diagnosis),
  `proc_if_cond_type.pf` (non-`bool` condition).
- **Retired** four `.pf.warn` siblings: `ghost_noninterference`,
  `proc_body_locals`, `proc_body_if_returns`, `nested_var_shadow` all contain
  `if` and now verify rather than defer. The two tautology postconditions
  (`… or not …`) that the weak auto-discharge cannot prove were replaced with
  provable branch-covering ones (`result = x`, `result = red or result =
  green`).

### Testing

- `python3 test-deduce.py --imperative` — all pass (both parsers).
- `python3 test-deduce.py` (full default suite) — all pass.
- `python3 -m ruff check .` and `python3 -m mypy .` — clean.

### Notes / follow-ups

- Auto-discharge (`checker_logic.check_implies` + `reduce`) is still weak: it
  proves structural/constructor equality, And/Or/IfThen decomposition, and
  modus-ponens contradictions, but not classical tautologies like `b or not b`.
  Positive postconditions are chosen to fall inside that fragment.
- Out of scope (per the issue): loops, heap writes, calls, alias analysis —
  later Phase 2 slices.

Resume this session on ginger: `~/deduce-runner/resume.sh ea9650b3-2dc9-43b4-8ca5-920ff40350df routine/20260807-220202`

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
