### PR TITLE
Resolve `<`/`length` in array_bounds_goal so read bounds discharge (closes #1166)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -577,26 +577,16 @@ def _array_bounds_obligation(aloc: Meta, array_name: str,
                              arr_binding: TermBinding, index: Term,
                              givens: list[tuple[str, Formula]],
                              env: Env) -> 'ImperativeObligation':
-  # The in-bounds obligation `i < length(a)` for a mutable-array access (#1118).
-  # Built by *type-checking* a `<`/`length` call so the operators resolve
-  # against their operand types exactly as a user's `requires i < length(a)`
-  # premise does -- a bare-name `<` (as `imperative_verifier.array_bounds_goal`
-  # builds for the unwired read path, #1166) would not match the resolved `<`
-  # in the premise once `discharge` reduces both sides. `length` is invariant
-  # under writes, so the base array handle is used regardless of earlier writes.
-  from imperative_verifier import ImperativeObligation, ObligationKind
+  # The in-bounds obligation `i < length(a)` for a mutable-array write `a[i]`
+  # (#1118). The goal is built by `index_in_bounds_goal`, shared with the read
+  # path so both resolve `<`/`length` identically (#1166). `length` is
+  # invariant under writes, so the base array handle -- not any symbolic write
+  # state -- is used as the `length` argument regardless of earlier writes.
+  from imperative_verifier import (
+      ImperativeObligation, ObligationKind, index_in_bounds_goal)
   base_handle = OverloadedVar(arr_binding.location, arr_binding.typ,
                               [array_name])
-  length_names = [n for n in env.dict if base_name(n) == 'length']
-  lt_names = [n for n in env.dict if base_name(n) == '<']
-  if not length_names or not lt_names:
-    user_error(aloc, 'a mutable-array bounds check needs `length` and `<` in '
-               'scope; add `import List` and `import UInt`')
-  length_call = Call(aloc, None, OverloadedVar(aloc, None, length_names),
-                     [base_handle])
-  lt_call = Call(aloc, None, OverloadedVar(aloc, None, lt_names),
-                 [index, length_call])
-  goal = cast(Formula, type_check_formula(lt_call, env))
+  goal = index_in_bounds_goal(aloc, base_handle, index, env)
   return ImperativeObligation(aloc, goal, ObligationKind.ARRAY_BOUNDS,
                               givens=list(givens))
 

--- a/imperative_verifier.py
+++ b/imperative_verifier.py
@@ -34,8 +34,8 @@ from lark.tree import Meta
 
 import style
 from abstract_syntax import (
-    And, ArrayGet, ArrayLength, Bool, Call, Env, Formula, Proof, ResolvedVar,
-    is_true,
+    And, ArrayGet, Bool, Call, Env, Formula, OverloadedVar, Proof, Term,
+    base_name, is_true,
 )
 
 
@@ -154,21 +154,46 @@ class ImperativeObligation:
 
 # --- array-bounds obligations for mutable-array reads (issue #1117) ----------
 
