### PR TITLE
Phase 2l: verify local-state while-loop invariants (closes #1121)

### DIFF
--- a/checker_pipeline.py
+++ b/checker_pipeline.py
@@ -14,7 +14,7 @@ File charter:
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, cast
 
 from lark.tree import Meta
 
@@ -31,7 +31,7 @@ from abstract_syntax import (
     MutableArrayType, ObjectDecl,
     ObjectField, ObserverDecl, Omitted, Or, OverloadType, OverloadedVar, PSorry, PVar,
     PatternBool, PatternCons, Postulate, Predicate, Print, ProcDecl, ProcParam,
-    ProcSpec, RecFun, ResolvedVar, ResourceDecl, Rule, Some,
+    ProcSpec, Proof, RecFun, ResolvedVar, ResourceDecl, Rule, Some,
     Statement, Switch, SwitchCase, TAnnote, TermBinding, TLet, Term, TermInst, Theorem,
     Trace, Type, TypeAlias, TypeInst, TypeType, Union, Var, VarRef, VerboseLevel,
     ViewDecl, ViewRecFun, alpha_equiv, base_name, callable_name,
@@ -171,8 +171,13 @@ def _imp_stmt_unmodeled(s: ImpStmt) -> bool:
           or (else_body is not None and _block_unmodeled(else_body))
     case ImpReturn() | ImpAssert() | ImpAssume():
       return False
+    case ImpWhile():
+      # A local-state `while` (Phase 2l, #1116/#1121) is modeled as long as its
+      # body is: a body that writes an array or calls a procedure keeps the
+      # whole loop -- and so the procedure -- deferred.
+      return _block_unmodeled(s.body)
     case _:
-      # `while` and `call` statements.
+      # `call` statements.
       return True
 
 def _block_unmodeled(stmts: list[ImpStmt]) -> bool:
@@ -287,6 +292,16 @@ def _type_check_imp_stmt(s: ImpStmt, env: Env,
       # given for the statements that follow (see `proc_obligations`). It has
       # no runtime effect, so it never contributes to the state.
       type_check_formula(formula, env)
+      return env
+    case ImpWhile(loc, cond, invariants, _, _, body, _, _, _):
+      # Phase 2l (#1121): the loop condition and each invariant must be a
+      # `bool`, and the body type-checks against the enclosing environment
+      # (its own locals stay block-scoped, matching uniquify). The `decreases`
+      # measure is left for the termination slice (#1122).
+      type_check_formula(cond, env)
+      for inv in invariants:
+        type_check_formula(inv, env)
+      _type_check_imp_block(body, env, return_type)
       return env
     case _:
       return env
@@ -414,6 +429,24 @@ def type_check_proc_body(decl: ProcDecl, env: Env) -> None:
 # right-hand sides. Loops (`while`), procedure calls, allocations, and object
 # field writes are later slices, so a body using any of them stays deferred
 # (and keeps the Phase 1m warning).
+def _loop_body_verifiable(s: ImpStmt) -> bool:
+  # Phase 2l (#1121): the body of a verifiable local-state `while` is
+  # straight-line local state -- local `var`/assignment (ordinary right-hand
+  # sides), `assert`, and `assume`. Branching, nested loops, `return`, calls,
+  # and mutable-array element writes inside a loop body are later slices
+  # (array loops are #1128), so a loop containing any of them keeps the whole
+  # procedure deferred.
+  match s:
+    case ImpVar():
+      return not isinstance(s.rhs, (ImpCallExpr, ImpAlloc))
+    case ImpAssign():
+      return isinstance(s.lhs, LValueVar) \
+          and not isinstance(s.rhs, (ImpCallExpr, ImpAlloc))
+    case ImpAssert() | ImpAssume():
+      return True
+    case _:
+      return False
+
 def _stmt_verifiable(s: ImpStmt) -> bool:
   match s:
     case ImpVar():
@@ -427,8 +460,10 @@ def _stmt_verifiable(s: ImpStmt) -> bool:
       return all(_stmt_verifiable(t) for t in then_body) \
           and (else_body is None
                or all(_stmt_verifiable(t) for t in else_body))
+    case ImpWhile():
+      return all(_loop_body_verifiable(t) for t in s.body)
     case _:
-      # `while` and `call` statements.
+      # `call` statements.
       return False
 
 def _assigns_to_a_parameter(decl: ProcDecl) -> bool:
@@ -447,6 +482,9 @@ def _assigns_to_a_parameter(decl: ProcDecl) -> bool:
         case ImpIf(_, _, then_body, else_body):
           if assigns(then_body) \
              or (else_body is not None and assigns(else_body)):
+            return True
+        case ImpWhile():
+          if assigns(s.body):
             return True
     return False
   return assigns(decl.body)
@@ -633,8 +671,11 @@ def proc_obligations(decl: ProcDecl,
           ImperativeObligation(post_loc, goal, ObligationKind.POSTCONDITION,
                                givens=list(givens)))
 
+  PathEnd = Callable[[Substitution, list[tuple[str, Formula]], Env], None]
+
   def walk(stmts: list[ImpStmt], state: Substitution,
-           givens: list[tuple[str, Formula]], cur_env: Env) -> None:
+           givens: list[tuple[str, Formula]], cur_env: Env,
+           on_end: PathEnd) -> None:
     def symbolic(rhs: Term, typ: Type) -> Term:
       checked = type_check_term(rhs, typ, cur_env, None, [])
       record_reads(checked, givens, cur_env)
@@ -720,21 +761,109 @@ def proc_obligations(decl: ProcDecl,
           # Both branches are checked against the same continuation; each gets
           # its own copy of `state` so a branch-local write does not leak out.
           walk(cast(list[ImpStmt], then_body) + rest, dict(state),
-               givens + [('if' + str(len(givens)), cond_frm)], cur_env)
+               givens + [('if' + str(len(givens)), cond_frm)], cur_env, on_end)
           else_stmts = cast(list[ImpStmt], else_body) if else_body is not None \
               else []
           walk(else_stmts + rest, dict(state),
-               givens + [('if' + str(len(givens)), neg)], cur_env)
+               givens + [('if' + str(len(givens)), neg)], cur_env, on_end)
           return  # both branch paths already handled the continuation
+        case ImpWhile():
+          handle_while(s, stmts[idx + 1:], state, givens, cur_env, on_end)
+          return  # the loop owns the continuation on every exit path
         case ImpReturn(_, value):
           result = symbolic(value, cast(Type, decl.return_type))
           emit_posts(result, state, givens)
           return  # a `return` is terminal; anything after it is unreachable
-    # This path fell off the end without returning: its postconditions hold
-    # with `result` unbound (so they may not mention `result`).
-    emit_posts(None, state, givens)
+    on_end(state, givens, cur_env)
 
-  walk(decl.body, {}, _proc_givens(decl), base_env)
+  def handle_while(s: ImpWhile, rest: list[ImpStmt], state: Substitution,
+                   givens: list[tuple[str, Formula]], cur_env: Env,
+                   on_end: PathEnd) -> None:
+    # Phase 2l (#1121): a local-state `while` loop. Its invariants must hold on
+    # ENTRY (in the current state), be PRESERVED by one arbitrary iteration, and
+    # -- with the negated loop condition -- carry the EXIT continuation. The
+    # `decreases` measure (termination, #1122) and `modifies` frames (#1119) are
+    # out of scope here; loop bodies are straight-line local state
+    # (`_loop_body_verifiable`), so preservation is a single path.
+    inv_checked = [cast(Formula, type_check_formula(inv, cur_env))
+                   for inv in s.invariants]
+    cond_checked = cast(Formula, type_check_formula(s.cond, cur_env))
+
+    def invariant_goals(sub: Substitution) -> list[tuple[Meta, Formula]]:
+      return [(inv.location, cast(Formula, checked.substitute(sub)))
+              for (inv, checked) in zip(s.invariants, inv_checked)]
+
+    def emit_invariants(sub: Substitution,
+                        path_givens: list[tuple[str, Formula]],
+                        kind: 'ObligationKind',
+                        proof: Optional[Proof]) -> None:
+      goals = invariant_goals(sub)
+      if not goals:
+        return
+      if proof is not None:
+        # A user `established`/`preserved` proof covers the whole invariant
+        # conjunction, so it drives one combined obligation at the loop header.
+        conj = goals[0][1] if len(goals) == 1 \
+            else cast(Formula, And(s.location, None, [g for (_l, g) in goals]))
+        obligations.append(
+            ImperativeObligation(goals[0][0], conj, kind,
+                                 givens=list(path_givens), proof=proof))
+      else:
+        for (goal_loc, goal) in goals:
+          obligations.append(
+              ImperativeObligation(goal_loc, goal, kind,
+                                   givens=list(path_givens)))
+
+    # Entry: the invariants must hold in the current (pre-loop) state.
+    emit_invariants(state, givens, ObligationKind.LOOP_ENTRY, s.established)
+
+    # Havoc the locals the loop assigns. Dropping them from the state leaves
+    # them symbolic (as themselves), constrained only by the invariants and the
+    # loop condition. A carried given that mentions one describes its pre-loop
+    # value and would be unsound to keep (e.g. an invariant an *earlier* loop
+    # exported about a local this loop reassigns), so such givens are dropped
+    # too; the invariants are the only facts about a modified local afterwards.
+    modified = {t.lhs.name for t in s.body
+                if isinstance(t, ImpAssign) and isinstance(t.lhs, LValueVar)}
+    havoc_state = {k: v for (k, v) in state.items() if k not in modified}
+    havoc_givens = [(lbl, frm) for (lbl, frm) in givens
+                    if not (_referenced_names(frm) & modified)]
+
+    def loop_givens(negate_cond: bool) -> list[tuple[str, Formula]]:
+      g = list(havoc_givens)
+      for (_l, inv) in invariant_goals(havoc_state):
+        g.append(('invariant' + str(len(g)), inv))
+      guard = cast(Formula, cond_checked.substitute(havoc_state))
+      if negate_cond:
+        guard = IfThen(s.cond.location, None, guard,
+                       Bool(s.cond.location, None, False))
+      g.append(('condition' + str(len(g)), guard))
+      return g
+
+    # Preservation: assume the invariants and the loop condition, run one
+    # iteration of the body, then re-check the invariants in the resulting
+    # state (the body's fall-through continuation).
+    def preserved_end(body_state: Substitution,
+                      body_givens: list[tuple[str, Formula]],
+                      _body_env: Env) -> None:
+      emit_invariants(body_state, body_givens,
+                      ObligationKind.LOOP_PRESERVATION, s.preserved)
+    walk(list(s.body), dict(havoc_state), loop_givens(negate_cond=False),
+         cur_env, preserved_end)
+
+    # Exit: continue past the loop with the invariants and the negated loop
+    # condition as givens, over the havoced state.
+    walk(rest, dict(havoc_state), loop_givens(negate_cond=True), cur_env,
+         on_end)
+
+  def top_end(state: Substitution, path_givens: list[tuple[str, Formula]],
+              _env: Env) -> None:
+    # A path that falls off the end of the procedure without returning: its
+    # postconditions hold with `result` unbound (so they may not mention
+    # `result`). The fall-through state still rewrites any mutated binding.
+    emit_posts(None, state, path_givens)
+
+  walk(decl.body, {}, _proc_givens(decl), base_env, top_end)
   discharge_env = base_env
   for (name, (vloc, var_ty)) in local_bindings.items():
     discharge_env = discharge_env.declare_term_var(vloc, name, var_ty,

--- a/test/imperative/should-error/loop_forgets_fact.pf
+++ b/test/imperative/should-error/loop_forgets_fact.pf
@@ -1,0 +1,18 @@
+// Phase 2l (issue #1121): a fact that holds before the loop about a
+// loop-modified local is not retained after the loop unless an invariant
+// restates it. Here `x` is required, so `y := x` makes `y` true before the
+// loop, but `y` is assigned in the body and therefore havoced; the useless
+// `invariant true` carries nothing about `y`, so `ensures result` cannot be
+// proved from the pre-loop value.
+proc forgets(x: bool, go: bool) -> bool
+  requires x
+  ensures result
+{
+  var y := x
+  while go
+    invariant true
+  {
+    y := y
+  }
+  return y
+}

--- a/test/imperative/should-error/loop_forgets_fact.pf.err
+++ b/test/imperative/should-error/loop_forgets_fact.pf.err
@@ -1,0 +1,8 @@
+./test/imperative/should-error/loop_forgets_fact.pf:9.3-9.17: incomplete proof
+could not prove this postcondition obligation
+Goal:
+	y
+Givens:
+	condition2: not go,
+	invariant1: true,
+	requires0: x

--- a/test/imperative/should-error/loop_missing_invariant.pf
+++ b/test/imperative/should-error/loop_missing_invariant.pf
@@ -1,0 +1,15 @@
+// Phase 2l (issue #1121): a loop without the invariant its continuation needs
+// fails at the postcondition. `y` is havoced across the loop (it is assigned
+// in the body), so with no invariant restating `y = x` the returned value
+// carries no information and `ensures result = x` cannot be proved. The only
+// given on exit is the negated loop condition.
+proc needs_invariant(x: bool, go: bool) -> bool
+  ensures result = x
+{
+  var y := x
+  while go
+  {
+    y := y
+  }
+  return y
+}

--- a/test/imperative/should-error/loop_missing_invariant.pf.err
+++ b/test/imperative/should-error/loop_missing_invariant.pf.err
@@ -1,0 +1,6 @@
+./test/imperative/should-error/loop_missing_invariant.pf:7.3-7.21: incomplete proof
+could not prove this postcondition obligation
+Goal:
+	y = x
+Givens:
+	condition0: not go

--- a/test/imperative/should-error/loop_not_preserved.pf
+++ b/test/imperative/should-error/loop_not_preserved.pf
@@ -1,0 +1,17 @@
+// Phase 2l (issue #1121): an invariant that holds on entry but is broken by
+// the body is rejected at the invariant annotation. `invariant y = x` holds
+// when the loop is reached (`y` starts at `x`), so the entry obligation
+// discharges, but the body flips `y`, so the preservation obligation -- checked
+// in the post-iteration state with the invariant and loop condition as givens
+// -- fails at the invariant.
+proc breaks_invariant(x: bool, go: bool) -> bool
+  ensures result = x
+{
+  var y := x
+  while go
+    invariant y = x
+  {
+    y := not y
+  }
+  return y
+}

--- a/test/imperative/should-error/loop_not_preserved.pf.err
+++ b/test/imperative/should-error/loop_not_preserved.pf.err
@@ -1,0 +1,7 @@
+./test/imperative/should-error/loop_not_preserved.pf:12.15-12.20: incomplete proof
+could not prove this loop invariant preservation obligation
+Goal:
+	(not y) = x
+Givens:
+	condition1: go,
+	invariant0: y = x

--- a/test/imperative/should-validate/loop_invariant.pf
+++ b/test/imperative/should-validate/loop_invariant.pf
@@ -1,0 +1,56 @@
+// Phase 2l (issue #1121): local-state `while` loops are verified against
+// user-written invariants. Each invariant must hold on entry, be preserved by
+// one arbitrary iteration, and -- together with the negated loop condition --
+// carry the continuation. The locals a loop assigns are havoced before the
+// preservation and exit checks, so nothing about them survives past the loop
+// unless an invariant restates it. Every procedure here is fully verified, so
+// the missing `.pf.warn` sibling pins that this run is warning-free.
+
+// The invariant `y = x` holds on entry (`y` starts at `x`), is preserved by
+// the no-op body, and lets the postcondition `result = x` discharge after the
+// loop even though `y` has been havoced.
+proc echo(x: bool, go: bool) -> bool
+  ensures result = x
+{
+  var y := x
+  while go
+    invariant y = x
+  {
+    y := y
+  }
+  return y
+}
+
+// Multiple invariants each keep their own source location and are checked
+// separately on entry and preservation. Only the invariant needed by the
+// continuation (`a = x`) feeds the returned value; both are still verified.
+proc echo_two(x: bool, z: bool, go: bool) -> bool
+  ensures result = x
+{
+  var a := x
+  var b := z
+  while go
+    invariant a = x
+    invariant b = z
+  {
+    a := a
+    b := b
+  }
+  return a
+}
+
+// A local the loop never assigns is not havoced, so a fact established before
+// the loop about it survives to the continuation without any invariant. Here
+// `kept` is returned and `result = x` discharges from the pre-loop state, even
+// though the loop-assigned `y` carries no invariant.
+proc retains_unwritten(x: bool, go: bool) -> bool
+  ensures result = x
+{
+  var kept := x
+  var y := x
+  while go
+  {
+    y := y
+  }
+  return kept
+}

--- a/test/unit/test_imperative_verify.py
+++ b/test/unit/test_imperative_verify.py
@@ -13,7 +13,7 @@ from lark.tree import Meta
 
 from abstract_syntax import (
     Bool, BoolType, Env, ImpAssert, ImpAssign, ImpAssume, ImpIf, ImpReturn,
-    ImpVar, ImpWhile, LValueVar, MutableArrayType, ResolvedVar,
+    ImpVar, ImpWhile, LValueIndex, LValueVar, MutableArrayType, ResolvedVar,
 )
 from abstract_syntax.declarations import ProcDecl, ProcParam, ProcSpec
 from abstract_syntax.literals import mkEqual
@@ -210,6 +210,142 @@ def test_void_fall_through_checks_postconditions_without_a_result() -> None:
   assert obs[0].kind is ObligationKind.POSTCONDITION
 
 
+# --- loops (Phase 2l, issue #1121) ------------------------------------------
+
+def _echo_loop() -> ProcDecl:
+  # proc echo(x, go) -> bool  ensures result = x {
+  #   var y := x  while go invariant y = x { y := y }  return y }
+  inv_loc = _meta(100, 110)
+  return _proc('echo', [_param('x'), _param('go')], _bool(),
+               [ProcSpec(_meta(), 'ensures', mkEqual(_meta(), _rv('result'),
+                                                     _rv('x')))],
+               [ImpVar(_meta(), 'y', None, _rv('x')),
+                ImpWhile(_meta(), _rv('go'),
+                         [mkEqual(inv_loc, _rv('y'), _rv('x'))], [], None,
+                         [ImpAssign(_meta(), LValueVar(_meta(), 'y'),
+                                    _rv('y'))]),
+                ImpReturn(_meta(), _rv('y'))], 'result')
+
+
+def test_loop_emits_entry_preservation_and_exit_obligations() -> None:
+  # Entry checks the invariant in the pre-loop state (`y = x` with `y := x`, so
+  # `x = x`); preservation checks it after one havoced iteration (`y = x` with
+  # the invariant and loop condition as givens); the exit continuation
+  # discharges the postcondition over the havoced state with the invariant and
+  # the negated condition as givens.
+  _env_out, obs = proc_obligations(_echo_loop(), _env())
+  assert [str(o.kind) for o in obs] == \
+      ['loop invariant on entry', 'loop invariant preservation',
+       'postcondition']
+  assert [str(o.goal) for o in obs] == ['x = x', 'y = x', 'y = x']
+  # Entry has no givens; preservation and exit carry the invariant plus the
+  # (positive / negated) loop condition.
+  assert [str(f) for (_l, f) in obs[0].givens] == []
+  assert [str(f) for (_l, f) in obs[1].givens] == ['y = x', 'go']
+  assert [str(f) for (_l, f) in obs[2].givens] == ['y = x', 'not go']
+
+
+def test_loop_entry_and_preservation_point_at_the_invariant() -> None:
+  # Both invariant obligations are anchored at the invariant annotation the
+  # user wrote, so a failure points there rather than at the loop header.
+  _env_out, obs = proc_obligations(_echo_loop(), _env())
+  assert obs[0].location.start_pos == 100
+  assert obs[1].location.start_pos == 100
+
+
+def test_loop_invariants_keep_their_individual_locations() -> None:
+  # Two invariants become two entry obligations (and two preservation
+  # obligations), each anchored at its own annotation.
+  loc0, loc1 = _meta(100, 110), _meta(120, 130)
+  decl = _proc('two', [_param('x'), _param('z'), _param('go')], None, [],
+               [ImpVar(_meta(), 'a', None, _rv('x')),
+                ImpVar(_meta(), 'b', None, _rv('z')),
+                ImpWhile(_meta(), _rv('go'),
+                         [mkEqual(loc0, _rv('a'), _rv('x')),
+                          mkEqual(loc1, _rv('b'), _rv('z'))], [], None,
+                         [ImpAssign(_meta(), LValueVar(_meta(), 'a'), _rv('a')),
+                          ImpAssign(_meta(), LValueVar(_meta(), 'b'),
+                                    _rv('b'))])])
+  _env_out, obs = proc_obligations(decl, _env())
+  entry = [o for o in obs if o.kind is ObligationKind.LOOP_ENTRY]
+  assert [o.location.start_pos for o in entry] == [100, 120]
+  assert [str(o.goal) for o in entry] == ['x = x', 'z = z']
+
+
+def test_loop_havocs_assigned_locals_but_retains_the_rest() -> None:
+  # A local the loop assigns (`y`) is havoced -- after the loop it stands for
+  # an arbitrary value, so returning it yields the symbolic `y`. A local the
+  # loop never assigns (`kept`) keeps its pre-loop value `x`.
+  def loop_returning(name: str) -> ProcDecl:
+    return _proc('r', [_param('x'), _param('go')], _bool(),
+                 [ProcSpec(_meta(), 'ensures', mkEqual(_meta(), _rv('result'),
+                                                       _rv('x')))],
+                 [ImpVar(_meta(), 'kept', None, _rv('x')),
+                  ImpVar(_meta(), 'y', None, _rv('x')),
+                  ImpWhile(_meta(), _rv('go'), [], [], None,
+                           [ImpAssign(_meta(), LValueVar(_meta(), 'y'),
+                                      _rv('y'))]),
+                  ImpReturn(_meta(), _rv(name))], 'result')
+  _e0, kept_obs = proc_obligations(loop_returning('kept'), _env())
+  assert [str(o.goal) for o in kept_obs] == ['x = x']  # retained
+  _e1, y_obs = proc_obligations(loop_returning('y'), _env())
+  assert [str(o.goal) for o in y_obs] == ['y = x']     # havoced
+
+
+def test_sequential_loop_drops_stale_givens_about_a_reassigned_local() -> None:
+  # A given an earlier loop exports about a local (its invariant `y`) must not
+  # be carried past a *later* loop that havocs the same local; otherwise the
+  # second loop's continuation could reuse the stale fact. Here the second loop
+  # reassigns `y` with no invariant, so after it `y` carries no given and the
+  # postcondition `result = y` cannot be proved -- the obligation's givens
+  # mention neither the stale `y` invariant nor `y`.
+  decl = _proc('two_loops', [_param('go1'), _param('go2')], _bool(),
+               [ProcSpec(_meta(), 'ensures', _rv('y_res'))],
+               [ImpVar(_meta(), 'y', None, Bool(_meta(), None, True)),
+                ImpWhile(_meta(), _rv('go1'), [_rv('y')], [], None,
+                         [ImpAssign(_meta(), LValueVar(_meta(), 'y'),
+                                    _rv('y'))]),
+                ImpWhile(_meta(), _rv('go2'), [], [], None,
+                         [ImpAssign(_meta(), LValueVar(_meta(), 'y'),
+                                    Bool(_meta(), None, False))]),
+                ImpReturn(_meta(), _rv('y'))], 'y_res')
+  _env_out, obs = proc_obligations(decl, _env())
+  post = [o for o in obs if o.kind is ObligationKind.POSTCONDITION]
+  assert len(post) == 1
+  # The stale `y` from loop 1's exit invariant is gone (loop 2 havocs `y`);
+  # only the `y`-free negated loop conditions survive, so the postcondition `y`
+  # is unprovable (as it should be).
+  givens = [str(f) for (_l, f) in post[0].givens]
+  assert givens == ['not go1', 'not go2']
+  assert not any('y' == g for g in givens)
+
+
+def test_loop_established_and_preserved_proofs_drive_combined_obligations() -> \
+    None:
+  # A user `established`/`preserved` proof covers the whole invariant
+  # conjunction, so it produces one combined obligation per phase (carrying the
+  # proof) instead of one per invariant.
+  from abstract_syntax import PTrue
+  decl = _proc('proved', [_param('x'), _param('go')], None, [],
+               [ImpVar(_meta(), 'a', None, _rv('x')),
+                ImpVar(_meta(), 'b', None, _rv('x')),
+                ImpWhile(_meta(), _rv('go'),
+                         [mkEqual(_meta(), _rv('a'), _rv('x')),
+                          mkEqual(_meta(), _rv('b'), _rv('x'))], [], None,
+                         [ImpAssign(_meta(), LValueVar(_meta(), 'a'), _rv('a')),
+                          ImpAssign(_meta(), LValueVar(_meta(), 'b'),
+                                    _rv('b'))],
+                         PTrue(_meta()), PTrue(_meta()))])
+  _env_out, obs = proc_obligations(decl, _env())
+  entry = [o for o in obs if o.kind is ObligationKind.LOOP_ENTRY]
+  preserve = [o for o in obs if o.kind is ObligationKind.LOOP_PRESERVATION]
+  assert len(entry) == 1 and entry[0].proof is not None
+  assert len(preserve) == 1 and preserve[0].proof is not None
+  # The single preservation goal is the conjunction of both invariants (in the
+  # havoced state, so the invariant variables `a`/`b` stay symbolic).
+  assert str(preserve[0].goal) == '((a = x) and (b = x))'
+
+
 # --- the _proc_verifiable gate ----------------------------------------------
 
 def test_straight_line_body_is_verifiable() -> None:
@@ -229,10 +365,12 @@ def test_branch_is_verifiable() -> None:
 
 def test_branch_with_unmodeled_statement_defers() -> None:
   # `_stmt_verifiable` recurses into branch bodies, so a still-unmodeled
-  # construct (here a `while`) nested inside a branch defers the whole proc.
-  loop = ImpWhile(_meta(), _rv('x'), [], [], None, [])
-  decl = _proc('loopy', [_param('x')], None, [],
-               [ImpIf(_meta(), _rv('x'), [loop], None)])
+  # construct nested inside a branch defers the whole proc. A `call` statement
+  # remains unmodeled, so the `case _` fall-through fires.
+  from abstract_syntax import ImpCall
+  call = ImpCall(_meta(), _rv('x'))
+  decl = _proc('callish', [_param('x')], None, [],
+               [ImpIf(_meta(), _rv('x'), [call], None)])
   assert not _proc_verifiable(decl)
 
 
@@ -263,6 +401,45 @@ def test_frame_declaration_defers_verification() -> None:
   decl = _proc('framed', [ProcParam(_meta(), 'a',
                                     MutableArrayType(_meta(), _bool()))],
                None, [ProcSpec(_meta(), 'modifies', [_rv('a')])], [])
+  assert not _proc_verifiable(decl)
+
+
+def test_local_state_loop_is_verifiable() -> None:
+  # Phase 2l (issue #1121): a `while` whose body is straight-line local state
+  # (a `var`/assignment, `assert`, `assume`) is verifiable.
+  decl = _proc('counting', [_param('go')], None, [],
+               [ImpVar(_meta(), 'y', None, _rv('go')),
+                ImpWhile(_meta(), _rv('go'), [], [], None,
+                         [ImpAssign(_meta(), LValueVar(_meta(), 'y'),
+                                    _rv('y'))])])
+  assert _proc_verifiable(decl)
+
+
+def test_nested_loop_in_a_loop_body_defers() -> None:
+  # A nested `while` is not a straight-line loop-body statement, so a loop
+  # containing one is deferred (nested loops are a later slice).
+  inner = ImpWhile(_meta(), _rv('go'), [], [], None, [])
+  outer = ImpWhile(_meta(), _rv('go'), [], [], None, [inner])
+  decl = _proc('nested', [_param('go')], None, [], [outer])
+  assert not _proc_verifiable(decl)
+
+
+def test_array_write_in_a_loop_body_defers() -> None:
+  # A mutable-array element write inside a loop body is a later slice (#1128),
+  # so a loop containing one is deferred.
+  write = ImpAssign(_meta(), LValueIndex(_meta(), 'a', _rv('i')), _rv('v'))
+  loop = ImpWhile(_meta(), _rv('go'), [], [], None, [write])
+  decl = _proc('arr', [_param('go')], None, [], [loop])
+  assert not _proc_verifiable(decl)
+
+
+def test_loop_assigning_a_parameter_defers() -> None:
+  # A loop that assigns a parameter defers for the same entry-vs-exit ambiguity
+  # as a straight-line parameter assignment (#1120).
+  loop = ImpWhile(_meta(), _rv('x'), [], [], None,
+                  [ImpAssign(_meta(), LValueVar(_meta(), 'x'),
+                             Bool(_meta(), None, True))])
+  decl = _proc('loopassign', [_param('x')], None, [], [loop])
   assert not _proc_verifiable(decl)
 
 


### PR DESCRIPTION
## Phase 2l: verify local-state `while`-loop invariants (closes #1121)

Verifies `while` loops over local state against user-written invariants, using
a continuation-based weakest-precondition rule. For a loop the checker now
proves three families of obligation:

- **entry** — each invariant holds when the loop is first reached (in the
  pre-loop symbolic state);
- **preservation** — assuming the invariants and the loop condition, one
  arbitrary iteration of the body re-establishes each invariant;
- **exit / continuation** — the statements after the loop are verified with the
  invariants and the *negated* loop condition as givens.

### How it works

`checker_pipeline.proc_obligations`' recursive path-sensitive `walk` gained an
`on_end` continuation argument: a path that falls off the end of a statement
list runs either the postcondition check (top level) or the loop-invariant
preservation check (inside a loop body). The new `handle_while`:

1. emits the invariants' **entry** obligations in the current state;
2. **havocs** the locals the loop assigns — they are dropped from the symbolic
   state so they stand for an arbitrary value constrained only by the
   invariants. A carried *given* that mentions a havoced local is dropped too
   (see the Codex fix below);
3. re-walks the body from the havoced state (with the invariants and loop
   condition as givens) to check **preservation**;
4. continues past the loop from the havoced state with the invariants and the
   negated condition as givens (**exit**).

Per-invariant obligations keep each invariant's own source location, so a
failure points at the annotation the user wrote. A user `established`/`preserved`
proof instead drives one combined obligation over the invariant conjunction.

### Codex review fix (P1 soundness)

The initial cut carried all prior `givens` into the exit/preservation
continuations. As Codex noted, that is unsound across *sequential* loops: an
invariant an earlier loop exports about a local `y` (a fact mentioning the
symbolic `y`) would survive a later loop that havocs `y`, letting the later
loop's continuation reuse a stale fact. `handle_while` now drops any carried
given that references a havoced local, so the invariants are the only facts
about a modified local after the loop. Covered by
`test_sequential_loop_drops_stale_givens_about_a_reassigned_local`.

### Scope

Loop bodies are restricted to straight-line local state (local `var`,
assignment, `assert`, `assume`). `decreases` (termination, #1122),
`modifies`/array frames (#1119), array writes in loops (#1128), and calls in
loops are out of scope and keep a procedure deferred (still warned). Auto-
discharge is the existing `check_implies`, so the demo fixtures use reflexive
invariants that discharge without a proof.

### Tests

- `test/imperative/should-validate/loop_invariant.pf` — entry/preservation/exit,
  multiple invariants, and havoc-vs-retention (a positive proof that a
  non-assigned local survives the loop).
- `test/imperative/should-error/loop_{missing_invariant,not_preserved,forgets_fact}.pf`
  — the acceptance failures: a missing invariant fails at the postcondition, a
  non-preserved invariant fails at the invariant annotation, and a forgotten
  fact about a havoced local fails.
- `test/unit/test_imperative_verify.py` — entry/preservation/exit formulas
  pinned separately, per-invariant locations, havoc/retention, the sequential-
  loop stale-given regression, combined-proof obligations, and the
  verifiability gate (loops verifiable; nested loop, array-write-in-body, and
  loop-assigns-a-parameter all defer). Updated the now-stale
  `test_branch_with_unmodeled_statement_defers`.

Rebased onto current `main` (after #1167/2i landed): `handle_while` composes
with the new array-read/write machinery in `walk`, and `identity` in
`proc_declarations.pf` stays deferred via `_declares_frame` (it declares
`reads`/`modifies`), so there is no should-warn fixture churn.

`python3 test-deduce.py` (all lanes, both parsers), `--imperative`, `ruff`,
`mypy .`, and the token/grammar checks all pass.

### Resuming this session

Resume this session on ginger: `~/deduce-runner/resume.sh 4b40fc0a-bbd7-409a-af4c-396fda9e8601 routine/20260808-030202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)