### PR TITLE
Dedup OverloadedVar/ResolvedVar __eq__ into VarRef._post_uniquify_eq (refs #813)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -484,6 +484,19 @@ class VarRef(Term):
     # name / brace forms. Only overridden by `ResolvedVar`.
     return None
 
+  def _post_uniquify_eq(self, other: object) -> bool:
+    # Shared equality for the post-uniquify forms (`OverloadedVar` /
+    # `ResolvedVar`): two references are equal iff their canonical names
+    # match. A named callable (`RecFun` / `GenRecFun`) matches by its
+    # name too, `TermInst` / `TAnnote` wrappers are transparent, and a
+    # pre-uniquify `Var` (or anything else) never matches.
+    if isinstance(other, (OverloadedVar, ResolvedVar, RecFun, GenRecFun)):
+      return self.get_name() == other.name
+    elif isinstance(other, (TermInst, TAnnote)):
+      return self == other.subject
+    else:
+      return False
+
   def copy(self) -> Self:
     return self._rebuild(self.typeof)
 
@@ -642,24 +655,7 @@ class OverloadedVar(VarRef):
            + '{' + ','.join(self.resolved_names) + '}'
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, OverloadedVar):
-      return self.resolved_names[0] == other.resolved_names[0]
-    elif isinstance(other, ResolvedVar):
-      # Symmetric with ResolvedVar.__eq__ (see comment there).
-      return self.resolved_names[0] == other.name
-    elif isinstance(other, RecFun):
-      return self.resolved_names[0] == other.name
-    elif isinstance(other, GenRecFun):
-      return self.resolved_names[0] == other.name
-    elif isinstance(other, TermInst):
-      return self == other.subject
-    elif isinstance(other, TAnnote):
-      return self == other.subject
-    elif isinstance(other, Var):
-      # Pre- and post-uniquify references are not interchangeable.
-      return False
-    else:
-      return False
+    return self._post_uniquify_eq(other)
 
   def uniquify(self, env: UniquifyEnv, ctx: UniquifyContext) -> OverloadedVar:
     # Already uniquified — re-uniquify is a no-op (we'd hit this if
@@ -698,27 +694,7 @@ class ResolvedVar(VarRef):
     return name2str(self.name) + '{' + self.name + '}'
 
   def __eq__(self, other: object) -> bool:
-    if isinstance(other, ResolvedVar):
-      return self.name == other.name
-    elif isinstance(other, OverloadedVar):
-      # A resolved name matches an overloaded reference iff it's
-      # the chosen candidate. Comparing across the boundary lets
-      # post-typecheck code keep working with code that hasn't yet
-      # narrowed (e.g. equality reduction in mixed sub-ASTs).
-      return self.name == other.resolved_names[0]
-    elif isinstance(other, RecFun):
-      return self.name == other.name
-    elif isinstance(other, GenRecFun):
-      return self.name == other.name
-    elif isinstance(other, TermInst):
-      return self == other.subject
-    elif isinstance(other, TAnnote):
-      return self == other.subject
-    elif isinstance(other, Var):
-      # Pre- and post-uniquify references are not interchangeable.
-      return False
-    else:
-      return False
+    return self._post_uniquify_eq(other)
 
   def _special_str(self) -> str | None:
     # UInt zero is the value `bzero`; render it as the decimal literal `0`,


### PR DESCRIPTION
## What

Deduplicate the near-identical `OverloadedVar.__eq__` and `ResolvedVar.__eq__`
bodies in `abstract_syntax/terms.py` into a single shared
`VarRef._post_uniquify_eq` helper.

Both post-uniquify `VarRef` forms implemented the same equality rule, spelled
out twice (18 lines each):

- Equal to another `OverloadedVar` / `ResolvedVar` iff their canonical names
  match (`OverloadedVar.name` is the `resolved_names[0]` property; `ResolvedVar.name`
  is the field).
- A named callable (`RecFun` / `GenRecFun`) matches by its `.name` too.
- `TermInst` / `TAnnote` wrappers are transparent (recurse into `.subject`).
- A pre-uniquify `Var` — and anything else — never matches.

Since all four candidate types expose `.name` and both classes expose the same
canonical name via `get_name()`, the two bodies collapse to one helper on the
`VarRef` base, joining the other `get_name()`-driven shared methods already
there (`copy`, `substitute`, `__str__`, `reduce`).

The explicit `__eq__` stubs are kept in each subclass (each just delegates to
the helper) so the `@dataclass` decorator does not regenerate a field-wise
`__eq__` — leaving `__eq__`/`__hash__` behavior byte-identical to before.

Net: 15 insertions, 39 deletions.

## Why

Refs #813 (reduce code duplication across files). `Var.__eq__` is deliberately
different (it matches `Var` and rejects the post-uniquify forms) and is left
untouched.

## Testing

- `python3 test-deduce.py` — all categories pass (lib, should-validate ×2
  parsers, should-error, should-warn, parser equivalence, round-trip).
- `python3 test-deduce.py --equiv` — RD/LALR AST equivalence + round-trip pass.
- `ruff check` and `mypy abstract_syntax/` clean.

Resume this session on ginger: `~/deduce-runner/resume.sh 9c5d7524-4a41-4992-95d6-b11e381107a2 routine/20260808-060202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
