### PR TITLE
Fold test/imperative into RD/LALR equivalence + round-trip coverage (refs #931)

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -282,7 +282,15 @@ EXPERIMENTAL_IMPERATIVE_FILES = frozenset({
 
 
 def _uses_experimental_imperative(path: str) -> bool:
-    return path in EXPERIMENTAL_IMPERATIVE_FILES
+    # Everything under ``test/imperative/`` is an imperative fixture by
+    # construction, so it always needs the flag; enrolling the directory keeps
+    # new fixtures covered without touching ``EXPERIMENTAL_IMPERATIVE_FILES``,
+    # which stays the explicit set for imperative fixtures that live *outside*
+    # that tree (in ``should-validate``/``should-warn``/``should-error``/
+    # ``test-imports``) and is vetted for staleness by
+    # ``_check_imperative_flag_enrollment``.
+    return (path in EXPERIMENTAL_IMPERATIVE_FILES
+            or "test/imperative/" in path)
 
 
 # Current parser-equivalence baseline. These files parse successfully with
@@ -694,6 +702,23 @@ def prelude_equiv_files() -> tuple[str, ...]:
     parsers, so no skip baseline is required.
     """
     return tuple(list_pf(PRELUDE_DIR))
+
+
+def imperative_validate_equiv_files() -> tuple[str, ...]:
+    """Every ``test/imperative/should-validate`` fixture, folded into the
+    parser-equivalence and round-trip corpus.
+
+    This is the only corpus exercising the experimental-imperative surface
+    syntax under drift detection: proc/observer/resource declarations,
+    ``while``/``call``/``return``/``assert`` statements, ``new`` allocation,
+    and ``modifies``/``reads`` frames. Every fixture checks successfully under
+    both parsers with ``--experimental-imperative`` auto-enabled (see
+    ``run_imperative_validate``), so both accept it at parse time and no
+    parse-error skip baseline is needed. ``_uses_experimental_imperative``
+    enables the flag for these paths by directory, and the directory is swept
+    so new imperative fixtures join drift detection automatically.
+    """
+    return tuple(list_pf(IMP_PASS_DIR))
 
 
 class ParsedFlags(TypedDict):
@@ -1275,7 +1300,9 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
     later phase but parse cleanly under both parsers, so their ASTs are still
     meaningful surface-syntax samples. The ``SHOULD_ERROR_PARSER_EQUIV_SKIP``
     baseline excludes only the fixtures where at least one parser rejects at
-    parse time today.
+    parse time today. The ``test/imperative/should-validate`` fixtures are
+    folded in too so the experimental-imperative surface syntax stays under
+    RD/LALR drift detection.
 
     ``test/parse`` remains RD-only because those fixtures intentionally lock
     down beginner-facing RD diagnostics, while the LALR parser is kept as an
@@ -1286,6 +1313,7 @@ def run_parser_equivalence(workers: int) -> list[tuple[str, str, str]]:
         + should_error_equiv_files()
         + should_warn_equiv_files()
         + prelude_equiv_files()
+        + imperative_validate_equiv_files()
         + tuple(sorted(PARSER_EQUIV_EXPECTED_DIVERGENCES))
     ))
     files = shard(list(all_files))
@@ -1417,7 +1445,8 @@ def _check_should_error_skip_set() -> list[tuple[str, str, str]]:
 
 def run_parser_round_trip(workers: int) -> list[tuple[str, str, str]]:
     """Pretty-print representative ASTs and re-parse with both parsers."""
-    files = shard(list(PARSER_ROUND_TRIP_FILES))
+    files = shard(list(PARSER_ROUND_TRIP_FILES
+                       + imperative_validate_equiv_files()))
     failures: list[tuple[str, str, str]] = []
     for file_failures in _map_or_serial(
         _parser_workers(workers, len(files)),
@@ -1443,6 +1472,10 @@ def run_parser_round_trip(workers: int) -> list[tuple[str, str, str]]:
 #     which must parse and check to be compiled.
 #   * ``tools/claude_fill_hole/examples`` -- hole-fill fixtures exercising the
 #     ``?`` / ``help`` hole syntax.
+#   * ``test/imperative/should-validate`` -- the experimental-imperative
+#     surface syntax (proc/observer declarations, ``while``/``call``/``new``,
+#     ``modifies``/``reads`` frames). ``_uses_experimental_imperative`` turns
+#     the flag on for these paths by directory.
 #
 # ``test/should-error`` files are meant to fail, but most fail in a *later*
 # phase (type/proof check) while parsing cleanly under both parsers -- their
@@ -1453,7 +1486,8 @@ def run_parser_round_trip(workers: int) -> list[tuple[str, str, str]]:
 # staleness check shrinks that set as parsers converge). This is the full-corpus
 # counterpart to the curated ``PARSER_ROUND_TRIP_FILES`` set.
 FULL_ROUND_TRIP_DIRS = (LIB_DIR, PASS_DIR, WARN_DIR, PRELUDE_DIR, EXAMPLES_DIR,
-                        IMPORTS_DIR, COMPILE_DIR, HOLE_FILL_EXAMPLES_DIR)
+                        IMPORTS_DIR, COMPILE_DIR, HOLE_FILL_EXAMPLES_DIR,
+                        IMP_PASS_DIR)
 
 
 def list_pf_recursive(d: Path) -> list[str]:


### PR DESCRIPTION
## Summary

The `test/imperative/` corpus — the only fixtures exercising the
experimental-imperative surface syntax (proc/observer/resource declarations,
`while`/`call`/`return`/`assert` statements, `new` allocation, and
`modifies`/`reads` frames) — was absent from **both** the curated `--equiv`
round-trip corpus and `FULL_ROUND_TRIP_DIRS`, so even `--equiv-full` skipped it.

The existing `--imperative` lane (`run_imperative_validate`) runs each fixture
through the **full checker** under both parsers, but it never:

- compares the RD and LALR ASTs **structurally** (both may build different
  ASTs that each happen to check), nor
- exercises the **pretty-printer round-trip** (print → reparse → same AST,
  plus idempotence and cross-parser byte-identical output).

So the brand-new, actively-growing imperative syntax sat outside RD/LALR drift
detection. A sweep with the harness's own `_worker_parser_equivalence` and
`_worker_parser_round_trip` confirmed all 13 `test/imperative/should-validate`
fixtures already pass both — they were simply unenrolled.

## Fix

Fold the imperative should-validate corpus into drift detection, auto-discovered
by directory (so new Phase 2 fixtures enroll automatically):

- `_uses_experimental_imperative` now enables `--experimental-imperative` for
  any `test/imperative/` path by directory. `EXPERIMENTAL_IMPERATIVE_FILES`
  stays the explicit set for imperative fixtures that live *outside* that tree
  (in `should-validate`/`should-warn`/`should-error`/`test-imports`) and is
  still vetted for staleness by `_check_imperative_flag_enrollment` (which
  iterates only the explicit set, so it is unaffected).
- New `imperative_validate_equiv_files()` folded into the parser-equivalence
  corpus (`run_parser_equivalence`) and the curated round-trip corpus
  (`run_parser_round_trip`).
- `IMP_PASS_DIR` added to `FULL_ROUND_TRIP_DIRS` so the opt-in `--equiv-full`
  audit covers it too.

The `test/imperative/should-error` fixtures are intentionally left out: some are
parse-error fixtures (e.g. `new_in_pure_term.pf`) that at least one parser
rejects at parse time and would need a skip baseline analogous to
`SHOULD_ERROR_PARSER_EQUIV_SKIP`. That is follow-up work.

## Tests

- `python3 test-deduce.py --equiv` — passes; the 13 imperative fixtures now
  participate in RD/LALR equivalence + round-trip.
- `python3 test-deduce.py --equiv-full` — **558** accepted-syntax files (was
  545), all passing.
- `python3 test-deduce.py --imperative` — passes (flag-enrollment staleness
  check unaffected).
- `python3 test-deduce.py` (full default suite) — all tests passed.
- Verified programmatically that all 13 files are present in the equiv,
  round-trip, and full corpora, the flag is enabled for them, and plain
  (non-imperative) files still parse with the flag off.

`ruff`/`mypy` are not installed in this container; the change is confined to
the `test-deduce.py` harness, adds no `.pf`/grammar surface, and is type-clean
(`tuple[str, ...]` throughout). CI's static leg will confirm.

## Scope

This expands pretty-printer round-trip coverage (#931) and dual-parser
equivalence coverage (#473) to the experimental-imperative corpus. Both are
open umbrellas with remaining work, so this is `Refs`, not a closing keyword.

Refs #931, refs #473.

Resume this session on ginger: `~/deduce-runner/resume.sh 71d15e92-7fb4-465e-b1be-d677967a7ed4 routine/20260808-120202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
