### PR TITLE
Dedup simplify/expand/replace proof head-string builders (refs #813)

### DIFF
--- a/abstract_syntax/proofs.py
+++ b/abstract_syntax/proofs.py
@@ -804,24 +804,37 @@ def _proof_list_item_str(p: Proof) -> str:
   return str(p)
 
 
+# The ``simplify``/``expand``/``replace`` tactics each come in a goal-directed
+# form and an ``in <fact>`` form that render the same leading head. These
+# helpers build that shared head so the Goal/Fact twins (and the goal form's
+# own ``pretty_print``) stay in sync.
+def _simplify_head(givens: List[Proof]) -> str:
+  head = 'simplify'
+  if givens:
+    head += ' with ' + ' | '.join(_proof_list_item_str(p) for p in givens)
+  return head
+
+
+def _expand_head(definitions: List[Term]) -> str:
+  return 'expand ' + ' | '.join(str(d) for d in definitions)
+
+
+def _replace_head(equations: List[Proof]) -> str:
+  return 'replace ' + ' | '.join(
+      _proof_list_item_str(eqn) for eqn in equations)
+
+
 @dataclass
 class SimplifyGoal(Proof):
   body: Proof
   givens: List[Proof]
 
-  def _head(self) -> str:
-      head = 'simplify'
-      if self.givens:
-        head += ' with ' + ' | '.join(
-            _proof_list_item_str(p) for p in self.givens)
-      return head
-
   def pretty_print(self, indent: int) -> str:
-      return indent*' ' + self._head() + '\n' \
+      return indent*' ' + _simplify_head(self.givens) + '\n' \
         + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
-      return self._head() + '\n' + str(self.body)
+      return _simplify_head(self.givens) + '\n' + str(self.body)
 
 
 @dataclass
@@ -830,11 +843,7 @@ class SimplifyFact(Proof):
   givens: List[Proof]
 
   def __str__(self) -> str:
-    head = 'simplify'
-    if self.givens:
-      head += ' with ' + ' | '.join(
-          _proof_list_item_str(p) for p in self.givens)
-    return head + ' in ' + str(self.subject)
+    return _simplify_head(self.givens) + ' in ' + str(self.subject)
 
 @dataclass
 class ApplyDefsGoal(Proof):
@@ -842,13 +851,11 @@ class ApplyDefsGoal(Proof):
   body: Proof
 
   def pretty_print(self, indent: int) -> str:
-      return indent*' ' + 'expand ' \
-        + ' | '.join([str(d) for d in self.definitions]) + '\n' \
+      return indent*' ' + _expand_head(self.definitions) + '\n' \
         + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
-      return 'expand ' + ' | '.join([str(d) for d in self.definitions]) \
-        + ' ' + str(self.body)
+      return _expand_head(self.definitions) + ' ' + str(self.body)
 
 @dataclass
 class ApplyDefsFact(Proof):
@@ -856,8 +863,7 @@ class ApplyDefsFact(Proof):
   subject: Proof
 
   def __str__(self) -> str:
-      return 'expand ' + ' | '.join([str(d) for d in self.definitions]) \
-        + ' in ' + str(self.subject)
+      return _expand_head(self.definitions) + ' in ' + str(self.subject)
 
 @dataclass
 class RewriteGoal(Proof):
@@ -865,14 +871,11 @@ class RewriteGoal(Proof):
   body: Proof
 
   def pretty_print(self, indent: int) -> str:
-      return indent*' ' + 'replace ' \
-        + ' | '.join(_proof_list_item_str(eqn) for eqn in self.equations) \
-        + '\n' + maybe_pretty_print(self.body, indent)
+      return indent*' ' + _replace_head(self.equations) + '\n' \
+        + maybe_pretty_print(self.body, indent)
 
   def __str__(self) -> str:
-      return 'replace ' \
-        + '|'.join(_proof_list_item_str(eqn) for eqn in self.equations) \
-        + '\n' + str(self.body)
+      return _replace_head(self.equations) + '\n' + str(self.body)
 
 @dataclass
 class RewriteFact(Proof):
@@ -880,6 +883,4 @@ class RewriteFact(Proof):
   equations: List[Proof]
 
   def __str__(self) -> str:
-      return 'replace ' \
-        + ' | '.join(_proof_list_item_str(eqn) for eqn in self.equations) \
-        + ' in ' + str(self.subject)
+      return _replace_head(self.equations) + ' in ' + str(self.subject)


### PR DESCRIPTION
## What

Consolidates the duplicated "head" string-building logic across the three
tactic pairs in `abstract_syntax/proofs.py` that come in both a
goal-directed form and an `in <fact>` form:

- `simplify` / `simplify with … | …` (`SimplifyGoal` / `SimplifyFact`)
- `expand …` (`ApplyDefsGoal` / `ApplyDefsFact`)
- `replace …` (`RewriteGoal` / `RewriteFact`)

Each pair (plus the goal form's own `pretty_print`) rebuilt the identical
leading head inline. This extracts three small module-level helpers —
`_simplify_head`, `_expand_head`, `_replace_head` — and routes every site
through them. `SimplifyGoal._head` (a method that only existed to dedup
within that one class) is removed in favor of the shared helper.

## Behavior

No functional change, with one intentional normalization: `RewriteGoal.__str__`
previously used `'|'.join(...)` (no surrounding spaces) while `RewriteFact.__str__`
and `RewriteGoal.pretty_print` both used `' | '.join(...)`. The shared
`_replace_head` uses the spaced form, so `RewriteGoal.__str__` now matches the
pretty-printer. No `test/should-error` or `test/should-warn` fixture renders a
multi-equation `replace` via `__str__`, and the pretty-print round-trip corpus
already used the spaced form, so nothing regresses.

## Testing

- `python3 test-deduce.py` (full default: lib + should-validate ×2 parsers +
  should-error + should-warn + prelude + parser equivalence + round-trip) — all pass.
- `python3 test-deduce.py --equiv` and `--errors --warns` individually — all pass.

`ruff`/`mypy` require python3.13 (absent in this container); the change is pure
Python matching the surrounding typing, so the static gate runs in CI.

Refs #813.

Resume this session on ginger: `~/deduce-runner/resume.sh 11e8bd7e-ef29-40fe-b378-a5f87ad6c303 routine/20260808-130202`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
