### PR TITLE
Fix mark walkers: handle GenRecFun/Omitted in find_mark/replace_mark (closes #1169)

### DIFF
--- a/abstract_syntax/rewrite.py
+++ b/abstract_syntax/rewrite.py
@@ -143,6 +143,8 @@ def find_mark(formula: AST) -> None:
       find_mark(body)
     case RecFun(_, _, _, _, _, cases):
       pass
+    case GenRecFun(_, _, _, _, _, _, _, body, _):
+      pass
     case Conditional(_, _, cond, thn, els):
       find_mark(cond)
       find_mark(thn)
@@ -157,6 +159,8 @@ def find_mark(formula: AST) -> None:
       find_mark(rhs)
       find_mark(body)
     case Hole(_, _):
+      pass
+    case Omitted(_, _):
       pass
     case ArrayGet(_, _, arr, ind):
       find_mark(arr)
@@ -219,6 +223,8 @@ def replace_mark(formula: Term | SwitchCase, replacement: Term) -> Term | Switch
       return SwitchCase(loc2, pat, replace_mark(body, replacement))
     case RecFun(_, _, typarams, _, _, cases):
       return formula
+    case GenRecFun(_, _, _, _, _, _, _, body, _):
+      return formula
     case Conditional(loc2, tyof, cond, thn, els):
       return Conditional(loc2, tyof, replace_mark(cond, replacement),
                          replace_mark(thn, replacement),
@@ -233,6 +239,8 @@ def replace_mark(formula: Term | SwitchCase, replacement: Term) -> Term | Switch
       return TLet(loc2, tyof, var, replace_mark(rhs, replacement),
                   replace_mark(body, replacement))
     case Hole(loc2, tyof):
+      return formula
+    case Omitted(loc2, tyof):
       return formula
     case ArrayGet(loc2, tyof, arr, ind):
       return ArrayGet(loc2, tyof, replace_mark(arr, replacement), replace_mark(ind, replacement))
@@ -400,6 +408,8 @@ def rewrite_aux(loc: Meta, formula: Term | SwitchCase, equation: Formula | AutoR
     case SwitchCase(loc2, pat, body):
       return SwitchCase(loc2, pat, rewrite_aux(loc, body, equation, env, depth - 1))
     case RecFun(loc, _, typarams, _, _, cases):
+      return formula
+    case GenRecFun(_, _, _, _, _, _, _, body, _):
       return formula
     case Conditional(loc2, tyof, cond, thn, els):
       return Conditional(loc2, tyof, rewrite_aux(loc, cond, equation, env, depth - 1),

--- a/test/unit/test_ast_walker_completeness.py
+++ b/test/unit/test_ast_walker_completeness.py
@@ -7,8 +7,17 @@ from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
 from typing import Any, Iterable
 
+import pytest
+
 import abstract_syntax as ast
 import proof_checker
+from abstract_syntax.rewrite import (
+    MarkException,
+    count_marks,
+    find_mark,
+    remove_mark,
+    replace_mark,
+)
 from test_ast_invariants import _SPECIMEN_FACTORIES, _make, _meta
 
 
@@ -113,3 +122,43 @@ def test_check_proofs_hash_walker_includes_ast_child_fields() -> None:
                 missed_fields.append(f"{cls.__name__}.{field.name}")
 
     assert missed_fields == []
+
+
+# ---------------------------------------------------------------------------
+# Mark-walker agreement (issue #1169)
+# ---------------------------------------------------------------------------
+#
+# ``count_marks``/``find_mark``/``replace_mark`` in ``abstract_syntax.rewrite``
+# must traverse the same set of node types. ``GenRecFun`` and ``Omitted`` were
+# handled only by ``count_marks``, so the other two walkers fell through to
+# their ``_`` arm and raised ``internal_error`` on those subterms. These build
+# a formula that embeds each opaque node and assert all three walkers agree.
+
+# GenRecFun and Omitted are the two node types the sibling walkers used to miss;
+# RecFun and Hole are their already-handled siblings, included as controls.
+_OPAQUE_SUBTERM_SPECIMENS = ["GenRecFun", "Omitted", "RecFun", "Hole"]
+
+
+@pytest.mark.parametrize("spec_name", _OPAQUE_SUBTERM_SPECIMENS)
+def test_mark_walkers_agree_on_opaque_subterms(spec_name: str) -> None:
+    """find_mark/replace_mark traverse the nodes count_marks already handles."""
+    factory = next(
+        f for cls, f in _SPECIMEN_FACTORIES.items() if cls.__name__ == spec_name
+    )
+    opaque = factory()
+
+    # No mark present: every walker must complete without an internal_error.
+    no_mark = ast.And(_meta(), None, [opaque])
+    assert count_marks(no_mark) == 0
+    assert find_mark(no_mark) is None
+    assert replace_mark(no_mark, ast.Var(_meta(), None, "r")) == no_mark
+
+    # Mark placed after the opaque subterm forces the walkers to traverse the
+    # opaque node before reaching the mark.
+    subject = ast.Var(_meta(), None, "s")
+    marked = ast.And(_meta(), None, [opaque, ast.Mark(_meta(), None, subject)])
+    assert count_marks(marked) == 1
+    with pytest.raises(MarkException) as exc:
+        find_mark(marked)
+    assert exc.value.subject == subject
+    assert remove_mark(marked) == ast.And(_meta(), None, [opaque, subject])


### PR DESCRIPTION
## Summary

Fixes #1169: the three mark-walking functions in `abstract_syntax/rewrite.py`
disagreed on which AST node types they traverse. `count_marks` handled
`GenRecFun` and `Omitted` opaquely (the same way it already handles their
siblings `RecFun` and `Hole`), but `find_mark` and `replace_mark` had no `case`
for either — so both fell through to their `_` arm and raised `internal_error`
on those subterms.

This mirrors the existing `RecFun`/`Hole` opaque arms into both sibling
walkers, so the three now agree on the node set they traverse:

- `find_mark`: add `GenRecFun` and `Omitted` cases (both `pass`).
- `replace_mark`: add `GenRecFun` and `Omitted` cases (both `return formula`).

While here, I also noticed the sibling walker `rewrite_aux` in the same file has
the same shape of gap: it already handles `Omitted`/`RecFun`/`Hole` opaquely but
had **no `GenRecFun` case**, so a `GenRecFun` subterm would hit the same latent
`internal_error`. Added the matching `GenRecFun` case (`return formula`) to keep
the whole rewrite-walker family consistent.

## Testing

- Added a parametrized regression test in
  `test/unit/test_ast_walker_completeness.py`
  (`test_mark_walkers_agree_on_opaque_subterms`) that runs `count_marks`,
  `find_mark`, and `remove_mark`/`replace_mark` over a formula embedding each
  of `GenRecFun`, `Omitted`, `RecFun`, and `Hole` (the latter two as passing
  controls), both with and without an enclosing `Mark`. Verified the test fails
  (`InternalError`) on the pre-fix code and passes after.
- `python3 test-deduce.py --equiv` — all passed.
- `python3 test-deduce.py --passable` — all passed.

Note: `test/unit` runs under pytest, which is not installed in this container
and (per repo notes) is not CI-gated; the new test was validated locally with a
minimal pytest stub.

Closes #1169

Resume this session on ginger: `~/deduce-runner/resume.sh e1d7c685-433b-4672-be33-2dbf5c1c2f30 routine/20260808-020202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)