-def array_bounds_goal(read: ArrayGet) -> Formula:
+def index_in_bounds_goal(loc: Meta, handle: Term, index: Term,
+                         env: Env) -> Formula:
+  """The in-bounds goal ``index < length(handle)`` for a mutable-array access.
+
+  Built by *type-checking* a surface ``index < length(handle)`` call against
+  ``env`` so the ``<`` and ``length`` operators resolve against their operand
+  types exactly as a user's ``requires i < length(a)`` premise does. Unlike
+  ``=`` -- which the checker treats specially -- ``<`` is an ordinary stdlib
+  function, so a bare-name ``ResolvedVar('<')`` would not match the
+  resolved/uniquified ``<`` a real premise carries and the obligation would
+  never discharge (issue #1166). ``length(handle)`` on a mutable-array handle
+  type-checks to the symbolic ``ArrayLength`` node the premise also carries.
+
+  Shared by the read path (``array_bounds_goal``) and the write path
+  (``checker_pipeline._array_bounds_obligation``) so both build the identical
+  goal -- the ``handle`` term is the only thing they supply differently (the
+  read's array subject vs. the write's base array handle, which ignores earlier
+  writes in the symbolic state)."""
+  from checker_types import type_check_formula
+  from error import user_error
+  length_names = [n for n in env.dict if base_name(n) == 'length']
+  lt_names = [n for n in env.dict if base_name(n) == '<']
+  if not length_names or not lt_names:
+    user_error(loc, 'a mutable-array bounds check needs `length` and `<` in '
+               'scope; add `import List` and `import UInt`')
+  length_call = Call(handle.location, None,
+                     OverloadedVar(handle.location, None, length_names),
+                     [handle])
+  lt_call = Call(loc, None, OverloadedVar(loc, None, lt_names),
+                 [index, length_call])
+  return cast(Formula, type_check_formula(lt_call, env))
+
+
+def array_bounds_goal(read: ArrayGet, env: Env) -> Formula:
   """The bounds proof goal ``i < length(a)`` for a mutable-array read ``a[i]``.
 
-  ``read`` is an already-type-checked ``ArrayGet`` over a mutable array. The
-  goal is built with a base-name ``ResolvedVar('<')`` over an ``ArrayLength``
-  node. NOTE (issue #1166): this bare-name ``<`` does not match a resolved
-  ``<`` from a ``requires`` clause once ``discharge`` reduces both sides --
-  discharging a bounds obligation against a real premise needs the operator
-  resolved against its operand types (see
-  ``checker_pipeline._array_bounds_obligation``, which builds the write-bounds
-  goal that way for #1118)."""
-  loc = read.location
-  length = ArrayLength(read.subject.location, None, read.subject)
-  return cast(Formula, Call(loc, None, ResolvedVar(loc, None, '<'),
-                            [read.position, length]))
+  ``read`` is an already-type-checked ``ArrayGet`` over a mutable array; the
+  goal resolves its ``<``/``length`` operators against ``env`` -- see
+  ``index_in_bounds_goal`` (issue #1166)."""
+  return index_in_bounds_goal(read.location, read.subject, read.position, env)
 
 
 def _read_key(read: ArrayGet) -> Tuple[object, object, str]:
@@ -189,16 +214,18 @@ class ArrayBoundsObligations:
   _seen: Set[Tuple[object, object, str]] = field(default_factory=set)
   _obligations: List[ImperativeObligation] = field(default_factory=list)
 
-  def record(self, read: ArrayGet,
+  def record(self, read: ArrayGet, env: Env,
              givens: Sequence[Tuple[str, Formula]] = ()) -> None:
-    """Record the bounds obligation for one mutable-array read. A read whose
-    source access was already recorded in this pass is ignored."""
+    """Record the bounds obligation for one mutable-array read. ``env`` is the
+    scope the read appears in -- the ``<``/``length`` operators of the goal
+    resolve against it. A read whose source access was already recorded in
+    this pass is ignored."""
     key = _read_key(read)
     if key in self._seen:
       return
     self._seen.add(key)
     self._obligations.append(
-        ImperativeObligation(read.location, array_bounds_goal(read),
+        ImperativeObligation(read.location, array_bounds_goal(read, env),
                              ObligationKind.ARRAY_BOUNDS,
                              givens=list(givens)))
 

--- a/test/unit/test_array_bounds.py
+++ b/test/unit/test_array_bounds.py
@@ -1,21 +1,24 @@
 """Unit tests for mutable-array read typing and array-bounds obligations
-(issue #1117, Phase 2h).
+(issue #1117, Phase 2h; issue #1166).
 
 Two halves, both exercised without the CLI or the stdlib:
 
   * ``type_synth_term`` on an ``ArrayGet`` distinguishes the pure ``[T]`` path
     (unchanged) from the mutable ``[T]!`` path (element type + index check);
-  * ``imperative_verifier`` builds and deduplicates the ``i < length(a)``
-    bounds obligation for a mutable-array read.
+  * ``imperative_verifier`` builds, deduplicates, and discharges the
+    ``i < length(a)`` bounds obligation for a mutable-array read. The goal's
+    ``<``/``length`` operators are *resolved* against the scope (not bare
+    names), so the obligation discharges from a ``requires i < length(a)``
+    premise that carries the same resolved operators (issue #1166).
 """
 
 from lark.tree import Meta
 
 from abstract_syntax import (
-    ArrayGet, ArrayLength, ArrayType, BoolType, Call, Env, MutableArrayType,
-    ResolvedVar,
+    ArrayGet, ArrayLength, ArrayType, BoolType, Call, Env, FunctionType,
+    MutableArrayType, OverloadedVar, ResolvedVar, base_name,
 )
-from checker_types import type_synth_term
+from checker_types import type_check_formula, type_synth_term
 from error import IncompleteProof, UserError
 from imperative_verifier import (
     ArrayBoundsObligations, ImperativeObligation, ObligationKind,
@@ -46,14 +49,19 @@ def _rv(name: str) -> ResolvedVar:
 
 def _uint_type() -> ResolvedVar:
   # A stand-in for the `UInt` type: `_check_array_index_type` only inspects the
-  # type's base name, so a bare `UInt` reference is enough here -- no stdlib.
+  # type's base name, and the `<`/`length` signatures below only compare it by
+  # equality, so a bare `UInt` reference is enough here -- no stdlib.
   return ResolvedVar(_meta(), None, 'UInt')
 
 
 def _typing_env() -> Env:
-  # A bare env with array/scalar term vars -- no stdlib needed because the
-  # ArrayGet path only reads the subject's `typeof` and (for the mutable path)
-  # the index's `typeof`.
+  # A bare env with array/scalar term vars plus resolved `<` and `length`
+  # operators. No stdlib is needed: the ArrayGet path only reads the subject's
+  # `typeof` and (for the mutable path) the index's `typeof`, and the
+  # bounds-goal path only needs a `<` (UInt, UInt) -> bool and a `length`
+  # returning the index type in scope. The operators carry uniquified-style
+  # names (`<.op`, `length.op`) so a bare-name `<` is visibly distinct from
+  # the resolved one a real premise would carry (issue #1166).
   env = _env()
   env = env.declare_term_var(_meta(), 'marr',
                              MutableArrayType(_meta(), BoolType(_meta())))
@@ -61,12 +69,41 @@ def _typing_env() -> Env:
                              ArrayType(_meta(), BoolType(_meta())))
   env = env.declare_term_var(_meta(), 'idx', _uint_type())
   env = env.declare_term_var(_meta(), 'flag', BoolType(_meta()))
+  env = env.declare_term_var(
+      _meta(), '<.op',
+      FunctionType(_meta(), [], [_uint_type(), _uint_type()],
+                   BoolType(_meta())))
+  env = env.declare_term_var(
+      _meta(), 'length.op',
+      FunctionType(_meta(), [], [_uint_type()], _uint_type()))
   return env
 
 
 def _read(subject: str = 'marr', index: str = 'idx',
           start: int = 0, end: int = 5) -> ArrayGet:
   return ArrayGet(_meta(start, end), None, _rv(subject), _rv(index))
+
+
+def _typed_read(subject: str = 'marr', index: str = 'idx',
+                start: int = 0, end: int = 5,
+                env: Env | None = None) -> ArrayGet:
+  # An `ArrayGet` whose subject/position carry resolved types, the shape the
+  # verifier hands to `array_bounds_goal`.
+  ret = type_synth_term(_read(subject, index, start, end),
+                        env or _typing_env(), None, [])
+  assert isinstance(ret, ArrayGet)
+  return ret
+
+
+def _user_premise(env: Env) -> object:
+  # How a `requires idx < length(marr)` clause type-checks: a surface `<` call
+  # over `length(marr)`, resolved against `env`. `array_bounds_goal` must build
+  # an identical formula for the obligation to discharge from this premise.
+  call = Call(_meta(), None, OverloadedVar(_meta(), None, ['<.op']),
+              [_rv('idx'),
+               Call(_meta(), None, OverloadedVar(_meta(), None, ['length.op']),
+                    [_rv('marr')])])
+  return type_check_formula(call, env)
 
 
 # --- ArrayType vs MutableArrayType typing -----------------------------------
@@ -105,17 +142,40 @@ def test_read_of_non_array_is_rejected() -> None:
 # --- bounds-obligation construction -----------------------------------------
 
 def test_bounds_goal_is_index_less_than_length() -> None:
-  goal = array_bounds_goal(_read('marr', 'idx'))
+  env = _typing_env()
+  goal = array_bounds_goal(_typed_read(env=env), env)
   assert isinstance(goal, Call)
-  assert isinstance(goal.rator, ResolvedVar) and goal.rator.get_name() == '<'
+  assert isinstance(goal.rator, ResolvedVar) and goal.rator.get_name() == '<.op'
   index, length = goal.args
   assert index == _rv('idx')
   assert isinstance(length, ArrayLength) and length.subject == _rv('marr')
 
 
+def test_bounds_goal_resolves_the_less_than_operator() -> None:
+  # The regression for #1166: the goal's `<` must be the *resolved* operator a
+  # user premise carries, not a bare-name `ResolvedVar('<')`.
+  env = _typing_env()
+  goal = array_bounds_goal(_typed_read(env=env), env)
+  assert isinstance(goal, Call)
+  assert base_name(goal.rator.get_name()) == '<'
+  assert goal.rator.get_name() != '<'
+  # It matches exactly the formula a type-checked `requires idx < length(marr)`
+  # premise produces.
+  assert goal == _user_premise(env)
+
+
+def test_bounds_goal_needs_operators_in_scope() -> None:
+  try:
+    array_bounds_goal(_typed_read(env=_typing_env()), _env())
+    assert False, 'expected a UserError when `<`/`length` are out of scope'
+  except UserError as e:
+    assert '`length` and `<`' in str(e)
+
+
 def test_recording_a_read_yields_one_array_bounds_obligation() -> None:
+  env = _typing_env()
   collector = ArrayBoundsObligations()
-  collector.record(_read())
+  collector.record(_typed_read(env=env), env)
   obligations = collector.obligations()
   assert len(obligations) == 1
   ob = obligations[0]
@@ -126,27 +186,49 @@ def test_recording_a_read_yields_one_array_bounds_obligation() -> None:
 
 
 def test_duplicate_source_access_is_recorded_once() -> None:
+  env = _typing_env()
   collector = ArrayBoundsObligations()
-  collector.record(_read(start=0, end=5))
-  collector.record(_read(start=0, end=5))   # same source access
-  collector.record(_read(start=6, end=11))  # a distinct access
+  collector.record(_typed_read(start=0, end=5, env=env), env)
+  collector.record(_typed_read(start=0, end=5, env=env), env)   # same access
+  collector.record(_typed_read(start=6, end=11, env=env), env)  # distinct
   assert len(collector.obligations()) == 2
 
 
 # --- discharge --------------------------------------------------------------
 
 def test_in_bounds_read_verifies_when_precondition_supplies_the_bound() -> None:
+  # The resolved goal discharges from a `requires idx < length(marr)` premise
+  # that carries the *same* resolved operators -- the case #1166 was about.
+  env = _typing_env()
   collector = ArrayBoundsObligations()
-  collector.record(_read(),
-                   givens=[('pre', array_bounds_goal(_read()))])
-  collector.obligations()[0].discharge(_env())  # returns normally
+  collector.record(_typed_read(env=env), env,
+                   givens=[('pre', _user_premise(env))])
+  collector.obligations()[0].discharge(env)  # returns normally
+
+
+def test_bare_name_less_than_does_not_discharge_from_a_resolved_premise() -> None:
+  # Pins the bug: a goal built with a bare-name `<` (the pre-#1166 shape) does
+  # NOT discharge from a premise carrying the resolved `<`, even though both
+  # read `idx < length(marr)` on the surface.
+  env = _typing_env()
+  bare_goal = Call(_meta(), None, ResolvedVar(_meta(), None, '<'),
+                   [_rv('idx'),
+                    ArrayLength(_meta(), None, _rv('marr'))])
+  ob = ImperativeObligation(_meta(), bare_goal, ObligationKind.ARRAY_BOUNDS,
+                            givens=[('pre', _user_premise(env))])
+  try:
+    ob.discharge(env)
+    assert False, 'expected an IncompleteProof for a bare-name `<` goal'
+  except IncompleteProof:
+    pass
 
 
 def test_missing_bounds_evidence_reports_array_bounds_diagnostic() -> None:
+  env = _typing_env()
   collector = ArrayBoundsObligations()
-  collector.record(_read())
+  collector.record(_typed_read(env=env), env)
   try:
-    collector.obligations()[0].discharge(_env())
+    collector.obligations()[0].discharge(env)
     assert False, 'expected an IncompleteProof'
   except IncompleteProof as e:
     assert 'array bounds' in str(e)


### PR DESCRIPTION
## What

Fixes #1166: `imperative_verifier.array_bounds_goal` built the mutable-array
read bounds goal `i < length(a)` with a **bare-name** `ResolvedVar('<')`
(mirroring the `mkEqual` idiom for `=`). But unlike `=` — which the checker
treats specially — `<` is an ordinary stdlib function, so a bare-name `<` never
compares equal to the resolved/uniquified `<` a user's `requires i < length(a)`
premise carries. When the read-bounds path is eventually wired to discharge
these obligations (#1117), they would never discharge against a matching
premise.

## Change

- `array_bounds_goal(read, env)` now builds the goal by **type-checking** a
  surface `i < length(a)` call against the read's scope, so `<` and `length`
  resolve against their operand types exactly as a user's `requires i < length(a)`
  premise does. `length(a)` on a mutable-array handle type-checks to the same
  symbolic `ArrayLength` node the premise carries. This mirrors the write-path
  construction (`checker_pipeline`, from #1118).
- `array_bounds_goal` and `ArrayBoundsObligations.record` now take the enclosing
  `Env`. There are no non-test callers on `main` yet (the read path is not wired
  to a body-walking pass — #1117 deferred that), so this is an isolated change.

## Tests

`test/unit/test_array_bounds.py`:
- the goal's operator is the *resolved* `<` (base name `<`, but not the bare
  string `<`) and the goal is `==` to a type-checked `requires idx < length(marr)`
  premise;
- the resolved goal **discharges** from that premise, while a bare-name `<` goal
  (the pre-fix shape) does **not** — pinning the regression;
- `array_bounds_goal` errors when `<`/`length` are out of scope.

All 623 unit tests pass; `test-deduce.py --imperative` passes; ruff + mypy clean
on the changed source.

Note: PR #1167 (Phase 2i) adds an analogous resolved-operator builder for the
*write* path in `checker_pipeline`; once both land, the two could share a helper
(a small dedup follow-up under #813). They are independent on `main` today.

Closes #1166. Refs #854, #1117, #1118.

Resume this session on ginger: `~/deduce-runner/resume.sh 0a0b60fe-b69f-45bd-8993-0e830c2d6175 routine/20260808-000202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
