### PR TITLE
Unbork the website by changing how the js regexes are autogenerated

### DIFF
--- a/gh_pages/scripts/code_block_syntax_generator.py
+++ b/gh_pages/scripts/code_block_syntax_generator.py
@@ -17,18 +17,24 @@ HTML_ENTITIES = {
 
 
 def escape_pattern(regex):
-    """HTML-escape a regex the way the site escapes code, but never inside a
-    ``[...]`` character class.
+    """HTML-escape a regex the way the site escapes code, with some special
+    handling inside ``[...]`` character classes.
 
     A character class can only ever match a single character, so rewriting
     ``=`` to the multi-character entity ``&equals;`` inside one does not make
     the class match escaped code -- it injects the letters ``e q u a l s`` as
     literal class members. That is what caused single-letter identifiers to be
-    highlighted as keywords (issue #1004). No class needs the substitution to
-    match anyway, so we simply leave class contents alone.
+    highlighted as keywords (issue #1004). However, some classes need this
+    substitution (issue #1183), so they get rewritten like this:
+    e.g. ``[#!=;]`` becomes ``([#!]|&equals;|&semi;)``
+    Beware that this rewriting could break on some more complicated regular
+    expressions involving character classes. One day the website may even have
+    to resort to usíng actual lexing instead of regex substitution hacks if
+    this keeps breaking!
     """
     out = []
     in_class = False
+    class_backlog = [""]
     i, n = 0, len(regex)
     while i < n:
         c = regex[i]
@@ -36,17 +42,35 @@ def escape_pattern(regex):
             # A backslash escapes the next character; it never opens or closes
             # a class. Outside a class the escaped char is still entity-mapped
             # (e.g. ``\/`` -> ``\&sol;`` in the comment patterns).
-            nxt = regex[i + 1]
+            i += 1
+            c = regex[i]
+            if in_class and c in HTML_ENTITIES:
+                # We eat the backslash when rewriting into a html entity inside
+                # a character class, which is probably the right thing to do.
+                class_backlog.append(HTML_ENTITIES.get(c))
+                i += 1
+                continue
             out.append('\\')
-            out.append(nxt if in_class else HTML_ENTITIES.get(nxt, nxt))
-            i += 2
-            continue
-        if c == '[':
+        elif c == '[':
             in_class = True
+            out.append('([')
+            i += 1
+            continue
         elif c == ']':
             in_class = False
-        out.append(c if in_class else HTML_ENTITIES.get(c, c))
+            # The empty string at the beginning of class_backlog
+            # makes '|'.join(class_backlog) always prepend a '|',
+            # but only if there are subsequent members.
+            out.append(']' + '|'.join(class_backlog) + ')')
+            class_backlog = [""]
+            i += 1
+            continue
+        if in_class and c in HTML_ENTITIES:
+            class_backlog.append(HTML_ENTITIES.get(c))
+        else:
+            out.append(c if in_class else HTML_ENTITIES.get(c, c))
         i += 1
+    assert not in_class
     return ''.join(out)
 
 


### PR DESCRIPTION
A previous commit removed the rewriting of certain characters into HTML entities inside regex character classes, since those do not understand HTML entities, fixing some syntax highlighting issues.

Regrettably, not rewriting characters inside character classes in turn causes issue #1183, and the fix is to rewrite the character classes by first removing the offending characters from the class, and then adding the corresponding HTML entity as an alternative at the end of the class.