### PR TITLE
Dedup And/Or reduce into shared _reduce_connective helper (refs #813)

### DIFF
--- a/abstract_syntax/terms.py
+++ b/abstract_syntax/terms.py
@@ -1774,6 +1774,35 @@ def is_true(b: Formula) -> bool:
     case _:
         return False
 
+def _reduce_connective(
+    formula: And | Or, env: Env,
+    flatten: Callable[[Sequence[Formula]], list[Formula]],
+    identity: bool,
+    cls: type[And] | type[Or],
+) -> Formula:
+  """Normalize an ``and``/``or`` monoid: reduce and flatten the arguments,
+  drop the identity constant (``true`` for ``and``, ``false`` for ``or``), and
+  short-circuit on the absorbing constant (``false``/``true``). Returns the
+  sole survivor unwrapped, the identity ``Bool`` when none survive, or a
+  rebuilt ``cls`` node."""
+  new_args = flatten([arg.reduce(env) for arg in formula.args])
+  newer_args = []
+  for arg in new_args:
+    match arg:
+      case Bool(_, _, val):
+        if val == identity:  # identity element: throw this away
+          pass
+        else:                # absorbing element: the whole thing collapses to it
+          return arg
+      case _:
+        newer_args.append(arg)
+  if len(newer_args) == 0:
+    return Bool(formula.location, BoolType(formula.location), identity)
+  elif len(newer_args) == 1:
+    return newer_args[0]
+  else:
+    return cls(formula.location, formula.typeof, newer_args)
+
 @dataclass
 class And(Formula):
   args: list[Formula]
@@ -1809,24 +1838,7 @@ class And(Formula):
     return eq_arg_list(self, other)
 
   def reduce(self, env: Env) -> Formula:
-    #new_args = [arg.reduce(env) for arg in self.args]
-    new_args = flatten_and([arg.reduce(env) for arg in self.args])
-    newer_args = []
-    for arg in new_args:
-      match arg:
-        case Bool(_, _, val):
-          if val:  # true: throw this away
-            pass
-          else:    # false: the whole thing is false
-            return arg
-        case _:
-          newer_args.append(arg)
-    if len(newer_args) == 0:
-      return Bool(self.location, BoolType(self.location), True)
-    elif len(newer_args) == 1:
-      return newer_args[0]
-    else:
-      return And(self.location, self.typeof, newer_args)
+    return _reduce_connective(self, env, flatten_and, True, And)
 
 def list_of_or(arg: Formula) -> list[Formula]:
   match arg:
@@ -1852,23 +1864,7 @@ class Or(Formula):
     return eq_arg_list(self, other)
 
   def reduce(self, env: Env) -> Formula:
-    new_args = flatten_or([arg.reduce(env) for arg in self.args])
-    newer_args = []
-    for arg in new_args:
-      match arg:
-        case Bool(_, _, val):
-          if val:  # true: the whole thing is true
-            return arg 
-          else:    # false: throw this away
-            pass
-        case _:
-          newer_args.append(arg)
-    if len(newer_args) == 0:
-      return Bool(self.location, BoolType(self.location), False)
-    elif len(newer_args) == 1:
-      return newer_args[0]
-    else:
-      return Or(self.location, self.typeof, newer_args)
+    return _reduce_connective(self, env, flatten_or, False, Or)
 
 @dataclass
 class IfThen(Formula):


### PR DESCRIPTION
## Summary

Dedup slice for the code-duplication umbrella. `And.reduce` and `Or.reduce` in
`abstract_syntax/terms.py` were mirror-image monoid normalizers: each reduced
and flattened its arguments, dropped the identity constant (`true` for `and`,
`false` for `or`), short-circuited on the absorbing constant (`false`/`true`),
and rebuilt its own node class. The two 18-line bodies differed only in three
things:

| | flatten fn | identity | node class |
|---|---|---|---|
| `And` | `flatten_and` | `True`  | `And` |
| `Or`  | `flatten_or`  | `False` | `Or`  |

This PR extracts one `_reduce_connective(formula, env, flatten, identity, cls)`
helper parameterized by exactly those three, so each `reduce` collapses to a
one-liner. Net −4 lines and, more importantly, one place to maintain the
normalization logic instead of two that have to be kept in sync by hand.

## Testing

- `python3 test-deduce.py --passable --lib --errors --warns --equiv` — all pass
  (`reduce` on `And`/`Or` is exercised throughout proof normalization).
- `python3 -m ruff check .` — clean.
- `python3 -m mypy .` — `Success: no issues found in 55 source files`.
- `keywords.py` / `reference_grammar.py` token/grammar checks — pass.

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh 63ef6bd5-e4a6-48b5-926d-ec6b65699e37 routine/20260808-110202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
