### PR TITLE
Sync RD/LALR on flag-off `emp`/`new` used as identifiers (refs #473)

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -288,7 +288,11 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
        subject = parse_tree_to_ast(e.children[0], e)
        return IfThen(e.meta, None, subject, Bool(e.meta, None, False))
     elif e.data == 'emp_resource':
-        _require_experimental_imperative(e.meta)
+        if not get_experimental_imperative_enabled():
+            # With the imperative layer off, `emp` is an ordinary identifier
+            # (issue #473), matching the recursive-descent parser, which
+            # demotes the keyword to IDENT in that mode.
+            return Var(e.meta, None, 'emp')
         return Emp(e.meta, None)
     elif e.data == 'sep_conj':
         _require_experimental_imperative(e.meta)
@@ -305,6 +309,12 @@ def parse_tree_to_ast(e: ParseNode, parent: ParseParent) -> Any:
         return FieldAccess(e.meta, None,
                            parse_tree_to_ast(e.children[0], e),
                            _field_name(e, 1))
+    elif e.data == 'rejected_new_term' \
+            and not get_experimental_imperative_enabled():
+        # A bare `new` in a pure term is an ordinary (here, undefined)
+        # identifier when the imperative layer is off (issue #473), matching
+        # the recursive-descent parser's keyword demotion.
+        return Var(e.meta, None, 'new')
     elif e.data == 'rejected_new_object' or e.data == 'rejected_new_term':
         raise ParseError(
             e.meta,

--- a/test-deduce.py
+++ b/test-deduce.py
@@ -650,6 +650,11 @@ PARSER_EQUIV_FILES = PARSER_ROUND_TRIP_FILES + (
     "./lib/Nat.pf",
     "./lib/UInt.pf",
     "./lib/Int.pf",
+    # Experimental-imperative keywords used as ordinary identifiers with the
+    # flag off, including `emp`/`new` in reference position (issue #473): both
+    # parsers must agree these are plain variables, not the resource/allocation
+    # literals.
+    "./test/should-validate/experimental_imperative_keywords_as_identifiers.pf",
     # The ``test/should-error``, ``test/should-warn``, and ``test/prelude``
     # corpora are folded in wholesale by ``should_error_equiv_files``,
     # ``should_warn_equiv_files``, and ``prelude_equiv_files`` below, so their

--- a/test/should-validate/experimental_imperative_keywords_as_identifiers.pf
+++ b/test/should-validate/experimental_imperative_keywords_as_identifiers.pf
@@ -18,6 +18,11 @@ define preserved = true
 define established = false
 define observer = true
 define resource = false
+// `emp` and `new` also have dedicated term-position meaning under the
+// imperative layer (the `Emp` resource literal and `new` allocation), so with
+// the flag off both parsers must still treat them as ordinary identifiers in
+// reference position -- not just as binding names (issue #473).
+define new = true
 
 // `while` in binding position (a parameter) and in reference position.
 fun negate(while : bool) {
@@ -26,6 +31,16 @@ fun negate(while : bool) {
 
 theorem experimental_keywords_are_identifiers:
   negate(call) = return
+proof
+  evaluate
+end
+
+// Reference `emp` and `new` in term position: before the fix the LALR parser
+// parsed these as the `Emp` resource literal / `new` allocation form even with
+// `--experimental-imperative` off and rejected them, while the recursive-
+// descent parser accepted them as identifiers.
+theorem experimental_keywords_referenceable_in_terms:
+  (emp = false) and (new = true)
 proof
   evaluate
 end


### PR DESCRIPTION
## Summary

A fresh in-process RD-vs-LALR snippet sweep (the technique from #1037) surfaced a live parser accept/reject divergence with `--experimental-imperative` **off**:

| snippet (flag off) | recursive-descent | LALR (before) |
| --- | --- | --- |
| `define d = emp` | `undefined variable: emp` | `experimental imperative syntax requires --experimental-imperative` |
| `define d = new` | `undefined variable: new` | `` `new` allocation syntax is only available in imperative statement right-hand sides `` |

In **term (reference) position** the LALR parser still parsed bare `emp` as the `Emp` resource literal and bare `new` as the `new` allocation form and rejected both, while the recursive-descent parser demotes the experimental-imperative keyword vocabulary to ordinary identifiers when the flag is off. That demotion is the documented #473 policy — see `test/should-validate/experimental_imperative_keywords_as_identifiers.pf`, which explicitly lists `emp` as a word that "must be usable as ordinary identifiers when `--experimental-imperative` is off, matching the LALR parser."

`emp` and `new` are the only two experimental keywords with dedicated term-position grammar rules (`emp_resource`, `rejected_new_term`), so they were the only ones still violating the contract. The LALR parser already un-reserves them in *binding* position (`define emp = false` parses), which made this a latent inconsistency: you could define `emp` but never reference it.

## Fix

In `parser.py` `parse_tree_to_ast`, when the imperative layer is off:
- `emp_resource` builds a plain `Var(..., 'emp')` instead of `Emp(...)`.
- a bare `rejected_new_term` builds `Var(..., 'new')` instead of raising.

Flag-**on** behavior is unchanged (`Emp` literal / the `new`-only-in-imperative-RHS error), and `new Obj<T..>(args)` (`rejected_new_object`) still raises its guidance error regardless of the flag.

After the fix both parsers agree in every mode:

- flag off: `emp`/`new` are ordinary identifiers → `undefined variable`, and `define emp = false` can now be referenced under both parsers.
- flag on: unchanged, both parsers identical.

## Tests

- Extended `experimental_imperative_keywords_as_identifiers.pf` to reference `emp`/`new` in term position (`(emp = false) and (new = true)`) and defined `new`; validates under both parsers.
- Folded that file into the `--equiv` parser-equivalence corpus (`PARSER_EQUIV_FILES`) so structural RD/LALR AST agreement is checked in CI.
- `python3 test-deduce.py` (full suite: lib + should-validate ×2 parsers + should-error + should-warn + prelude + parser equivalence + round-trip) — **all tests passed**.
- The snippet sweep that found the bug now reports **0 divergences** across 315 snippets.

`ruff`/`mypy` are not installed in this container; the change mirrors the existing `term_var` branch and is type-clean. CI's static leg will confirm.

## Scope

This closes one concrete drift item under the #473 umbrella (dual-parser equivalence). Other #473 work remains open, so this is `Refs #473`, not a closing keyword.

Refs #473

Resume this session on ginger: `~/deduce-runner/resume.sh ea89242f-3830-489b-b9d9-f6f5f7c2aa94 routine/20260808-080202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
