### PR TITLE
Dedup rec_desc_parser left-assoc binop and iff-chain parsers (refs #813)

### DIFF
--- a/rec_desc_parser.py
+++ b/rec_desc_parser.py
@@ -2,7 +2,7 @@
 # is to provide better error messages. -Jeremy
 
 from contextlib import contextmanager
-from typing import Iterator, Optional, cast
+from typing import Callable, Iterator, Optional, cast
 
 from abstract_syntax import (
     All, AllElim, AllElimTypes, AllIntro, And, ApplyDefsFact,
@@ -573,66 +573,36 @@ def parse_make_array() -> Term:
     return parse_call()
 
 
-def parse_term_expt() -> Term:
+def parse_left_assoc_binop(next_level: Callable[[], Term],
+                           operators: set[str]) -> Term:
+  # Shared left-associative binary-operator loop: parse the tighter level,
+  # then fold each `<op> <next_level>` into a `Call` of the operator's `Var`.
   token = current_token()
-  term = parse_make_array()
-
-  while (not end_of_file()) and current_token().value in expt_operators:
+  term = next_level()
+  while (not end_of_file()) and current_token().value in operators:
     rator = Var(meta_from_tokens(current_token(), current_token()),
                 None, to_unicode.get(current_token().value,
                                      current_token().value))
     advance()
-    right = parse_make_array()
+    right = next_level()
     term = Call(meta_from_tokens(token, previous_token()), None,
                 rator, [term,right])
-
   return term
+
+def parse_term_expt() -> Term:
+  return parse_left_assoc_binop(parse_make_array, expt_operators)
 
 def parse_term_mult() -> Term:
-  token = current_token()
-  term = parse_term_expt()
-
-  while (not end_of_file()) and current_token().value in mult_operators:
-    rator = Var(meta_from_tokens(current_token(), current_token()),
-                None, to_unicode.get(current_token().value,
-                                     current_token().value))
-    advance()
-    right = parse_term_expt()
-    term = Call(meta_from_tokens(token, previous_token()), None,
-                rator, [term,right])
-
-  return term
+  return parse_left_assoc_binop(parse_term_expt, mult_operators)
 
 def parse_term_add() -> Term:
-  token = current_token()
-  term = parse_term_mult()
-
-  while (not end_of_file()) and current_token().value in add_operators:
-    rator = Var(meta_from_tokens(current_token(), current_token()),
-                None, to_unicode.get(current_token().value, current_token().value))
-    advance()
-    right = parse_term_mult()
-    term = Call(meta_from_tokens(token, previous_token()), None,
-                rator, [term,right])
-
-  return term
+  return parse_left_assoc_binop(parse_term_mult, add_operators)
 
 def parse_term_compare() -> Term:
-  token = current_token()
-  term = parse_term_add()
-
-  while (not end_of_file()) and current_token().value in compare_operators:
-    rator = Var(meta_from_tokens(current_token(), current_token()),
-                None, to_unicode.get(current_token().value, current_token().value))
-    advance()
-    # Left-associative, matching the LALR grammar
-    # (`comparison_term "<" additive_term`): recurse into the tighter level,
-    # not back into `parse_term_compare`, so `a < b < c` is `(a < b) < c`.
-    right = parse_term_add()
-    term = Call(meta_from_tokens(token, previous_token()), None,
-                rator, [term,right])
-
-  return term
+  # Left-associative, matching the LALR grammar
+  # (`comparison_term "<" additive_term`): recurse into the tighter level,
+  # not back into `parse_term_compare`, so `a < b < c` is `(a < b) < c`.
+  return parse_left_assoc_binop(parse_term_add, compare_operators)
 
 def parse_term_equal() -> Term:
   token = current_token()
@@ -710,17 +680,21 @@ def parse_term_logic() -> Term:
                 list_of_or(term) + list_of_or(right))
   return term
 
-def parse_term_iff() -> Term:
+def parse_iff_chain(next_level: Callable[[], Term]) -> Term:
+  # Desugar `p iff q` into `(if p then q) and (if q then p)`, left-associatively.
   token = current_token()
-  term = parse_term_logic()
+  term = next_level()
   while (not end_of_file()) and (current_token().value in iff_operators):
     advance()
-    right = parse_term_logic()
+    right = next_level()
     loc = meta_from_tokens(token, previous_token())
     left_right = IfThen(loc, None, term.copy(), right.copy())
     right_left = IfThen(loc, None, right.copy(), term.copy())
     term = And(loc, None, [left_right, right_left])
   return term
+
+def parse_term_iff() -> Term:
+  return parse_iff_chain(parse_term_logic)
 
 def parse_term() -> Term:
   if end_of_file():
@@ -1418,16 +1392,7 @@ def parse_equation_side() -> Term:
   # `iff`/`and`/`or` (which sit below `=` in the normal precedence ladder) by
   # parsing them on top of comparison terms, leaving the top-level `=` to
   # separate the two sides of the step. See Deduce.lark `equation_side`.
-  token = current_token()
-  term = parse_equation_side_logic()
-  while (not end_of_file()) and (current_token().value in iff_operators):
-    advance()
-    right = parse_equation_side_logic()
-    loc = meta_from_tokens(token, previous_token())
-    left_right = IfThen(loc, None, term.copy(), right.copy())
-    right_left = IfThen(loc, None, right.copy(), term.copy())
-    term = And(loc, None, [left_right, right_left])
-  return term
+  return parse_iff_chain(parse_equation_side_logic)
 
 def parse_equation() -> tuple[Term, Term, Proof]:
   lhs = parse_equation_side()


### PR DESCRIPTION
## Summary

A code-duplication slice for the dedup umbrella. Two families of byte-identical
parser bodies in `rec_desc_parser.py` collapse into shared helpers:

- **Left-associative binary operators.** `parse_term_expt`, `parse_term_mult`,
  `parse_term_add`, and `parse_term_compare` had identical loop bodies differing
  only in (a) the operator set they match and (b) the next-tighter sub-parser
  they recurse into. They now delegate to one
  `parse_left_assoc_binop(next_level, operators)` helper. `parse_term_equal` is
  intentionally left alone — it carries `≠`/`/=` special-casing and is not a
  clean member of this family.
- **`iff` desugaring.** `parse_term_iff` and `parse_equation_side` ran the same
  `p iff q → (if p then q) and (if q then p)` loop, differing only in the
  sub-parser. They now delegate to `parse_iff_chain(next_level)`.

No AST or grammar change — this is a pure internal refactor.

## Line count

Net **−35 lines** (25 insertions, 60 deletions); 38 fewer non-comment code
lines. Satisfies the #813 LOC-reduction gate.

## Testing

- `python3 test-deduce.py --equiv` — RD/LALR AST equivalence + pretty-print
  round-trip: green.
- `python3 test-deduce.py` (full default: lib + should-validate + should-error +
  should-warn + prelude + equiv, both parsers): green.

`ruff`/`mypy` are not installed in this container; they run in CI's static
checks leg.

## Scope

Refs #813 — this is one slice; the dedup umbrella stays open for further
opportunities. Not a `Closes` keyword.

Resume this session on ginger: `~/deduce-runner/resume.sh 612e73f7-e9ba-4aad-8a8b-6306f9a8dd32 routine/20260808-070202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
