### PR TITLE
Dedup TLet reduceLets guard into a reduce_lets helper (refs #813)

### DIFF
--- a/abstract_syntax/literals.py
+++ b/abstract_syntax/literals.py
@@ -74,9 +74,7 @@ def mkEqualVar(loc: Meta, arg1: Term, arg2: Term) -> Formula:
   return cast(Formula, ret)
 
 def split_equation(loc: Meta, equation: Term, env: Env) -> tuple[Term, Term]:
-  if isinstance(equation, TLet):
-    equation = equation.reduceLets(env)
-    
+  equation = reduce_lets(equation, env)
   match equation:
     case Call(_, _, rator, [L, R]) if isinstance(rator, VarRef) and rator.get_name() == '=':
       return (L, R)
@@ -88,9 +86,7 @@ def split_equation(loc: Meta, equation: Term, env: Env) -> tuple[Term, Term]:
 def split_auto_rule(loc: Meta, equation: Formula, env: Env) -> AutoRewriteRule:
   variables: list[Term] = []
   premises: list[Formula] = []
-  body = equation
-  if isinstance(body, TLet):
-    body = cast(Formula, body.reduceLets(env))
+  body = cast(Formula, reduce_lets(equation, env))
 
   while isinstance(body, All):
     x, typ = body.var

--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1717,6 +1717,10 @@ class TLet(Term):
       return False
     return _alpha_equiv_tlet(self, other, {}, {})
 
+def reduce_lets(term: Term, env: Env) -> Term:
+  """Collapse a leading ``TLet`` binding via ``reduceLets``; pass other terms through."""
+  return term.reduceLets(env) if isinstance(term, TLet) else term
+
 @dataclass
 class Hole(Term):
 

--- a/checker_logic.py
+++ b/checker_logic.py
@@ -38,7 +38,6 @@ from abstract_syntax import (
     Switch,
     SwitchCase,
     TermBinding,
-    TLet,
     Term,
     Type,
     VarRef,
@@ -55,6 +54,7 @@ from abstract_syntax import (
     is_equation,
     is_true,
     name2str,
+    reduce_lets,
     replace_mark,
     reset_num_rewrites,
     reset_reduced_defs,
@@ -340,8 +340,7 @@ def collect_all_if_then(loc: Meta, frm: Formula,
                         env: Env) -> tuple[list[Term], list[ImplicationPremise]]:
     """Returns a list of all variables that need be instantiated, and anythings that need applied"""
 
-    if isinstance(frm, TLet):
-      frm = cast(Formula, frm.reduceLets(env))
+    frm = cast(Formula, reduce_lets(frm, env))
 
     match frm:
       case All(loc2, _, var, _, frm):

--- a/checker_proofs.py
+++ b/checker_proofs.py
@@ -33,7 +33,7 @@ from abstract_syntax import (
     Union, Var, VarRef, ViewDecl, base_name, bijective_view_for_source_type,
     callable_name, formula_match,
     get_predicate_decl, get_type_name, is_constructor, is_equation, is_true,
-    mkEqual, remove_mark, set_dont_reduce_opaque, set_reduce_all,
+    mkEqual, reduce_lets, remove_mark, set_dont_reduce_opaque, set_reduce_all,
     get_reduce_only, set_reduce_only, split_equation, type_match,
 )
 from checker_common import *
@@ -164,8 +164,7 @@ def _check_proof_true(proof: PTrue, env: Env) -> CheckedFormula:
 def _check_proof_and_elim(proof: PAndElim, env: Env) -> CheckedFormula:
   loc = proof.location
   formula = check_proof(proof.subject, env)
-  if isinstance(formula, TLet):
-    formula = formula.reduceLets(env)
+  formula = reduce_lets(formula, env)
 
   match formula:
     case And(_, _, args):
@@ -305,8 +304,7 @@ def _check_proof_all_elim(proof: AllElim, env: Env) -> CheckedFormula:
   loc = proof.location
   allfrm = check_proof(proof.univ, env)
 
-  if isinstance(allfrm, TLet):
-    allfrm = allfrm.reduceLets(env)
+  allfrm = reduce_lets(allfrm, env)
 
   match allfrm:
     case All(_, _, var, _, _):
@@ -335,8 +333,7 @@ def _check_proof_all_elim_types(proof: AllElimTypes, env: Env) -> CheckedFormula
   loc = proof.location
   allfrm = check_proof(proof.univ, env)
 
-  if isinstance(allfrm, TLet):
-    allfrm = allfrm.reduceLets(env)
+  allfrm = reduce_lets(allfrm, env)
 
   match allfrm:
     case All(_, _, vars, _, _):
@@ -1479,8 +1476,7 @@ def _check_proof_of_all_intro(proof: AllIntro, formula: CheckedFormula, env: Env
   x, ty = var
   checked_ty = check_type(ty, env)
 
-  if isinstance(formula, TLet):
-    formula = formula.reduceLets(env)
+  formula = reduce_lets(formula, env)
 
   match formula:
     case All(_, _, var2, (s, _), formula2):
@@ -1510,8 +1506,7 @@ def _check_proof_of_some_intro(proof: SomeIntro, formula: CheckedFormula, env: E
   # room for improvement, if var has type annotation, could type_check the witness
   witnesses = [type_synth_term(trm, env, None, []) for trm in proof.witnesses]
 
-  if isinstance(formula, TLet):
-    formula = formula.reduceLets(env)
+  formula = reduce_lets(formula, env)
 
   match formula:
     case Some(_, _, vars, formula2):
@@ -1526,8 +1521,7 @@ def _check_proof_of_some_elim(proof: SomeElim, formula: CheckedFormula, env: Env
   loc = proof.location
   someFormula = check_proof(proof.some, env)
 
-  if isinstance(someFormula, TLet):
-    someFormula = someFormula.reduceLets(env)
+  someFormula = reduce_lets(someFormula, env)
 
   match someFormula:
     case Some(loc2, _, vars, formula2):
@@ -1551,8 +1545,7 @@ def _check_proof_of_imp_intro(proof: ImpIntro, formula: CheckedFormula, env: Env
   loc = proof.location
 
   if proof.premise is None:
-    if isinstance(formula, TLet):
-      formula = formula.reduceLets(env)
+    formula = reduce_lets(formula, env)
 
     match formula:
       case IfThen(_, _, prem, conc):
@@ -1662,9 +1655,7 @@ def _check_proof_of_cases(proof: Cases, formula: CheckedFormula, env: Env) -> No
   sub_frm = check_proof(proof.subject, env)
 
   # sub_red = sub_frm.reduce(env)
-  sub_red = sub_frm
-  if isinstance(sub_frm, TLet):
-    sub_red = sub_frm.reduceLets(env)
+  sub_red = reduce_lets(sub_frm, env)
 
   match sub_red:
     case Or(_, _, frms):
@@ -1751,8 +1742,7 @@ def _check_proof_of_induction(proof: Induction, formula: CheckedFormula, env: En
   typ = check_type(proof.typ, env)
   cases = proof.cases
 
-  if isinstance(formula, TLet):
-    formula = formula.reduceLets(env)
+  formula = reduce_lets(formula, env)
   match formula:
     case All(_, _, (_,ty), _, _):
       if typ != ty:


### PR DESCRIPTION
## Summary

Deduplicates the repeated "collapse a leading `TLet` binding" idiom under the
#813 code-duplication umbrella.

The three-line guard

```python
if isinstance(x, TLet):
    x = x.reduceLets(env)
```

(sometimes wrapped in `cast(Formula, ...)`) was copied ~12 times across
`checker_proofs.py` (9 sites), `checker_logic.py` (1), and
`abstract_syntax/literals.py` (2). This PR extracts a single helper next to
`TLet.reduceLets` in `abstract_syntax/terms.py`:

```python
def reduce_lets(term: Term, env: Env) -> Term:
  """Collapse a leading ``TLet`` binding via ``reduceLets``; pass other terms through."""
  return term.reduceLets(env) if isinstance(term, TLet) else term
```

and routes every site through it. The helper is auto re-exported through the
`abstract_syntax` package facade. The now-unused `TLet` import in
`checker_logic.py` is dropped.

Net change: -11 lines, no behavior change.

## Testing

- `python3 test-deduce.py` — all tests passed (lib + should-validate ×2
  parsers + should-error + should-warn + parser equivalence + round-trip).

Refs #813

Resume this session on ginger: `~/deduce-runner/resume.sh 089de33f-823c-4cca-9ced-965161c6c5f2 routine/20260808-100202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
